### PR TITLE
Reorder Pioneer sidebar tabs

### DIFF
--- a/pioneer/packages/apps-routing/src/index.ts
+++ b/pioneer/packages/apps-routing/src/index.ts
@@ -65,10 +65,9 @@ if (appSettings.isFullMode) {
     extrinsics,
     sudo,
     js,
-    toolbox,
+    toolbox
   );
 }
-
 
 const setup: Routing = {
   default: 'media',

--- a/pioneer/packages/apps-routing/src/index.ts
+++ b/pioneer/packages/apps-routing/src/index.ts
@@ -39,46 +39,39 @@ import transfer from './transfer';
 
 let routes: Routes = ([] as Routes);
 
-if (appSettings.isFullMode) {
-  routes = routes.concat(explorer);
-}
-
 // Basic routes
 routes = routes.concat(
-  staking,
-  roles,
-  storageRoles,
-  transfer,
-  null,
   media,
+  roles,
+  proposals,
+  election,
   forum,
+  storageRoles,
   members,
+  staking,
+  null,
+  transfer,
   accounts,
   addressbook,
-  null,
-  election,
-  proposals,
-  null
+  settings,
+  pages
 );
 
 if (appSettings.isFullMode) {
   routes = routes.concat(
+    null,
+    explorer,
     storage,
     extrinsics,
     sudo,
     js,
     toolbox,
-    null
   );
 }
 
-routes = routes.concat(
-  settings,
-  pages
-);
 
 const setup: Routing = {
-  default: 'staking',
+  default: 'media',
   routes
 };
 


### PR DESCRIPTION
This PR reorders Pioneer sidebar tabs according to #556. The default route was also updated to the Media tab. All of the advanced tabs visible in the "Fully featured" mode were grouped together and placed at the bottom of the sidebar.

One thing worth noting is that the media view takes a couple of seconds to load the content. Because of that and it being the new default view, it may seem like the whole page is loading longer.

Standard mode:
<img width="181" alt="Screen Shot 2020-06-08 at 15 06 51" src="https://user-images.githubusercontent.com/12646744/84033840-c9442c00-a999-11ea-8f11-ab8b4cef6a7f.png">

Fully featured:
<img width="184" alt="Screen Shot 2020-06-08 at 15 07 26" src="https://user-images.githubusercontent.com/12646744/84033867-d2cd9400-a999-11ea-9e54-d22749213446.png">

Resolves #556 