### PR TITLE
@joystream/types - publish v0.10.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/Joystream/substrate-runtime-joystream/issues",
   "dependencies": {
-    "@joystream/types": "^0.9.1",
+    "@joystream/types": "^0.10.0",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.14.0",
     "@oclif/plugin-help": "^2.2.3",

--- a/pioneer/package.json
+++ b/pioneer/package.json
@@ -82,6 +82,6 @@
     "node-sass": "^4.13.0",
     "sass-loader": "^8.0.0",
     "style-loader": "^1.0.0",
-    "@joystream/types": "^0.9.1"
+    "@joystream/types": "^0.10.0"
   }
 }

--- a/tests/network-tests/package.json
+++ b/tests/network-tests/package.json
@@ -10,7 +10,7 @@
     "prettier": "prettier --write ./src"
   },
   "dependencies": {
-    "@constantinople/types@npm:@joystream/types": "^0.9.1",
+    "@constantinople/types@npm:@joystream/types": "^0.10.0",
     "@polkadot/api": "^0.96.1",
     "@polkadot/keyring": "^1.7.0-beta.5",
     "@rome/types@npm:@joystream/types": "^0.7.0",

--- a/types/package.json
+++ b/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/types",
-  "version": "0.9.1",
-  "description": "Types for Joystream Substrate Runtime 6.13.0 (Constantinople)",
+  "version": "0.10.0",
+  "description": "Types for Joystream Substrate Runtime 6.15.0",
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "npm run build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,10 +1355,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@constantinople/types@npm:@joystream/types@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@joystream/types/-/types-0.9.1.tgz#9dfacd679e91fe7e2e5e72eb1dc292bfa65b227e"
-  integrity sha512-UiaD2mf1wRPhmG1lPWFH0H835Ic79cZynSvyDnanAXKBiazW2rqZRxTWyc0gRXPGCcu79PN9VbJdK67QkNI9Gg==
+"@constantinople/types@npm:@joystream/types@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@joystream/types/-/types-0.10.0.tgz#7e98ef221410b26a7d952cfc3d1c03d28395ad69"
+  integrity sha512-RDZizqGKWGYpLR5PnUWM4aGa7InpWNh2Txlr7Al3ROFYOHoyQf62/omPfEz29F6scwlFxysOdmEfQaLeVRaUxA==
   dependencies:
     "@polkadot/types" "^0.96.1"
     "@types/vfile" "^4.0.0"


### PR DESCRIPTION
Updated and published `@joystream/types` to npm.

yarn package alias using `"@constantinople/types@npm:@joystream/types": "^0.10.0"` used in network integration tests  forces us to publish package which is not ideal while developing the tests. @gleb-urvanov is looking into a workaround, worst case we just drop the alias (but keep it for the older network tests)