### PR TITLE
Export proposals constants in the API metadata

### DIFF
--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -340,6 +340,12 @@ decl_module! {
         /// Predefined errors
         type Error = Error;
 
+        /// Exports max allowed text proposal length const.
+        const TextProposalMaxLength: u32 = T::TextProposalMaxLength::get();
+
+        /// Exports max wasm code length of the runtime upgrade proposal const.
+        const RuntimeUpgradeWasmProposalMaxLength: u32 = T::RuntimeUpgradeWasmProposalMaxLength::get();
+
         /// Create 'Text (signal)' proposal type.
         pub fn create_text_proposal(
             origin,

--- a/runtime-modules/proposals/discussion/src/lib.rs
+++ b/runtime-modules/proposals/discussion/src/lib.rs
@@ -190,6 +190,18 @@ decl_module! {
         /// Emits an event. Default substrate implementation.
         fn deposit_event() = default;
 
+        /// Exports post edition number limit const.
+        const MaxPostEditionNumber: u32 = T::MaxPostEditionNumber::get();
+
+        /// Exports thread title length limit const.
+        const ThreadTitleLengthLimit: u32 = T::ThreadTitleLengthLimit::get();
+
+        /// Exports post length limit const.
+        const PostLengthLimit: u32 = T::PostLengthLimit::get();
+
+        /// Exports max thread by same author in a row number limit const.
+        const MaxThreadInARowNumber: u32 = T::MaxThreadInARowNumber::get();
+
         /// Adds a post with author origin check.
         pub fn add_post(
             origin,

--- a/runtime-modules/proposals/engine/src/lib.rs
+++ b/runtime-modules/proposals/engine/src/lib.rs
@@ -315,6 +315,21 @@ decl_module! {
         /// Emits an event. Default substrate implementation.
         fn deposit_event() = default;
 
+        /// Exports const - the fee is applied when cancel the proposal. A fee would be slashed (burned).
+        const CancellationFee: BalanceOf<T> = T::CancellationFee::get();
+
+        /// Exports const -  the fee is applied when the proposal gets rejected. A fee would be slashed (burned).
+        const RejectionFee: BalanceOf<T> = T::RejectionFee::get();
+
+        /// Exports const -  max allowed proposal title length.
+        const TitleMaxLength: u32 = T::TitleMaxLength::get();
+
+        /// Exports const -  max allowed proposal description length.
+        const DescriptionMaxLength: u32 = T::DescriptionMaxLength::get();
+
+        /// Exports const -  max simultaneous active proposals number.
+        const MaxActiveProposalLimit: u32 = T::MaxActiveProposalLimit::get();
+
         /// Vote extrinsic. Conditions:  origin must allow votes.
         pub fn vote(origin, voter_id: MemberId<T>, proposal_id: T::ProposalId, vote: VoteKind)  {
             T::VoterOriginValidator::ensure_actor_origin(


### PR DESCRIPTION
Constants were exported for all proposals modules: engine, discussions, codex.