### PR TITLE
Runtime v6.14.0 and joystream-node v2.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "ctrlc",
  "derive_more 0.14.1",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "6.13.0"
+version = "6.14.0"
 dependencies = [
  "parity-scale-codec",
  "safe-mix",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '2.2.0'
+version = '2.3.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -1,8 +1,12 @@
+### Version 6.14.0 - Constantinople runtime upgrade A - June 2020
+- Updated runtime to sort out type name clashes between the proposal discussion module
+and forum module, in preparing to roll out proposal discussion system in pioneer.
+
 ### Version 6.13.0 - (Constantinople) runtime upgrade - May 20th 2020
 - New proposal system that strengthens the governance structure of the platform
 - Adjusted inflation curve to better reflect a new realistic economic system for the platform
 
-### Version 6.8.0 (Rome release) - March 9th 2020
+### Version 6.8.0 (Rome release - new chain) - March 9th 2020
 - New versioned and permissioned content mangement system that powers a new media experience.
 - Content Working Group - introduces staked content curator roles to maintain quality of content and ensure that is meets the platform's terms of service.
 - Update of core substrate to pre-release of version 2.0 - [c37bb08](https://github.com/paritytech/substrate/commit/c37bb08535c49a12320af7facfd555ce05cce2e8)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '6.13.0'
+version = '6.14.0'
 
 [features]
 default = ['std']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -142,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 6,
-    spec_version: 13,
+    spec_version: 14,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
 };


### PR DESCRIPTION
Assuming this is the last runtime change for the next release, setting version numbers