### PR TITLE
memo: give memo text its own type name

### DIFF
--- a/src/memo.rs
+++ b/src/memo.rs
@@ -9,9 +9,11 @@ pub trait Trait: system::Trait + GovernanceCurrency {
     type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 }
 
+pub type MemoText = Vec<u8>;
+
 decl_storage! {
     trait Store for Module<T: Trait> as Memo {
-        Memo get(memo) : map T::AccountId => Vec<u8>;
+        Memo get(memo) : map T::AccountId => MemoText;
         MaxMemoLength get(max_memo_length) : u32 = 4096;
     }
 }
@@ -26,13 +28,13 @@ decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
         fn deposit_event<T>() = default;
 
-        fn update_memo(origin, memo: Vec<u8>) {
+        fn update_memo(origin, memo: MemoText) {
             let sender = ensure_signed(origin)?;
 
             ensure!(!T::Currency::total_balance(&sender).is_zero(), "account must have a balance");
             ensure!(memo.len() as u32 <= Self::max_memo_length(), "memo too long");
 
-            <Memo<T>>::insert(sender.clone(), memo);
+            <Memo<T>>::insert(&sender, memo);
             Self::deposit_event(RawEvent::MemoUpdated(sender));
         }
     }


### PR DESCRIPTION
Giving memo text its own type allows us to deal with with better as a `Text` type in the client side.
Associated PR in [pioneer](https://github.com/Joystream/apps/pull/239)