### PR TITLE
Fix ‘cargo install issue’ with codex

### DIFF
--- a/runtime-modules/proposals/codex/Cargo.toml
+++ b/runtime-modules/proposals/codex/Cargo.toml
@@ -25,6 +25,8 @@ std = [
     'governance/std',
     'mint/std',
     'roles/std',
+    'common/std',
+    'content_working_group/std',
 ]
 
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -59,6 +59,9 @@ std = [
     'roles/std',
     'service_discovery/std',
     'storage/std',
+    'proposals_engine/std',
+    'proposals_discussion/std',
+    'proposals_codex/std',
 ]
 
 # [dependencies]


### PR DESCRIPTION
GenesisConfig couldn't be found only when trying to install the node using the
"cargo install" command.

The fix seems to be unrelated to the problem, but it fixes it:

The "proposals_*" crates were added to the 'std' feature list.

Related issue:
https://github.com/Joystream/joystream/issues/305