### PR TITLE
Add a council mint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "2.1.3"
+version = "2.1.6"
 dependencies = [
  "ctrlc",
  "derive_more 0.14.1",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "6.9.0"
+version = "6.12.0"
 dependencies = [
  "parity-scale-codec",
  "safe-mix",
@@ -4796,6 +4796,7 @@ dependencies = [
  "substrate-common-module",
  "substrate-membership-module",
  "substrate-primitives",
+ "substrate-token-mint-module",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '2.1.3'
+version = '2.1.6'
 default-run = "joystream-node"
 
 [[bin]]

--- a/runtime-modules/governance/Cargo.toml
+++ b/runtime-modules/governance/Cargo.toml
@@ -17,6 +17,7 @@ std = [
 	'rstd/std',
 	'common/std',
 	'membership/std',
+	'minting/std',
 ]
 
 [dependencies.sr-primitives]
@@ -87,3 +88,8 @@ default_features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'srml-balances'
 rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'
+
+[dependencies.minting]
+default_features = false
+package = 'substrate-token-mint-module'
+path = '../token-minting'

--- a/runtime-modules/governance/src/council.rs
+++ b/runtime-modules/governance/src/council.rs
@@ -67,7 +67,7 @@ impl<T: Trait> Module<T> {
         Self::active_council().iter().any(|c| c.member == *sender)
     }
 
-    // Initializes a new mint, discarding previous mint if it existed.
+    /// Initializes a new mint, discarding previous mint if it existed.
     pub fn create_new_council_mint(
         capacity: minting::BalanceOf<T>,
     ) -> Result<T::MintId, &'static str> {

--- a/runtime-modules/governance/src/election.rs
+++ b/runtime-modules/governance/src/election.rs
@@ -156,7 +156,7 @@ impl<T: Trait> Module<T> {
     }
 
     fn can_participate(sender: &T::AccountId) -> bool {
-        !T::Currency::free_balance(sender).is_zero()
+        !<T as GovernanceCurrency>::Currency::free_balance(sender).is_zero()
             && <membership::members::Module<T>>::is_member_account(sender)
     }
 
@@ -356,7 +356,10 @@ impl<T: Trait> Module<T> {
         for stakeholder in Self::existing_stake_holders().iter() {
             let stake = Self::transferable_stakes(stakeholder);
             if !stake.seat.is_zero() || !stake.backing.is_zero() {
-                T::Currency::unreserve(stakeholder, stake.seat + stake.backing);
+                <T as GovernanceCurrency>::Currency::unreserve(
+                    stakeholder,
+                    stake.seat + stake.backing,
+                );
             }
         }
     }
@@ -381,7 +384,7 @@ impl<T: Trait> Module<T> {
 
         // return new stake to account's free balance
         if !stake.new.is_zero() {
-            T::Currency::unreserve(applicant, stake.new);
+            <T as GovernanceCurrency>::Currency::unreserve(applicant, stake.new);
         }
 
         // return unused transferable stake
@@ -435,7 +438,7 @@ impl<T: Trait> Module<T> {
                 // return new stake to account's free balance
                 let SealedVote { voter, stake, .. } = sealed_vote;
                 if !stake.new.is_zero() {
-                    T::Currency::unreserve(voter, stake.new);
+                    <T as GovernanceCurrency>::Currency::unreserve(voter, stake.new);
                 }
 
                 // return unused transferable stake
@@ -626,12 +629,12 @@ impl<T: Trait> Module<T> {
         let new_stake = Self::new_stake_reusing_transferable(&mut transferable_stake.seat, stake);
 
         ensure!(
-            T::Currency::can_reserve(&applicant, new_stake.new),
+            <T as GovernanceCurrency>::Currency::can_reserve(&applicant, new_stake.new),
             "not enough free balance to reserve"
         );
 
         ensure!(
-            T::Currency::reserve(&applicant, new_stake.new).is_ok(),
+            <T as GovernanceCurrency>::Currency::reserve(&applicant, new_stake.new).is_ok(),
             "failed to reserve applicant stake!"
         );
 
@@ -662,12 +665,12 @@ impl<T: Trait> Module<T> {
             Self::new_stake_reusing_transferable(&mut transferable_stake.backing, stake);
 
         ensure!(
-            T::Currency::can_reserve(&voter, vote_stake.new),
+            <T as GovernanceCurrency>::Currency::can_reserve(&voter, vote_stake.new),
             "not enough free balance to reserve"
         );
 
         ensure!(
-            T::Currency::reserve(&voter, vote_stake.new).is_ok(),
+            <T as GovernanceCurrency>::Currency::reserve(&voter, vote_stake.new).is_ok(),
             "failed to reserve voting stake!"
         );
 

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -70,7 +70,10 @@ impl membership::members::Trait for Test {
     type ActorId = u32;
     type InitialMembersBalance = InitialMembersBalance;
 }
-
+impl minting::Trait for Test {
+    type Currency = Balances;
+    type MintId = u64;
+}
 parameter_types! {
     pub const ExistentialDeposit: u32 = 0;
     pub const TransferFee: u32 = 0;

--- a/runtime-modules/token-minting/src/lib.rs
+++ b/runtime-modules/token-minting/src/lib.rs
@@ -82,6 +82,15 @@ impl From<GeneralError> for &'static str {
     }
 }
 
+impl From<TransferError> for &'static str {
+    fn from(err: TransferError) -> &'static str {
+        match err {
+            TransferError::MintNotFound => "MintNotFound",
+            TransferError::NotEnoughCapacity => "NotEnoughCapacity",
+        }
+    }
+}
+
 #[derive(Encode, Decode, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Adjustment<Balance: Zero, BlockNumber> {
     // First adjustment will be after AdjustOnInterval.block_interval

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '6.9.0'
+version = '6.12.0'
 
 [features]
 default = ['std']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 6,
-    spec_version: 9,
+    spec_version: 12,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
 };

--- a/runtime/src/migration.rs
+++ b/runtime/src/migration.rs
@@ -1,5 +1,5 @@
 use crate::VERSION;
-use sr_primitives::print;
+use sr_primitives::{print, traits::Zero};
 use srml_support::{decl_event, decl_module, decl_storage};
 use sudo;
 use system;
@@ -14,8 +14,10 @@ impl<T: Trait> Module<T> {
         // have been initialized with config() or build() mechanism.
         // ...
 
-        // Create the Council mint
-        governance::council::Module::<T>::create_new_council_mint();
+        // Create the Council mint. If it fails, we can't do anything about it here.
+        let _ = governance::council::Module::<T>::create_new_council_mint(
+            minting::BalanceOf::<T>::zero(),
+        );
 
         Self::deposit_event(RawEvent::Migrated(
             <system::Module<T>>::block_number(),

--- a/runtime/src/migration.rs
+++ b/runtime/src/migration.rs
@@ -15,7 +15,7 @@ impl<T: Trait> Module<T> {
         // ...
 
         // Create the Council mint
-        governance::council::Module::<T>::initialize_mint();
+        governance::council::Module::<T>::create_new_council_mint();
 
         Self::deposit_event(RawEvent::Migrated(
             <system::Module<T>>::block_number(),


### PR DESCRIPTION
Implements #242 and #244

- Adding a mint to the council, ~~initialized at genesis~~
- Migration step at runtime upgrade to create the council mint
- root dispatchable methods for proposal
  - spend_from_council_mint() - fails if no mint exists
  - set_council_mint_capacity() - creates mint if it doesn't exist