### PR TITLE
Increase the MaximumBlockWeight

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -176,7 +176,7 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
     pub const BlockHashCount: BlockNumber = 250;
-    pub const MaximumBlockWeight: Weight = 1_000_000;
+    pub const MaximumBlockWeight: Weight = 1_000_000_000;
     pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
     pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
     pub const Version: RuntimeVersion = VERSION;


### PR DESCRIPTION
The maximum block weight was too small. 
This explains the issue https://github.com/Joystream/joystream/issues/260 being identified.

The issue wasn't as serious since most of joystream's extrinsics are not weighted

This PR Increases the MaximumBlockWeight, to be 1000x times larger - this allows approximately  750 balances::transfer transactions per block.