### PR TITLE
CLI: Memberships management

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -69,6 +69,9 @@
       "account": {
         "description": "Accounts management - create, import or switch currently used account"
       },
+      "membership": {
+        "description": "Memberships management - register membership, display and modify your profile"
+      },
       "api": {
         "description": "Inspect the substrate node api, perform lower-level api calls or change the current api provider uri"
       }

--- a/cli/src/ExitCodes.ts
+++ b/cli/src/ExitCodes.ts
@@ -6,6 +6,8 @@ enum ExitCodes {
     InvalidFile = 402,
     NoAccountFound = 403,
     NoAccountSelected = 404,
+    NoMembershipFound = 405,
+    NoTermsFound = 406,
 
     UnexpectedException = 500,
     FsOperationFailed = 501,

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -1,9 +1,10 @@
 import BN from 'bn.js';
 import { ElectionStage, Seat } from '@joystream/types';
-import { Option } from '@polkadot/types';
+import { Option, Vec } from '@polkadot/types';
 import { BlockNumber, Balance } from '@polkadot/types/interfaces';
 import { DerivedBalances } from '@polkadot/api-derive/types';
 import { KeyringPair } from '@polkadot/keyring/types';
+import { MemberId } from '@joystream/types/src/members';
 
 // KeyringPair type extended with mandatory "meta.name"
 // It's used for accounts/keys management within CLI.
@@ -56,6 +57,13 @@ export function createCouncilInfoObj(
         stage
     };
 }
+
+// Account memberships information retrieved from the api:
+// MembershipIds by root account and controller account (for given address/Account)
+export type AccountMemberships = {
+    rootIds: Vec<MemberId>,
+    controllerIds: Vec<MemberId>
+};
 
 // Object with "name" and "value" properties, used for rendering simple CLI tables like:
 // Total balance:   100 JOY

--- a/cli/src/base/AccountsCommandBase.ts
+++ b/cli/src/base/AccountsCommandBase.ts
@@ -10,6 +10,7 @@ import { formatBalance } from '@polkadot/util';
 import { NamedKeyringPair } from '../Types';
 import { DerivedBalances } from '@polkadot/api-derive/types';
 import { toFixedLength } from '../helpers/display';
+import { Profile } from '@joystream/types/src/members';
 
 const ACCOUNTS_DIRNAME = '/accounts';
 
@@ -142,6 +143,16 @@ export default abstract class AccountsCommandBase extends ApiCommandBase {
         }
 
         return selectedAccount;
+    }
+
+    async getRequiredMembership(promptIfMissing: boolean = true): Promise<Profile> {
+        const selectedAccount = await this.getRequiredSelectedAccount(promptIfMissing);
+        const membership = await this.getApi().getCurrentMembershipByAddress(selectedAccount.address);
+        if (!membership) {
+            this.error('No memberships are available for this accout', { exit: ExitCodes.NoMembershipFound });
+        }
+
+        return membership;
     }
 
     async setSelectedAccount(account: NamedKeyringPair): Promise<void> {

--- a/cli/src/commands/membership/current.ts
+++ b/cli/src/commands/membership/current.ts
@@ -1,0 +1,41 @@
+import AccountsCommandBase from '../../base/AccountsCommandBase';
+import { NameValueObj } from '../../Types';
+import { displayHeader, displayNameValueTable } from '../../helpers/display';
+import moment from 'moment';
+import ExitCodes from '../../ExitCodes';
+import { Role, ActorInRole } from '@joystream/types/src/members';
+
+export default class MembershipCurrent extends AccountsCommandBase {
+    static description = 'Display information about current\'s account memberships';
+    static aliases = ['memberships:info'];
+
+    async run() {
+        const selectedAccount = await this.getRequiredSelectedAccount();
+
+        const membership = await this.getApi().getCurrentMembershipByAddress(selectedAccount.address);
+        if (!membership) {
+            this.error('No memberships are available for this accout', { exit: ExitCodes.NoMembershipFound });
+        }
+
+        const roles = membership.roles
+            .map((actorInRole: ActorInRole): string | null => {
+                const role = <Role | undefined> actorInRole.get('role');
+                return role ? role.type : null;
+            })
+            .filter(r => r !== null);
+
+        const registerDateStr: string = moment(membership.registered_at_time.toNumber()).format('YYYY-MM-DD HH:mm:ss');
+        const registeredStr: string = `${registerDateStr} (block #${ membership.registered_at_block.toNumber() })`;
+
+        displayHeader('Profile');
+        const membershipDetailsRows: NameValueObj[] = [
+            { name: 'Handle:', value: membership.handle.toString() },
+            { name: 'Registered:',  value: registeredStr },
+            { name: 'Roles:', value: roles.length ? roles.join(', ') : 'None' },
+            { name: 'Suspended:', value: membership.suspended.isTrue ? 'Yes' : 'No' },
+            { name: 'Avatar uri:', value: membership.avatar_uri.toString() },
+            { name: 'About:',  value: membership.about.toString() }
+        ];
+        displayNameValueTable(membershipDetailsRows);
+    }
+  }

--- a/cli/src/commands/membership/current.ts
+++ b/cli/src/commands/membership/current.ts
@@ -7,15 +7,10 @@ import { Role, ActorInRole } from '@joystream/types/src/members';
 
 export default class MembershipCurrent extends AccountsCommandBase {
     static description = 'Display information about current\'s account memberships';
-    static aliases = ['memberships:info'];
+    static aliases = ['membership:info'];
 
     async run() {
-        const selectedAccount = await this.getRequiredSelectedAccount();
-
-        const membership = await this.getApi().getCurrentMembershipByAddress(selectedAccount.address);
-        if (!membership) {
-            this.error('No memberships are available for this accout', { exit: ExitCodes.NoMembershipFound });
-        }
+        const membership = await this.getRequiredMembership(false);
 
         const roles = membership.roles
             .map((actorInRole: ActorInRole): string | null => {

--- a/cli/src/commands/membership/edit.ts
+++ b/cli/src/commands/membership/edit.ts
@@ -1,0 +1,34 @@
+import AccountsCommandBase from '../../base/AccountsCommandBase';
+import { flags } from '@oclif/command';
+import { IFlag } from '@oclif/command/lib/flags';
+
+// Command flags type
+type ApiInspectFlags = {
+    handle: string,
+    avatarUri: string,
+    about: string
+};
+
+export default class MembershipEdit extends AccountsCommandBase {
+    static description = 'Edit current member profile.';
+
+    static flags: { [T in keyof ApiInspectFlags]: IFlag<any> } = {
+        handle: flags.string({
+            char: 'h',
+            description: 'Updated profile handle',
+        }),
+        avatarUri: flags.string({
+            char: 'a',
+            description: 'Updated avatar uri'
+        }),
+        about: flags.string({
+            char: 'A',
+            description: 'Updated "About" description',
+            dependsOn: ['module'],
+        })
+    };
+
+    async run() {
+        this.log('To be implemented...');
+    }
+}

--- a/cli/src/commands/membership/terms.ts
+++ b/cli/src/commands/membership/terms.ts
@@ -1,0 +1,22 @@
+import AccountsCommandBase from '../../base/AccountsCommandBase';
+import { NameValueObj } from '../../Types';
+import { displayNameValueTable } from '../../helpers/display';
+import { formatBalance } from '@polkadot/util';
+import ExitCodes from '../../ExitCodes';
+
+export default class MembershipCurrent extends AccountsCommandBase {
+    static description = 'Display information about current paid membership terms';
+
+    async run() {
+        const terms = await this.getApi().getCurrentMembershipTerms();
+        if (!terms) {
+            this.error('No paid membership terms found!', { exit: ExitCodes.NoTermsFound });
+        }
+
+        const membershipTermsRows: NameValueObj[] = [
+            { name: 'Register fee:', value: formatBalance(terms.fee) },
+            { name: 'Terms:', value: terms.text.toString() || '< Terms string is empty >' }
+        ];
+        displayNameValueTable(membershipTermsRows);
+    }
+  }


### PR DESCRIPTION
This PR contains some of my initial work related to memberships management.
Related issue: https://github.com/Joystream/joystream/issues/282

### Determining current membership

Currently in my implementation there is an assumption that each account (key pair) either has or hasn't got an associated membership, this logic is based more or less on how the account's memership is beeing determined in the Pioneer's _Memberships_ tab.

All commands that require information about user's current membership (based on the account currently selected via `account:choose`) can extend the abstract `AccountsCommandBase` class and then use:

`const membership = await this.getRequiredMembership();`

Or:

`const membership = await this.getRequiredMembership(false);`

In the first example the user will be prompted to select an account first (if no account was previously selected via `account:choose`). In the second example the command will exit with the error message if no account is already choosen. In both cases the command will exit with an error if the current account has no associated membership.

The `Api` class has been extended with a few methods related to fetching the account membership information and currently active membership terms. I hope this will allow to change the logic of retrieving user's available memberships easily in the future if there's a need for that (ie. if there is or would be a way for one account to have multiple associated memberships or if selecting a membership will have to become something prior to selecting an account).

### Commands implementation

**There are 2 new commands already implemented:**

- `membership:current` - displays information about membership related to currently selected account (via `account:choose`). **The way it currently displays associated roles is not the best, so this could be changed, ie. if I have two channels it displays: `Roles: ChannelOwner ChannelOwner`.**
- `membership:terms` - displays currently active paid membership terms. In Pioneer those are used ie. to display the current fee when user wants to register a new membership, so this logic can be used when implementing a command like `membership:register`.

**Commands I planned to implement:**

I also created a draft of `membership:edit` command that will allow the user to modify the profile information. I was planning to use the `api.tx.members.updateProfile` and update the values based on provided flags. Prompting for input if no flags are provided can also be implemented. There is some logic of prompting for optional arguments already in `ApInspect.promptForOption` (`commands/api/inspect.ts`).

I was also planning to implement the `membership:register`, as this should be pretty easy once we have `membership:edit` and `membership:terms`.

I'm not sure if this way of handling memberships will be sufficient in regards to activities like voting in elections etc., but from what I could gather, there is not too much distinction currently beeing made between accounts (keys) and memberships (besides the fact that some accounts may not have an associated membership). If there is a need to handle this differently in the future, I think this will not be too hard to change and some way of selecting a membership could be implemented in a similar manner to how the account selection is currently possible via `account:choose`.