### PR TITLE
Rename discussion module types.

### DIFF
--- a/runtime-modules/proposals/discussion/src/lib.rs
+++ b/runtime-modules/proposals/discussion/src/lib.rs
@@ -56,7 +56,7 @@ use rstd::vec::Vec;
 use srml_support::{decl_error, decl_event, decl_module, decl_storage, ensure, Parameter};
 
 use srml_support::traits::Get;
-use types::{Post, Thread, ThreadCounter};
+use types::{DiscussionPost, DiscussionThread, ThreadCounter};
 
 use common::origin_validator::ActorOriginValidator;
 use srml_support::dispatch::DispatchResult;
@@ -163,14 +163,14 @@ decl_storage! {
     pub trait Store for Module<T: Trait> as ProposalDiscussion {
         /// Map thread identifier to corresponding thread.
         pub ThreadById get(thread_by_id): map T::ThreadId =>
-            Thread<MemberId<T>, T::BlockNumber>;
+            DiscussionThread<MemberId<T>, T::BlockNumber>;
 
         /// Count of all threads that have been created.
         pub ThreadCount get(fn thread_count): u64;
 
         /// Map thread id and post id to corresponding post.
         pub PostThreadIdByPostId: double_map T::ThreadId, twox_128(T::PostId) =>
-             Post<MemberId<T>, T::BlockNumber, T::ThreadId>;
+             DiscussionPost<MemberId<T>, T::BlockNumber, T::ThreadId>;
 
         /// Count of all posts that have been created.
         pub PostCount get(fn post_count): u64;
@@ -226,7 +226,7 @@ decl_module! {
             let next_post_count_value = Self::post_count() + 1;
             let new_post_id = next_post_count_value;
 
-            let new_post = Post {
+            let new_post = DiscussionPost {
                 text,
                 created_at: Self::current_block(),
                 updated_at: Self::current_block(),
@@ -269,7 +269,7 @@ decl_module! {
             ensure!(post.edition_number < T::MaxPostEditionNumber::get(),
                 Error::PostEditionNumberExceeded);
 
-            let new_post = Post {
+            let new_post = DiscussionPost {
                 text,
                 updated_at: Self::current_block(),
                 edition_number: post.edition_number + 1,
@@ -296,7 +296,7 @@ impl<T: Trait> Module<T> {
         let next_thread_count_value = Self::thread_count() + 1;
         let new_thread_id = next_thread_count_value;
 
-        let new_thread = Thread {
+        let new_thread = DiscussionThread {
             title,
             created_at: Self::current_block(),
             author_id: thread_author_id,

--- a/runtime-modules/proposals/discussion/src/tests/mod.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mod.rs
@@ -37,7 +37,7 @@ fn assert_thread_content(thread_entry: TestThreadEntry, post_entries: Vec<TestPo
     assert!(<ThreadById<Test>>::exists(thread_entry.thread_id));
 
     let actual_thread = <ThreadById<Test>>::get(thread_entry.thread_id);
-    let expected_thread = Thread {
+    let expected_thread = DiscussionThread {
         title: thread_entry.title,
         created_at: 1,
         author_id: 1,
@@ -47,7 +47,7 @@ fn assert_thread_content(thread_entry: TestThreadEntry, post_entries: Vec<TestPo
     for post_entry in post_entries {
         let actual_post =
             <PostThreadIdByPostId<Test>>::get(thread_entry.thread_id, post_entry.post_id);
-        let expected_post = Post {
+        let expected_post = DiscussionPost {
             text: post_entry.text,
             created_at: 1,
             updated_at: 1,

--- a/runtime-modules/proposals/discussion/src/types.rs
+++ b/runtime-modules/proposals/discussion/src/types.rs
@@ -9,7 +9,7 @@ use rstd::prelude::*;
 /// Represents a discussion thread
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq)]
-pub struct Thread<ThreadAuthorId, BlockNumber> {
+pub struct DiscussionThread<ThreadAuthorId, BlockNumber> {
     /// Title
     pub title: Vec<u8>,
 
@@ -23,7 +23,7 @@ pub struct Thread<ThreadAuthorId, BlockNumber> {
 /// Post for the discussion thread
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq)]
-pub struct Post<PostAuthorId, BlockNumber, ThreadId> {
+pub struct DiscussionPost<PostAuthorId, BlockNumber, ThreadId> {
     /// Text
     pub text: Vec<u8>,
 


### PR DESCRIPTION
Rename Post and Thread types from the discussion module to prevent name interference with forum types. The current Substrate doesn't support namespaces on the frontend part.