### PR TITLE
CLI: Fixed balances naming and logic

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -14,14 +14,6 @@ export type NamedKeyringPair = KeyringPair & {
     }
 }
 
-// Simplified account balances (used when listing multiple accounts etc.)
-// Combines results returned by api.query.balances.freeBalance and api.query.balances.reservedBalance
-export type AccountBalances = {
-    free: Balance,
-    reserved: Balance,
-    total: Balance
-};
-
 // Summary of the account information fetched from the api for "account:current" purposes (currently just balances)
 export type AccountSummary = {
     balances: DerivedBalances

--- a/cli/src/commands/account/current.ts
+++ b/cli/src/commands/account/current.ts
@@ -1,5 +1,6 @@
 import AccountsCommandBase from '../../base/AccountsCommandBase';
 import { AccountSummary, NameValueObj, NamedKeyringPair } from '../../Types';
+import { DerivedBalances } from '@polkadot/api-derive/types';
 import { displayHeader, displayNameValueTable } from '../../helpers/display';
 import { formatBalance } from '@polkadot/util';
 import moment from 'moment';
@@ -24,11 +25,17 @@ export default class AccountCurrent extends AccountsCommandBase {
         displayNameValueTable(accountRows);
 
         displayHeader('Balances');
-        const balancesRows: NameValueObj[] = [
-            { name: 'Available balance:', value: formatBalance(summary.balances.availableBalance) },
-            { name: 'Free balance:', value: formatBalance(summary.balances.freeBalance) },
-            { name: 'Locked balance:', value: formatBalance(summary.balances.lockedBalance) }
+        const balances: DerivedBalances = summary.balances;
+        let balancesRows: NameValueObj[] = [
+            { name: 'Total balance:', value: formatBalance(balances.votingBalance) },
+            { name: 'Transferable balance:', value: formatBalance(balances.availableBalance) }
         ];
+        if (balances.lockedBalance.gtn(0)) {
+            balancesRows.push({ name: 'Locked balance:', value: formatBalance(balances.lockedBalance) });
+        }
+        if (balances.reservedBalance.gtn(0)) {
+            balancesRows.push({ name: 'Reserved balance:', value: formatBalance(balances.reservedBalance) });
+        }
         displayNameValueTable(balancesRows);
     }
   }

--- a/cli/src/commands/account/transferTokens.ts
+++ b/cli/src/commands/account/transferTokens.ts
@@ -4,9 +4,9 @@ import chalk from 'chalk';
 import ExitCodes from '../../ExitCodes';
 import { formatBalance } from '@polkadot/util';
 import { Hash } from '@polkadot/types/interfaces';
-import Api from '../../Api';
-import { AccountBalances, NamedKeyringPair } from '../../Types';
+import { NamedKeyringPair } from '../../Types';
 import { checkBalance, validateAddress } from '../../helpers/validation';
+import { DerivedBalances } from '@polkadot/api-derive/types';
 
 type AccountTransferArgs = {
     recipient: string,
@@ -36,7 +36,7 @@ export default class AccountTransferTokens extends AccountsCommandBase {
 
         // Initial validation
         validateAddress(args.recipient, 'Invalid recipient address');
-        const accBalances: AccountBalances = (await this.getApi().getAccountsBalancesInfo([ selectedAccount.address ]))[0];
+        const accBalances: DerivedBalances = (await this.getApi().getAccountsBalancesInfo([ selectedAccount.address ]))[0];
         checkBalance(accBalances, amountBN);
 
         await this.requestAccountDecoding(selectedAccount);

--- a/cli/src/helpers/display.ts
+++ b/cli/src/helpers/display.ts
@@ -23,3 +23,11 @@ export function displayNameValueTable(rows: NameValueObj[]) {
     );
 }
 
+export function toFixedLength(text: string, length: number, spacesOnLeft = false): string {
+    if (text.length > length && length > 3) {
+        return text.slice(0, length-3) + '...';
+    }
+    while(text.length < length) { spacesOnLeft ? text = ' '+text : text += ' ' };
+
+    return text;
+}

--- a/cli/src/helpers/validation.ts
+++ b/cli/src/helpers/validation.ts
@@ -1,7 +1,7 @@
 import BN from 'bn.js';
 import ExitCodes from '../ExitCodes';
 import { decodeAddress } from '@polkadot/util-crypto';
-import { AccountBalances } from '../Types';
+import { DerivedBalances } from '@polkadot/api-derive/types';
 import { CLIError } from '@oclif/errors';
 
 export function validateAddress(address: string, errorMessage: string = 'Invalid address'): void {
@@ -12,8 +12,8 @@ export function validateAddress(address: string, errorMessage: string = 'Invalid
     }
 }
 
-export function checkBalance(accBalances: AccountBalances, requiredBalance: BN): void {
-    if (requiredBalance.gt(accBalances.free)) {
+export function checkBalance(accBalances: DerivedBalances, requiredBalance: BN): void {
+    if (requiredBalance.gt(accBalances.availableBalance)) {
         throw new CLIError('Not enough balance available', { exit: ExitCodes.InvalidInput });
     }
 }


### PR DESCRIPTION
Based on this issue: https://github.com/Joystream/joystream/issues/285 I fixed the names and some logic of the account balances inside the CLI.

This includes:
1. Retrieving the balances using `api.derive.balances.votingBalances(addresses)`. This is probably the best method for this currently, as it returns all the needed balances (same as `api.derive.balances.all(address)`), but allows specifying multiple addresses in one call. No other method for retrieving balances is now used.
2. During account selection (`account:choose`) the two balances that are displayed are now: `balances.votingBalance` and `balances.availableBalance` (those are called _total balance_ and _transferrable balance_ respectively in Pioneer). I also fixed the apperance of the list a little bit, so it looks clearer.
3. Balances displayed when using `account:current` now reflect those displayed in Pioneer in the _My keys_ tab (excluding _bonded_ and _redeemable_). The naming is also the same, so we have:
- Total balance (`balances.votingBalance`)
- Transferrable balance (`balances.availableBalance`)
- Locked balance (`balances.lockedBalance`) - displayed only when >=0
- Reserved balance (`balances.reservedBalance`) - displayed only when >=0

4. In the `checkBalance` method (used ie. when validating token transfer during `account:transferTokens`), the `balances.availableBalance` is not used to perform the check.