### PR TITLE
Make proposals view take full screen width

### DIFF
--- a/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
@@ -59,7 +59,7 @@ function ProposalPreviewList ({ bestNumber }: ProposalPreviewListProps) {
   const filteredProposals = proposalsMap.get(activeFilter) as ParsedProposal[];
 
   return (
-    <Container className="Proposal">
+    <Container className="Proposal" fluid>
       <PromiseComponent error={ error } loading={ loading } message="Fetching proposals...">
         <Menu tabular className="list-menu">
           {filters.map((filter, idx) => (


### PR DESCRIPTION
Resolves #462, changed the proposals view container to take the full width, getting rid of the content centering:

<img width="1777" alt="Screen Shot 2020-06-10 at 12 23 11" src="https://user-images.githubusercontent.com/12646744/84257145-316b4d00-ab15-11ea-8148-4744bdf99ec9.png">
