### PR TITLE
Query node CLI build fix

### DIFF
--- a/query-node/substrate-query-framework/cli/package.json
+++ b/query-node/substrate-query-framework/cli/package.json
@@ -67,6 +67,7 @@
   },
   "repository": "joystream/joystream/joystream-query-node/cli",
   "scripts": {
+    "build": "tsc --build tsconfig.json",
     "postpack": "rm -f oclif.manifest.json",
     "lint": "eslint . --cache --ext .ts --config .eslintrc.js",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",

--- a/query-node/substrate-query-framework/cli/tsconfig.json
+++ b/query-node/substrate-query-framework/cli/tsconfig.json
@@ -4,7 +4,7 @@
     "importHelpers": true,
     "module": "commonjs",
     "outDir": "lib",
-    "rootDir": ".",
+    "rootDir": "./src",
     "strict": true,
     "target": "es2017",
     "esModuleInterop": true,

--- a/query-node/substrate-query-framework/cli/tsconfig.json
+++ b/query-node/substrate-query-framework/cli/tsconfig.json
@@ -9,7 +9,10 @@
     "target": "es2017",
     "esModuleInterop": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "typeRoots": [
+        "./src/node_modules/@types"
+    ] 
   },
-  "include": ["./**/*.ts"]
+  "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
This PR adds a `build` target to `package.json` and  adds necessary settings to `tsconfig.json` so that after the build the command files land under `lib/commands` and oclif picks them up.