### PR TITLE
disable and clear account indices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,9 +182,9 @@ impl balances::Trait for Runtime {
 	/// The type for recording an account's balance.
 	type Balance = u128;
 	/// What to do if an account's free balance gets zeroed.
-	type OnFreeBalanceZero = Staking;
+	type OnFreeBalanceZero = ();
 	/// What to do if a new account is created.
-	type OnNewAccount = Indices;
+	type OnNewAccount = ();
 	/// Restrict whether an account can transfer funds. We don't place any further restrictions.
 	type EnsureAccountLiquid = Staking;
 	/// The uniquitous event type.

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -1,13 +1,15 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use srml_support::{StorageValue, dispatch::Result, decl_module, decl_storage, decl_event, ensure};
+use srml_support::{StorageValue, StorageMap, dispatch::Result, decl_module, decl_storage, decl_event, ensure};
+use runtime_primitives::traits::{As};
 use system;
 use rstd::prelude::*;
 use runtime_io::print;
 use crate::{VERSION};
 use crate::membership::members;
+use {indices};
 
-pub trait Trait: system::Trait + members::Trait {
+pub trait Trait: system::Trait + members::Trait + indices::Trait {
     type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 }
 
@@ -39,6 +41,12 @@ impl<T: Trait> Module<T> {
         print("running runtime initializers");
 
         <members::Module<T>>::initialize_storage();
+
+
+        // Clear account indices
+        for i in 0..65535 {
+            <indices::EnumSet<T>>::remove(&<T as indices::Trait>::AccountIndex::sa(i));
+        }
 
         // ...
         // add initialization of other modules introduced in this runtime


### PR DESCRIPTION
Clear indices, and prevent new accounts from generating an AccountIndex.

https://github.com/Joystream/substrate-runtime-joystream/pull/2 for context

The base issue is in our testnet we allow accounts to go to zero balance and not get reaped, because we configured existential deposit to be zero. Without this change account index reuse will occur and if anyone is relying on the account index in place of full account id (mainly in transfers) they may be unpleasantly surprised. 