### PR TITLE
Proposal execution fixes

### DIFF
--- a/runtime-modules/governance/src/council.rs
+++ b/runtime-modules/governance/src/council.rs
@@ -136,7 +136,7 @@ decl_module! {
 
         /// Sets the capacity of the the council mint, if it doesn't exist, attempts to
         /// create a new one.
-        fn set_council_mint_capacity(origin, capacity: minting::BalanceOf<T>) {
+        pub fn set_council_mint_capacity(origin, capacity: minting::BalanceOf<T>) {
             ensure_root(origin)?;
 
             if let Some(mint_id) = Self::council_mint() {

--- a/runtime-modules/proposals/codex/Cargo.toml
+++ b/runtime-modules/proposals/codex/Cargo.toml
@@ -91,12 +91,6 @@ git = 'https://github.com/paritytech/substrate.git'
 package = 'srml-staking'
 rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'
 
-[dependencies.runtime-io]
-default_features = false
-git = 'https://github.com/paritytech/substrate.git'
-package = 'sr-io'
-rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'
-
 [dependencies.stake]
 default_features = false
 package = 'substrate-stake-module'
@@ -171,6 +165,12 @@ path = '../../recurring-reward'
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'sr-staking-primitives'
+rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'
+
+[dev-dependencies.runtime-io]
+default_features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'sr-io'
 rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'
 
 # don't rename the dependency it is causing some strange compiler error:

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -55,7 +55,6 @@ use rstd::convert::TryInto;
 use rstd::prelude::*;
 use rstd::str::from_utf8;
 use rstd::vec::Vec;
-use runtime_io::blake2_256;
 use sr_primitives::traits::SaturatedConversion;
 use sr_primitives::traits::{One, Zero};
 use sr_primitives::Perbill;
@@ -372,16 +371,10 @@ decl_module! {
             ensure!(wasm.len() as u32 <= T::RuntimeUpgradeWasmProposalMaxLength::get(),
                 Error::RuntimeProposalSizeExceeded);
 
-            let wasm_hash = blake2_256(&wasm);
-
-            // The runtime upgrade proposal has two proposal details: wasm and wasm hash.
-            // This is an exception for the optimization.
-
             let proposal_parameters = proposal_types::parameters::runtime_upgrade_proposal::<T>();
             let proposal_details = ProposalDetails::RuntimeUpgrade(wasm);
             let proposal_code = T::ProposalEncoder::encode_proposal(proposal_details.clone());
 
-            let proposal_details_for_hash = ProposalDetails::RuntimeUpgradeHash(wasm_hash.to_vec());
             Self::create_proposal(
                 origin,
                 member_id,
@@ -390,7 +383,7 @@ decl_module! {
                 stake_balance,
                 proposal_code,
                 proposal_parameters,
-                proposal_details_for_hash,
+                proposal_details,
             )?;
         }
 

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -34,6 +34,9 @@
 //! - [governance](../substrate_governance_module/index.html)
 //! - [content_working_group](../substrate_content_working_group_module/index.html)
 //!
+//! ### Notes
+//! The module uses [ProposalEncoder](./trait.ProposalEncoder.html) to encode the proposal using
+//! its details. Encoded byte vector is passed to the _proposals engine_ as serialized executable code.
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -93,6 +96,7 @@ pub trait Trait:
         Self::AccountId,
     >;
 
+    /// Encodes the proposal usint its details
     type ProposalEncoder: ProposalEncoder<Self>;
 }
 

--- a/runtime-modules/proposals/codex/src/proposal_types/mod.rs
+++ b/runtime-modules/proposals/codex/src/proposal_types/mod.rs
@@ -30,12 +30,7 @@ pub enum ProposalDetails<MintedBalance, CurrencyBalance, BlockNumber, AccountId,
     /// The text of the `text` proposal
     Text(Vec<u8>),
 
-    /// The hash of wasm code for the `runtime upgrade` proposal. The runtime upgrade proposal has
-    /// two proposal details: wasm and wasm hash. This is an exception for the optimization.
-    RuntimeUpgradeHash(Vec<u8>),
-
-    /// The wasm code for the `runtime upgrade` proposal. The runtime upgrade proposal has
-    /// two proposal details: wasm and wasm hash. This is an exception for the optimization.
+    /// The wasm code for the `runtime upgrade` proposal
     RuntimeUpgrade(Vec<u8>),
 
     /// Election parameters for the `set election parameters` proposal

--- a/runtime-modules/proposals/codex/src/proposal_types/mod.rs
+++ b/runtime-modules/proposals/codex/src/proposal_types/mod.rs
@@ -8,6 +8,21 @@ use serde::{Deserialize, Serialize};
 use crate::ElectionParameters;
 use roles::actors::RoleParameters;
 
+/// Encodes proposal using its details information.
+pub trait ProposalEncoder<T: crate::Trait> {
+    /// Encodes proposal using its details information.
+    fn encode_proposal(proposal_details: ProposalDetailsOf<T>) -> Vec<u8>;
+}
+
+/// _ProposalDetails_ alias for type simplification
+pub type ProposalDetailsOf<T> = ProposalDetails<
+    crate::BalanceOfMint<T>,
+    crate::BalanceOfGovernanceCurrency<T>,
+    <T as system::Trait>::BlockNumber,
+    <T as system::Trait>::AccountId,
+    crate::MemberId<T>,
+>;
+
 /// Proposal details provide voters the information required for the perceived voting.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
@@ -15,7 +30,12 @@ pub enum ProposalDetails<MintedBalance, CurrencyBalance, BlockNumber, AccountId,
     /// The text of the `text` proposal
     Text(Vec<u8>),
 
-    /// The hash of wasm code for the `runtime upgrade` proposal
+    /// The hash of wasm code for the `runtime upgrade` proposal. The runtime upgrade proposal has
+    /// two proposal details: wasm and wasm hash. This is an exception for the optimization.
+    RuntimeUpgradeHash(Vec<u8>),
+
+    /// The wasm code for the `runtime upgrade` proposal. The runtime upgrade proposal has
+    /// two proposal details: wasm and wasm hash. This is an exception for the optimization.
     RuntimeUpgrade(Vec<u8>),
 
     /// Election parameters for the `set election parameters` proposal

--- a/runtime-modules/proposals/codex/src/proposal_types/parameters.rs
+++ b/runtime-modules/proposals/codex/src/proposal_types/parameters.rs
@@ -126,33 +126,32 @@ pub(crate) fn set_storage_role_parameters_proposal<T: crate::Trait>(
     }
 }
 
-//TODO: uncomment
-// #[cfg(test)]
-// mod test {
-//     use crate::proposal_types::parameters::get_required_stake_by_fraction;
-//     use crate::tests::{increase_total_balance_issuance, initial_test_ext, Test};
-//
-//     pub use sr_primitives::Perbill;
-//
-//     #[test]
-//     fn calculate_get_required_stake_by_fraction_with_zero_issuance() {
-//         initial_test_ext()
-//             .execute_with(|| assert_eq!(get_required_stake_by_fraction::<Test>(5, 7), 0));
-//     }
-//
-//     #[test]
-//     fn calculate_stake_by_percentage_for_defined_issuance_succeeds() {
-//         initial_test_ext().execute_with(|| {
-//             increase_total_balance_issuance(50000);
-//             assert_eq!(get_required_stake_by_fraction::<Test>(1, 1000), 50)
-//         });
-//     }
-//
-//     #[test]
-//     fn calculate_stake_by_percentage_for_defined_issuance_with_fraction_loss() {
-//         initial_test_ext().execute_with(|| {
-//             increase_total_balance_issuance(1111);
-//             assert_eq!(get_required_stake_by_fraction::<Test>(3, 1000), 3);
-//         });
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use crate::proposal_types::parameters::get_required_stake_by_fraction;
+    use crate::tests::{increase_total_balance_issuance, initial_test_ext, Test};
+
+    pub use sr_primitives::Perbill;
+
+    #[test]
+    fn calculate_get_required_stake_by_fraction_with_zero_issuance() {
+        initial_test_ext()
+            .execute_with(|| assert_eq!(get_required_stake_by_fraction::<Test>(5, 7), 0));
+    }
+
+    #[test]
+    fn calculate_stake_by_percentage_for_defined_issuance_succeeds() {
+        initial_test_ext().execute_with(|| {
+            increase_total_balance_issuance(50000);
+            assert_eq!(get_required_stake_by_fraction::<Test>(1, 1000), 50)
+        });
+    }
+
+    #[test]
+    fn calculate_stake_by_percentage_for_defined_issuance_with_fraction_loss() {
+        initial_test_ext().execute_with(|| {
+            increase_total_balance_issuance(1111);
+            assert_eq!(get_required_stake_by_fraction::<Test>(3, 1000), 3);
+        });
+    }
+}

--- a/runtime-modules/proposals/codex/src/proposal_types/parameters.rs
+++ b/runtime-modules/proposals/codex/src/proposal_types/parameters.rs
@@ -126,32 +126,33 @@ pub(crate) fn set_storage_role_parameters_proposal<T: crate::Trait>(
     }
 }
 
-#[cfg(test)]
-mod test {
-    use crate::proposal_types::parameters::get_required_stake_by_fraction;
-    use crate::tests::{increase_total_balance_issuance, initial_test_ext, Test};
-
-    pub use sr_primitives::Perbill;
-
-    #[test]
-    fn calculate_get_required_stake_by_fraction_with_zero_issuance() {
-        initial_test_ext()
-            .execute_with(|| assert_eq!(get_required_stake_by_fraction::<Test>(5, 7), 0));
-    }
-
-    #[test]
-    fn calculate_stake_by_percentage_for_defined_issuance_succeeds() {
-        initial_test_ext().execute_with(|| {
-            increase_total_balance_issuance(50000);
-            assert_eq!(get_required_stake_by_fraction::<Test>(1, 1000), 50)
-        });
-    }
-
-    #[test]
-    fn calculate_stake_by_percentage_for_defined_issuance_with_fraction_loss() {
-        initial_test_ext().execute_with(|| {
-            increase_total_balance_issuance(1111);
-            assert_eq!(get_required_stake_by_fraction::<Test>(3, 1000), 3);
-        });
-    }
-}
+//TODO: uncomment
+// #[cfg(test)]
+// mod test {
+//     use crate::proposal_types::parameters::get_required_stake_by_fraction;
+//     use crate::tests::{increase_total_balance_issuance, initial_test_ext, Test};
+//
+//     pub use sr_primitives::Perbill;
+//
+//     #[test]
+//     fn calculate_get_required_stake_by_fraction_with_zero_issuance() {
+//         initial_test_ext()
+//             .execute_with(|| assert_eq!(get_required_stake_by_fraction::<Test>(5, 7), 0));
+//     }
+//
+//     #[test]
+//     fn calculate_stake_by_percentage_for_defined_issuance_succeeds() {
+//         initial_test_ext().execute_with(|| {
+//             increase_total_balance_issuance(50000);
+//             assert_eq!(get_required_stake_by_fraction::<Test>(1, 1000), 50)
+//         });
+//     }
+//
+//     #[test]
+//     fn calculate_stake_by_percentage_for_defined_issuance_with_fraction_loss() {
+//         initial_test_ext().execute_with(|| {
+//             increase_total_balance_issuance(1111);
+//             assert_eq!(get_required_stake_by_fraction::<Test>(3, 1000), 3);
+//         });
+//     }
+// }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -3,6 +3,7 @@
 // TODO: remove after post-Rome substrate upgrade
 #![allow(array_into_iter)]
 
+use crate::{ProposalDetailsOf, ProposalEncoder};
 pub use primitives::{Blake2Hasher, H256};
 use proposal_engine::VotersParameters;
 use sr_primitives::curve::PiecewiseLinear;
@@ -249,6 +250,13 @@ impl crate::Trait for Test {
     type TextProposalMaxLength = TextProposalMaxLength;
     type RuntimeUpgradeWasmProposalMaxLength = RuntimeUpgradeWasmProposalMaxLength;
     type MembershipOriginValidator = ();
+    type ProposalEncoder = ();
+}
+
+impl ProposalEncoder<Test> for () {
+    fn encode_proposal(_proposal_details: ProposalDetailsOf<Test>) -> Vec<u8> {
+        Vec::new()
+    }
 }
 
 impl system::Trait for Test {

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -8,7 +8,6 @@ use system::RawOrigin;
 use crate::{BalanceOf, Error, ProposalDetails};
 use proposal_engine::ProposalParameters;
 use roles::actors::RoleParameters;
-use runtime_io::blake2_256;
 use srml_support::dispatch::DispatchResult;
 
 pub use mock::*;
@@ -223,7 +222,7 @@ fn create_runtime_upgrade_common_checks_succeed() {
                 )
             },
             proposal_parameters: crate::proposal_types::parameters::runtime_upgrade_proposal::<Test>(),
-            proposal_details: ProposalDetails::RuntimeUpgradeHash(blake2_256(b"wasm").to_vec()),
+            proposal_details: ProposalDetails::RuntimeUpgrade(b"wasm".to_vec()),
         };
         proposal_fixture.check_all();
     });

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -223,7 +223,7 @@ fn create_runtime_upgrade_common_checks_succeed() {
                 )
             },
             proposal_parameters: crate::proposal_types::parameters::runtime_upgrade_proposal::<Test>(),
-            proposal_details: ProposalDetails::RuntimeUpgrade(blake2_256(b"wasm").to_vec()),
+            proposal_details: ProposalDetails::RuntimeUpgradeHash(blake2_256(b"wasm").to_vec()),
         };
         proposal_fixture.check_all();
     });

--- a/runtime/src/integration/proposals/mod.rs
+++ b/runtime/src/integration/proposals/mod.rs
@@ -3,9 +3,11 @@
 mod council_elected_handler;
 mod council_origin_validator;
 mod membership_origin_validator;
+mod proposal_encoder;
 mod staking_events_handler;
 
 pub use council_elected_handler::CouncilElectedHandler;
 pub use council_origin_validator::CouncilManager;
 pub use membership_origin_validator::{MemberId, MembershipOriginValidator};
+pub use proposal_encoder::ExtrinsicProposalEncoder;
 pub use staking_events_handler::StakingEventsHandler;

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -4,7 +4,6 @@ use roles::actors::Role;
 
 use codec::Encode;
 use rstd::vec::Vec;
-use srml_support::print;
 
 /// _ProposalEncoder_ implementation. It encodes extrinsics with proposal details parameters
 /// using Runtime Call and parity codec.
@@ -43,25 +42,10 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
                 roles::actors::Call::set_role_parameters(Role::StorageProvider, role_parameters),
             )
             .encode(),
-            ProposalDetails::RuntimeUpgrade(wasm_code) => {
-                // The runtime upgrade proposal has two proposal details: wasm and wasm hash.
-                // This is an exception for the optimization.
-
-                // This is a real extrinsic call.
-                Call::ProposalsCodex(proposals_codex::Call::execute_runtime_upgrade_proposal(
-                    wasm_code,
-                ))
-                .encode()
-            }
-            ProposalDetails::RuntimeUpgradeHash(_) => {
-                // The runtime upgrade proposal has two proposal details: wasm and wasm hash.
-                // This is an exception for the optimization.
-
-                // Cannot be here. This is a bug.
-                print("Invalid proposal: cannot encode ProposalDetails::RuntimeUpgradeHash");
-
-                Vec::new()
-            }
+            ProposalDetails::RuntimeUpgrade(wasm_code) => Call::ProposalsCodex(
+                proposals_codex::Call::execute_runtime_upgrade_proposal(wasm_code),
+            )
+            .encode(),
         }
     }
 }

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -1,0 +1,25 @@
+use crate::integration::proposals::MemberId;
+use crate::*;
+use proposals_codex::{ProposalDetails, ProposalEncoder};
+
+pub struct ExtrinsicProposalEncoder;
+
+impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
+    fn encode_proposal(
+        proposal_details: ProposalDetails<
+            Balance,
+            Balance,
+            BlockNumber,
+            AccountId,
+            MemberId<Runtime>,
+        >,
+    ) -> Vec<u8> {
+        match proposal_details {
+            ProposalDetails::Text(text) => {
+                crate::Call::ProposalsCodex(proposals_codex::Call::execute_text_proposal(text))
+                    .encode()
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -1,25 +1,67 @@
-use crate::integration::proposals::MemberId;
-use crate::*;
-use proposals_codex::{ProposalDetails, ProposalEncoder};
+use crate::{Call, Runtime};
+use proposals_codex::{ProposalDetails, ProposalDetailsOf, ProposalEncoder};
+use roles::actors::Role;
 
+use codec::Encode;
+use rstd::vec::Vec;
+use srml_support::print;
+
+/// _ProposalEncoder_ implementation. It encodes extrinsics with proposal details parameters
+/// using Runtime Call and parity codec.
 pub struct ExtrinsicProposalEncoder;
-
 impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
-    fn encode_proposal(
-        proposal_details: ProposalDetails<
-            Balance,
-            Balance,
-            BlockNumber,
-            AccountId,
-            MemberId<Runtime>,
-        >,
-    ) -> Vec<u8> {
+    fn encode_proposal(proposal_details: ProposalDetailsOf<Runtime>) -> Vec<u8> {
         match proposal_details {
             ProposalDetails::Text(text) => {
-                crate::Call::ProposalsCodex(proposals_codex::Call::execute_text_proposal(text))
+                Call::ProposalsCodex(proposals_codex::Call::execute_text_proposal(text)).encode()
+            }
+            ProposalDetails::SetElectionParameters(election_parameters) => Call::CouncilElection(
+                governance::election::Call::set_election_parameters(election_parameters),
+            )
+            .encode(),
+            ProposalDetails::SetContentWorkingGroupMintCapacity(mint_balance) => {
+                Call::ContentWorkingGroup(content_working_group::Call::set_mint_capacity(
+                    mint_balance,
+                ))
+                .encode()
+            }
+            ProposalDetails::Spending(balance, destination) => Call::Council(
+                governance::council::Call::spend_from_council_mint(balance, destination),
+            )
+            .encode(),
+            ProposalDetails::SetLead(new_lead) => {
+                Call::ContentWorkingGroup(content_working_group::Call::replace_lead(new_lead))
                     .encode()
             }
-            _ => unreachable!(),
+            ProposalDetails::EvictStorageProvider(actor_account) => {
+                Call::Actors(roles::actors::Call::remove_actor(actor_account)).encode()
+            }
+            ProposalDetails::SetValidatorCount(new_validator_count) => {
+                Call::Staking(staking::Call::set_validator_count(new_validator_count)).encode()
+            }
+            ProposalDetails::SetStorageRoleParameters(role_parameters) => Call::Actors(
+                roles::actors::Call::set_role_parameters(Role::StorageProvider, role_parameters),
+            )
+            .encode(),
+            ProposalDetails::RuntimeUpgrade(wasm_code) => {
+                // The runtime upgrade proposal has two proposal details: wasm and wasm hash.
+                // This is an exception for the optimization.
+
+                // This is a real extrinsic call.
+                Call::ProposalsCodex(proposals_codex::Call::execute_runtime_upgrade_proposal(
+                    wasm_code,
+                ))
+                .encode()
+            }
+            ProposalDetails::RuntimeUpgradeHash(_) => {
+                // The runtime upgrade proposal has two proposal details: wasm and wasm hash.
+                // This is an exception for the optimization.
+
+                // Cannot be here. This is a bug.
+                print("Invalid proposal: cannot encode ProposalDetails::RuntimeUpgradeHash");
+
+                Vec::new()
+            }
         }
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -59,7 +59,7 @@ pub use srml_support::{
 pub use staking::StakerStatus;
 pub use timestamp::Call as TimestampCall;
 
-use integration::proposals::{CouncilManager, MembershipOriginValidator};
+use integration::proposals::{CouncilManager, ExtrinsicProposalEncoder, MembershipOriginValidator};
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -866,6 +866,7 @@ impl proposals_codex::Trait for Runtime {
     type MembershipOriginValidator = MembershipOriginValidator<Self>;
     type TextProposalMaxLength = TextProposalMaxLength;
     type RuntimeUpgradeWasmProposalMaxLength = RuntimeUpgradeWasmProposalMaxLength;
+    type ProposalEncoder = ExtrinsicProposalEncoder;
 }
 
 construct_runtime!(

--- a/runtime/src/test/proposals_integration.rs
+++ b/runtime/src/test/proposals_integration.rs
@@ -396,8 +396,6 @@ fn text_proposal_execution_succeeds() {
         setup_members(7);
         setup_council();
 
-        println!("{}", CouncilManager::<Runtime>::total_voters_count());
-
         let member_id = 1;
         let account_id: [u8; 32] = [member_id; 32];
         increase_total_balance_issuance_using_account_id(account_id.clone().into(), 500000);

--- a/runtime/src/test/proposals_integration.rs
+++ b/runtime/src/test/proposals_integration.rs
@@ -2,19 +2,22 @@
 
 #![cfg(test)]
 
-use crate::{BlockNumber, ProposalCancellationFee, Runtime};
+use crate::{BlockNumber, ElectionParameters, ProposalCancellationFee, Runtime};
 use codec::Encode;
 use governance::election::CouncilElected;
 use membership::members;
+use membership::role_types::Role;
 use proposals_engine::{
     ActiveStake, ApprovedProposalStatus, BalanceOf, Error, FinalizationData, Proposal,
     ProposalDecisionStatus, ProposalParameters, ProposalStatus, VoteKind, VotersParameters,
     VotingResults,
 };
+use roles::actors::RoleParameters;
+
 use sr_primitives::traits::{DispatchResult, OnFinalize, OnInitialize};
 use sr_primitives::AccountId32;
 use srml_support::traits::Currency;
-use srml_support::StorageLinkedMap;
+use srml_support::{StorageLinkedMap, StorageMap, StorageValue};
 use system::RawOrigin;
 
 use crate::CouncilManager;
@@ -32,7 +35,9 @@ type System = system::Module<Runtime>;
 type Membership = membership::members::Module<Runtime>;
 type ProposalsEngine = proposals_engine::Module<Runtime>;
 type Council = governance::council::Module<Runtime>;
+type Election = governance::election::Module<Runtime>;
 type ProposalCodex = proposals_codex::Module<Runtime>;
+type Mint = minting::Module<Runtime>;
 
 fn setup_members(count: u8) {
     let authority_account_id = <Runtime as system::Trait>::AccountId::default();
@@ -396,6 +401,7 @@ where
     SuccessfulCall: Fn() -> DispatchResult<proposals_codex::Error>,
 {
     successful_call: SuccessfulCall,
+    member_id: u64,
 }
 
 impl<SuccessfulCall> CodexProposalTestFixture<SuccessfulCall>
@@ -406,8 +412,7 @@ where
         setup_members(15);
         setup_council();
 
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let account_id: [u8; 32] = [self.member_id as u8; 32];
         increase_total_balance_issuance_using_account_id(account_id.clone().into(), 500000);
 
         assert_eq!((self.successful_call)(), Ok(()));
@@ -450,6 +455,7 @@ fn text_proposal_execution_succeeds() {
         let account_id: [u8; 32] = [member_id; 32];
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture {
+            member_id: member_id as u64,
             successful_call: || {
                 ProposalCodex::create_text_proposal(
                     RawOrigin::Signed(account_id.into()).into(),
@@ -473,6 +479,7 @@ fn set_lead_proposal_execution_succeeds() {
         let account_id: [u8; 32] = [member_id; 32];
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture {
+            member_id: member_id as u64,
             successful_call: || {
                 ProposalCodex::create_set_lead_proposal(
                     RawOrigin::Signed(account_id.clone().into()).into(),
@@ -505,6 +512,7 @@ fn spending_proposal_execution_succeeds() {
         assert!(Council::set_council_mint_capacity(RawOrigin::Root.into(), new_balance).is_ok());
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture {
+            member_id: member_id as u64,
             successful_call: || {
                 ProposalCodex::create_spending_proposal(
                     RawOrigin::Signed(account_id.clone().into()).into(),
@@ -529,5 +537,193 @@ fn spending_proposal_execution_succeeds() {
             Balances::free_balance::<AccountId32>(target_account_id.into()),
             new_balance
         );
+    });
+}
+
+#[test]
+fn set_content_working_group_mint_capacity_execution_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 1;
+        let account_id: [u8; 32] = [member_id; 32];
+        let new_balance = <BalanceOf<Runtime>>::from(55u32);
+
+        let mint_id =
+            Mint::add_mint(0, None).expect("Failed to create a mint for the content working group");
+        <content_working_group::Mint<Runtime>>::put(mint_id);
+
+        assert_eq!(Mint::get_mint_capacity(mint_id), Ok(0));
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture {
+            member_id: member_id as u64,
+            successful_call: || {
+                ProposalCodex::create_set_content_working_group_mint_capacity_proposal(
+                    RawOrigin::Signed(account_id.clone().into()).into(),
+                    member_id as u64,
+                    b"title".to_vec(),
+                    b"body".to_vec(),
+                    Some(<BalanceOf<Runtime>>::from(1250u32)),
+                    new_balance,
+                )
+            },
+        };
+
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(Mint::get_mint_capacity(mint_id), Ok(new_balance));
+    });
+}
+
+#[test]
+fn set_election_parameters_proposal_execution_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 1;
+        let account_id: [u8; 32] = [member_id; 32];
+
+        let election_parameters = ElectionParameters {
+            announcing_period: 14400,
+            voting_period: 14400,
+            revealing_period: 14400,
+            council_size: 4,
+            candidacy_limit: 25,
+            new_term_duration: 14400,
+            min_council_stake: 1,
+            min_voting_stake: 1,
+        };
+        assert_eq!(Election::announcing_period(), 0);
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture {
+            member_id: member_id as u64,
+            successful_call: || {
+                ProposalCodex::create_set_election_parameters_proposal(
+                    RawOrigin::Signed(account_id.clone().into()).into(),
+                    member_id as u64,
+                    b"title".to_vec(),
+                    b"body".to_vec(),
+                    Some(<BalanceOf<Runtime>>::from(3750u32)),
+                    election_parameters,
+                )
+            },
+        };
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(Election::announcing_period(), 14400);
+    });
+}
+
+#[test]
+fn evict_storage_provider_proposal_execution_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 1;
+        let account_id: [u8; 32] = [member_id; 32];
+
+        let target_member_id = 3;
+        let target_account: [u8; 32] = [target_member_id; 32];
+        let target_account_id: AccountId32 = target_account.into();
+
+        <roles::actors::Parameters<Runtime>>::insert(
+            Role::StorageProvider,
+            roles::actors::RoleParameters::default(),
+        );
+
+        <roles::actors::AccountIdsByRole<Runtime>>::insert(
+            Role::StorageProvider,
+            vec![target_account_id.clone()],
+        );
+
+        <roles::actors::ActorByAccountId<Runtime>>::insert(
+            target_account_id.clone(),
+            roles::actors::Actor {
+                member_id: target_member_id as u64,
+                role: Role::StorageProvider,
+                account: target_account_id,
+                joined_at: 1,
+            },
+        );
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture {
+            member_id: member_id as u64,
+            successful_call: || {
+                ProposalCodex::create_evict_storage_provider_proposal(
+                    RawOrigin::Signed(account_id.clone().into()).into(),
+                    member_id as u64,
+                    b"title".to_vec(),
+                    b"body".to_vec(),
+                    Some(<BalanceOf<Runtime>>::from(500u32)),
+                    target_account.into(),
+                )
+            },
+        };
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(
+            <roles::actors::AccountIdsByRole<Runtime>>::get(Role::StorageProvider),
+            Vec::new()
+        );
+    });
+}
+
+#[test]
+fn set_storage_role_parameters_proposal_execution_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 1;
+        let account_id: [u8; 32] = [member_id; 32];
+
+        <roles::actors::Parameters<Runtime>>::insert(
+            Role::StorageProvider,
+            RoleParameters::default(),
+        );
+
+        let target_role_parameters = RoleParameters {
+            startup_grace_period: 700,
+            ..RoleParameters::default()
+        };
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture {
+            member_id: member_id as u64,
+            successful_call: || {
+                ProposalCodex::create_set_storage_role_parameters_proposal(
+                    RawOrigin::Signed(account_id.clone().into()).into(),
+                    member_id as u64,
+                    b"title".to_vec(),
+                    b"body".to_vec(),
+                    Some(<BalanceOf<Runtime>>::from(1250u32)),
+                    target_role_parameters.clone(),
+                )
+            },
+        };
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(
+            <roles::actors::Parameters<Runtime>>::get(Role::StorageProvider),
+            Some(target_role_parameters)
+        );
+    });
+}
+
+#[test]
+fn set_validator_count_proposal_execution_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 1;
+        let account_id: [u8; 32] = [member_id; 32];
+
+        let new_validator_count = 8;
+        assert_eq!(<staking::ValidatorCount>::get(), 0);
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture {
+            member_id: member_id as u64,
+            successful_call: || {
+                ProposalCodex::create_set_validator_count_proposal(
+                    RawOrigin::Signed(account_id.clone().into()).into(),
+                    member_id as u64,
+                    b"title".to_vec(),
+                    b"body".to_vec(),
+                    Some(<BalanceOf<Runtime>>::from(1250u32)),
+                    new_validator_count,
+                )
+            },
+        };
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(<staking::ValidatorCount>::get(), new_validator_count);
     });
 }


### PR DESCRIPTION
## This PR contains a change in the proposal serialization model
- the new proposal encoder introduced in the runtime
- codex proposal extrinsics were migrated to the new model
- some integration tests were added

## Notes
RuntimeUpgrade proposal contains two ProposalDetails enum entries as an exception for the serialization