### PR TITLE
Update min_actors from RoleParameters

### DIFF
--- a/runtime-modules/roles/src/actors.rs
+++ b/runtime-modules/roles/src/actors.rs
@@ -67,7 +67,7 @@ impl<Balance: From<u32>, BlockNumber: From<u32>> Default for RoleParameters<Bala
             entry_request_fee: Balance::from(50),
 
             // not currently used
-            min_actors: 5,
+            min_actors: 1,
             bonding_period: BlockNumber::from(600),
             min_service_period: BlockNumber::from(600),
             startup_grace_period: BlockNumber::from(600),


### PR DESCRIPTION
Set the min_actors value to “1” because of the new requirements.

All values can be found [here](https://github.com/Joystream/joystream/issues/235).