### PR TITLE
Make PP and ToS routes work again

### DIFF
--- a/pioneer/packages/apps-routing/src/index.ts
+++ b/pioneer/packages/apps-routing/src/index.ts
@@ -14,7 +14,7 @@ import members from './joy-members';
 import proposals from './joy-proposals';
 import roles from './joy-roles';
 import storageRoles from './joy-storage';
-// import pages from './joy-pages';
+import pages from './joy-pages';
 
 // import template from './123code';
 import accounts from './accounts';
@@ -73,7 +73,8 @@ if (appSettings.isFullMode) {
 }
 
 routes = routes.concat(
-  settings
+  settings,
+  pages
 );
 
 const setup: Routing = {

--- a/pioneer/packages/apps-routing/src/joy-pages.ts
+++ b/pioneer/packages/apps-routing/src/joy-pages.ts
@@ -5,7 +5,9 @@ import { ToS, Privacy } from '@polkadot/joy-pages/index';
 export default ([
   {
     Component: ToS,
-    display: {},
+    display: {
+      isHidden: true
+    },
     i18n: {
       defaultValue: 'Terms of Service'
     },
@@ -14,7 +16,9 @@ export default ([
   },
   {
     Component: Privacy,
-    display: {},
+    display: {
+      isHidden: true
+    },
     i18n: {
       defaultValue: 'Privacy Policy'
     },


### PR DESCRIPTION
This PR fixes a bug with `Privacy Policy` and `Terms of Service` links not working on member register page, due to the fact that those routes has been mistakenly removed while we only wanted to remove the tabs from the sidebar.