### PR TITLE
CLI: Init working-groups commands family

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -71,6 +71,9 @@
       },
       "api": {
         "description": "Inspect the substrate node api, perform lower-level api calls or change the current api provider uri"
+      },
+      "working-groups": {
+        "description": "Working group lead and worker actions"
       }
     }
   },
@@ -84,6 +87,7 @@
     "posttest": "eslint . --ext .ts --config .eslintrc",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
+    "build": "tsc --build tsconfig.json",
     "version": "oclif-dev readme && git add README.md"
   },
   "types": "lib/index.d.ts"

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -160,12 +160,8 @@ export default class Api {
         return this._api.query[module];
     }
 
-    protected async memberProfileById(memberId: MemberId, throwError = true): Promise<Profile | null> {
+    protected async memberProfileById(memberId: MemberId): Promise<Profile | null> {
         const profile = await this._api.query.members.memberProfile(memberId) as Option<Profile>;
-
-        if (throwError && profile.isNone) {
-          throw new Error(`Profile not found for member id: ${memberId.toNumber()}!`);
-        }
 
         return profile.unwrapOr(null);
     }
@@ -178,7 +174,11 @@ export default class Api {
         }
 
         const lead = optLead.unwrap();
-        const profile = (await this.memberProfileById(lead.member_id))!;
+        const profile = await this.memberProfileById(lead.member_id);
+
+        if (!profile) {
+            throw new Error(`Group lead profile not found! (member id: ${lead.member_id.toNumber()})`);
+        }
 
         return { lead, profile };
     }
@@ -206,7 +206,11 @@ export default class Api {
         const roleAccount = worker.role_account;
         const memberId = worker.member_id;
 
-        const profile = (await this.memberProfileById(memberId))!;
+        const profile = await this.memberProfileById(memberId);
+
+        if (!profile) {
+            throw new Error(`Group member profile not found! (member id: ${memberId.toNumber()})`);
+        }
 
         let stakeValue: Balance = this._api.createType("Balance", 0);
         if (worker.role_stake_profile && worker.role_stake_profile.isSome) {

--- a/cli/src/ExitCodes.ts
+++ b/cli/src/ExitCodes.ts
@@ -6,6 +6,7 @@ enum ExitCodes {
     InvalidFile = 402,
     NoAccountFound = 403,
     NoAccountSelected = 404,
+    AccessDenied = 405,
 
     UnexpectedException = 500,
     FsOperationFailed = 501,

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -1,9 +1,11 @@
 import BN from 'bn.js';
 import { ElectionStage, Seat } from '@joystream/types/';
 import { Option } from '@polkadot/types';
-import { BlockNumber, Balance } from '@polkadot/types/interfaces';
+import { BlockNumber, Balance, AccountId } from '@polkadot/types/interfaces';
 import { DerivedBalances } from '@polkadot/api-derive/types';
 import { KeyringPair } from '@polkadot/keyring/types';
+import { WorkerId, Lead } from '@joystream/types/lib/bureaucracy';
+import { Profile, MemberId } from '@joystream/types/lib/members';
 
 // KeyringPair type extended with mandatory "meta.name"
 // It's used for accounts/keys management within CLI.
@@ -61,3 +63,28 @@ export function createCouncilInfoObj(
 // Total balance:   100 JOY
 // Free calance:     50 JOY
 export type NameValueObj = { name: string, value: string };
+
+// Working groups related types
+export enum WorkingGroups {
+    StorageProviders = 'storageProviders'
+}
+
+// In contrast to Pioneer, currently only StorageProviders group is available in CLI
+export const AvailableGroups: readonly WorkingGroups[] = [
+  WorkingGroups.StorageProviders
+] as const;
+
+// Compound working group types
+export type GroupLeadWithProfile = {
+    lead: Lead;
+    profile: Profile;
+}
+
+export type GroupMember = {
+    workerId: WorkerId;
+    memberId: MemberId;
+    roleAccount: AccountId;
+    profile: Profile;
+    stake: Balance;
+    earned: Balance;
+}

--- a/cli/src/base/AccountsCommandBase.ts
+++ b/cli/src/base/AccountsCommandBase.ts
@@ -12,6 +12,7 @@ import { DerivedBalances } from '@polkadot/api-derive/types';
 import { toFixedLength } from '../helpers/display';
 
 const ACCOUNTS_DIRNAME = '/accounts';
+const SPECIAL_ACCOUNT_POSTFIX = '__DEV';
 
 /**
  * Abstract base class for account-related commands.
@@ -25,12 +26,12 @@ export default abstract class AccountsCommandBase extends ApiCommandBase {
         return path.join(this.config.dataDir, ACCOUNTS_DIRNAME);
     }
 
-    getAccountFilePath(account: NamedKeyringPair): string {
-        return path.join(this.getAccountsDirPath(), this.generateAccountFilename(account));
+    getAccountFilePath(account: NamedKeyringPair, isSpecial: boolean = false): string {
+        return path.join(this.getAccountsDirPath(), this.generateAccountFilename(account, isSpecial));
     }
 
-    generateAccountFilename(account: NamedKeyringPair): string {
-        return `${ slug(account.meta.name, '_') }__${ account.address }.json`;
+    generateAccountFilename(account: NamedKeyringPair, isSpecial: boolean = false): string {
+        return `${ slug(account.meta.name, '_') }__${ account.address }${ isSpecial ? SPECIAL_ACCOUNT_POSTFIX : '' }.json`;
     }
 
     private initAccountsFs(): void {
@@ -39,12 +40,25 @@ export default abstract class AccountsCommandBase extends ApiCommandBase {
         }
     }
 
-    saveAccount(account: NamedKeyringPair, password: string): void {
+    saveAccount(account: NamedKeyringPair, password: string, isSpecial: boolean = false): void {
         try {
-            fs.writeFileSync(this.getAccountFilePath(account), JSON.stringify(account.toJson(password)));
+            const destPath = this.getAccountFilePath(account, isSpecial);
+            fs.writeFileSync(destPath, JSON.stringify(account.toJson(password)));
         } catch(e) {
             throw this.createDataWriteError();
         }
+    }
+
+    // Add dev "Alice" and "Bob" accounts
+    initSpecialAccounts() {
+        const keyring = new Keyring({ type: 'sr25519' });
+        keyring.addFromUri('//Alice', { name: 'Alice' });
+        keyring.addFromUri('//Bob', { name: 'Bob' });
+        keyring.getPairs().forEach(pair => this.saveAccount(
+            { ...pair, meta: { name: pair.meta.name } },
+            '',
+            true
+        ));
     }
 
     fetchAccountFromJsonFile(jsonBackupFilePath: string): NamedKeyringPair {
@@ -91,7 +105,7 @@ export default abstract class AccountsCommandBase extends ApiCommandBase {
         }
     }
 
-    fetchAccounts(): NamedKeyringPair[] {
+    fetchAccounts(includeSpecial: boolean = false): NamedKeyringPair[] {
         let files: string[] = [];
         const accountDir = this.getAccountsDirPath();
         try {
@@ -104,6 +118,7 @@ export default abstract class AccountsCommandBase extends ApiCommandBase {
         return <NamedKeyringPair[]> files
             .map(fileName => {
                 const filePath = path.join(accountDir, fileName);
+                if (!includeSpecial && filePath.includes(SPECIAL_ACCOUNT_POSTFIX+'.')) return null;
                 return this.fetchAccountOrNullFromFile(filePath);
             })
             .filter(accObj => accObj !== null);
@@ -145,7 +160,11 @@ export default abstract class AccountsCommandBase extends ApiCommandBase {
     }
 
     async setSelectedAccount(account: NamedKeyringPair): Promise<void> {
-        await this.setPreservedState({ selectedAccountFilename: this.generateAccountFilename(account) });
+        const accountFilename = fs.existsSync(this.getAccountFilePath(account, true))
+            ? this.generateAccountFilename(account, true)
+            : this.generateAccountFilename(account);
+
+        await this.setPreservedState({ selectedAccountFilename: accountFilename });
     }
 
     async promptForPassword(message:string = 'Your account\'s password') {
@@ -210,6 +229,7 @@ export default abstract class AccountsCommandBase extends ApiCommandBase {
         await super.init();
         try {
             this.initAccountsFs();
+            this.initSpecialAccounts();
         } catch (e) {
             throw this.createDataDirInitError();
         }

--- a/cli/src/base/WorkingGroupsCommandBase.ts
+++ b/cli/src/base/WorkingGroupsCommandBase.ts
@@ -1,0 +1,78 @@
+import ExitCodes from '../ExitCodes';
+import AccountsCommandBase from './AccountsCommandBase';
+import { flags } from '@oclif/command';
+import { WorkingGroups, AvailableGroups, NamedKeyringPair, GroupLeadWithProfile, GroupMember } from '../Types';
+import { CLIError } from '@oclif/errors';
+import inquirer from 'inquirer';
+
+const DEFAULT_GROUP = WorkingGroups.StorageProviders;
+
+/**
+ * Abstract base class for commands related to working groups
+ */
+export default abstract class WorkingGroupsCommandBase extends AccountsCommandBase {
+    group: WorkingGroups = DEFAULT_GROUP;
+
+    static flags = {
+        group: flags.string({
+            char: 'g',
+            description:
+                "The working group context in which the command should be executed\n" +
+                `Available values are: ${AvailableGroups.join(', ')}.`,
+            required: true,
+            default: DEFAULT_GROUP
+        }),
+    };
+
+    // Use when lead access is required in given command
+    async getRequiredLead(): Promise<GroupLeadWithProfile> {
+        let selectedAccount: NamedKeyringPair = await this.getRequiredSelectedAccount();
+        let lead = await this.getApi().groupLead(this.group);
+
+        if (!lead || lead.lead.role_account_id.toString() !== selectedAccount.address) {
+            this.error('Lead access required for this command!', { exit: ExitCodes.AccessDenied });
+        }
+
+        return lead;
+    }
+
+    // Use when worker access is required in given command
+    async getRequiredWorker(): Promise<GroupMember> {
+        let selectedAccount: NamedKeyringPair = await this.getRequiredSelectedAccount();
+        let groupMembers = await this.getApi().groupMembers(this.group);
+        let groupMembersByAccount = groupMembers.filter(m => m.roleAccount.toString() === selectedAccount.address);
+
+        if (!groupMembersByAccount.length) {
+            this.error('Worker access required for this command!', { exit: ExitCodes.AccessDenied });
+        }
+        else if (groupMembersByAccount.length === 1) {
+            return groupMembersByAccount[0];
+        }
+        else {
+            return await this.promptForWorker(groupMembersByAccount);
+        }
+    }
+
+    async promptForWorker(groupMembers: GroupMember[]): Promise<GroupMember> {
+        const { choosenWorkerIndex } = await inquirer.prompt([{
+            name: 'chosenWorkerIndex',
+            message: 'Choose the worker to execute the command as',
+            type: 'list',
+            choices: groupMembers.map((groupMember, index) => ({
+                name: `Worker ID ${ groupMember.workerId.toString() }`,
+                value: index
+            }))
+        }]);
+
+        return groupMembers[choosenWorkerIndex];
+    }
+
+    async init() {
+        await super.init();
+        const { flags } = this.parse(WorkingGroupsCommandBase);
+        if (!AvailableGroups.includes(flags.group as any)) {
+            throw new CLIError('Invalid group!', { exit: ExitCodes.InvalidInput });
+        }
+        this.group = flags.group as WorkingGroups;
+    }
+}

--- a/cli/src/commands/account/choose.ts
+++ b/cli/src/commands/account/choose.ts
@@ -1,13 +1,21 @@
 import AccountsCommandBase from '../../base/AccountsCommandBase';
 import chalk from 'chalk';
 import ExitCodes from '../../ExitCodes';
-import { NamedKeyringPair } from '../../Types'
+import { NamedKeyringPair } from '../../Types';
+import { flags } from '@oclif/command';
 
 export default class AccountChoose extends AccountsCommandBase {
     static description = 'Choose default account to use in the CLI';
+    static flags = {
+        showSpecial: flags.boolean({
+            description: 'Whether to show special (DEV chain) accounts',
+            required: false
+        }),
+    };
 
     async run() {
-        const accounts: NamedKeyringPair[] = this.fetchAccounts();
+        const { showSpecial } = this.parse(AccountChoose).flags;
+        const accounts: NamedKeyringPair[] = this.fetchAccounts(showSpecial);
         const selectedAccount: NamedKeyringPair | null = this.getSelectedAccount();
 
         this.log(chalk.white(`Found ${ accounts.length } existing accounts...\n`));

--- a/cli/src/commands/working-groups/overview.ts
+++ b/cli/src/commands/working-groups/overview.ts
@@ -1,0 +1,38 @@
+import WorkingGroupsCommandBase from '../../base/WorkingGroupsCommandBase';
+import { displayHeader, displayNameValueTable, displayTable } from '../../helpers/display';
+import { formatBalance } from '@polkadot/util';
+import chalk from 'chalk';
+
+export default class WorkingGroupsOverview extends WorkingGroupsCommandBase {
+    static description = 'Shows an overview of given working group (current lead and workers)';
+    static flags = {
+        ...WorkingGroupsCommandBase.flags,
+    };
+
+    async run() {
+        const lead = await this.getApi().groupLead(this.group);
+        const members = await this.getApi().groupMembers(this.group);
+
+        displayHeader('Group lead');
+        if (lead) {
+            displayNameValueTable([
+                { name: 'Member id:', value: lead.lead.member_id.toString() },
+                { name: 'Member handle:', value: lead.profile.handle.toString() },
+                { name: 'Role account:', value: lead.lead.role_account_id.toString() },
+            ]);
+        }
+        else {
+            this.log(chalk.yellow('No lead assigned!'));
+        }
+
+        displayHeader('Members');
+        const membersRows = members.map(m => ({
+            'Worker id': m.workerId.toString(),
+            'Member id': m.memberId.toString(),
+            'Member handle': m.profile.handle.toString(),
+            'Stake': formatBalance(m.stake),
+            'Earned': formatBalance(m.earned)
+        }));
+        displayTable(membersRows, 20);
+    }
+  }

--- a/cli/src/helpers/display.ts
+++ b/cli/src/helpers/display.ts
@@ -24,6 +24,9 @@ export function displayNameValueTable(rows: NameValueObj[]) {
 }
 
 export function displayTable(rows: { [k: string]: string }[], minColumnWidth = 0) {
+    if (!rows.length) {
+        return;
+    }
     const columnDef = (columnName: string) => ({
         get: (row: typeof rows[number])  => chalk.white(row[columnName]),
         minWidth: minColumnWidth

--- a/cli/src/helpers/display.ts
+++ b/cli/src/helpers/display.ts
@@ -1,4 +1,4 @@
-import { cli } from 'cli-ux';
+import { cli, Table } from 'cli-ux';
 import chalk from 'chalk';
 import { NameValueObj } from '../Types';
 
@@ -21,6 +21,16 @@ export function displayNameValueTable(rows: NameValueObj[]) {
         },
         { 'no-header': true }
     );
+}
+
+export function displayTable(rows: { [k: string]: string }[], minColumnWidth = 0) {
+    const columnDef = (columnName: string) => ({
+        get: (row: typeof rows[number])  => chalk.white(row[columnName]),
+        minWidth: minColumnWidth
+    });
+    let columns: Table.table.Columns<{ [k: string]: string }> = {};
+    Object.keys(rows[0]).forEach(columnName => columns[columnName] = columnDef(columnName))
+    cli.table(rows, columns);
 }
 
 export function toFixedLength(text: string, length: number, spacesOnLeft = false): string {

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -7,7 +7,8 @@
     "rootDir": "src",
     "strict": true,
     "target": "es2017",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+	"types" : [ "node" ]
   },
   "include": [
     "src/**/*"

--- a/types/src/recurring-rewards/index.ts
+++ b/types/src/recurring-rewards/index.ts
@@ -54,6 +54,10 @@ export class RewardRelationship extends JoyStruct<IRewardRelationship> {
   get recipient(): RecipientId {
     return this.getField<RecipientId>('recipient')
   }
+
+  get total_reward_received(): u128 {
+    return this.getField<u128>('total_reward_received');
+  }
 };
 
 export function registerRecurringRewardsTypes () {


### PR DESCRIPTION
Implements https://github.com/Joystream/joystream/issues/598

Core functionality implemented:
- `./cli/bin/run working-groups` commands family
- `./cli/bin/run working-groups:overview --group=GROUP` command that displays working group leader and members/workers information (similar to working group overview in Pioneer)
- added reusable `getRequiredLead` and `getRequiredWorker` methods inside `WorkingGroupsCommandBase` class, which serve as both a gate that will prevent users without access (worker/lead) from trying to execute a command that requires it AND a way of retrieving lead/worker entity and member profile information associated with the selected CLI account (since there could be more than 1 worker associated with a given key, there is also a support for choosing one of the available roles in that case)

I also introduced a few general improvements:
- Default currency symbol and decimals for `formatBalance` are now set based on the values provided by the runtime when initializing the api (same way it's done within Pioneer)
- Added dev `Alice` and `Bob` accounts as "special" hidden accounts that can be selected using `./cli/bin/run accounts:choose --showSpecial` (for easier testing)
- Added `build` script for `joystream-cli` workspace and fixed the `tsconfig` issue (jest vs mocha types conflict)
