### PR TITLE
Increase font size of proposal description and properties values

### DIFF
--- a/pioneer/packages/joy-proposals/src/Proposal/Body.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/Body.tsx
@@ -119,6 +119,9 @@ const paramParsers: { [x in ProposalType]: (params: any[]) => { [key: string]: s
   })
 };
 
+const StyledProposalDescription = styled(Card.Description)`
+  font-size: 1.15rem;
+`;
 const ProposalParams = styled.div`
   display: grid;
   font-weight: bold;
@@ -127,7 +130,7 @@ const ProposalParams = styled.div`
   border: 1px solid rgba(0,0,0,.2);
   padding: 1.5rem 1.5rem 1rem 1.25rem;
   position: relative;
-  margin-top: 1.5rem;
+  margin-top: 1.7rem;
   @media screen and (max-width: 767px) {
     grid-template-columns: 1fr;
   }
@@ -149,6 +152,7 @@ const ProposalParamValue = styled.div`
   color: black;
   word-wrap: break-word;
   word-break: break-word;
+  font-size: 1.15rem;
   & .TextProposalContent {
     font-weight: normal;
   }
@@ -176,9 +180,9 @@ export default function Body ({
         <Card.Header>
           <Header as="h1">{title}</Header>
         </Card.Header>
-        <Card.Description>
+        <StyledProposalDescription>
           <ReactMarkdown source={description} linkTarget='_blank' />
-        </Card.Description>
+        </StyledProposalDescription>
         <ProposalParams>
           <ParamsHeader>Parameters:</ParamsHeader>
           { Object.entries(parsedParams).map(([paramName, paramValue]) => (


### PR DESCRIPTION
This PR tackles #463. However, most of the issues with the readability of proposals were already solved by #621, so this PR only increases the font size of the description and property values.

<img width="1465" alt="Screen Shot 2020-06-09 at 13 03 32" src="https://user-images.githubusercontent.com/12646744/84140278-a37a5e00-aa51-11ea-82a5-46e44b7738e4.png">

Resolves #463