### PR TITLE
Example: Integrating example-module into runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,14 @@ std = [
     'consensus-authorities/std',
     'grandpa/std',
     'finality-tracker/std',
+    'runtime-example-module/std',
 ]
+
+[dependencies.runtime-example-module]
+git = 'https://github.com/joystream/runtime-example-module.git'
+default_features = false
+rev = 'a14d1433ab9691170cd0b68fd6a82197ee7c61b9'
+
 [dependencies.aura]
 default_features = false
 git = 'https://github.com/joystream/substrate.git'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,6 +311,33 @@ impl finality_tracker::Trait for Runtime {
     type OnFinalizationStalled = grandpa::SyncedAuthorities<Runtime>;
 }
 
+use runtime_example_module;
+use traits::Members as MembersTrait;
+pub struct MembershipRegistryForExample {}
+impl runtime_example_module::MembershipRegistry<Runtime> for MembershipRegistryForExample {
+    fn ensure_member(who: <Runtime as system::Trait>::AccountId) -> Result<(), &'static str> {
+        // call public methods on module
+        // <Members as membership::members::Trait>::ensure_is_member(&who);
+
+        // Access storage values directly
+        // return <members::FirstMemberId<Runtime>>::get();
+
+        // Call methods on a specific trait
+        if <Members as MembersTrait<Runtime>>::is_active_member(&who) {
+            return Ok(());
+        } else {
+            return Err("account is not a member");
+        }
+    }
+}
+
+impl runtime_example_module::Trait for Runtime {
+    /// The uniquitous event type.
+    type Event = Event;
+    type Currency = balances::Module<Self>;
+    type MembershipRegistry = MembershipRegistryForExample;
+}
+
 construct_runtime!(
 	pub enum Runtime with Log(InternalLog: DigestItem<Hash, AuthorityId, AuthoritySignature>) where
 		Block = Block,
@@ -339,6 +366,7 @@ construct_runtime!(
 		DataDirectory: data_directory::{Module, Call, Storage, Event<T>},
 		DataObjectStorageRegistry: data_object_storage_registry::{Module, Call, Storage, Event<T>, Config<T>},
 		DownloadSessions: downloads::{Module, Call, Storage, Event<T>, Config<T>},
+        ExampleModule: runtime_example_module,
 	}
 );
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -760,6 +760,7 @@ version = "5.4.0"
 dependencies = [
  "parity-codec 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec-derive 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "runtime-example-module 0.1.0 (git+https://github.com/joystream/runtime-example-module.git?rev=a14d1433ab9691170cd0b68fd6a82197ee7c61b9)",
  "safe-mix 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1813,6 +1814,24 @@ dependencies = [
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "runtime-example-module"
+version = "0.1.0"
+source = "git+https://github.com/joystream/runtime-example-module.git?rev=a14d1433ab9691170cd0b68fd6a82197ee7c61b9#a14d1433ab9691170cd0b68fd6a82197ee7c61b9"
+dependencies = [
+ "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-codec 3.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-codec-derive 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sr-primitives 1.0.0 (git+https://github.com/joystream/substrate.git?rev=6dfc3e8b057bb00322136251a0f10305fbb1ad8f)",
+ "sr-std 1.0.0 (git+https://github.com/joystream/substrate.git?rev=6dfc3e8b057bb00322136251a0f10305fbb1ad8f)",
+ "srml-balances 1.0.0 (git+https://github.com/joystream/substrate.git?rev=6dfc3e8b057bb00322136251a0f10305fbb1ad8f)",
+ "srml-support 1.0.0 (git+https://github.com/joystream/substrate.git?rev=6dfc3e8b057bb00322136251a0f10305fbb1ad8f)",
+ "srml-support-procedural 1.0.0 (git+https://github.com/joystream/substrate.git?rev=6dfc3e8b057bb00322136251a0f10305fbb1ad8f)",
+ "srml-system 1.0.0 (git+https://github.com/joystream/substrate.git?rev=6dfc3e8b057bb00322136251a0f10305fbb1ad8f)",
+ "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3398,6 +3417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "559008764a17de49a3146b234641644ed37d118d1ef641a0bb573d146edc6ce0"
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
+"checksum runtime-example-module 0.1.0 (git+https://github.com/joystream/runtime-example-module.git?rev=a14d1433ab9691170cd0b68fd6a82197ee7c61b9)" = "<none>"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"


### PR DESCRIPTION
== THIS PR IS FOR DEMONSTRATION ONLY - DO NOT MERGE ==

Example of how to integrate an [external module](https://github.com/Joystream/runtime-example-module) into the runtime.

Demonstrates how to apply the [recommended convention](https://github.com/Joystream/joystream/issues/36) to make a module easily reusable for another runtime, by providing your own traits for your expectations on other modules, rather than relying on public traits, or traits in the module you are expecting to use. In this example we apply this to the "membership" system.