### PR TITLE
Clippy linter support &  fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 
 before_install:
   - rustup component add rustfmt
-  - cargo fmt --all -- --check
+#  - cargo fmt --all -- --check
   - rustup component add clippy
   - BUILD_DUMMY_WASM_BINARY=1 cargo clippy -- -D warnings
   - rustup default stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 
 before_install:
   - rustup component add rustfmt
-#  - cargo fmt --all -- --check
+  - cargo fmt --all -- --check
   - rustup component add clippy
   - BUILD_DUMMY_WASM_BINARY=1 cargo clippy -- -D warnings
   - rustup default stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
 before_install:
   - rustup component add rustfmt
   - cargo fmt --all -- --check
+  - rustup component add clippy
+  - BUILD_DUMMY_WASM_BINARY=1 cargo clippy -- -D warnings
   - rustup default stable
   - rustup update nightly
   - rustup target add wasm32-unknown-unknown --toolchain nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "6.12.0"
+version = "6.12.1"
 dependencies = [
  "parity-scale-codec",
  "safe-mix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "6.12.1"
+version = "6.12.2"
 dependencies = [
  "parity-scale-codec",
  "safe-mix",

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Joystream node.  If not, see <http://www.gnu.org/licenses/>.
 
+// Clippy linter warning.
+#![allow(clippy::identity_op)] // disable it because we use such syntax for a code readability
+                               // Example:  voting_period: 1 * DAY
+
 use node_runtime::{
     versioned_store::InputValidationLengthConstraint as VsInputValidation, ActorsConfig,
     AuthorityDiscoveryConfig, BabeConfig, Balance, BalancesConfig, ContentWorkingGroupConfig,
@@ -154,7 +158,7 @@ impl Alternative {
 }
 
 fn new_vs_validation(min: u16, max_min_diff: u16) -> VsInputValidation {
-    return VsInputValidation { min, max_min_diff };
+    VsInputValidation { min, max_min_diff }
 }
 
 pub fn chain_spec_properties() -> json::map::Map<String, json::Value> {
@@ -218,9 +222,7 @@ pub fn testnet_genesis(
             slash_reward_fraction: Perbill::from_percent(10),
             ..Default::default()
         }),
-        sudo: Some(SudoConfig {
-            key: root_key.clone(),
-        }),
+        sudo: Some(SudoConfig { key: root_key }),
         babe: Some(BabeConfig {
             authorities: vec![],
         }),
@@ -274,7 +276,7 @@ pub fn testnet_genesis(
             class_description_constraint: new_vs_validation(1, 999),
         }),
         content_wg: Some(ContentWorkingGroupConfig {
-            mint_capacity: 100000,
+            mint_capacity: 100_000,
             curator_opening_by_id: vec![],
             next_curator_opening_id: 0,
             curator_application_by_id: vec![],

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -90,7 +90,7 @@ where
         let exit = e
             .into_exit()
             .map_err(|_| error::Error::Other("Exit future failed.".into()));
-        let service = service.map_err(|err| error::Error::Service(err));
+        let service = service.map_err(error::Error::Service);
         let select = service.select(exit).map(|_| ()).map_err(|(err, _)| err);
         runtime.block_on(select)
     };

--- a/node/src/forum_config/mod.rs
+++ b/node/src/forum_config/mod.rs
@@ -6,5 +6,5 @@ pub mod from_serialized;
 use node_runtime::forum::InputValidationLengthConstraint;
 
 pub fn new_validation(min: u16, max_min_diff: u16) -> InputValidationLengthConstraint {
-    return InputValidationLengthConstraint { min, max_min_diff };
+    InputValidationLengthConstraint { min, max_min_diff }
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -16,6 +16,12 @@
 
 #![warn(unused_extern_crates)]
 
+// Clippy linter warning.
+#![allow(clippy::type_complexity)] // disable it because this is foreign code and can be changed any time
+
+// Clippy linter warning.
+#![allow(clippy::redundant_closure_call)] // disable it because of the substrate lib design
+
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
 use client_db::Backend;

--- a/runtime-modules/content-working-group/src/lib.rs
+++ b/runtime-modules/content-working-group/src/lib.rs
@@ -2660,7 +2660,7 @@ impl<T: Trait> Module<T> {
             false
         };
 
-        // When the curator is staked, unstaking must first be initaated,
+        // When the curator is staked, unstaking must first be initiated,
         // otherwise they can be terminated right away.
 
         // Create exit summary for this termination

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -1,216 +1,10 @@
-// Copyright 2017-2019 Parity Technologies (UK) Ltd.
-
-// This is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
-
-// Copyright 2019 Joystream Contributors
-
-//! # Runtime Example Module
-//!
-//! <!-- Original author of paragraph: @gavofyork -->
-//! The Example: A simple example of a runtime module demonstrating
-//! concepts, APIs and structures common to most runtime modules.
-//!
-//! Run `cargo doc --package runtime-example-module --open` to view this module's documentation.
-//!
-//! ### Documentation Template:<br>
-//! Add heading with custom module name
-//!
-//! # <INSERT_CUSTOM_MODULE_NAME> Module
-//!
-//! Add simple description
-//!
-//! Include the following links that shows what trait needs to be implemented to use the module
-//! and the supported dispatchables that are documented in the Call enum.
-//!
-//! - [`<INSERT_CUSTOM_MODULE_NAME>::Trait`](./trait.Trait.html)
-//! - [`Call`](./enum.Call.html)
-//! - [`Module`](./struct.Module.html)
-//!
-//! ## Overview
-//!
-//! <!-- Original author of paragraph: Various. See https://github.com/paritytech/substrate-developer-hub/issues/44 -->
-//! Short description of module purpose.
-//! Links to Traits that should be implemented.
-//! What this module is for.
-//! What functionality the module provides.
-//! When to use the module (use case examples).
-//! How it is used.
-//! Inputs it uses and the source of each input.
-//! Outputs it produces.
-//!
-//! <!-- Original author of paragraph: @Kianenigma in PR https://github.com/paritytech/substrate/pull/1951 -->
-//! <!-- and comment https://github.com/paritytech/substrate-developer-hub/issues/44#issuecomment-471982710 -->
-//!
-//! ## Terminology
-//!
-//! Add terminology used in the custom module. Include concepts, storage items, or actions that you think
-//! deserve to be noted to give context to the rest of the documentation or module usage. The author needs to
-//! use some judgment about what is included. We don't want a list of every storage item nor types - the user
-//! can go to the code for that. For example, "transfer fee" is obvious and should not be included, but
-//! "free balance" and "reserved balance" should be noted to give context to the module.
-//! Please do not link to outside resources. The reference docs should be the ultimate source of truth.
-//!
-//! <!-- Original author of heading: @Kianenigma in PR https://github.com/paritytech/substrate/pull/1951 -->
-//!
-//! ## Goals
-//!
-//! Add goals that the custom module is designed to achieve.
-//!
-//! <!-- Original author of heading: @Kianenigma in PR https://github.com/paritytech/substrate/pull/1951 -->
-//!
-//! ### Scenarios
-//!
-//! <!-- Original author of paragraph: @Kianenigma. Based on PR https://github.com/paritytech/substrate/pull/1951 -->
-//!
-//! #### <INSERT_SCENARIO_NAME>
-//!
-//! Describe requirements prior to interacting with the custom module.
-//! Describe the process of interacting with the custom module for this scenario and public API functions used.
-//!
-//! ## Interface
-//!
-//! ### Supported Origins
-//!
-//! What origins are used and supported in this module (root, signed, inherent)
-//! i.e. root when `ensure_root` used
-//! i.e. inherent when `ensure_inherent` used
-//! i.e. signed when `ensure_signed` used
-//!
-//! `inherent` <INSERT_DESCRIPTION>
-//!
-//! <!-- Original author of paragraph: @Kianenigma in comment -->
-//! <!-- https://github.com/paritytech/substrate-developer-hub/issues/44#issuecomment-471982710 -->
-//!
-//! ### Types
-//!
-//! Type aliases. Include any associated types and where the user would typically define them.
-//!
-//! `ExampleType` <INSERT_DESCRIPTION>
-//!
-//! <!-- Original author of paragraph: ??? -->
-//!
-//!
-//! ### Dispatchable Functions
-//!
-//! <!-- Original author of paragraph: @AmarRSingh & @joepetrowski -->
-//!
-//! // A brief description of dispatchable functions and a link to the rustdoc with their actual documentation.
-//!
-//! <b>MUST</b> have link to Call enum
-//! <b>MUST</b> have origin information included in function doc
-//! <b>CAN</b> have more info up to the user
-//!
-//! ### Public Functions
-//!
-//! <!-- Original author of paragraph: @joepetrowski -->
-//!
-//! A link to the rustdoc and any notes about usage in the module, not for specific functions.
-//! For example, in the balances module: "Note that when using the publicly exposed functions,
-//! you (the runtime developer) are responsible for implementing any necessary checks
-//! (e.g. that the sender is the signer) before calling a function that will affect storage."
-//!
-//! <!-- Original author of paragraph: @AmarRSingh -->
-//!
-//! It is up to the writer of the respective module (with respect to how much information to provide).
-//!
-//! #### Public Inspection functions - Immutable (getters)
-//!
-//! Insert a subheading for each getter function signature
-//!
-//! ##### `example_getter_name()`
-//!
-//! What it returns
-//! Why, when, and how often to call it
-//! When it could panic or error
-//! When safety issues to consider
-//!
-//! #### Public Mutable functions (changing state)
-//!
-//! Insert a subheading for each setter function signature
-//!
-//! ##### `example_setter_name(origin, parameter_name: T::ExampleType)`
-//!
-//! What state it changes
-//! Why, when, and how often to call it
-//! When it could panic or error
-//! When safety issues to consider
-//! What parameter values are valid and why
-//!
-//! ### Storage Items
-//!
-//! Explain any storage items included in this module
-//!
-//! ### Digest Items
-//!
-//! Explain any digest items included in this module
-//!
-//! ### Inherent Data
-//!
-//! Explain what inherent data (if any) is defined in the module and any other related types
-//!
-//! ### Events:
-//!
-//! Insert events for this module if any
-//!
-//! ### Errors:
-//!
-//! Explain what generates errors
-//!
-//! ## Usage
-//!
-//! Insert 2-3 examples of usage and code snippets that show how to use <INSERT_CUSTOM_MODULE_NAME> module in a custom module.
-//!
-//! ### Prerequisites
-//!
-//! Show how to include necessary imports for <INSERT_CUSTOM_MODULE_NAME> and derive
-//! your module configuration trait with the `INSERT_CUSTOM_MODULE_NAME` trait.
-//!
-//! ```rust
-//! // use <INSERT_CUSTOM_MODULE_NAME>;
-//!
-//! // pub trait Trait: <INSERT_CUSTOM_MODULE_NAME>::Trait { }
-//! ```
-//!
-//! ### Simple Code Snippet
-//!
-//! Show a simple example (e.g. how to query a public getter function of <INSERT_CUSTOM_MODULE_NAME>)
-//!
-//! ## Genesis Config
-//!
-//! <!-- Original author of paragraph: @joepetrowski -->
-//!
-//! ## Dependencies
-//!
-//! Dependencies on other SRML modules and the genesis config should be mentioned,
-//! but not the Rust Standard Library.
-//! Genesis configuration modifications that may be made to incorporate this module
-//! Interaction with other modules
-//!
-//! <!-- Original author of heading: @AmarRSingh -->
-//!
-//! ## Related Modules
-//!
-//! Interaction with other modules in the form of a bullet point list
-//!
-//! ## References
-//!
-//! <!-- Original author of paragraph: @joepetrowski -->
-//!
-//! Links to reference material, if applicable. For example, Phragmen, W3F research, etc.
-//! that the implementation is based on.
-
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "std")]
 use serde_derive::{Deserialize, Serialize};
 
+use rstd::borrow::ToOwned;
 use rstd::prelude::*;
 
 use codec::{Decode, Encode};
@@ -633,7 +427,7 @@ decl_module! {
              */
 
             // Hold on to old value
-            let old_forum_sudo = <ForumSudo<T>>::get().clone();
+            let old_forum_sudo = <ForumSudo<T>>::get();
 
             // Update forum sudo
             match new_forum_sudo.clone() {
@@ -703,8 +497,8 @@ decl_module! {
             // Create new category
             let new_category = Category {
                 id : next_category_id,
-                title : title.clone(),
-                description: description.clone(),
+                title,
+                description,
                 created_at : Self::current_block_and_time(),
                 deleted: false,
                 archived: false,
@@ -753,7 +547,7 @@ decl_module! {
                 // We must skip checking category itself.
                 // NB: This is kind of hacky way to avoid last element,
                 // something clearn can be done later.
-                let mut path_to_check = category_tree_path.clone();
+                let mut path_to_check = category_tree_path;
                 path_to_check.remove(0);
 
                 Self::ensure_can_mutate_in_path_leaf(&path_to_check)?;
@@ -843,7 +637,7 @@ decl_module! {
             Self::ensure_is_forum_sudo(&who)?;
 
             // Get thread
-            let mut thread = Self::ensure_thread_exists(&thread_id)?;
+            let mut thread = Self::ensure_thread_exists(thread_id)?;
 
             // Thread is not already moderated
             ensure!(thread.moderation.is_none(), ERROR_THREAD_ALREADY_MODERATED);
@@ -867,7 +661,7 @@ decl_module! {
             thread.moderation = Some(ModerationAction {
                 moderated_at: Self::current_block_and_time(),
                 moderator_id: who,
-                rationale: rationale.clone()
+                rationale
             });
 
             <ThreadById<T>>::insert(thread_id, thread.clone());
@@ -901,7 +695,7 @@ decl_module! {
             Self::ensure_post_text_is_valid(&text)?;
 
             // Make sure thread exists and is mutable
-            let thread = Self::ensure_thread_is_mutable(&thread_id)?;
+            let thread = Self::ensure_thread_is_mutable(thread_id)?;
 
             // Get path from parent to root of category tree.
             let category_tree_path = Self::ensure_valid_category_and_build_category_tree_path(thread.category_id)?;
@@ -939,7 +733,7 @@ decl_module! {
             Self::ensure_post_text_is_valid(&new_text)?;
 
             // Make sure there exists a mutable post with post id `post_id`
-            let post = Self::ensure_post_is_mutable(&post_id)?;
+            let post = Self::ensure_post_is_mutable(post_id)?;
 
             // Signer does not match creator of post with identifier postId
             ensure!(post.author_id == who, ERROR_ACCOUNT_DOES_NOT_MATCH_POST_AUTHOR);
@@ -978,7 +772,7 @@ decl_module! {
             Self::ensure_is_forum_sudo(&who)?;
 
             // Make sure post exists and is mutable
-            let post = Self::ensure_post_is_mutable(&post_id)?;
+            let post = Self::ensure_post_is_mutable(post_id)?;
 
             Self::ensure_post_moderation_rationale_is_valid(&rationale)?;
 
@@ -990,7 +784,7 @@ decl_module! {
             let moderation_action = ModerationAction{
                 moderated_at: Self::current_block_and_time(),
                 moderator_id: who,
-                rationale: rationale.clone()
+                rationale
             };
 
             <PostById<T>>::mutate(post_id, |p| {
@@ -1013,7 +807,7 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
-    fn ensure_category_title_is_valid(title: &Vec<u8>) -> dispatch::Result {
+    fn ensure_category_title_is_valid(title: &[u8]) -> dispatch::Result {
         CategoryTitleConstraint::get().ensure_valid(
             title.len(),
             ERROR_CATEGORY_TITLE_TOO_SHORT,
@@ -1021,7 +815,7 @@ impl<T: Trait> Module<T> {
         )
     }
 
-    fn ensure_category_description_is_valid(description: &Vec<u8>) -> dispatch::Result {
+    fn ensure_category_description_is_valid(description: &[u8]) -> dispatch::Result {
         CategoryDescriptionConstraint::get().ensure_valid(
             description.len(),
             ERROR_CATEGORY_DESCRIPTION_TOO_SHORT,
@@ -1029,7 +823,7 @@ impl<T: Trait> Module<T> {
         )
     }
 
-    fn ensure_thread_moderation_rationale_is_valid(rationale: &Vec<u8>) -> dispatch::Result {
+    fn ensure_thread_moderation_rationale_is_valid(rationale: &[u8]) -> dispatch::Result {
         ThreadModerationRationaleConstraint::get().ensure_valid(
             rationale.len(),
             ERROR_THREAD_MODERATION_RATIONALE_TOO_SHORT,
@@ -1037,7 +831,7 @@ impl<T: Trait> Module<T> {
         )
     }
 
-    fn ensure_thread_title_is_valid(title: &Vec<u8>) -> dispatch::Result {
+    fn ensure_thread_title_is_valid(title: &[u8]) -> dispatch::Result {
         ThreadTitleConstraint::get().ensure_valid(
             title.len(),
             ERROR_THREAD_TITLE_TOO_SHORT,
@@ -1045,7 +839,7 @@ impl<T: Trait> Module<T> {
         )
     }
 
-    fn ensure_post_text_is_valid(text: &Vec<u8>) -> dispatch::Result {
+    fn ensure_post_text_is_valid(text: &[u8]) -> dispatch::Result {
         PostTextConstraint::get().ensure_valid(
             text.len(),
             ERROR_POST_TEXT_TOO_SHORT,
@@ -1053,7 +847,7 @@ impl<T: Trait> Module<T> {
         )
     }
 
-    fn ensure_post_moderation_rationale_is_valid(rationale: &Vec<u8>) -> dispatch::Result {
+    fn ensure_post_moderation_rationale_is_valid(rationale: &[u8]) -> dispatch::Result {
         PostModerationRationaleConstraint::get().ensure_valid(
             rationale.len(),
             ERROR_POST_MODERATION_RATIONALE_TOO_SHORT,
@@ -1069,7 +863,7 @@ impl<T: Trait> Module<T> {
     }
 
     fn ensure_post_is_mutable(
-        post_id: &PostId,
+        post_id: PostId,
     ) -> Result<Post<T::BlockNumber, T::Moment, T::AccountId>, &'static str> {
         // Make sure post exists
         let post = Self::ensure_post_exists(post_id)?;
@@ -1078,13 +872,13 @@ impl<T: Trait> Module<T> {
         ensure!(post.moderation.is_none(), ERROR_POST_MODERATED);
 
         // and make sure thread is mutable
-        Self::ensure_thread_is_mutable(&post.thread_id)?;
+        Self::ensure_thread_is_mutable(post.thread_id)?;
 
         Ok(post)
     }
 
     fn ensure_post_exists(
-        post_id: &PostId,
+        post_id: PostId,
     ) -> Result<Post<T::BlockNumber, T::Moment, T::AccountId>, &'static str> {
         if <PostById<T>>::exists(post_id) {
             Ok(<PostById<T>>::get(post_id))
@@ -1094,10 +888,10 @@ impl<T: Trait> Module<T> {
     }
 
     fn ensure_thread_is_mutable(
-        thread_id: &ThreadId,
+        thread_id: ThreadId,
     ) -> Result<Thread<T::BlockNumber, T::Moment, T::AccountId>, &'static str> {
         // Make sure thread exists
-        let thread = Self::ensure_thread_exists(&thread_id)?;
+        let thread = Self::ensure_thread_exists(thread_id)?;
 
         // and is unmoderated
         ensure!(thread.moderation.is_none(), ERROR_THREAD_MODERATED);
@@ -1109,7 +903,7 @@ impl<T: Trait> Module<T> {
     }
 
     fn ensure_thread_exists(
-        thread_id: &ThreadId,
+        thread_id: ThreadId,
     ) -> Result<Thread<T::BlockNumber, T::Moment, T::AccountId>, &'static str> {
         if <ThreadById<T>>::exists(thread_id) {
             Ok(<ThreadById<T>>::get(thread_id))
@@ -1194,7 +988,7 @@ impl<T: Trait> Module<T> {
         // Get path from parent to root of category tree.
         let category_tree_path = Self::build_category_tree_path(category_id);
 
-        assert!(category_tree_path.len() > 0);
+        assert!(!category_tree_path.is_empty());
 
         Ok(category_tree_path)
     }
@@ -1239,7 +1033,7 @@ impl<T: Trait> Module<T> {
 
     fn add_new_thread(
         category_id: CategoryId,
-        title: &Vec<u8>,
+        title: &[u8],
         author_id: &T::AccountId,
     ) -> Thread<T::BlockNumber, T::Moment, T::AccountId> {
         // Get category
@@ -1250,8 +1044,8 @@ impl<T: Trait> Module<T> {
 
         let new_thread = Thread {
             id: new_thread_id,
-            title: title.clone(),
-            category_id: category_id,
+            title: title.to_owned(),
+            category_id,
             nr_in_category: category.num_threads_created() + 1,
             moderation: None,
             num_unmoderated_posts: 0,
@@ -1280,7 +1074,7 @@ impl<T: Trait> Module<T> {
     /// `thread_id` must be valid
     fn add_new_post(
         thread_id: ThreadId,
-        text: &Vec<u8>,
+        text: &[u8],
         author_id: &T::AccountId,
     ) -> Post<T::BlockNumber, T::Moment, T::AccountId> {
         // Get thread
@@ -1291,9 +1085,9 @@ impl<T: Trait> Module<T> {
 
         let new_post = Post {
             id: new_post_id,
-            thread_id: thread_id,
+            thread_id,
             nr_in_thread: thread.num_posts_ever_created() + 1,
-            current_text: text.clone(),
+            current_text: text.to_owned(),
             moderation: None,
             text_change_history: vec![],
             created_at: Self::current_block_and_time(),

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -1,3 +1,8 @@
+// Clippy linter warning
+#![allow(clippy::type_complexity)]
+// disable it because of possible frontend API break
+// TODO: remove post-Constaninople
+
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -947,6 +952,9 @@ impl<T: Trait> Module<T> {
         Self::ensure_can_mutate_in_path_leaf(&category_tree_path)
     }
 
+    // Clippy linter warning
+    #[allow(clippy::ptr_arg)] // disable it because of possible frontend API break
+                              // TODO: remove post-Constaninople
     fn ensure_can_mutate_in_path_leaf(
         category_tree_path: &CategoryTreePath<T::BlockNumber, T::Moment, T::AccountId>,
     ) -> dispatch::Result {
@@ -961,6 +969,9 @@ impl<T: Trait> Module<T> {
         Ok(())
     }
 
+    // TODO: remove post-Constaninople
+    // Clippy linter warning
+    #[allow(clippy::ptr_arg)] // disable it because of possible frontend API break
     fn ensure_can_add_subcategory_path_leaf(
         category_tree_path: &CategoryTreePath<T::BlockNumber, T::Moment, T::AccountId>,
     ) -> dispatch::Result {

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -484,12 +484,12 @@ pub fn genesis_config(
 ) -> GenesisConfig<Runtime> {
     GenesisConfig::<Runtime> {
         category_by_id: category_by_id.clone(),
-        next_category_id: next_category_id,
+        next_category_id,
         thread_by_id: thread_by_id.clone(),
-        next_thread_id: next_thread_id,
+        next_thread_id,
         post_by_id: post_by_id.clone(),
-        next_post_id: next_post_id,
-        forum_sudo: forum_sudo,
+        next_post_id,
+        forum_sudo,
         category_title_constraint: category_title_constraint.clone(),
         category_description_constraint: category_description_constraint.clone(),
         thread_title_constraint: thread_title_constraint.clone(),

--- a/runtime-modules/governance/src/election.rs
+++ b/runtime-modules/governance/src/election.rs
@@ -235,11 +235,11 @@ impl<T: Trait> Module<T> {
     fn start_election(current_council: Seats<T::AccountId, BalanceOf<T>>) -> Result {
         ensure!(!Self::is_election_running(), "election already in progress");
         ensure!(
-            Self::existing_stake_holders().len() == 0,
+            Self::existing_stake_holders().is_empty(),
             "stake holders must be empty"
         );
-        ensure!(Self::applicants().len() == 0, "applicants must be empty");
-        ensure!(Self::commitments().len() == 0, "commitments must be empty");
+        ensure!(Self::applicants().is_empty(), "applicants must be empty");
+        ensure!(Self::commitments().is_empty(), "commitments must be empty");
 
         // Take snapshot of seat and backing stakes of an existing council
         // Its important to note that the election system takes ownership of these stakes, and is responsible
@@ -663,7 +663,7 @@ impl<T: Trait> Module<T> {
             *transferable
         };
 
-        *transferable = *transferable - transferred;
+        *transferable -= transferred;
 
         Stake {
             new: new_stake - transferred,
@@ -699,7 +699,7 @@ impl<T: Trait> Module<T> {
             <Applicants<T>>::mutate(|applicants| applicants.insert(0, applicant.clone()));
         }
 
-        <ApplicantStakes<T>>::insert(applicant.clone(), total_stake);
+        <ApplicantStakes<T>>::insert(applicant, total_stake);
 
         Ok(())
     }
@@ -754,7 +754,7 @@ impl<T: Trait> Module<T> {
             "vote for non-applicant not allowed"
         );
 
-        let mut salt = salt.clone();
+        let mut salt = salt;
 
         // Tries to unseal, if salt is invalid will return error
         sealed_vote.unseal(vote_for, &mut salt, <T as system::Trait>::Hashing::hash)?;

--- a/runtime-modules/membership/src/members.rs
+++ b/runtime-modules/membership/src/members.rs
@@ -1,12 +1,12 @@
 // Clippy linter requirement
 #![allow(clippy::redundant_closure_call)] // disable it because of the substrate lib design
-// example:  pub PaidMembershipTermsById get(paid_membership_terms_by_id) build(|config: &GenesisConfig<T>| {}
+                                          // example:  pub PaidMembershipTermsById get(paid_membership_terms_by_id) build(|config: &GenesisConfig<T>| {}
 
 use codec::{Codec, Decode, Encode};
 use common::currency::{BalanceOf, GovernanceCurrency};
 
-use rstd::prelude::*;
 use rstd::borrow::ToOwned;
+use rstd::prelude::*;
 use sr_primitives::traits::{MaybeSerialize, Member, One, SimpleArithmetic};
 use srml_support::traits::{Currency, Get};
 use srml_support::{decl_event, decl_module, decl_storage, dispatch, ensure, Parameter};

--- a/runtime-modules/membership/src/members.rs
+++ b/runtime-modules/membership/src/members.rs
@@ -1,7 +1,12 @@
+// Clippy linter requirement
+#![allow(clippy::redundant_closure_call)] // disable it because of the substrate lib design
+// example:  pub PaidMembershipTermsById get(paid_membership_terms_by_id) build(|config: &GenesisConfig<T>| {}
+
 use codec::{Codec, Decode, Encode};
 use common::currency::{BalanceOf, GovernanceCurrency};
 
 use rstd::prelude::*;
+use rstd::borrow::ToOwned;
 use sr_primitives::traits::{MaybeSerialize, Member, One, SimpleArithmetic};
 use srml_support::traits::{Currency, Get};
 use srml_support::{decl_event, decl_module, decl_storage, dispatch, ensure, Parameter};
@@ -252,7 +257,7 @@ decl_module! {
             let _ = T::Currency::slash(&who, terms.fee);
             let member_id = Self::insert_member(&who, &user_info, EntryMethod::Paid(paid_terms_id));
 
-            Self::deposit_event(RawEvent::MemberRegistered(member_id, who.clone()));
+            Self::deposit_event(RawEvent::MemberRegistered(member_id, who));
         }
 
         /// Change member's about text
@@ -448,12 +453,13 @@ impl<T: Trait> Module<T> {
         Ok(terms)
     }
 
+    #[allow(clippy::ptr_arg)] // cannot change to the "&[u8]" suggested by clippy
     fn ensure_unique_handle(handle: &Vec<u8>) -> dispatch::Result {
         ensure!(!<Handles<T>>::exists(handle), "handle already registered");
         Ok(())
     }
 
-    fn validate_handle(handle: &Vec<u8>) -> dispatch::Result {
+    fn validate_handle(handle: &[u8]) -> dispatch::Result {
         ensure!(
             handle.len() >= Self::min_handle_length() as usize,
             "handle too short"
@@ -465,13 +471,13 @@ impl<T: Trait> Module<T> {
         Ok(())
     }
 
-    fn validate_text(text: &Vec<u8>) -> Vec<u8> {
-        let mut text = text.clone();
+    fn validate_text(text: &[u8]) -> Vec<u8> {
+        let mut text = text.to_owned();
         text.truncate(Self::max_about_text_length() as usize);
         text
     }
 
-    fn validate_avatar(uri: &Vec<u8>) -> dispatch::Result {
+    fn validate_avatar(uri: &[u8]) -> dispatch::Result {
         ensure!(
             uri.len() <= Self::max_avatar_uri_length() as usize,
             "avatar uri too long"
@@ -533,7 +539,7 @@ impl<T: Trait> Module<T> {
         new_member_id
     }
 
-    fn _change_member_about_text(id: T::MemberId, text: &Vec<u8>) -> dispatch::Result {
+    fn _change_member_about_text(id: T::MemberId, text: &[u8]) -> dispatch::Result {
         let mut profile = Self::ensure_profile(id)?;
         let text = Self::validate_text(text);
         profile.about = text;
@@ -542,10 +548,10 @@ impl<T: Trait> Module<T> {
         Ok(())
     }
 
-    fn _change_member_avatar(id: T::MemberId, uri: &Vec<u8>) -> dispatch::Result {
+    fn _change_member_avatar(id: T::MemberId, uri: &[u8]) -> dispatch::Result {
         let mut profile = Self::ensure_profile(id)?;
         Self::validate_avatar(uri)?;
-        profile.avatar_uri = uri.clone();
+        profile.avatar_uri = uri.to_owned();
         Self::deposit_event(RawEvent::MemberUpdatedAvatar(id));
         <MemberProfile<T>>::insert(id, profile);
         Ok(())
@@ -593,7 +599,7 @@ impl<T: Trait> Module<T> {
             ensure_signed(origin).map_err(|_| MemberControllerAccountDidNotSign::UnsignedOrigin)?;
 
         // Ensure member exists
-        let profile = Self::ensure_profile(member_id.clone())
+        let profile = Self::ensure_profile(*member_id)
             .map_err(|_| MemberControllerAccountDidNotSign::MemberIdInvalid)?;
 
         ensure!(
@@ -609,7 +615,7 @@ impl<T: Trait> Module<T> {
         member_id: &T::MemberId,
     ) -> Result<(), MemberControllerAccountMismatch> {
         // Ensure member exists
-        let profile = Self::ensure_profile(member_id.clone())
+        let profile = Self::ensure_profile(*member_id)
             .map_err(|_| MemberControllerAccountMismatch::MemberIdInvalid)?;
 
         ensure!(
@@ -625,7 +631,7 @@ impl<T: Trait> Module<T> {
         member_id: &T::MemberId,
     ) -> Result<(), MemberRootAccountMismatch> {
         // Ensure member exists
-        let profile = Self::ensure_profile(member_id.clone())
+        let profile = Self::ensure_profile(*member_id)
             .map_err(|_| MemberRootAccountMismatch::MemberIdInvalid)?;
 
         ensure!(

--- a/runtime-modules/membership/src/role_types.rs
+++ b/runtime-modules/membership/src/role_types.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default)] // disable because Default for enums doesn't make sense
+
 use codec::{Decode, Encode};
 use rstd::collections::btree_set::BTreeSet;
 use rstd::prelude::*;

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -34,6 +34,12 @@
 //! - [governance](../substrate_governance_module/index.html)
 //! - [content_working_group](../substrate_content_working_group_module/index.html)
 //!
+// Clippy linter warning. TODO: remove after the Constaninople release
+#![allow(clippy::type_complexity)]
+// disable it because of possible frontend API break
+
+// Clippy linter warning. TODO: refactor "this function has too many argument"
+#![allow(clippy::too_many_arguments)] // disable it because of possible API break
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -336,7 +342,7 @@ decl_module! {
             Self::ensure_council_election_parameters_valid(&election_parameters)?;
 
             let proposal_code =
-                <governance::election::Call<T>>::set_election_parameters(election_parameters.clone());
+                <governance::election::Call<T>>::set_election_parameters(election_parameters);
 
             let proposal_parameters =
                 proposal_types::parameters::set_election_parameters_proposal::<T>();
@@ -373,7 +379,7 @@ decl_module! {
             );
 
             let proposal_code =
-                <content_working_group::Call<T>>::set_mint_capacity(mint_balance.clone());
+                <content_working_group::Call<T>>::set_mint_capacity(mint_balance);
 
             let proposal_parameters =
                 proposal_types::parameters::set_content_working_group_mint_capacity_proposal::<T>();
@@ -416,7 +422,7 @@ decl_module! {
             );
 
             let proposal_code = <governance::council::Call<T>>::spend_from_council_mint(
-                balance.clone(),
+                balance,
                 destination.clone()
             );
 
@@ -552,7 +558,7 @@ decl_module! {
 
             let proposal_code = <roles::actors::Call<T>>::set_role_parameters(
                 Role::StorageProvider,
-                role_parameters.clone()
+                role_parameters
             );
 
             let proposal_parameters =
@@ -646,8 +652,7 @@ impl<T: Trait> Module<T> {
             T::MemberId,
         >,
     ) -> DispatchResult<Error> {
-        let account_id =
-            T::MembershipOriginValidator::ensure_actor_origin(origin, member_id.clone())?;
+        let account_id = T::MembershipOriginValidator::ensure_actor_origin(origin, member_id)?;
 
         <proposal_engine::Module<T>>::ensure_create_proposal_parameters_are_valid(
             &proposal_parameters,
@@ -656,7 +661,7 @@ impl<T: Trait> Module<T> {
             stake_balance,
         )?;
 
-        <proposal_discussion::Module<T>>::ensure_can_create_thread(member_id.clone(), &title)?;
+        <proposal_discussion::Module<T>>::ensure_can_create_thread(member_id, &title)?;
 
         let discussion_thread_id =
             <proposal_discussion::Module<T>>::create_thread(member_id, title.clone())?;
@@ -829,7 +834,7 @@ impl<T: Trait> Module<T> {
 
         ensure!(
             election_parameters.min_voting_stake
-                <= <BalanceOfGovernanceCurrency<T>>::from(100000u32),
+                <= <BalanceOfGovernanceCurrency<T>>::from(100_000_u32),
             Error::InvalidCouncilElectionParameterMinVotingStake
         );
 
@@ -839,7 +844,7 @@ impl<T: Trait> Module<T> {
         );
 
         ensure!(
-            election_parameters.new_term_duration <= T::BlockNumber::from(432000),
+            election_parameters.new_term_duration <= T::BlockNumber::from(432_000),
             Error::InvalidCouncilElectionParameterNewTermDuration
         );
 
@@ -880,7 +885,7 @@ impl<T: Trait> Module<T> {
 
         ensure!(
             election_parameters.min_council_stake
-                <= <BalanceOfGovernanceCurrency<T>>::from(100000u32),
+                <= <BalanceOfGovernanceCurrency<T>>::from(100_000_u32),
             Error::InvalidCouncilElectionParameterMinCouncilStake
         );
 

--- a/runtime-modules/proposals/codex/src/proposal_types/parameters.rs
+++ b/runtime-modules/proposals/codex/src/proposal_types/parameters.rs
@@ -46,7 +46,7 @@ pub(crate) fn set_election_parameters_proposal<T: crate::Trait>(
 ) -> ProposalParameters<T::BlockNumber, BalanceOf<T>> {
     ProposalParameters {
         voting_period: T::BlockNumber::from(72000u32),
-        grace_period: T::BlockNumber::from(201601u32),
+        grace_period: T::BlockNumber::from(201_601_u32),
         approval_quorum_percentage: 66,
         approval_threshold_percentage: 80,
         slashing_quorum_percentage: 60,

--- a/runtime-modules/recurring-reward/src/lib.rs
+++ b/runtime-modules/recurring-reward/src/lib.rs
@@ -1,3 +1,10 @@
+// Clippy linter warning. TODO: remove after the Constaninople release
+#![allow(clippy::type_complexity)]
+// disable it because of possible frontend API break
+
+// Clippy linter warning. TODO: refactor the Option<Option<>>
+#![allow(clippy::option_option)] // disable it because of possible API break
+
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 use rstd::prelude::*;

--- a/runtime-modules/roles/src/actors.rs
+++ b/runtime-modules/roles/src/actors.rs
@@ -1,6 +1,6 @@
-// Clippy linter requirement
+// Clippy linter warning
 #![allow(clippy::redundant_closure_call)] // disable it because of the substrate lib design
-// example:  pub Parameters get(parameters) build(|config: &GenesisConfig| {..}
+                                          // example:  pub Parameters get(parameters) build(|config: &GenesisConfig| {..}
 
 use codec::{Decode, Encode};
 use common::currency::{BalanceOf, GovernanceCurrency};
@@ -16,7 +16,6 @@ use system::{self, ensure_root, ensure_signed};
 use serde::{Deserialize, Serialize};
 
 pub use membership::members::Role;
-
 
 const STAKING_ID: LockIdentifier = *b"role_stk";
 

--- a/runtime-modules/service-discovery/src/discovery.rs
+++ b/runtime-modules/service-discovery/src/discovery.rs
@@ -100,7 +100,7 @@ decl_module! {
                 expires_at: <system::Module<T>>::block_number() + ttl,
             });
 
-            Self::deposit_event(RawEvent::AccountInfoUpdated(sender.clone(), id.clone()));
+            Self::deposit_event(RawEvent::AccountInfoUpdated(sender, id));
         }
 
         pub fn unset_ipns_id(origin) {

--- a/runtime-modules/stake/src/lib.rs
+++ b/runtime-modules/stake/src/lib.rs
@@ -378,9 +378,9 @@ where
 
                     Ok((stake_to_reduce, staked_state.staked_amount))
                 }
-                _ => return Err(DecreasingStakeError::CannotDecreaseStakeWhileUnstaking),
+                _ => Err(DecreasingStakeError::CannotDecreaseStakeWhileUnstaking),
             },
-            _ => return Err(DecreasingStakeError::NotStaked),
+            _ => Err(DecreasingStakeError::NotStaked),
         }
     }
 
@@ -463,11 +463,9 @@ where
                 );
 
                 // pause Unstaking if unstaking is active
-                match staked_state.staked_status {
-                    StakedStatus::Unstaking(ref mut unstaking_state) => {
-                        unstaking_state.is_active = false;
-                    }
-                    _ => (),
+                if let StakedStatus::Unstaking(ref mut unstaking_state) = staked_state.staked_status
+                {
+                    unstaking_state.is_active = false;
                 }
 
                 Ok(slash_id)
@@ -523,11 +521,10 @@ where
 
                 // unpause unstaking on last ongoing slash cancelled
                 if staked_state.ongoing_slashes.is_empty() {
-                    match staked_state.staked_status {
-                        StakedStatus::Unstaking(ref mut unstaking_state) => {
-                            unstaking_state.is_active = true;
-                        }
-                        _ => (),
+                    if let StakedStatus::Unstaking(ref mut unstaking_state) =
+                        staked_state.staked_status
+                    {
+                        unstaking_state.is_active = true;
                     }
                 }
 

--- a/runtime-modules/stake/src/tests.rs
+++ b/runtime-modules/stake/src/tests.rs
@@ -321,7 +321,7 @@ fn decreasing_stake() {
                 Stake {
                     created: 0,
                     staking_status: StakingStatus::Staked(StakedState {
-                        staked_amount: staked_amount,
+                        staked_amount,
                         ongoing_slashes: BTreeMap::new(),
                         next_slash_id: 0,
                         staked_status: StakedStatus::Normal,
@@ -379,7 +379,7 @@ fn initiating_pausing_resuming_cancelling_slashes() {
             Stake {
                 created: System::block_number(),
                 staking_status: StakingStatus::Staked(StakedState {
-                    staked_amount: staked_amount,
+                    staked_amount,
                     ongoing_slashes: BTreeMap::new(),
                     next_slash_id: 0,
                     staked_status: StakedStatus::Unstaking(UnstakingState {
@@ -413,7 +413,7 @@ fn initiating_pausing_resuming_cancelling_slashes() {
             Stake {
                 created: System::block_number(),
                 staking_status: StakingStatus::Staked(StakedState {
-                    staked_amount: staked_amount,
+                    staked_amount,
                     ongoing_slashes: expected_ongoing_slashes.clone(),
                     next_slash_id: slash_id + 1,
                     staked_status: StakedStatus::Unstaking(UnstakingState {
@@ -449,7 +449,7 @@ fn initiating_pausing_resuming_cancelling_slashes() {
             Stake {
                 created: System::block_number(),
                 staking_status: StakingStatus::Staked(StakedState {
-                    staked_amount: staked_amount,
+                    staked_amount,
                     ongoing_slashes: expected_ongoing_slashes.clone(),
                     next_slash_id: slash_id + 1,
                     staked_status: StakedStatus::Unstaking(UnstakingState {
@@ -485,7 +485,7 @@ fn initiating_pausing_resuming_cancelling_slashes() {
             Stake {
                 created: System::block_number(),
                 staking_status: StakingStatus::Staked(StakedState {
-                    staked_amount: staked_amount,
+                    staked_amount,
                     ongoing_slashes: expected_ongoing_slashes.clone(),
                     next_slash_id: slash_id + 1,
                     staked_status: StakedStatus::Unstaking(UnstakingState {
@@ -512,7 +512,7 @@ fn initiating_pausing_resuming_cancelling_slashes() {
             Stake {
                 created: System::block_number(),
                 staking_status: StakingStatus::Staked(StakedState {
-                    staked_amount: staked_amount,
+                    staked_amount,
                     ongoing_slashes: BTreeMap::new(),
                     next_slash_id: slash_id + 1,
                     staked_status: StakedStatus::Unstaking(UnstakingState {
@@ -545,7 +545,7 @@ fn initiating_pausing_resuming_cancelling_slashes() {
             Stake {
                 created: System::block_number(),
                 staking_status: StakingStatus::Staked(StakedState {
-                    staked_amount: staked_amount,
+                    staked_amount,
                     ongoing_slashes: expected_ongoing_slashes.clone(),
                     next_slash_id: slash_id + 1,
                     staked_status: StakedStatus::Unstaking(UnstakingState {

--- a/runtime-modules/storage/src/data_directory.rs
+++ b/runtime-modules/storage/src/data_directory.rs
@@ -145,9 +145,9 @@ decl_module! {
                 size,
                 added_at: Self::current_block_and_time(),
                 owner: who.clone(),
-                liaison: liaison,
+                liaison,
                 liaison_judgement: LiaisonJudgement::Pending,
-                ipfs_content_id: ipfs_content_id.clone(),
+                ipfs_content_id,
             };
 
             <DataObjectByContentId<T>>::insert(&content_id, data);
@@ -157,7 +157,7 @@ decl_module! {
         // The LiaisonJudgement can be updated, but only by the liaison.
         fn accept_content(origin, content_id: T::ContentId) {
             let who = ensure_signed(origin)?;
-            Self::update_content_judgement(&who, content_id.clone(), LiaisonJudgement::Accepted)?;
+            Self::update_content_judgement(&who, content_id, LiaisonJudgement::Accepted)?;
             <KnownContentIds<T>>::mutate(|ids| ids.push(content_id));
             Self::deposit_event(RawEvent::ContentAccepted(content_id, who));
         }
@@ -198,11 +198,11 @@ decl_module! {
 
 impl<T: Trait> ContentIdExists<T> for Module<T> {
     fn has_content(content_id: &T::ContentId) -> bool {
-        Self::data_object_by_content_id(content_id.clone()).is_some()
+        Self::data_object_by_content_id(*content_id).is_some()
     }
 
     fn get_data_object(content_id: &T::ContentId) -> Result<DataObject<T>, &'static str> {
-        match Self::data_object_by_content_id(content_id.clone()) {
+        match Self::data_object_by_content_id(*content_id) {
             Some(data) => Ok(data),
             None => Err(MSG_CID_NOT_FOUND),
         }

--- a/runtime-modules/storage/src/data_directory.rs
+++ b/runtime-modules/storage/src/data_directory.rs
@@ -164,7 +164,7 @@ decl_module! {
 
         fn reject_content(origin, content_id: T::ContentId) {
             let who = ensure_signed(origin)?;
-            Self::update_content_judgement(&who, content_id.clone(), LiaisonJudgement::Rejected)?;
+            Self::update_content_judgement(&who, content_id, LiaisonJudgement::Rejected)?;
             Self::deposit_event(RawEvent::ContentRejected(content_id, who));
         }
 

--- a/runtime-modules/storage/src/data_object_storage_registry.rs
+++ b/runtime-modules/storage/src/data_object_storage_registry.rs
@@ -1,3 +1,7 @@
+// Clippy linter requirement
+#![allow(clippy::redundant_closure_call)] // disable it because of the substrate lib design
+                                          // example:  pub NextRelationshipId get(next_relationship_id) build(|config: &GenesisConfig<T>|
+
 use crate::data_directory::Trait as DDTrait;
 use crate::traits::{ContentHasStorage, ContentIdExists};
 use codec::{Codec, Decode, Encode};
@@ -97,14 +101,14 @@ impl<T: Trait> ContentHasStorage<T> for Module<T> {
     // TODO deprecated
     fn has_storage_provider(which: &T::ContentId) -> bool {
         let dosr_list = Self::relationships_by_content_id(which);
-        return dosr_list.iter().any(|&dosr_id| {
+        dosr_list.iter().any(|&dosr_id| {
             let res = Self::relationships(dosr_id);
             if res.is_none() {
                 return false;
             }
             let dosr = res.unwrap();
             dosr.ready
-        });
+        })
     }
 
     // TODO deprecated

--- a/runtime-modules/storage/src/data_object_storage_registry.rs
+++ b/runtime-modules/storage/src/data_object_storage_registry.rs
@@ -110,14 +110,14 @@ impl<T: Trait> ContentHasStorage<T> for Module<T> {
     // TODO deprecated
     fn is_ready_at_storage_provider(which: &T::ContentId, provider: &T::AccountId) -> bool {
         let dosr_list = Self::relationships_by_content_id(which);
-        return dosr_list.iter().any(|&dosr_id| {
+        dosr_list.iter().any(|&dosr_id| {
             let res = Self::relationships(dosr_id);
             if res.is_none() {
                 return false;
             }
             let dosr = res.unwrap();
             dosr.storage_provider == *provider && dosr.ready
-        });
+        })
     }
 }
 
@@ -138,7 +138,7 @@ decl_module! {
             // Create new ID, data.
             let new_id = Self::next_relationship_id();
             let dosr: DataObjectStorageRelationship<T> = DataObjectStorageRelationship {
-                content_id: cid.clone(),
+                content_id: cid,
                 storage_provider: who.clone(),
                 ready: false,
             };
@@ -148,9 +148,9 @@ decl_module! {
 
             // Also add the DOSR to the list of DOSRs for the CID. Uniqueness is guaranteed
             // by the map, so we can just append the new_id to the list.
-            let mut dosr_list = Self::relationships_by_content_id(cid.clone());
+            let mut dosr_list = Self::relationships_by_content_id(cid);
             dosr_list.push(new_id);
-            <RelationshipsByContentId<T>>::insert(cid.clone(), dosr_list);
+            <RelationshipsByContentId<T>>::insert(cid, dosr_list);
 
             // Emit event
             Self::deposit_event(RawEvent::DataObjectStorageRelationshipAdded(new_id, cid, who));

--- a/runtime-modules/storage/src/data_object_type_registry.rs
+++ b/runtime-modules/storage/src/data_object_type_registry.rs
@@ -1,3 +1,7 @@
+// Clippy linter requirement
+#![allow(clippy::redundant_closure_call)] // disable it because of the substrate lib design
+                                          // example:   NextDataObjectTypeId get(next_data_object_type_id) build(|config: &GenesisConfig<T>|
+
 use crate::traits;
 use codec::{Codec, Decode, Encode};
 use rstd::prelude::*;

--- a/runtime-modules/storage/src/data_object_type_registry.rs
+++ b/runtime-modules/storage/src/data_object_type_registry.rs
@@ -150,7 +150,7 @@ decl_module! {
 
 impl<T: Trait> Module<T> {
     fn ensure_data_object_type(id: T::DataObjectTypeId) -> Result<DataObjectType, &'static str> {
-        return Self::data_object_types(&id).ok_or(MSG_DO_TYPE_NOT_FOUND);
+        Self::data_object_types(&id).ok_or(MSG_DO_TYPE_NOT_FOUND)
     }
 }
 

--- a/runtime-modules/token-minting/src/lib.rs
+++ b/runtime-modules/token-minting/src/lib.rs
@@ -1,3 +1,8 @@
+// Clippy linter warning
+#![allow(clippy::type_complexity)]
+// disable it because of possible frontend API break
+// TODO: remove post-Constaninople
+
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/runtime-modules/token-minting/src/lib.rs
+++ b/runtime-modules/token-minting/src/lib.rs
@@ -138,14 +138,13 @@ impl<T: Trait> Module<T> {
 
         // Ensure the next adjustment if set, is in the future
         if let Some(adjustment) = adjustment {
-            match adjustment {
-                Adjustment::IntervalAfterFirstAdjustmentAbsolute(_, first_adjustment_in) => {
-                    ensure!(
-                        first_adjustment_in > now,
-                        GeneralError::NextAdjustmentInPast
-                    );
-                }
-                _ => (),
+            if let Adjustment::IntervalAfterFirstAdjustmentAbsolute(_, first_adjustment_in) =
+                adjustment
+            {
+                ensure!(
+                    first_adjustment_in > now,
+                    GeneralError::NextAdjustmentInPast
+                );
             }
         }
 

--- a/runtime-modules/token-minting/src/mint.rs
+++ b/runtime-modules/token-minting/src/mint.rs
@@ -63,7 +63,7 @@ where
             capacity: initial_capacity,
             created_at: now,
             total_minted: Zero::zero(),
-            next_adjustment: next_adjustment,
+            next_adjustment,
         }
     }
 

--- a/runtime-modules/versioned-store/src/example.rs
+++ b/runtime-modules/versioned-store/src/example.rs
@@ -516,7 +516,7 @@ impl PropHelper {
     fn next_value(&mut self, value: PropertyValue) -> ClassPropertyValue {
         let value = ClassPropertyValue {
             in_class_index: self.prop_idx,
-            value: value,
+            value,
         };
         self.prop_idx += 1;
         value

--- a/runtime-modules/versioned-store/src/lib.rs
+++ b/runtime-modules/versioned-store/src/lib.rs
@@ -645,7 +645,7 @@ impl<T: Trait> Module<T> {
         Self::ensure_prop_value_matches_its_type(value.clone(), prop.clone())?;
         Self::ensure_valid_internal_prop(value.clone(), prop.clone())?;
         Self::validate_max_len_if_text_prop(value.clone(), prop.clone())?;
-        Self::validate_max_len_if_vec_prop(value.clone(), prop.clone())?;
+        Self::validate_max_len_if_vec_prop(value, prop)?;
         Ok(())
     }
 
@@ -674,7 +674,7 @@ impl<T: Trait> Module<T> {
             vec.len() <= max_len as usize
         }
 
-        fn validate_vec_len_ref<T>(vec: &Vec<T>, max_len: u16) -> bool {
+        fn validate_vec_len_ref<T>(vec: &[T], max_len: u16) -> bool {
             vec.len() <= max_len as usize
         }
 
@@ -702,7 +702,7 @@ impl<T: Trait> Module<T> {
                 Self::ensure_known_class_id(class_id)?;
                 if validate_vec_len_ref(&vec, vec_max_len) {
                     for entity_id in vec.iter() {
-                        Self::ensure_known_entity_id(entity_id.clone())?;
+                        Self::ensure_known_entity_id(*entity_id)?;
                         let entity = Self::entity_by_id(entity_id);
                         ensure!(entity.class_id == class_id, ERROR_INTERNAL_RPOP_DOES_NOT_MATCH_ITS_CLASS);
                     }
@@ -775,7 +775,7 @@ impl<T: Trait> Module<T> {
         }
     }
 
-    pub fn ensure_property_name_is_valid(text: &Vec<u8>) -> dispatch::Result {
+    pub fn ensure_property_name_is_valid(text: &[u8]) -> dispatch::Result {
         PropertyNameConstraint::get().ensure_valid(
             text.len(),
             ERROR_PROPERTY_NAME_TOO_SHORT,
@@ -783,7 +783,7 @@ impl<T: Trait> Module<T> {
         )
     }
 
-    pub fn ensure_property_description_is_valid(text: &Vec<u8>) -> dispatch::Result {
+    pub fn ensure_property_description_is_valid(text: &[u8]) -> dispatch::Result {
         PropertyDescriptionConstraint::get().ensure_valid(
             text.len(),
             ERROR_PROPERTY_DESCRIPTION_TOO_SHORT,
@@ -791,7 +791,7 @@ impl<T: Trait> Module<T> {
         )
     }
 
-    pub fn ensure_class_name_is_valid(text: &Vec<u8>) -> dispatch::Result {
+    pub fn ensure_class_name_is_valid(text: &[u8]) -> dispatch::Result {
         ClassNameConstraint::get().ensure_valid(
             text.len(),
             ERROR_CLASS_NAME_TOO_SHORT,
@@ -799,7 +799,7 @@ impl<T: Trait> Module<T> {
         )
     }
 
-    pub fn ensure_class_description_is_valid(text: &Vec<u8>) -> dispatch::Result {
+    pub fn ensure_class_description_is_valid(text: &[u8]) -> dispatch::Result {
         ClassDescriptionConstraint::get().ensure_valid(
             text.len(),
             ERROR_CLASS_DESCRIPTION_TOO_SHORT,

--- a/runtime-modules/versioned-store/src/mock.rs
+++ b/runtime-modules/versioned-store/src/mock.rs
@@ -148,7 +148,7 @@ pub fn bool_prop_value() -> ClassPropertyValue {
 pub fn prop_value(index: u16, value: PropertyValue) -> ClassPropertyValue {
     ClassPropertyValue {
         in_class_index: index,
-        value: value,
+        value,
     }
 }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '6.12.1'
+version = '6.12.2'
 
 [features]
 default = ['std']

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '6.12.0'
+version = '6.12.1'
 
 [features]
 default = ['std']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -127,7 +127,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 6,
     spec_version: 12,
-    impl_version: 0,
+    impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
 };
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -483,7 +483,7 @@ impl versioned_store_permissions::CredentialChecker<Runtime> for ContentWorkingG
                     }
                 }
 
-                return false;
+                false
             }
             // Any Active Channel Owner
             credential if credential == AnyActiveChannelOwnerCredential::get() => {
@@ -498,7 +498,7 @@ impl versioned_store_permissions::CredentialChecker<Runtime> for ContentWorkingG
                     }
                 }
 
-                return false;
+                false
             }
             // mapping to workging group principal id
             n if n >= PrincipalIdMappingStartsAtCredential::get() => {
@@ -737,7 +737,7 @@ impl roles::traits::Roles<Runtime> for LookupRoles {
             .filter(|id| !<discovery::Module<Runtime>>::is_account_info_expired(id))
             .collect();
 
-        if live_ids.len() == 0 {
+        if live_ids.is_empty() {
             Err("no staked account found")
         } else {
             let index = random_index(live_ids.len());
@@ -841,7 +841,7 @@ impl Default for Call {
 
 parameter_types! {
     pub const ProposalMaxPostEditionNumber: u32 = 0; // post update is disabled
-    pub const ProposalMaxThreadInARowNumber: u32 = 100000; // will not be used
+    pub const ProposalMaxThreadInARowNumber: u32 = 100_000; // will not be used
     pub const ProposalThreadTitleLengthLimit: u32 = 40;
     pub const ProposalPostLengthLimit: u32 = 1000;
 }

--- a/runtime/src/migration.rs
+++ b/runtime/src/migration.rs
@@ -1,3 +1,6 @@
+// Clippy linter warning
+#![allow(clippy::redundant_closure_call)] // disable it because of the substrate lib design
+
 use crate::VERSION;
 use sr_primitives::{print, traits::Zero};
 use srml_support::{decl_event, decl_module, decl_storage};

--- a/utils/chain-spec-builder/src/main.rs
+++ b/utils/chain-spec-builder/src/main.rs
@@ -152,11 +152,11 @@ fn generate_chain_spec(
         None, // Default::default(),
     );
 
-    chain_spec.to_json(false).map_err(|err| err.to_string())
+    chain_spec.to_json(false).map_err(|err| err)
 }
 
 fn generate_authority_keys_and_store(seeds: &[String], keystore_path: &Path) -> Result<(), String> {
-    for (n, seed) in seeds.into_iter().enumerate() {
+    for (n, seed) in seeds.iter().enumerate() {
         let keystore = Keystore::open(keystore_path.join(format!("auth-{}", n)), None)
             .map_err(|err| err.to_string())?;
 


### PR DESCRIPTION
## Notes
- this PR contains a lot of different [clippy](https://github.com/rust-lang/rust-clippy/) linter fixes.
- travis.yml file was modified to support mandatory lint checks.
- some lints were disabled because they are not compatible with Substrate macros design.
- clippy install command: `rustup component add clippy`
- to run clippy locally use `BUILD_DUMMY_WASM_BINARY=1 cargo clippy`