### PR TITLE
testing hiring module fixes: 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
  "substrate-client 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3)",
  "substrate-consensus-babe-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3)",
  "substrate-forum-module 1.1.0 (git+https://github.com/Joystream/substrate-forum-module?rev=4bdeadaadfcca1fd6e822c520f429d4beacc4c8a)",
- "substrate-hiring-module 1.0.0 (git+https://github.com/Joystream/substrate-hiring-module?rev=30ac830aecb2e61fb943a8c4327bcf52c289e383)",
+ "substrate-hiring-module 1.0.0 (git+https://github.com/shamil-gadelshin/substrate-hiring-module.git?rev=b6071f7279a668c4aa02b2d6c985768e9fe0acf8)",
  "substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3)",
  "substrate-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3)",
  "substrate-recurring-reward-module 1.0.0 (git+https://github.com/Joystream/substrate-recurring-reward-module?rev=417f7bb5b82ae50f02716ac4eefa2fc7952e0f61)",
@@ -3208,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "substrate-hiring-module"
 version = "1.0.0"
-source = "git+https://github.com/Joystream/substrate-hiring-module?rev=30ac830aecb2e61fb943a8c4327bcf52c289e383#30ac830aecb2e61fb943a8c4327bcf52c289e383"
+source = "git+https://github.com/shamil-gadelshin/substrate-hiring-module.git?rev=b6071f7279a668c4aa02b2d6c985768e9fe0acf8#b6071f7279a668c4aa02b2d6c985768e9fe0acf8"
 dependencies = [
  "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4491,7 +4491,7 @@ dependencies = [
 "checksum substrate-finality-grandpa-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3)" = "<none>"
 "checksum substrate-forum-module 1.1.0 (git+https://github.com/Joystream/substrate-forum-module?rev=4bdeadaadfcca1fd6e822c520f429d4beacc4c8a)" = "<none>"
 "checksum substrate-header-metadata 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3)" = "<none>"
-"checksum substrate-hiring-module 1.0.0 (git+https://github.com/Joystream/substrate-hiring-module?rev=30ac830aecb2e61fb943a8c4327bcf52c289e383)" = "<none>"
+"checksum substrate-hiring-module 1.0.0 (git+https://github.com/shamil-gadelshin/substrate-hiring-module.git?rev=b6071f7279a668c4aa02b2d6c985768e9fe0acf8)" = "<none>"
 "checksum substrate-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3)" = "<none>"
 "checksum substrate-keyring 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3)" = "<none>"
 "checksum substrate-offchain-primitives 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=0e3001a1ad6fa3d1ba7da7342a8d0d3b3facb2f3)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,9 +282,9 @@ rev = '0516efe9230da112bc095e28f34a3715c2e03ca8'
 
 [dependencies.hiring]
 default_features = false
-git = 'https://github.com/Joystream/substrate-hiring-module'
+git = 'https://github.com/shamil-gadelshin/substrate-hiring-module.git'
 package = 'substrate-hiring-module'
-rev = '30ac830aecb2e61fb943a8c4327bcf52c289e383'
+rev = 'b6071f7279a668c4aa02b2d6c985768e9fe0acf8'
 
 [dependencies.versioned_store]
 default_features = false


### PR DESCRIPTION
DONT MERGE - Just for Testing..

Testing https://github.com/Joystream/substrate-hiring-module/pull/20

Three test cases are failing:
panicked at 'Unstaking must be possible at this time: Error(UnstakingError(NotStaked))'

failures:
    content_working_group::tests::leave_curator_role_success
    content_working_group::tests::terminate_curator_role_success
    content_working_group::tests::unstaked_curator_success

Panic is occurring in the call to `fn deactivate_curator()`: 
https://github.com/Joystream/substrate-runtime-joystream/blob/1b1f136db68221afc923dbc6465afb7490b1d71c/src/content_working_group/lib.rs#L2589

cc: @shamil-gadelshin @bedeho 