### PR TITLE
Introduce new features

### DIFF
--- a/query-node/substrate-query-framework/cli/package.json
+++ b/query-node/substrate-query-framework/cli/package.json
@@ -20,7 +20,7 @@
     "mustache": "^4.0.1",
     "tslib": "1.11.2",
     "typeorm-model-generator": "^0.4.2",
-    "warthog": "^2.9.1"
+    "warthog": "https://github.com/metmirr/warthog/releases/download/v2.9.7/warthog-v2.9.7.tgz"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",

--- a/query-node/substrate-query-framework/cli/src/helpers/ModelCodeGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/helpers/ModelCodeGenerator.ts
@@ -1,8 +1,9 @@
-import { ObjectTypeDefinitionNode, FieldDefinitionNode, ListTypeNode, NamedTypeNode, DirectiveNode, ArgumentNode, StringValueNode } from 'graphql';
+import { ObjectTypeDefinitionNode, FieldDefinitionNode, ListTypeNode, NamedTypeNode } from 'graphql';
 import { GraphQLSchemaParser, Visitors, SchemaNode } from './SchemaParser';
 import { WarthogModel, Field, ObjectType } from '../model';
 import Debug from 'debug';
 import { DIRECTIVES } from './SchemaDirective';
+import { ENTITY_DIRECTIVE } from './constant'
 
 const debug = Debug('qnode-cli:model-generator');
 
@@ -62,6 +63,15 @@ export class DatabaseModelCodeGenerator {
     return field;
   }
 
+  /**
+   * Mark the object type as entity if '@entity' directive is used
+   * @param o ObjectTypeDefinitionNode
+   */
+  private isEntity(o: ObjectTypeDefinitionNode): boolean {
+    const entityDirective = o.directives?.find(d => d.name.value === ENTITY_DIRECTIVE)
+    return entityDirective ? true : false
+  }
+
 
   /**
    * Generate a new ObjectType from ObjectTypeDefinitionNode
@@ -92,7 +102,7 @@ export class DatabaseModelCodeGenerator {
 
     debug(`Read and parsed fields: ${JSON.stringify(fields, null, 2)}`)
 
-    return { name: o.name.value, fields: fields } as ObjectType;
+    return { name: o.name.value, fields: fields, isEntity: this.isEntity(o) } as ObjectType;
   }
 
   generateWarthogModel(): WarthogModel {

--- a/query-node/substrate-query-framework/cli/src/helpers/ModelCodeGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/helpers/ModelCodeGenerator.ts
@@ -3,7 +3,7 @@ import { GraphQLSchemaParser, Visitors, SchemaNode } from './SchemaParser';
 import { WarthogModel, Field, ObjectType } from '../model';
 import Debug from 'debug';
 import { DIRECTIVES } from './SchemaDirective';
-import { ENTITY_DIRECTIVE } from './constant'
+import { ENTITY_DIRECTIVE } from './constant';
 
 const debug = Debug('qnode-cli:model-generator');
 
@@ -28,24 +28,23 @@ export class DatabaseModelCodeGenerator {
     return !this._schemaParser.getTypeNames().includes(type);
   }
 
-  // NOT IMPLEMENTED YET!
-  private _listType(fieldNode: FieldDefinitionNode): Field {
-    const typeNode = fieldNode.type as ListTypeNode;
+  private _listType(typeNode: ListTypeNode, fieldName: string): Field {
+    let field: Field;
 
-    const field = new Field(fieldNode.name.value, '');
-
-    if (typeNode.type.kind === 'NamedType') {
-      field.type = typeNode.type.name.value;
-      field.nullable = true;
+    if (typeNode.type.kind === 'ListType') {
+      throw new Error('Only one level lists are allowed');
+    } else if (typeNode.type.kind === 'NamedType') {
+      field = this._namedType(fieldName, typeNode.type);
       field.isList = true;
-    } else if (typeNode.type.kind === 'NonNullType') {
-      if (typeNode.type.type.kind === 'NamedType') {
-        field.type = typeNode.type.type.name.value;
-        field.nullable = false;
-      }
     } else {
-      // It is a list
+      if (typeNode.type.type.kind === 'ListType') {
+        throw new Error('Only one level lists are allowed');
     }
+      field = this._namedType(fieldName, typeNode.type.type);
+      field.nullable = false;
+    }
+
+    field.isList = true;
     field.isBuildinType = this._isBuildinType(field.type);
     return field;
   }
@@ -68,10 +67,9 @@ export class DatabaseModelCodeGenerator {
    * @param o ObjectTypeDefinitionNode
    */
   private isEntity(o: ObjectTypeDefinitionNode): boolean {
-    const entityDirective = o.directives?.find(d => d.name.value === ENTITY_DIRECTIVE)
-    return entityDirective ? true : false
+    const entityDirective = o.directives?.find((d) => d.name.value === ENTITY_DIRECTIVE);
+    return entityDirective ? true : false;
   }
-
 
   /**
    * Generate a new ObjectType from ObjectTypeDefinitionNode
@@ -85,22 +83,21 @@ export class DatabaseModelCodeGenerator {
       if (typeNode.kind === 'NamedType') {
         return this._namedType(fieldName, typeNode);
       } else if (typeNode.kind === 'NonNullType') {
-        if (typeNode.type.kind === 'NamedType') {
-          // It is named type. and nullable will be set false
-          const field = this._namedType(fieldName, typeNode.type);
+        const field =
+          typeNode.type.kind === 'NamedType'
+            ? this._namedType(fieldName, typeNode.type)
+            : this._listType(typeNode.type, fieldName);
+
           field.nullable = false;
           return field;
-        } else {
-          throw new Error('ListType is not supported yet.');
-        }
       } else if (typeNode.kind === 'ListType') {
-        throw new Error('ListType is not supported yet.');
+        return this._listType(typeNode, fieldName);
       } else {
         throw new Error(`Unrecognized type. ${JSON.stringify(typeNode, null, 2)}`);
       }
     });
 
-    debug(`Read and parsed fields: ${JSON.stringify(fields, null, 2)}`)
+    debug(`Read and parsed fields: ${JSON.stringify(fields, null, 2)}`);
 
     return { name: o.name.value, fields: fields, isEntity: this.isEntity(o) } as ObjectType;
   }

--- a/query-node/substrate-query-framework/cli/src/helpers/SchemaParser.ts
+++ b/query-node/substrate-query-framework/cli/src/helpers/SchemaParser.ts
@@ -12,17 +12,9 @@ import * as fs from 'fs-extra';
 import Debug from "debug";
 import { cloneDeep } from 'lodash';
 import { DIRECTIVES } from './SchemaDirective'
+import { SCHEMA_DEFINITIONS_PREAMBLE } from './constant';
 
 const debug = Debug('qnode-cli:schema-parser');
-
-
-// this preamble is added to the schema 
-// in order to pass the SDL validation
-const SCHEMA_DEFINITIONS_PREAMBLE = `
-type Query {
-    _dummy: String # empty queries are not allowed
-}
-`
 
 export type SchemaNode = ObjectTypeDefinitionNode | FieldDefinitionNode | DirectiveNode;
 

--- a/query-node/substrate-query-framework/cli/src/helpers/constant.ts
+++ b/query-node/substrate-query-framework/cli/src/helpers/constant.ts
@@ -11,3 +11,5 @@ type Query {
     _dummy: String           # empty queries are not allowed
 }
 `
+
+export const ENTITY_DIRECTIVE = 'entity'

--- a/query-node/substrate-query-framework/cli/src/helpers/constant.ts
+++ b/query-node/substrate-query-framework/cli/src/helpers/constant.ts
@@ -1,0 +1,13 @@
+/**
+ * This preamble is added to the schema in order to pass the SDL validation
+ * Add additional scalar types and directives to the schema
+ */
+export const SCHEMA_DEFINITIONS_PREAMBLE = `
+directive @entity on OBJECT  # Make type defination entity
+scalar BigInt                # Arbitrarily large integers
+scalar BigDecimal            # is used to represent arbitrary precision decimals
+scalar Bytes                 # Byte array, represented as a hexadecimal string
+type Query {
+    _dummy: String           # empty queries are not allowed
+}
+`

--- a/query-node/substrate-query-framework/cli/src/model/ScalarTypes.ts
+++ b/query-node/substrate-query-framework/cli/src/model/ScalarTypes.ts
@@ -1,0 +1,16 @@
+export interface ScalarType {
+  [name: string]: string;
+}
+
+// Supported built-in scalar types and corressponding warthog type
+export const availableTypes: ScalarType = {
+  ID: '', // store as a string
+  String: '',
+  Int: 'int',
+  Boolean: 'bool',
+  Date: 'date',
+  Float: 'float',
+  BigInt: 'numeric',
+  BigDecimal: 'decimal',
+  Bytes: 'bytes'
+};

--- a/query-node/substrate-query-framework/cli/src/model/ScalarTypes.ts
+++ b/query-node/substrate-query-framework/cli/src/model/ScalarTypes.ts
@@ -4,13 +4,13 @@ export interface ScalarType {
 
 // Supported built-in scalar types and corressponding warthog type
 export const availableTypes: ScalarType = {
-  ID: '', // store as a string
-  String: '',
+  ID: 'string',
+  String: 'string',
   Int: 'int',
   Boolean: 'bool',
   Date: 'date',
   Float: 'float',
   BigInt: 'numeric',
   BigDecimal: 'decimal',
-  Bytes: 'bytes'
+  Bytes: 'bytes',
 };

--- a/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
+++ b/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
@@ -1,14 +1,5 @@
 import { FTSQuery } from './FTSQuery';
-
-// Available types for model code generation
-export const availableTypes: { [key: string]: string } = {
-    String: '',
-    Int: 'int',
-    Boolean: 'bool',
-    Date: 'date',
-    Float: 'float'
-  };
-  
+import { availableTypes } from './ScalarTypes'
 
 export class WarthogModel {
     _types: ObjectType[];

--- a/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
+++ b/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
@@ -128,7 +128,7 @@ export class Field {
     const columnType: string = this.isBuildinType ? availableTypes[this.type] : this.type;
     let column: string = columnType === 'string' ? this.name : this.name.concat(colon, columnType);
 
-    if (!this.isBuildinType && !this.isList) {
+    if (!this.isBuildinType && !this.isList && this.type !== 'otm' && this.type !== 'mto') {
       column = this.name.concat(colon, 'oto');
     } else if (this.isBuildinType && this.isList) {
       column = this.name + colon + 'array' + columnType;

--- a/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
+++ b/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
@@ -124,14 +124,14 @@ export class Field {
      * it adds exclamation mark (!) at then end of string
      */
     format(): string {
-        let column: string;
-        const columnType = this.isBuildinType ? availableTypes[this.type] : this.type;
+    const colon = ':';
+    const columnType: string = this.isBuildinType ? availableTypes[this.type] : this.type;
+    let column: string = columnType === 'string' ? this.name : this.name.concat(colon, columnType);
 
-        if (columnType === '') {
-        // String type is provided implicitly
-        column = this.name;
-        } else {
-        column = this.name + ':' + columnType;
+    if (!this.isBuildinType && !this.isList) {
+      column = this.name.concat(colon, 'oto');
+    } else if (this.isBuildinType && this.isList) {
+      column = this.name + colon + 'array' + columnType;
         }
         return this.nullable ? column : column + '!';
     }

--- a/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
+++ b/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
@@ -21,7 +21,9 @@ export class WarthogModel {
         this._ftsQueries = [];
     }
 
-    addObjectType(type: ObjectType):void {
+    addObjectType(type: ObjectType): void {
+        if (!type.isEntity) return;
+
         this._types.push(type);
         this._name2type[type.name] = type; 
     }
@@ -92,6 +94,7 @@ export class WarthogModel {
 export interface ObjectType {
     name: string;
     fields: Field[];
+    isEntity: boolean;
 }
 
 


### PR DESCRIPTION
This PR:
- Add support for new types `BigInt`, `BigDecimal`, `Bytes`
- Add support for GraphQL list type
- Add support for `OneToOne`, `ManyToOne` and `OneToOne` entity relationship
- Add `@entity` directive to mark types as entities

**Note**: Features listed above are only available with this warthog release: https://github.com/metmirr/warthog/tree/joysteam