### PR TITLE
update forum dependency to tag v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,4 +193,4 @@ rev = '6dfc3e8b057bb00322136251a0f10305fbb1ad8f'
 default_features = false
 git = 'https://github.com/joystream/substrate-forum-module'
 package = 'substrate-forum-module'
-rev = '5ab4944344966e0b460f3883cbc45eab94ef666e'
+tag = "v1.0.0"


### PR DESCRIPTION
![Screen Shot 2019-06-20 at 12 52 21 PM](https://user-images.githubusercontent.com/1621012/59840262-abca1c80-935a-11e9-91de-7950f6d99f93.png)
