### PR TITLE
Pioneer proposals: spending address validation and council votes fix

### DIFF
--- a/pioneer/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/ProposalDetails.tsx
@@ -5,7 +5,7 @@ import Body from './Body';
 import VotingSection from './VotingSection';
 import Votes from './Votes';
 import { MyAccountProps, withMyAccount } from '@polkadot/joy-utils/MyAccount';
-import { ParsedProposal, ProposalVote } from '@polkadot/joy-utils/types/proposals';
+import { ParsedProposal, ProposalVotes } from '@polkadot/joy-utils/types/proposals';
 import { withCalls } from '@polkadot/react-api';
 import { withMulti } from '@polkadot/react-api/with';
 
@@ -115,7 +115,7 @@ export function getExtendedStatus (proposal: ParsedProposal, bestNumber: BlockNu
 type ProposalDetailsProps = MyAccountProps & {
   proposal: ParsedProposal;
   proposalId: ProposalId;
-  votesListState: { data: ProposalVote[]; error: any; loading: boolean };
+  votesListState: { data: ProposalVotes | null; error: any; loading: boolean };
   bestNumber?: BlockNumber;
   council?: Seat[];
 };
@@ -160,7 +160,7 @@ function ProposalDetails ({
             error={votesListState.error}
             loading={votesListState.loading}
             message="Fetching the votes...">
-            <Votes votes={votesListState.data} />
+            <Votes votes={votesListState.data as ProposalVotes} />
           </PromiseComponent>
         </ProposalDetailsVoting>
       </ProposalDetailsMain>

--- a/pioneer/packages/joy-proposals/src/Proposal/Votes.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/Votes.tsx
@@ -1,31 +1,29 @@
 import React from 'react';
 import { Header, Divider, Table, Icon } from 'semantic-ui-react';
 import useVoteStyles from './useVoteStyles';
-import { ProposalVote } from '@polkadot/joy-utils/types/proposals';
+import { ProposalVotes } from '@polkadot/joy-utils/types/proposals';
 import { VoteKind } from '@joystream/types/proposals';
 import { VoteKindStr } from './VotingSection';
 import ProfilePreview from '@polkadot/joy-utils/MemberProfilePreview';
 
 type VotesProps = {
-  votes: ProposalVote[];
+  votes: ProposalVotes;
 };
 
 export default function Votes ({ votes }: VotesProps) {
-  const nonEmptyVotes = votes.filter(proposalVote => proposalVote.vote !== null);
-
-  if (!nonEmptyVotes.length) {
+  if (!votes.votes.length) {
     return <Header as="h4">No votes has been submitted!</Header>;
   }
 
   return (
     <>
       <Header as="h3">
-        All Votes: ({nonEmptyVotes.length})
+        All Votes: ({votes.votes.length}/{votes.councilMembersLength})
       </Header>
       <Divider />
       <Table basic="very">
         <Table.Body>
-          {nonEmptyVotes.map((proposalVote, idx) => {
+          {votes.votes.map((proposalVote, idx) => {
             const { vote, member } = proposalVote;
             const voteStr = (vote as VoteKind).type.toString() as VoteKindStr;
             const { icon, textColor } = useVoteStyles(voteStr);

--- a/pioneer/packages/joy-proposals/src/Proposal/Votes.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/Votes.tsx
@@ -20,7 +20,7 @@ export default function Votes ({ votes }: VotesProps) {
   return (
     <>
       <Header as="h3">
-        All Votes: ({nonEmptyVotes.length} / {votes.length})
+        All Votes: ({nonEmptyVotes.length})
       </Header>
       <Divider />
       <Table basic="very">

--- a/pioneer/packages/joy-proposals/src/validationSchema.ts
+++ b/pioneer/packages/joy-proposals/src/validationSchema.ts
@@ -1,5 +1,4 @@
 import * as Yup from 'yup';
-import { checkAddress } from '@polkadot/util-crypto';
 
 // TODO: If we really need this (currency unit) we can we make "Validation" a functiction that returns an object.
 // We could then "instantialize" it in "withFormContainer" where instead of passing
@@ -242,7 +241,6 @@ const Validation: ValidationType = {
       .required('You need to specify an amount of tokens.'),
     destinationAccount: Yup.string()
       .required('Select a destination account!')
-      .test('address-test', 'Invalid account address.', account => checkAddress(account, 5)[0])
   },
   SetLead: {
     workingGroupLead: Yup.string().required('Select a proposed lead!')

--- a/pioneer/packages/joy-utils/src/react/hooks/proposals/useProposalSubscription.tsx
+++ b/pioneer/packages/joy-utils/src/react/hooks/proposals/useProposalSubscription.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { ParsedProposal, ProposalVote } from '../../../types/proposals';
+import { ParsedProposal, ProposalVotes } from '../../../types/proposals';
 import { useTransport, usePromise } from '../';
 import { ProposalId } from '@joystream/types/proposals';
 
@@ -15,9 +15,9 @@ const useProposalSubscription = (id: ProposalId) => {
     {} as ParsedProposal
   );
 
-  const [votes, votesError, votesLoading, refreshVotes] = usePromise<ProposalVote[]>(
+  const [votes, votesError, votesLoading, refreshVotes] = usePromise<ProposalVotes | null>(
     () => transport.proposals.votes(id),
-    []
+    null
   );
 
   // Function to re-fetch the data using transport

--- a/pioneer/packages/joy-utils/src/transport/council.ts
+++ b/pioneer/packages/joy-utils/src/transport/council.ts
@@ -7,13 +7,25 @@ import { Balance, BlockNumber } from '@polkadot/types/interfaces';
 import { FIRST_MEMBER_ID } from '../consts/members';
 import { ApiPromise } from '@polkadot/api';
 import MembersTransport from './members';
+import ChainTransport from './chain';
 
 export default class CouncilTransport extends BaseTransport {
   private membersT: MembersTransport;
+  private chainT: ChainTransport;
 
-  constructor (api: ApiPromise, membersTransport: MembersTransport) {
+  constructor (api: ApiPromise, membersTransport: MembersTransport, chainTransport: ChainTransport) {
     super(api);
     this.membersT = membersTransport;
+    this.chainT = chainTransport;
+  }
+
+  async councilMembersLength (atBlock?: number): Promise<number> {
+    if (atBlock) {
+      const blockHash = await this.chainT.blockHash(atBlock);
+      return ((await this.council.activeCouncil.at(blockHash)) as Seats).length;
+    }
+
+    return ((await this.council.activeCouncil()) as Seats).length;
   }
 
   async councilMembers (): Promise<(ParsedMember & { memberId: MemberId })[]> {

--- a/pioneer/packages/joy-utils/src/transport/index.ts
+++ b/pioneer/packages/joy-utils/src/transport/index.ts
@@ -24,8 +24,8 @@ export default class Transport {
     this.members = new MembersTransport(api);
     this.storageProviders = new StorageProvidersTransport(api);
     this.validators = new ValidatorsTransport(api);
-    this.council = new CouncilTransport(api, this.members);
+    this.council = new CouncilTransport(api, this.members, this.chain);
     this.contentWorkingGroup = new ContentWorkingGroupTransport(api, this.members);
-    this.proposals = new ProposalsTransport(api, this.members, this.chain);
+    this.proposals = new ProposalsTransport(api, this.members, this.chain, this.council);
   }
 }

--- a/pioneer/packages/joy-utils/src/transport/index.ts
+++ b/pioneer/packages/joy-utils/src/transport/index.ts
@@ -26,6 +26,6 @@ export default class Transport {
     this.validators = new ValidatorsTransport(api);
     this.council = new CouncilTransport(api, this.members);
     this.contentWorkingGroup = new ContentWorkingGroupTransport(api, this.members);
-    this.proposals = new ProposalsTransport(api, this.members, this.chain, this.council);
+    this.proposals = new ProposalsTransport(api, this.members, this.chain);
   }
 }

--- a/pioneer/packages/joy-utils/src/transport/members.ts
+++ b/pioneer/packages/joy-utils/src/transport/members.ts
@@ -6,4 +6,8 @@ export default class MembersTransport extends BaseTransport {
   memberProfile (id: MemberId | number): Promise<Option<Profile>> {
     return this.members.memberProfile(id) as Promise<Option<Profile>>;
   }
+
+  async membersCreated (): Promise<number> {
+    return (await this.members.membersCreated() as MemberId).toNumber();
+  }
 }

--- a/pioneer/packages/joy-utils/src/transport/proposals.ts
+++ b/pioneer/packages/joy-utils/src/transport/proposals.ts
@@ -122,7 +122,7 @@ export default class ProposalsTransport extends BaseTransport {
       'proposalsEngine.voteExistsByProposalByVoter', // Double map of intrest
       proposalId, // First double-map key value
       (v) => new VoteKind(v), // Converter from hex
-      async () => (await this.membersT.membersCreated()), // A function that returns max. possible value for second double-map key (memberId)
+      async () => (await this.membersT.membersCreated()), // A function that returns the number of iterations to go through when chekcing possible values for the second double-map key (memberId)
       FIRST_MEMBER_ID.toNumber() // Min. possible value for second double-map key (memberId)
     );
 

--- a/pioneer/packages/joy-utils/src/types/proposals.ts
+++ b/pioneer/packages/joy-utils/src/types/proposals.ts
@@ -46,6 +46,11 @@ export type ProposalVote = {
   member: ParsedMember & { memberId: MemberId };
 };
 
+export type ProposalVotes = {
+  councilMembersLength: number;
+  votes: ProposalVote[];
+};
+
 export const Categories = {
   storage: 'Storage',
   council: 'Council',


### PR DESCRIPTION
This PR covers possible fixes for issues https://github.com/Joystream/joystream/issues/694 and https://github.com/Joystream/joystream/issues/695

- Removes address validation with `checkAddress` as it turns out it doesn't work the way it was expected (requires different form of prefix) and in fact isn't necessary anyway, since address is already validated through the `InputAddress` component beeing used in `SpendingProposalForm`.
- Uses the new `doubleMapEntries` method to fetch proposal votes, instead of only checking the votes of active council members. The problem with the second approach is that the votes are "lost" on old proposal details pages when the council changes (and some of the old members are not part of the current council anymore). This also forces us to replace the votes section header from _**Votes: (X/Y)**_ (ie. **_Votes: (5/10)_**) to _**Votes (X)**_, since we're not aware of how many council members were active at the time when voting took place (which could possibly have been way back in the past). Alternatively we could add a query to fetch the number of currently active council members and display the **_Votes: (X/Y)_** header only when the proposal is still in the voting period (otherwise just display **_Votes: (X)_**) or use the query with `.at()` to get the number of active council member at the block when proposal was created (which would be probably the best solution).