### PR TITLE
update spec version for next release, include indices reuse bug fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,43 +35,43 @@ std = [
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-aura'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.balances]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-balances'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.consensus]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-consensus'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.consensus-aura]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'substrate-consensus-aura-primitives'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.executive]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-executive'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.fees]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-fees'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.indices]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-indices'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.parity-codec]
 default-features = false
@@ -85,25 +85,25 @@ version = '3.0'
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'substrate-primitives'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.rstd]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'sr-std'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.runtime-io]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'sr-io'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.runtime-primitives]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'sr-primitives'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.safe-mix]
 default-features = false
@@ -120,45 +120,45 @@ version = '1.0'
 [dependencies.srml-support]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.substrate-client]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.sudo]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-sudo'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.system]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-system'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.timestamp]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-timestamp'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.version]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'sr-version'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.staking]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-staking'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'
 
 [dependencies.session]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'
 package = 'srml-session'
-rev = 'df5e65927780b323482e2e8b5031822f423a032d'
+rev = 'cc8049b2429f5daea4d3bfb3074826d35de7da0e'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("joystream-node"),
 	impl_name: create_runtime_str!("joystream-node"),
 	authoring_version: 3,
-	spec_version: 4,
+	spec_version: 5,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 };

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -504,25 +504,25 @@ dependencies = [
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-aura 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-balances 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-executive 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-fees 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-indices 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-session 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-staking 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-sudo 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-timestamp 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-client 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-consensus-aura-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-aura 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-balances 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-executive 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-fees 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-indices 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-session 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-staking 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-sudo 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-timestamp 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-client 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-consensus-aura-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sr-api-macros"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1248,24 +1248,24 @@ dependencies = [
 [[package]]
 name = "sr-io"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "environmental 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hash-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-state-machine 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-state-machine 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sr-primitives"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "integer-sqrt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1274,15 +1274,15 @@ dependencies = [
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "sr-std"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1290,190 +1290,190 @@ dependencies = [
 [[package]]
 name = "sr-version"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "impl-serde 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-aura"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-staking 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-timestamp 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-staking 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-timestamp 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-balances"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-consensus"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-executive"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-fees"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-indices"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-metadata"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-session"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-timestamp 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-timestamp 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-staking"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-session 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-session 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-sudo"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support-procedural 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support-procedural 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-support"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1482,42 +1482,42 @@ dependencies = [
  "paste 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-metadata 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support-procedural 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-metadata 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support-procedural 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-support-procedural"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support-procedural-tools 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-api-macros 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support-procedural-tools 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
  "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "proc-macro-crate 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "srml-support-procedural-tools-derive 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "srml-support-procedural-tools-derive 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
  "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "srml-support-procedural-tools-derive"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "srml-system"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1535,28 +1535,28 @@ dependencies = [
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "srml-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
@@ -1572,7 +1572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "substrate-client"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1585,32 +1585,32 @@ dependencies = [
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-api-macros 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-consensus-common 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-executor 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-state-machine 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-telemetry 0.3.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-api-macros 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-consensus-common 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-executor 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-state-machine 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-telemetry 0.3.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "substrate-consensus-aura-primitives"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
- "substrate-client 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "substrate-client 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "substrate-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1618,17 +1618,17 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
  "tokio 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "substrate-executor"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1639,13 +1639,13 @@ dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-panic-handler 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-serializer 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-state-machine 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-panic-handler 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-serializer 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-state-machine 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1653,29 +1653,29 @@ dependencies = [
 [[package]]
 name = "substrate-inherents"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "substrate-keyring"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hex-literal 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
 ]
 
 [[package]]
 name = "substrate-panic-handler"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "substrate-primitives"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1703,7 +1703,7 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
  "twox-hash 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "substrate-serializer"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-machine"
 version = "0.1.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hash-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1729,9 +1729,9 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "substrate-panic-handler 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
- "substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)",
+ "substrate-panic-handler 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
+ "substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)",
  "trie-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "trie-root 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1739,7 +1739,7 @@ dependencies = [
 [[package]]
 name = "substrate-telemetry"
 version = "0.3.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "substrate-trie"
 version = "0.4.0"
-source = "git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d#df5e65927780b323482e2e8b5031822f423a032d"
+source = "git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e#cc8049b2429f5daea4d3bfb3074826d35de7da0e"
 dependencies = [
  "hash-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory-db 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2284,41 +2284,41 @@ dependencies = [
 "checksum slog-scope 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "60c04b4726fa04595ccf2c2dad7bcd15474242c4c5e109a8a376e8a2c9b1539a"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
-"checksum sr-api-macros 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-aura 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-balances 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-executive 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-fees 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-indices 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-metadata 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-session 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-staking 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-sudo 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-support-procedural 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-support-procedural-tools 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-support-procedural-tools-derive 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum srml-timestamp 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
+"checksum sr-api-macros 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum sr-io 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum sr-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum sr-std 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum sr-version 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-aura 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-balances 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-consensus 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-executive 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-fees 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-indices 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-metadata 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-session 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-staking 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-sudo 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-support 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-support-procedural 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-support-procedural-tools 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-support-procedural-tools-derive 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-system 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum srml-timestamp 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
-"checksum substrate-client 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-consensus-aura-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-consensus-common 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-executor 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-panic-handler 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-serializer 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-state-machine 0.1.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-telemetry 0.3.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
-"checksum substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=df5e65927780b323482e2e8b5031822f423a032d)" = "<none>"
+"checksum substrate-client 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-consensus-aura-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-consensus-common 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-executor 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-inherents 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-keyring 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-panic-handler 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-primitives 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-serializer 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-state-machine 0.1.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-telemetry 0.3.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
+"checksum substrate-trie 0.4.0 (git+https://github.com/joystream/substrate.git?rev=cc8049b2429f5daea4d3bfb3074826d35de7da0e)" = "<none>"
 "checksum subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "702662512f3ddeb74a64ce2fbbf3707ee1b6bb663d28bb054e0779bbc720d926"
 "checksum syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)" = "525bd55255f03c816e5d7f615587bd13030c7103354fadb104993dcee6a788ec"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"


### PR DESCRIPTION
Bump next runtime spec version from 4 to 5.

Include fix for indices reuse bug, by updating substrate package dependencies to point to: https://github.com/Joystream/substrate/tree/joy-indices-reuse-fix

See: https://github.com/paritytech/substrate/pull/1966 for context on the bug.