### PR TITLE
Proposals view tweaks

### DIFF
--- a/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
@@ -55,7 +55,7 @@ type ProposalPreviewListProps = {
 const FilterContainer = styled.div`
   display: flex;
   justify-content: flex-end;
-`
+`;
 const FilterOption = styled.span`
   display: inline-flex;
   align-items: center;

--- a/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
@@ -57,6 +57,7 @@ function ProposalPreviewList ({ bestNumber }: ProposalPreviewListProps) {
 
   const proposalsMap = mapFromProposals(proposals);
   const filteredProposals = proposalsMap.get(activeFilter) as ParsedProposal[];
+  const sortedProposals = filteredProposals.sort((p1, p2) => p2.id.cmp(p1.id));
 
   return (
     <Container className="Proposal">
@@ -72,9 +73,9 @@ function ProposalPreviewList ({ bestNumber }: ProposalPreviewListProps) {
           ))}
         </Menu>
         {
-          filteredProposals.length ? (
+          sortedProposals.length ? (
             <Card.Group>
-              {filteredProposals.map((prop: ParsedProposal, idx: number) => (
+              {sortedProposals.map((prop: ParsedProposal, idx: number) => (
                 <ProposalPreview key={`${prop.title}-${idx}`} proposal={prop} bestNumber={bestNumber} />
               ))}
             </Card.Group>

--- a/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Card, Container, Menu } from 'semantic-ui-react';
+import { Card, Container } from 'semantic-ui-react';
 import styled from 'styled-components';
 
 import ProposalPreview from './ProposalPreview';
@@ -8,6 +8,7 @@ import { useTransport, usePromise } from '@polkadot/joy-utils/react/hooks';
 import { PromiseComponent } from '@polkadot/joy-utils/react/components';
 import { withCalls } from '@polkadot/react-api';
 import { BlockNumber } from '@polkadot/types/interfaces';
+import { Dropdown } from '@polkadot/react-components';
 
 const filters = ['All', 'Active', 'Canceled', 'Approved', 'Rejected', 'Slashed', 'Expired'] as const;
 
@@ -51,6 +52,10 @@ type ProposalPreviewListProps = {
   bestNumber?: BlockNumber;
 };
 
+const FilterOption = styled.span`
+  display: inline-flex;
+  align-items: center;
+`;
 const ProposalFilterCountBadge = styled.span`
   background-color: rgba(0, 0, 0, .3);
   color: #fff;
@@ -70,6 +75,14 @@ const ProposalFilterCountBadge = styled.span`
 
   margin-left: 6px;
 `;
+const StyledDropdown = styled(Dropdown)`
+  padding-left: 0 !important;
+  margin-bottom: 1.75rem;
+
+  label {
+    left: 1.55rem !important;
+  }
+`;
 
 function ProposalPreviewList ({ bestNumber }: ProposalPreviewListProps) {
   const transport = useTransport();
@@ -80,24 +93,27 @@ function ProposalPreviewList ({ bestNumber }: ProposalPreviewListProps) {
   const filteredProposals = proposalsMap.get(activeFilter) as ParsedProposal[];
   const sortedProposals = filteredProposals.sort((p1, p2) => p2.id.cmp(p1.id));
 
+  const filterOptions = filters.map(filter => ({
+    text: (
+      <FilterOption>
+        {filter}
+        <ProposalFilterCountBadge>{(proposalsMap.get(filter) as ParsedProposal[]).length}</ProposalFilterCountBadge>
+      </FilterOption>
+    ),
+    value: filter
+  }));
+
+  const _onChangePrefix = (f: ProposalFilter) => setActiveFilter(f);
+
   return (
     <Container className="Proposal">
       <PromiseComponent error={ error } loading={ loading } message="Fetching proposals...">
-        <Menu tabular className="list-menu">
-          {filters.map((filter, idx) => (
-            <Menu.Item
-              key={`${filter} - ${idx}`}
-              name={filter}
-              active={activeFilter === filter}
-              onClick={() => setActiveFilter(filter)}
-            >
-              {filter}
-              <ProposalFilterCountBadge>
-                {(proposalsMap.get(filter) as ParsedProposal[]).length}
-              </ProposalFilterCountBadge>
-            </Menu.Item>
-          ))}
-        </Menu>
+        <StyledDropdown
+          label="Proposal state"
+          options={filterOptions}
+          value={activeFilter}
+          onChange={_onChangePrefix}
+        />
         {
           sortedProposals.length ? (
             <Card.Group>

--- a/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Card, Container, Menu } from 'semantic-ui-react';
+import styled from 'styled-components';
 
 import ProposalPreview from './ProposalPreview';
 import { ParsedProposal } from '@polkadot/joy-utils/types/proposals';
@@ -50,6 +51,26 @@ type ProposalPreviewListProps = {
   bestNumber?: BlockNumber;
 };
 
+const ProposalFilterCountBadge = styled.span`
+  background-color: rgba(0, 0, 0, .3);
+  color: #fff;
+
+  border-radius: 10px;
+  height: 19px;
+  min-width: 19px;
+  padding: 0 4px;
+
+  font-size: .8rem;
+  font-weight: 500;
+  line-height: 1;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  margin-left: 6px;
+`;
+
 function ProposalPreviewList ({ bestNumber }: ProposalPreviewListProps) {
   const transport = useTransport();
   const [proposals, error, loading] = usePromise<ParsedProposal[]>(() => transport.proposals.proposals(), []);
@@ -66,10 +87,15 @@ function ProposalPreviewList ({ bestNumber }: ProposalPreviewListProps) {
           {filters.map((filter, idx) => (
             <Menu.Item
               key={`${filter} - ${idx}`}
-              name={`${filter.toLowerCase()} - ${(proposalsMap.get(filter) as ParsedProposal[]).length}`}
+              name={filter}
               active={activeFilter === filter}
               onClick={() => setActiveFilter(filter)}
-            />
+            >
+              {filter}
+              <ProposalFilterCountBadge>
+                {(proposalsMap.get(filter) as ParsedProposal[]).length}
+              </ProposalFilterCountBadge>
+            </Menu.Item>
           ))}
         </Menu>
         {

--- a/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
@@ -52,6 +52,10 @@ type ProposalPreviewListProps = {
   bestNumber?: BlockNumber;
 };
 
+const FilterContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`
 const FilterOption = styled.span`
   display: inline-flex;
   align-items: center;
@@ -76,12 +80,10 @@ const ProposalFilterCountBadge = styled.span`
   margin-left: 6px;
 `;
 const StyledDropdown = styled(Dropdown)`
-  padding-left: 0 !important;
-  margin-bottom: 1.75rem;
-
-  label {
-    left: 1.55rem !important;
+  .dropdown {
+    width: 200px;
   }
+  margin-bottom: 1.75rem;
 `;
 
 function ProposalPreviewList ({ bestNumber }: ProposalPreviewListProps) {
@@ -108,12 +110,14 @@ function ProposalPreviewList ({ bestNumber }: ProposalPreviewListProps) {
   return (
     <Container className="Proposal">
       <PromiseComponent error={ error } loading={ loading } message="Fetching proposals...">
-        <StyledDropdown
-          label="Proposal state"
-          options={filterOptions}
-          value={activeFilter}
-          onChange={_onChangePrefix}
-        />
+        <FilterContainer>
+          <StyledDropdown
+            label="Proposal state"
+            options={filterOptions}
+            value={activeFilter}
+            onChange={_onChangePrefix}
+          />
+        </FilterContainer>
         {
           sortedProposals.length ? (
             <Card.Group>


### PR DESCRIPTION
This PR tries to tackle some of the UX issues with proposals view. Firstly, it changes proposals to be sorted starting from the newest. Secondly, filter tabs are visually tweaked to better present count of proposals. 

#461 also mentions two levels of tabs as a potential issue. However, this can be tackled as part of #458 - after that task, the top-level tabs should go away. I believe tabs for filters will look good after that.

View after changes:
<img width="1207" alt="Screen Shot 2020-06-08 at 17 20 31" src="https://user-images.githubusercontent.com/12646744/84049767-21385e00-a9ad-11ea-85dd-dd6aa4cc9bcc.png">

Resolves #461