### PR TITLE
Proposals v2. Discussion system. Iteration5

### DIFF
--- a/modules/proposals/codex/src/lib.rs
+++ b/modules/proposals/codex/src/lib.rs
@@ -11,20 +11,21 @@
 // Do not delete! Cannot be uncommented by default, because of Parity decl_module! issue.
 //#![warn(missing_docs)]
 
-pub use proposal_types::{ProposalType, RuntimeUpgradeProposalExecutable, TextProposalExecutable};
-
 mod proposal_types;
 #[cfg(test)]
 mod tests;
 
 use codec::Encode;
-use proposal_engine::*;
 use rstd::clone::Clone;
 use rstd::marker::PhantomData;
 use rstd::prelude::*;
 use rstd::vec::Vec;
+use runtime_primitives::traits::One;
 use srml_support::{decl_error, decl_module, decl_storage, ensure};
 use system::RawOrigin;
+
+use proposal_engine::*;
+pub use proposal_types::{ProposalType, RuntimeUpgradeProposalExecutable, TextProposalExecutable};
 
 /// 'Proposals codex' substrate module Trait
 pub trait Trait: system::Trait + proposal_engine::Trait + proposal_discussion::Trait {
@@ -100,6 +101,7 @@ decl_module! {
 
             let discussion_thread_id = <proposal_discussion::Module<T>>::create_thread(
                 cloned_origin1,
+                T::ThreadAuthorId::one(), //TODO: temporary stub, provide implementation
                 title.clone(),
             )?;
 
@@ -142,6 +144,7 @@ decl_module! {
 
             let discussion_thread_id = <proposal_discussion::Module<T>>::create_thread(
                 cloned_origin1,
+                T::ThreadAuthorId::one(), //TODO: temporary stub, provide implementation
                 title.clone(),
             )?;
 

--- a/modules/proposals/codex/src/tests/mock.rs
+++ b/modules/proposals/codex/src/tests/mock.rs
@@ -107,6 +107,7 @@ impl proposal_engine::Trait for Test {
 
 parameter_types! {
     pub const MaxPostEditionNumber: u32 = 5;
+    pub const MaxThreadInARowNumber: u32 = 3;
     pub const ThreadTitleLengthLimit: u32 = 200;
     pub const PostLengthLimit: u32 = 2000;
 }
@@ -121,6 +122,7 @@ impl proposal_discussion::Trait for Test {
     type MaxPostEditionNumber = MaxPostEditionNumber;
     type ThreadTitleLengthLimit = ThreadTitleLengthLimit;
     type PostLengthLimit = PostLengthLimit;
+    type MaxThreadInARowNumber = MaxThreadInARowNumber;
 }
 
 pub struct MockVotersParameters;

--- a/modules/proposals/codex/src/tests/mock.rs
+++ b/modules/proposals/codex/src/tests/mock.rs
@@ -105,6 +105,12 @@ impl proposal_engine::Trait for Test {
     type MaxActiveProposalLimit = MaxActiveProposalLimit;
 }
 
+impl proposal_discussion::ActorOriginValidator<Origin, u64> for () {
+    fn validate_actor_origin(_: Origin, _: u64) -> bool {
+        true
+    }
+}
+
 parameter_types! {
     pub const MaxPostEditionNumber: u32 = 5;
     pub const MaxThreadInARowNumber: u32 = 3;
@@ -113,8 +119,9 @@ parameter_types! {
 }
 
 impl proposal_discussion::Trait for Test {
-    type ThreadAuthorOrigin = system::EnsureSigned<Self::AccountId>;
-    type PostAuthorOrigin = system::EnsureSigned<Self::AccountId>;
+    type Event = ();
+    type ThreadAuthorOriginValidator = ();
+    type PostAuthorOriginValidator = ();
     type ThreadId = u32;
     type PostId = u32;
     type ThreadAuthorId = u64;

--- a/modules/proposals/discussion/src/errors.rs
+++ b/modules/proposals/discussion/src/errors.rs
@@ -1,0 +1,14 @@
+pub(crate) const MSG_NOT_AUTHOR: &str = "Author should match the post creator";
+pub(crate) const MSG_POST_EDITION_NUMBER_EXCEEDED: &str = "Post edition limit reached.";
+pub(crate) const MSG_EMPTY_TITLE_PROVIDED: &str = "Discussion cannot have an empty title";
+pub(crate) const MSG_TOO_LONG_TITLE: &str = "Title is too long";
+pub(crate) const MSG_THREAD_DOESNT_EXIST: &str = "Thread doesn't exist";
+pub(crate) const MSG_POST_DOESNT_EXIST: &str = "Post doesn't exist";
+pub(crate) const MSG_EMPTY_POST_PROVIDED: &str = "Post cannot be empty";
+pub(crate) const MSG_TOO_LONG_POST: &str = "Post is too long";
+pub(crate) const MSG_MAX_THREAD_IN_A_ROW_LIMIT_EXCEEDED: &str =
+	"Max number of threads by same author in a row limit exceeded";
+pub(crate) const MSG_INVALID_THREAD_AUTHOR_ORIGIN: &str =
+	"Invalid combination of the origin and thread_author_id";
+pub(crate) const MSG_INVALID_POST_AUTHOR_ORIGIN: &str =
+	"Invalid combination of the origin and post_author_id";

--- a/modules/proposals/discussion/src/errors.rs
+++ b/modules/proposals/discussion/src/errors.rs
@@ -7,8 +7,8 @@ pub(crate) const MSG_POST_DOESNT_EXIST: &str = "Post doesn't exist";
 pub(crate) const MSG_EMPTY_POST_PROVIDED: &str = "Post cannot be empty";
 pub(crate) const MSG_TOO_LONG_POST: &str = "Post is too long";
 pub(crate) const MSG_MAX_THREAD_IN_A_ROW_LIMIT_EXCEEDED: &str =
-	"Max number of threads by same author in a row limit exceeded";
+    "Max number of threads by same author in a row limit exceeded";
 pub(crate) const MSG_INVALID_THREAD_AUTHOR_ORIGIN: &str =
-	"Invalid combination of the origin and thread_author_id";
+    "Invalid combination of the origin and thread_author_id";
 pub(crate) const MSG_INVALID_POST_AUTHOR_ORIGIN: &str =
-	"Invalid combination of the origin and post_author_id";
+    "Invalid combination of the origin and post_author_id";

--- a/modules/proposals/discussion/src/lib.rs
+++ b/modules/proposals/discussion/src/lib.rs
@@ -15,21 +15,21 @@
 // Do not delete! Cannot be uncommented by default, because of Parity decl_module! issue.
 //#![warn(missing_docs)]
 
+mod errors;
 #[cfg(test)]
 mod tests;
 mod types;
-mod errors;
 
 use rstd::clone::Clone;
 use rstd::prelude::*;
 use rstd::vec::Vec;
-use srml_support::{decl_module, decl_event, decl_storage, ensure, Parameter};
+use srml_support::{decl_event, decl_module, decl_storage, ensure, Parameter};
 
+use runtime_primitives::traits::SimpleArithmetic;
 use srml_support::traits::Get;
-use types::ActorOriginValidator;
+pub use types::ActorOriginValidator;
 use types::{Post, Thread, ThreadCounter};
 
-// TODO: create events
 // TODO: move errors to decl_error macro (after substrate version upgrade)
 
 decl_event!(
@@ -60,7 +60,7 @@ pub trait Trait: system::Trait {
     /// Validates thread author id and origin combination
     type ThreadAuthorOriginValidator: ActorOriginValidator<Self::Origin, Self::ThreadAuthorId>;
 
-    /// Validates  post author id and origin combination
+    /// Validates post author id and origin combination
     type PostAuthorOriginValidator: ActorOriginValidator<Self::Origin, Self::PostAuthorId>;
 
     /// Discussion thread Id type
@@ -70,7 +70,7 @@ pub trait Trait: system::Trait {
     type PostId: From<u32> + Parameter + Default + Copy;
 
     /// Type for the thread author id. Should be authenticated by account id.
-    type ThreadAuthorId: From<Self::AccountId> + Parameter + Default;
+    type ThreadAuthorId: From<Self::AccountId> + Parameter + Default + SimpleArithmetic;
 
     /// Type for the post author id. Should be authenticated by account id.
     type PostAuthorId: From<Self::AccountId> + Parameter + Default;

--- a/modules/proposals/discussion/src/tests/mock.rs
+++ b/modules/proposals/discussion/src/tests/mock.rs
@@ -30,6 +30,7 @@ parameter_types! {
 
 parameter_types! {
     pub const MaxPostEditionNumber: u32 = 5;
+    pub const MaxThreadInARowNumber: u32 = 3;
     pub const ThreadTitleLengthLimit: u32 = 200;
     pub const PostLengthLimit: u32 = 2000;
 }
@@ -44,6 +45,7 @@ impl crate::Trait for Test {
     type MaxPostEditionNumber = MaxPostEditionNumber;
     type ThreadTitleLengthLimit = ThreadTitleLengthLimit;
     type PostLengthLimit = PostLengthLimit;
+    type MaxThreadInARowNumber = MaxThreadInARowNumber;
 }
 
 impl system::Trait for Test {

--- a/modules/proposals/discussion/src/tests/mock.rs
+++ b/modules/proposals/discussion/src/tests/mock.rs
@@ -10,6 +10,7 @@ pub use runtime_primitives::{
     BuildStorage, Perbill,
 };
 
+use crate::{ActorOriginValidator};
 use srml_support::{impl_outer_origin, parameter_types};
 
 impl_outer_origin! {
@@ -36,7 +37,7 @@ parameter_types! {
 }
 
 impl crate::Trait for Test {
-    type ThreadAuthorOrigin = system::EnsureSigned<Self::AccountId>;
+    type ThreadAuthorOriginValidator = ();
     type PostAuthorOrigin = system::EnsureSigned<Self::AccountId>;
     type ThreadId = u32;
     type PostId = u32;
@@ -46,6 +47,12 @@ impl crate::Trait for Test {
     type ThreadTitleLengthLimit = ThreadTitleLengthLimit;
     type PostLengthLimit = PostLengthLimit;
     type MaxThreadInARowNumber = MaxThreadInARowNumber;
+}
+
+impl ActorOriginValidator<Origin, u64> for () {
+    fn validate_actor_origin(_: Origin, actor_id: u64) -> bool {
+        actor_id == 1
+    }
 }
 
 impl system::Trait for Test {

--- a/modules/proposals/discussion/src/tests/mock.rs
+++ b/modules/proposals/discussion/src/tests/mock.rs
@@ -11,7 +11,7 @@ pub use runtime_primitives::{
 };
 
 use crate::ActorOriginValidator;
-use srml_support::{impl_outer_origin, parameter_types, impl_outer_event};
+use srml_support::{impl_outer_event, impl_outer_origin, parameter_types};
 
 impl_outer_origin! {
     pub enum Origin for Test {}

--- a/modules/proposals/discussion/src/tests/mock.rs
+++ b/modules/proposals/discussion/src/tests/mock.rs
@@ -10,7 +10,7 @@ pub use runtime_primitives::{
     BuildStorage, Perbill,
 };
 
-use crate::{ActorOriginValidator};
+use crate::ActorOriginValidator;
 use srml_support::{impl_outer_origin, parameter_types};
 
 impl_outer_origin! {
@@ -38,7 +38,7 @@ parameter_types! {
 
 impl crate::Trait for Test {
     type ThreadAuthorOriginValidator = ();
-    type PostAuthorOrigin = system::EnsureSigned<Self::AccountId>;
+    type PostAuthorOriginValidator = ();
     type ThreadId = u32;
     type PostId = u32;
     type ThreadAuthorId = u64;
@@ -50,7 +50,11 @@ impl crate::Trait for Test {
 }
 
 impl ActorOriginValidator<Origin, u64> for () {
-    fn validate_actor_origin(_: Origin, actor_id: u64) -> bool {
+    fn validate_actor_origin(origin: Origin, actor_id: u64) -> bool {
+        if system::ensure_none(origin).is_ok() {
+            return true;
+        }
+
         actor_id == 1
     }
 }

--- a/modules/proposals/discussion/src/tests/mock.rs
+++ b/modules/proposals/discussion/src/tests/mock.rs
@@ -11,7 +11,7 @@ pub use runtime_primitives::{
 };
 
 use crate::ActorOriginValidator;
-use srml_support::{impl_outer_origin, parameter_types};
+use srml_support::{impl_outer_origin, parameter_types, impl_outer_event};
 
 impl_outer_origin! {
     pub enum Origin for Test {}
@@ -36,7 +36,18 @@ parameter_types! {
     pub const PostLengthLimit: u32 = 2000;
 }
 
+mod discussion {
+    pub use crate::Event;
+}
+
+impl_outer_event! {
+    pub enum TestEvent for Test {
+        discussion<T>,
+    }
+}
+
 impl crate::Trait for Test {
+    type Event = TestEvent;
     type ThreadAuthorOriginValidator = ();
     type PostAuthorOriginValidator = ();
     type ThreadId = u32;
@@ -69,7 +80,7 @@ impl system::Trait for Test {
     type AccountId = u64;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
-    type Event = ();
+    type Event = TestEvent;
     type BlockHashCount = BlockHashCount;
     type MaximumBlockWeight = MaximumBlockWeight;
     type MaximumBlockLength = MaximumBlockLength;
@@ -92,3 +103,4 @@ pub fn initial_test_ext() -> runtime_io::TestExternalities {
 }
 
 pub type Discussions = crate::Module<Test>;
+pub type System = system::Module<Test>;

--- a/modules/proposals/discussion/src/tests/mod.rs
+++ b/modules/proposals/discussion/src/tests/mod.rs
@@ -2,8 +2,8 @@ mod mock;
 
 use mock::*;
 
-use crate::*;
 use crate::errors::*;
+use crate::*;
 use system::RawOrigin;
 use system::{EventRecord, Phase};
 

--- a/modules/proposals/discussion/src/tests/mod.rs
+++ b/modules/proposals/discussion/src/tests/mod.rs
@@ -354,3 +354,18 @@ fn update_post_call_with_invalid_text_failed() {
         post_fixture3.update_post_and_assert(Err(MSG_TOO_LONG_POST));
     });
 }
+
+#[test]
+fn add_discussion_thread_fails_because_of_max_thread_by_same_author_in_a_row_limit_exceeded() {
+    initial_test_ext().execute_with(|| {
+        let discussion_fixture = DiscussionFixture::default();
+        for idx in 1..=3 {
+            discussion_fixture
+                .create_discussion_and_assert(Ok(idx))
+                .unwrap();
+        }
+
+        discussion_fixture
+            .create_discussion_and_assert(Err(MSG_MAX_THREAD_IN_A_ROW_LIMIT_EXCEEDED));
+    });
+}

--- a/modules/proposals/discussion/src/types.rs
+++ b/modules/proposals/discussion/src/types.rs
@@ -40,3 +40,32 @@ pub struct Post<PostAuthorId, BlockNumber, ThreadId> {
     /// Defines how many times this post was edited. Zero on creation.
     pub edition_number: u32,
 }
+
+/// Post for the discussion thread
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
+#[derive(Encode, Decode, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ThreadCounter<ThreadAuthorId> {
+    /// Author of the threads.
+    pub author_id: ThreadAuthorId,
+
+    /// ThreadCount
+    pub counter: u32,
+}
+
+impl<ThreadAuthorId: Clone> ThreadCounter<ThreadAuthorId> {
+    /// Increments existing counter
+    pub fn increment(&self) -> Self {
+        ThreadCounter {
+            counter: self.counter + 1,
+            author_id: self.author_id.clone(),
+        }
+    }
+
+    /// Creates new counter by author_id. Counter instantiated with 1.
+    pub fn new(author_id: ThreadAuthorId) -> Self {
+        ThreadCounter {
+            author_id,
+            counter: 1,
+        }
+    }
+}

--- a/modules/proposals/discussion/src/types.rs
+++ b/modules/proposals/discussion/src/types.rs
@@ -69,3 +69,9 @@ impl<ThreadAuthorId: Clone> ThreadCounter<ThreadAuthorId> {
         }
     }
 }
+
+/// Abstract validator for the origin(account_id) and actor_id (eg.: thread author id).
+pub trait ActorOriginValidator<Origin, ActorId> {
+    /// Check for valid combination of origin and actor_id
+    fn validate_actor_origin(origin: Origin, actor_id: ActorId) -> bool;
+}


### PR DESCRIPTION
Features:
- spam-gate: max allowed post count in a row
- modification of the post and thread author authentication
- discussion events

Work to do after the Rome-release:
- create a monorepo
- **stake** fixes: https://github.com/Joystream/substrate-runtime-joystream/issues/161
- change origins and include **membership** and **council** actors: https://github.com/Joystream/substrate-runtime-joystream/issues/174
- **discussions** - two write access modes:
	a) open: any member can write.
	b) closed: only author, the current **council** (which may change at any time), and other specially added **members** can post. 
- **stake** modification: to store an account_id to perform an unstake to (modify StakingEventHandler)
- move **engine** and **discussion** modules to `decl_error` approach (after the **substrate** update)
- provide an implementation of the `T::ThreadAuthorId` in the **codex** call of the **discussion** `create_thread()` (remove temporary stub)