### PR TITLE
Git hooks management with husky

### DIFF
--- a/devops/git-hooks/pre-commit
+++ b/devops/git-hooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+echo 'cargo fmt --all -- --check'
+cargo fmt --all -- --check

--- a/devops/git-hooks/pre-push
+++ b/devops/git-hooks/pre-push
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+export BUILD_DUMMY_WASM_BINARY=1
+
+echo '+cargo test --all'
+cargo test --all
+
+echo '+cargo clippy --all -- -D warnings'
+cargo clippy --all -- -D warnings

--- a/package.json
+++ b/package.json
@@ -7,5 +7,14 @@
 	},
 	"workspaces": [
 		"tests/network-tests"
-	]
+	],
+	"devDependencies": {
+		"husky": "^4.2.5"
+	},
+	"husky": {
+	  "hooks": {
+		"pre-commit": "devops/git-hooks/pre-commit",
+		"pre-push": "devops/git-hooks/pre-push"
+	  }
+	}
 }

--- a/setup.sh
+++ b/setup.sh
@@ -7,8 +7,9 @@ set -e
 #  - rustup - rust insaller
 #  - rust compiler and toolchains
 #  - skips installing substrate and subkey
-curl https://getsubstrate.io -sSf | bash -s -- --fast \
-    && rustup component add rustfmt
+curl https://getsubstrate.io -sSf | bash -s -- --fast
+
+rustup component add rustfmt clippy
 
 # TODO: Install additional tools...
 # - b2sum


### PR DESCRIPTION
Manage git hooks with [Husky](https://github.com/typicode/husky)

After trying two other approaches [custom scritps](https://github.com/mnaamani/joystream/commit/08e13cf425b989d43063710099b33fc8dfab1b74) and [using cargo husky](https://github.com/mnaamani/joystream/commit/ac2ae026d7953ab385cbd9559fefc28b0030397f) which depends on [cargo-husky](https://github.com/rhysd/cargo-husky) I found that Husky is the best choice for our repository, which has multiple project types (cargo and yarn workspaces) and gives the most control.

To install husky just run yarn to install dependencies.

The hook scripts are in `/devops/git-hooks` 

In this PR there is a pre-commit hook which will make sure only rustfmt formatted code will be committed, and a pre-push hook which will run the cargo unit tests and linter before pushing code.

See the [documentation](https://github.com/typicode/husky) for information on how to configure husky.