### PR TITLE
Add back Pioneer build check

### DIFF
--- a/.github/workflows/pioneer-pr.yml
+++ b/.github/workflows/pioneer-pr.yml
@@ -1,0 +1,37 @@
+name: Pioneer-PR
+on: [pull_request]
+
+jobs:
+  pioneer_build_code:
+    name: Pioneer Build Code
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: build
+      run: |
+        yarn install --frozen-lockfile
+        yarn workspace pioneer run build:code
+
+  pioneer_build_i18n:
+    name: Pioneer Build i18n
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: build
+      run: |
+        yarn install --frozen-lockfile
+        yarn workspace pioneer run build:i18n

--- a/.github/workflows/pioneer-pr.yml
+++ b/.github/workflows/pioneer-pr.yml
@@ -1,5 +1,5 @@
 name: Pioneer-PR
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   pioneer_build_code:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"test": "yarn && yarn workspaces run test",
 		"test-migration": "yarn && yarn workspaces run test-migration",
 		"postinstall": "yarn workspace @joystream/types build",
-    "cargo-checks": "devops/git-hooks/pre-commit && devops/git-hooks/pre-push",
+		"cargo-checks": "devops/git-hooks/pre-commit && devops/git-hooks/pre-push",
 		"cargo-build": "scripts/cargo-build.sh"
 	},
 	"workspaces": [


### PR DESCRIPTION
Ported the github actions from `pioneer/.github/workflows` excluding the linter actions, and deploy to gh pages from masrer branch.

The checks aren't running as part of this PR yet, I think because the workflows need to be already merged into the repo.