### PR TITLE
Fix CLI data directory issue

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -19,6 +19,7 @@
     "cli-ux": "^5.4.5",
     "inquirer": "^7.1.0",
     "moment": "^2.24.0",
+    "platform-folders": "^0.5.1",
     "proper-lockfile": "^4.1.1",
     "slug": "^2.1.1",
     "tslib": "^1.11.1"
@@ -26,6 +27,7 @@
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",
     "@oclif/test": "^1.2.5",
+    "@polkadot/ts": "^0.1.56",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.18",
@@ -37,8 +39,7 @@
     "mocha": "^5.2.0",
     "nyc": "^14.1.1",
     "ts-node": "^8.8.2",
-    "typescript": "^3.8.3",
-    "@polkadot/ts": "^0.1.56"
+    "typescript": "^3.8.3"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -19,7 +19,6 @@
     "cli-ux": "^5.4.5",
     "inquirer": "^7.1.0",
     "moment": "^2.24.0",
-    "platform-folders": "^0.5.1",
     "proper-lockfile": "^4.1.1",
     "slug": "^2.1.1",
     "tslib": "^1.11.1"

--- a/cli/src/base/AccountsCommandBase.ts
+++ b/cli/src/base/AccountsCommandBase.ts
@@ -18,12 +18,12 @@ const SPECIAL_ACCOUNT_POSTFIX = '__DEV';
  * Abstract base class for account-related commands.
  *
  * All the accounts available in the CLI are stored in the form of json backup files inside:
- * { this.config.dataDir }/{ ACCOUNTS_DIRNAME } (ie. ~/.local/share/joystream-cli/accounts on Ubuntu)
- * Where: this.config.dataDir is provided by oclif and ACCOUNTS_DIRNAME is a const (see above).
+ * { APP_DATA_PATH }/{ ACCOUNTS_DIRNAME } (ie. ~/.local/share/joystream-cli/accounts on Ubuntu)
+ * Where: APP_DATA_PATH is provided by StateAwareCommandBase and ACCOUNTS_DIRNAME is a const (see above).
  */
 export default abstract class AccountsCommandBase extends ApiCommandBase {
     getAccountsDirPath(): string {
-        return path.join(this.config.dataDir, ACCOUNTS_DIRNAME);
+        return path.join(this.getAppDataPath(), ACCOUNTS_DIRNAME);
     }
 
     getAccountFilePath(account: NamedKeyringPair, isSpecial: boolean = false): string {

--- a/cli/src/base/StateAwareCommandBase.ts
+++ b/cli/src/base/StateAwareCommandBase.ts
@@ -42,7 +42,7 @@ export default abstract class StateAwareCommandBase extends DefaultCommandBase {
             process.env.APPDATA ||
             (
                 process.platform === 'darwin'
-                    ? path.join(os.homedir(), '/Library/Preferences')
+                    ? path.join(os.homedir(), '/Library/Application Support')
                     : path.join(os.homedir(), '/.local/share')
             );
         const packageJson: { name?: string } = require('../../package.json');

--- a/cli/src/base/StateAwareCommandBase.ts
+++ b/cli/src/base/StateAwareCommandBase.ts
@@ -5,7 +5,7 @@ import { CLIError } from '@oclif/errors';
 import { DEFAULT_API_URI } from '../Api';
 import lockFile from 'proper-lockfile';
 import DefaultCommandBase from './DefaultCommandBase';
-import { getDataHome } from 'platform-folders';
+import os from 'os';
 
 // Type for the state object (which is preserved as json in the state file)
 type StateObject = {
@@ -32,17 +32,24 @@ enum DataDirErrorType {
 /**
  * Abstract base class for commands that need to work with the preserved state.
  *
- * The preserved state is kept in a json file inside the data directory (created with the support of platform-folders package).
+ * The preserved state is kept in a json file inside the data directory.
  * The state object contains all the information that needs to be preserved across sessions, ie. the default account
  * choosen by the user after executing account:choose command etc. (see "StateObject" type above).
  */
 export default abstract class StateAwareCommandBase extends DefaultCommandBase {
     getAppDataPath(): string {
+        const systemAppDataPath =
+            process.env.APPDATA ||
+            (
+                process.platform === 'darwin'
+                    ? path.join(os.homedir(), '/Library/Preferences')
+                    : path.join(os.homedir(), '/.local/share')
+            );
         const packageJson: { name?: string } = require('../../package.json');
         if (!packageJson || !packageJson.name) {
             throw new CLIError('Cannot get package name from package.json!');
         }
-        return path.join(getDataHome(), packageJson.name);
+        return path.join(systemAppDataPath, packageJson.name);
     }
 
     getStateFilePath(): string {

--- a/cli/src/base/StateAwareCommandBase.ts
+++ b/cli/src/base/StateAwareCommandBase.ts
@@ -5,6 +5,7 @@ import { CLIError } from '@oclif/errors';
 import { DEFAULT_API_URI } from '../Api';
 import lockFile from 'proper-lockfile';
 import DefaultCommandBase from './DefaultCommandBase';
+import { getDataHome } from 'platform-folders';
 
 // Type for the state object (which is preserved as json in the state file)
 type StateObject = {
@@ -18,7 +19,7 @@ const DEFAULT_STATE: StateObject = {
     apiUri: DEFAULT_API_URI
 }
 
-// State file path (relative to this.config.dataDir)
+// State file path (relative to getAppDataPath())
 const STATE_FILE = '/state.json';
 
 // Possible data directory access errors
@@ -31,13 +32,21 @@ enum DataDirErrorType {
 /**
  * Abstract base class for commands that need to work with the preserved state.
  *
- * The preserved state is kept in a json file inside the data directory (this.config.dataDir, supplied by oclif).
+ * The preserved state is kept in a json file inside the data directory (created with the support of platform-folders package).
  * The state object contains all the information that needs to be preserved across sessions, ie. the default account
  * choosen by the user after executing account:choose command etc. (see "StateObject" type above).
  */
 export default abstract class StateAwareCommandBase extends DefaultCommandBase {
+    getAppDataPath(): string {
+        const packageJson: { name?: string } = require('../../package.json');
+        if (!packageJson || !packageJson.name) {
+            throw new CLIError('Cannot get package name from package.json!');
+        }
+        return path.join(getDataHome(), packageJson.name);
+    }
+
     getStateFilePath(): string {
-        return path.join(this.config.dataDir, STATE_FILE);
+        return path.join(this.getAppDataPath(), STATE_FILE);
     }
 
     private createDataDirFsError(errorType: DataDirErrorType, specificPath: string = '') {
@@ -49,7 +58,7 @@ export default abstract class StateAwareCommandBase extends DefaultCommandBase {
 
         const errorMsg =
             `Unexpected error while trying to ${ actionStrs[errorType] } the data directory.`+
-            `(${ path.join(this.config.dataDir, specificPath) })! Permissions issue?`;
+            `(${ path.join(this.getAppDataPath(), specificPath) })! Permissions issue?`;
 
         return new CLIError(errorMsg, { exit: ExitCodes.FsOperationFailed });
     }
@@ -67,8 +76,8 @@ export default abstract class StateAwareCommandBase extends DefaultCommandBase {
     }
 
     private initStateFs(): void {
-        if (!fs.existsSync(this.config.dataDir)) {
-            fs.mkdirSync(this.config.dataDir);
+        if (!fs.existsSync(this.getAppDataPath())) {
+            fs.mkdirSync(this.getAppDataPath());
         }
         if (!fs.existsSync(this.getStateFilePath())) {
             fs.writeFileSync(this.getStateFilePath(), JSON.stringify(DEFAULT_STATE));

--- a/yarn.lock
+++ b/yarn.lock
@@ -16332,6 +16332,13 @@ pkg-up@2.0.0, pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+platform-folders@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/platform-folders/-/platform-folders-0.5.1.tgz#303611a2e3adbb00f62c65eae80b312449e1cd4f"
+  integrity sha512-XIB+R/hDzDKNIQQx6KWWWUFKvkCDZlzM7JCqmER0/gccRehKfxjDC7cKTdRj5PCGXP4xAv2+FdbQ1/wepbuF1g==
+  dependencies:
+    bindings "^1.5.0"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -21269,10 +21276,15 @@ typescript-formatter@^7.2.2:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
 
-typescript@3.7.2, typescript@3.7.x, typescript@^3.0.3, typescript@^3.6.4, typescript@^3.7.2, typescript@^3.8.3:
+typescript@3.7.2, typescript@3.7.x, typescript@^3.0.3, typescript@^3.6.4, typescript@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+
+typescript@^3.8.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 u2f-api@0.2.7:
   version "0.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16332,13 +16332,6 @@ pkg-up@2.0.0, pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-platform-folders@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/platform-folders/-/platform-folders-0.5.1.tgz#303611a2e3adbb00f62c65eae80b312449e1cd4f"
-  integrity sha512-XIB+R/hDzDKNIQQx6KWWWUFKvkCDZlzM7JCqmER0/gccRehKfxjDC7cKTdRj5PCGXP4xAv2+FdbQ1/wepbuF1g==
-  dependencies:
-    bindings "^1.5.0"
-
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -21276,15 +21269,10 @@ typescript-formatter@^7.2.2:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
 
-typescript@3.7.2, typescript@3.7.x, typescript@^3.0.3, typescript@^3.6.4, typescript@^3.7.2:
+typescript@3.7.2, typescript@3.7.x, typescript@^3.0.3, typescript@^3.6.4, typescript@^3.7.2, typescript@^3.8.3:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
-
-typescript@^3.8.3:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
-  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 u2f-api@0.2.7:
   version "0.2.7"


### PR DESCRIPTION
This PR is an attempt to fix: https://github.com/Joystream/joystream/issues/542

Instead of relying on OCLIF to provide the right appData directory I decided to use a package called `platform-folders` (https://www.npmjs.com/package/platform-folders).

It should now use correct data directory based on the platform, ie.:
- `/home/<Username>/.local/share` (Linux)
- `c:\Users\<Username>\AppData\Roaming` (Windows)
- `/Users/<Username>/Library/Application Support` (Mac OS)