### PR TITLE
Pioneer forum improvements

### DIFF
--- a/pioneer/packages/joy-forum/src/CategoryList.tsx
+++ b/pioneer/packages/joy-forum/src/CategoryList.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import { Table, Dropdown, Button, Segment, Label } from 'semantic-ui-react';
+import styled from 'styled-components';
 import { History } from 'history';
 import orderBy from 'lodash/orderBy';
 import BN from 'bn.js';
@@ -108,6 +109,10 @@ type ViewCategoryProps = InnerViewCategoryProps & {
   id: CategoryId;
 };
 
+const CategoryPreviewRow = styled(Table.Row)`
+  height: 55px;
+`;
+
 function InnerViewCategory (props: InnerViewCategoryProps) {
   const { history, category, page = 1, preview = false } = props;
 
@@ -127,7 +132,7 @@ function InnerViewCategory (props: InnerViewCategoryProps) {
 
   if (preview) {
     return (
-      <Table.Row>
+      <CategoryPreviewRow>
         <Table.Cell>
           <Link to={`/forum/categories/${id.toString()}`}>
             {category.archived
@@ -143,12 +148,9 @@ function InnerViewCategory (props: InnerViewCategoryProps) {
           {category.num_direct_subcategories.toString()}
         </Table.Cell>
         <Table.Cell>
-          {renderCategoryActions()}
+          {category.description}
         </Table.Cell>
-        <Table.Cell>
-          <MemberPreview accountId={category.moderator_id} />
-        </Table.Cell>
-      </Table.Row>
+      </CategoryPreviewRow>
     );
   }
 
@@ -391,8 +393,7 @@ function InnerCategoryList (props: CategoryListProps) {
           <Table.HeaderCell>Category</Table.HeaderCell>
           <Table.HeaderCell>Threads</Table.HeaderCell>
           <Table.HeaderCell>Subcategories</Table.HeaderCell>
-          <Table.HeaderCell>Actions</Table.HeaderCell>
-          <Table.HeaderCell>Creator</Table.HeaderCell>
+          <Table.HeaderCell>Description</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
       <Table.Body>{categories.map((category, i) => (

--- a/pioneer/packages/joy-forum/src/CategoryList.tsx
+++ b/pioneer/packages/joy-forum/src/CategoryList.tsx
@@ -372,27 +372,19 @@ function InnerCategoryList (props: CategoryListProps) {
   }
 
   return (
-    <>
-      {!parentId && (
-        <>
-          <CategoryCrumbs root />
-          <h1 className="ForumPageTitle">Top categories</h1>
-        </>
-      )}
-      <Table celled selectable compact>
-        <Table.Header>
-          <Table.Row>
-            <Table.HeaderCell>Category</Table.HeaderCell>
-            <Table.HeaderCell>Threads</Table.HeaderCell>
-            <Table.HeaderCell>Subcategories</Table.HeaderCell>
-            <Table.HeaderCell>Description</Table.HeaderCell>
-          </Table.Row>
-        </Table.Header>
-        <Table.Body>{categories.map((category, i) => (
-          <InnerViewCategory key={i} preview category={category} />
-        ))}</Table.Body>
-      </Table>
-    </>
+    <Table celled selectable compact>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell>Category</Table.HeaderCell>
+          <Table.HeaderCell>Threads</Table.HeaderCell>
+          <Table.HeaderCell>Subcategories</Table.HeaderCell>
+          <Table.HeaderCell>Description</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>{categories.map((category, i) => (
+        <InnerViewCategory key={i} preview category={category} />
+      ))}</Table.Body>
+    </Table>
   );
 }
 

--- a/pioneer/packages/joy-forum/src/CategoryList.tsx
+++ b/pioneer/packages/joy-forum/src/CategoryList.tsx
@@ -387,19 +387,27 @@ function InnerCategoryList (props: CategoryListProps) {
   }
 
   return (
-    <Table celled selectable compact>
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell>Category</Table.HeaderCell>
-          <Table.HeaderCell>Threads</Table.HeaderCell>
-          <Table.HeaderCell>Subcategories</Table.HeaderCell>
-          <Table.HeaderCell>Description</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>{categories.map((category, i) => (
-        <InnerViewCategory key={i} preview category={category} />
-      ))}</Table.Body>
-    </Table>
+    <>
+      {!parentId && (
+        <>
+          <CategoryCrumbs root />
+          <h1 className="ForumPageTitle">Top categories</h1>
+        </>
+      )}
+      <Table celled selectable compact>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Category</Table.HeaderCell>
+            <Table.HeaderCell>Threads</Table.HeaderCell>
+            <Table.HeaderCell>Subcategories</Table.HeaderCell>
+            <Table.HeaderCell>Description</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>{categories.map((category, i) => (
+          <InnerViewCategory key={i} preview category={category} />
+        ))}</Table.Body>
+      </Table>
+    </>
   );
 }
 

--- a/pioneer/packages/joy-forum/src/CategoryList.tsx
+++ b/pioneer/packages/joy-forum/src/CategoryList.tsx
@@ -301,6 +301,7 @@ function InnerCategoryThreads (props: CategoryThreadsProps) {
           <Table.HeaderCell>Thread</Table.HeaderCell>
           <Table.HeaderCell>Replies</Table.HeaderCell>
           <Table.HeaderCell>Creator</Table.HeaderCell>
+          <Table.HeaderCell>Created</Table.HeaderCell>
         </Table.Row>
       </Table.Header>
       <Table.Body>

--- a/pioneer/packages/joy-forum/src/EditReply.tsx
+++ b/pioneer/packages/joy-forum/src/EditReply.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Button, Message } from 'semantic-ui-react';
+import styled from 'styled-components';
 import { Form, Field, withFormik, FormikProps } from 'formik';
 import * as Yup from 'yup';
-import { History } from 'history';
 
 import TxButton from '@polkadot/joy-utils/TxButton';
 import { SubmittableResult } from '@polkadot/api';
@@ -14,7 +14,6 @@ import { PostId, Post, ThreadId } from '@joystream/types/forum';
 import { withOnlyMembers } from '@polkadot/joy-utils/MyAccount';
 import Section from '@polkadot/joy-utils/Section';
 import { useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
-import { UrlHasIdProps, CategoryCrumbs } from './utils';
 import { withForumCalls } from './calls';
 import { ValidationProps, withReplyValidation } from './validation';
 import { TxFailedCallback, TxCallback } from '@polkadot/react-components/Status/types';
@@ -39,11 +38,17 @@ const buildSchema = (props: ValidationProps) => {
   });
 };
 
+const FormActionsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
 type OuterProps = ValidationProps & {
-  history?: History;
   id?: PostId;
   struct?: Post;
   threadId: ThreadId;
+  onEditSuccess?: () => void;
+  onEditCancel?: () => void;
 };
 
 type FormValues = {
@@ -56,7 +61,6 @@ const LabelledField = JoyForms.LabelledField<FormValues>();
 
 const InnerForm = (props: FormProps) => {
   const {
-    history,
     id,
     threadId,
     struct,
@@ -65,18 +69,16 @@ const InnerForm = (props: FormProps) => {
     isValid,
     isSubmitting,
     setSubmitting,
-    resetForm
+    resetForm,
+    onEditSuccess,
+    onEditCancel
   } = props;
 
   const {
     text
   } = values;
 
-  const goToThreadView = () => {
-    if (history) {
-      history.push('/forum/threads/' + threadId.toString());
-    }
-  };
+  const isNew = struct === undefined;
 
   const onSubmit = (sendTx: () => void) => {
     if (isValid) sendTx();
@@ -92,10 +94,11 @@ const InnerForm = (props: FormProps) => {
 
   const onTxSuccess: TxCallback = (_txResult: SubmittableResult) => {
     setSubmitting(false);
-    goToThreadView();
+    resetForm();
+    if (!isNew && onEditSuccess) {
+      onEditSuccess();
+    }
   };
-
-  const isNew = struct === undefined;
 
   const buildTxParams = () => {
     if (!isValid) return [];
@@ -116,43 +119,57 @@ const InnerForm = (props: FormProps) => {
       </LabelledField>
 
       <LabelledField {...props}>
-        <TxButton
-          type='submit'
-          size='large'
-          label={isNew
-            ? 'Post a reply'
-            : 'Update a reply'
+        <FormActionsContainer>
+          <div>
+            <TxButton
+              type='submit'
+              size='large'
+              label={isNew
+                ? 'Post a reply'
+                : 'Update a reply'
+              }
+              isDisabled={!dirty || isSubmitting}
+              params={buildTxParams()}
+              tx={isNew
+                ? 'forum.addPost'
+                : 'forum.editPostText'
+              }
+              onClick={onSubmit}
+              txFailedCb={onTxFailed}
+              txSuccessCb={onTxSuccess}
+            />
+            <Button
+              type='button'
+              size='large'
+              disabled={!dirty || isSubmitting}
+              onClick={() => resetForm()}
+              content='Reset form'
+            />
+          </div>
+          {
+            !isNew && (
+              <Button
+                type='button'
+                size='large'
+                disabled={isSubmitting}
+                content='Cancel edit'
+                onClick={() => onEditCancel && onEditCancel()}
+              />
+            )
           }
-          isDisabled={!dirty || isSubmitting}
-          params={buildTxParams()}
-          tx={isNew
-            ? 'forum.addPost'
-            : 'forum.editPostText'
-          }
-          onClick={onSubmit}
-          txFailedCb={onTxFailed}
-          txSuccessCb={onTxSuccess}
-        />
-        <Button
-          type='button'
-          size='large'
-          disabled={!dirty || isSubmitting}
-          onClick={() => resetForm()}
-          content='Reset form'
-        />
+        </FormActionsContainer>
       </LabelledField>
     </Form>;
 
   const sectionTitle = isNew
     ? 'New reply'
-    : 'Edit my reply';
+    : `Edit my reply #${struct?.nr_in_thread}`;
 
-  return <>
-    <CategoryCrumbs threadId={threadId} />
+  return (
     <Section className='EditEntityBox' title={sectionTitle}>
       {form}
     </Section>
-  </>;
+  );
 };
 
 const EditForm = withFormik<OuterProps, FormValues>({
@@ -192,43 +209,15 @@ function FormOrLoading (props: OuterProps) {
   return <Message error className='JoyMainStatus' header='You are not allowed edit this reply.' />;
 }
 
-function withThreadIdFromUrl (Component: React.ComponentType<OuterProps>) {
-  return function (props: UrlHasIdProps) {
-    const { match: { params: { id } } } = props;
-    try {
-      return <Component {...props} threadId={new ThreadId(id)} />;
-    } catch (err) {
-      return <em>Invalid thread ID: {id}</em>;
-    }
-  };
-}
-
-type HasPostIdProps = {
-  id: PostId;
-};
-
-function withIdFromUrl (Component: React.ComponentType<HasPostIdProps>) {
-  return function (props: UrlHasIdProps) {
-    const { match: { params: { id } } } = props;
-    try {
-      return <Component {...props} id={new PostId(id)} />;
-    } catch (err) {
-      return <em>Invalid reply ID: {id}</em>;
-    }
-  };
-}
-
 export const NewReply = withMulti(
   EditForm,
   withOnlyMembers,
-  withThreadIdFromUrl,
   withReplyValidation
 );
 
 export const EditReply = withMulti(
   FormOrLoading,
   withOnlyMembers,
-  withIdFromUrl,
   withReplyValidation,
   withForumCalls<OuterProps>(
     ['postById', { paramName: 'id', propName: 'struct' }]

--- a/pioneer/packages/joy-forum/src/EditReply.tsx
+++ b/pioneer/packages/joy-forum/src/EditReply.tsx
@@ -47,6 +47,7 @@ type OuterProps = ValidationProps & {
   id?: PostId;
   struct?: Post;
   threadId: ThreadId;
+  quotedPost?: Post | null;
   onEditSuccess?: () => void;
   onEditCancel?: () => void;
 };
@@ -172,13 +173,24 @@ const InnerForm = (props: FormProps) => {
   );
 };
 
+const getQuotedPostString = (post: Post) => {
+  const lines = post.current_text.split('\n');
+  return lines.reduce((acc, line) => {
+    return `${acc}> ${line}\n`;
+  }, '');
+};
+
 const EditForm = withFormik<OuterProps, FormValues>({
 
   // Transform outer props into form values
   mapPropsToValues: props => {
-    const { struct } = props;
+    const { struct, quotedPost } = props;
     return {
-      text: (struct && struct.current_text) || ''
+      text: struct
+        ? struct.current_text
+        : quotedPost
+          ? getQuotedPostString(quotedPost)
+          : ''
     };
   },
 

--- a/pioneer/packages/joy-forum/src/ForumRoot.tsx
+++ b/pioneer/packages/joy-forum/src/ForumRoot.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { orderBy } from 'lodash';
+import BN from 'bn.js';
+
+import Section from '@polkadot/joy-utils/Section';
+import { withMulti, withApi } from '@polkadot/react-api';
+import { PostId, Post, Thread } from '@joystream/types/forum';
+import { bnToStr } from '@polkadot/joy-utils/';
+import { ApiProps } from '@polkadot/react-api/types';
+import { MemberPreview } from '@polkadot/joy-members/MemberPreview';
+
+import { CategoryCrumbs, RecentActivityPostsCount, ReplyIdxQueryParam, TimeAgoDate } from './utils';
+import { withForumCalls } from './calls';
+import { CategoryList } from './CategoryList';
+
+const ForumRoot: React.FC = () => {
+  return (
+    <>
+      <CategoryCrumbs root />
+      <Section title="Top categories">
+        <CategoryList />
+      </Section>
+      <RecentActivity />
+    </>
+  );
+};
+
+const RecentActivityEntry = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 10px 0;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid #ddd;
+  }
+`;
+
+const StyledMemberPreview = styled(MemberPreview)`
+  && {
+    margin-right: .3rem;
+  }
+`;
+
+const StyledPostLink = styled(Link)`
+  margin: 0 .3rem;
+  font-weight: 700;
+`;
+
+type RecentActivityProps = ApiProps & {
+  nextPostId?: PostId;
+};
+
+const InnerRecentActivity: React.FC<RecentActivityProps> = ({ nextPostId, api }) => {
+  const [recentPosts, setRecentPosts] = useState<Post[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [threadsLookup, setThreadsLookup] = useState<Record<number, Thread>>({});
+
+  useEffect(() => {
+    const loadPosts = async () => {
+      if (!nextPostId) return;
+
+      const newId = (id: number | BN) => new PostId(id);
+      const apiCalls: Promise<Post>[] = [];
+      let id = newId(1);
+      while (nextPostId.gt(id)) {
+        apiCalls.push(api.query.forum.postById(id) as Promise<Post>);
+        id = newId(id.add(newId(1)));
+      }
+
+      const allPosts = await Promise.all(apiCalls);
+      const sortedPosts = orderBy(
+        allPosts,
+        [x => x.id.toNumber()],
+        ['desc']
+      );
+
+      const threadsIdsLookup = {} as Record<number, boolean>;
+      const postsWithUniqueThreads = sortedPosts.reduce((acc, post) => {
+        const threadId = post.thread_id.toNumber();
+        if (threadsIdsLookup[threadId]) return acc;
+
+        threadsIdsLookup[threadId] = true;
+        return [
+          ...acc,
+          post
+        ];
+      }, [] as Post[]);
+
+      const recentUniquePosts = postsWithUniqueThreads.slice(0, RecentActivityPostsCount);
+      setRecentPosts(recentUniquePosts);
+      setLoaded(true);
+    };
+
+    loadPosts();
+  }, [bnToStr(nextPostId)]);
+
+  useEffect(() => {
+    const loadThreads = async () => {
+      const apiCalls: Promise<Thread>[] = recentPosts
+        .filter(p => !threadsLookup[p.thread_id.toNumber()])
+        .map(p => api.query.forum.threadById(p.thread_id) as Promise<Thread>);
+
+      const threads = await Promise.all(apiCalls);
+      const newThreadsLookup = threads.reduce((acc, thread) => {
+        acc[thread.id.toNumber()] = thread;
+        return acc;
+      }, {} as Record<number, Thread>);
+      const newLookup = {
+        ...threadsLookup,
+        ...newThreadsLookup
+      };
+
+      setThreadsLookup(newLookup);
+    };
+
+    loadThreads();
+  }, [recentPosts]);
+
+  const renderSectionContent = () => {
+    if (!loaded) {
+      return <i>Loading recent activity...</i>;
+    }
+    if (loaded && !recentPosts.length) {
+      return <span>No recent activity</span>;
+    }
+
+    return recentPosts.map(p => {
+      const threadId = p.thread_id.toNumber();
+
+      const postLinkSearch = new URLSearchParams();
+      postLinkSearch.set(ReplyIdxQueryParam, p.nr_in_thread.toString());
+      const postLinkPathname = `/forum/threads/${threadId}`;
+
+      const thread = threadsLookup[threadId];
+
+      return (
+        <RecentActivityEntry key={p.id.toNumber()}>
+          <StyledMemberPreview accountId={p.author_id} inline />
+          posted in
+          {thread && (
+            <StyledPostLink to={{ pathname: postLinkPathname, search: postLinkSearch.toString() }}>{thread.title}</StyledPostLink>
+          )}
+          <TimeAgoDate date={p.created_at.momentDate} id={p.id.toNumber()} />
+        </RecentActivityEntry>
+      );
+    });
+  };
+
+  return (
+    <Section title="Recent activity">
+      {renderSectionContent()}
+    </Section>
+  );
+};
+
+const RecentActivity = withMulti<RecentActivityProps>(
+  InnerRecentActivity,
+  withApi,
+  withForumCalls(
+    ['nextPostId', { propName: 'nextPostId' }]
+  )
+);
+
+export default ForumRoot;

--- a/pioneer/packages/joy-forum/src/ForumRoot.tsx
+++ b/pioneer/packages/joy-forum/src/ForumRoot.tsx
@@ -19,10 +19,10 @@ const ForumRoot: React.FC = () => {
   return (
     <>
       <CategoryCrumbs root />
+      <RecentActivity />
       <Section title="Top categories">
         <CategoryList />
       </Section>
-      <RecentActivity />
     </>
   );
 };

--- a/pioneer/packages/joy-forum/src/LegacyPagingRedirect.tsx
+++ b/pioneer/packages/joy-forum/src/LegacyPagingRedirect.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useLocation, Redirect } from 'react-router-dom';
+
+export const LegacyPagingRedirect: React.FC = () => {
+  const { pathname } = useLocation();
+  const parsingRegexp = /(.+)\/page\/(\d+)/;
+  const groups = parsingRegexp.exec(pathname);
+  if (!groups) {
+    return <em>Failed to parse the URL</em>;
+  }
+
+  const basePath = groups[1];
+  const page = groups[2];
+  const search = new URLSearchParams();
+  search.set('page', page);
+  return <Redirect to={{ pathname: basePath, search: search.toString() }} />;
+};

--- a/pioneer/packages/joy-forum/src/ViewReply.tsx
+++ b/pioneer/packages/joy-forum/src/ViewReply.tsx
@@ -15,6 +15,13 @@ import { TimeAgoDate, ReplyIdxQueryParam } from './utils';
 const HORIZONTAL_PADDING = '1em';
 const ReplyMarkdown = styled(ReactMarkdown)`
   font-size: 1.15rem;
+
+  blockquote {
+    color: rgba(78, 78, 78, 0.6);
+    margin-left: 15px;
+    padding-left: 15px;
+    border-left: 2px solid rgba(78, 78, 78, 0.6);
+  }
 `;
 const ReplyContainer = styled.div<{ selected?: boolean }>`
   && {

--- a/pioneer/packages/joy-forum/src/ViewReply.tsx
+++ b/pioneer/packages/joy-forum/src/ViewReply.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
-import { Segment, Button } from 'semantic-ui-react';
+import Tooltip from 'react-tooltip';
+import { Segment, Button, Icon } from 'semantic-ui-react';
 
 import { Post, Category, Thread } from '@joystream/types/forum';
 import { Moderate } from './Moderate';
@@ -10,10 +11,41 @@ import { JoyWarn } from '@polkadot/joy-utils/JoyStatus';
 import { useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
 import { IfIAmForumSudo } from './ForumSudo';
 import { MemberPreview } from '@polkadot/joy-members/MemberPreview';
-import { FlexCenter } from '@polkadot/joy-utils/FlexCenter';
 
-const ReplyDetails = styled(ReactMarkdown)`
+const HORIZONTAL_PADDING = '1em';
+const ReplyMarkdown = styled(ReactMarkdown)`
   font-size: 1.15rem;
+`;
+const ReplyContainer = styled(Segment)`
+  && {
+    padding: 0;
+  }
+  overflow: hidden;
+`;
+const ReplyHeader = styled.div`
+  background-color: #fafcfc;
+`;
+const ReplyHeaderAuthorRow = styled.div`
+  padding: 0.7em ${HORIZONTAL_PADDING};
+`;
+const ReplyHeaderDetailsRow = styled.div`
+  padding: 0.5em ${HORIZONTAL_PADDING};
+  border-top: 1px dashed rgba(34, 36, 38, .15);
+  border-bottom: 1px solid rgba(34, 36, 38, .15);
+  display: flex;
+  justify-content: space-between;
+`;
+const ReplyContent = styled.div`
+  padding: 1em ${HORIZONTAL_PADDING};
+`;
+const ReplyFooter = styled.div`
+  border-top: 1px solid rgba(34, 36, 38, .15);
+  background-color: #fafcfc;
+  padding: 0.5em ${HORIZONTAL_PADDING};
+`;
+const ReplyFooterActionsRow = styled.div`
+  display: flex;
+  justify-content: space-between;
 `;
 
 type ViewReplyProps = {
@@ -33,7 +65,7 @@ export function ViewReply (props: ViewReplyProps) {
   }
 
   const renderReplyDetails = () => {
-    return <ReplyDetails className='JoyMemo--full' source={reply.current_text} linkTarget='_blank' />;
+    return <ReplyMarkdown className='JoyMemo--full' source={reply.current_text} linkTarget='_blank' />;
   };
 
   const renderModerationRationale = () => {
@@ -51,43 +83,65 @@ export function ViewReply (props: ViewReplyProps) {
       return null;
     }
     const isMyPost = reply.author_id.eq(myAddress);
-    return <span className='JoyInlineActions' style={{ marginLeft: '.5rem' }}>
-      {isMyPost &&
-        <Link
-          to={`/forum/replies/${id.toString()}/edit`}
-          className='ui small button'
-        >
-          <i className='pencil alternate icon' />
-          Edit
-        </Link>
-      }
+    return <ReplyFooterActionsRow>
+      <div>
+        {isMyPost &&
+          <Button as={Link} to={`/forum/replies/${id.toString()}/edit`} size="mini">
+            <Icon name="pencil" />
+            Edit
+          </Button>
+        }
 
-      <IfIAmForumSudo>
-        <Button
-          type='button'
-          size='small'
-          content={'Moderate'}
-          onClick={() => setShowModerateForm(!showModerateForm)}
-        />
-      </IfIAmForumSudo>
-    </span>;
+        <IfIAmForumSudo>
+          <Button
+            size="mini"
+            onClick={() => setShowModerateForm(!showModerateForm)}
+          >
+            Moderate
+          </Button>
+        </IfIAmForumSudo>
+      </div>
+      <Button size="mini">
+        <Icon name="quote left" />
+        Quote
+      </Button>
+    </ReplyFooterActionsRow>;
   };
 
+  const replyDate = reply.created_at.momentDate;
+
   return (
-    <Segment>
-      <FlexCenter>
-        <MemberPreview accountId={reply.author_id} />
-        {renderActions()}
-      </FlexCenter>
-      <div style={{ marginTop: '1rem' }}>
-        {showModerateForm &&
-          <Moderate id={id} onCloseForm={() => setShowModerateForm(false)} />
-        }
+    <ReplyContainer>
+      <ReplyHeader>
+        <ReplyHeaderAuthorRow>
+          <MemberPreview accountId={reply.author_id} />
+        </ReplyHeaderAuthorRow>
+        <ReplyHeaderDetailsRow>
+          <span data-tip data-for="reply-full-date">
+            {replyDate.fromNow()}
+          </span>
+          <Tooltip id="reply-full-date" place="top" effect="solid">
+            {replyDate.toLocaleString()}
+          </Tooltip>
+          <a>
+            #{reply.nr_in_thread.toNumber()}
+          </a>
+        </ReplyHeaderDetailsRow>
+      </ReplyHeader>
+
+      <ReplyContent>
         {reply.moderated
           ? renderModerationRationale()
           : renderReplyDetails()
         }
-      </div>
-    </Segment>
+      </ReplyContent>
+
+      <ReplyFooter>
+        {renderActions()}
+        {showModerateForm &&
+          <Moderate id={id} onCloseForm={() => setShowModerateForm(false)} />
+        }
+      </ReplyFooter>
+    </ReplyContainer>
   );
 }

--- a/pioneer/packages/joy-forum/src/ViewReply.tsx
+++ b/pioneer/packages/joy-forum/src/ViewReply.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import { Segment, Button } from 'semantic-ui-react';
@@ -10,6 +11,10 @@ import { useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
 import { IfIAmForumSudo } from './ForumSudo';
 import { MemberPreview } from '@polkadot/joy-members/MemberPreview';
 import { FlexCenter } from '@polkadot/joy-utils/FlexCenter';
+
+const ReplyDetails = styled(ReactMarkdown)`
+  font-size: 1.15rem;
+`;
 
 type ViewReplyProps = {
   reply: Post;
@@ -28,7 +33,7 @@ export function ViewReply (props: ViewReplyProps) {
   }
 
   const renderReplyDetails = () => {
-    return <ReactMarkdown className='JoyMemo--full' source={reply.current_text} linkTarget='_blank' />;
+    return <ReplyDetails className='JoyMemo--full' source={reply.current_text} linkTarget='_blank' />;
   };
 
   const renderModerationRationale = () => {

--- a/pioneer/packages/joy-forum/src/ViewReply.tsx
+++ b/pioneer/packages/joy-forum/src/ViewReply.tsx
@@ -10,7 +10,7 @@ import { JoyWarn } from '@polkadot/joy-utils/JoyStatus';
 import { useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
 import { IfIAmForumSudo } from './ForumSudo';
 import { MemberPreview } from '@polkadot/joy-members/MemberPreview';
-import { TimeAgoDate } from './utils';
+import { TimeAgoDate, ReplyIdxQueryParam } from './utils';
 
 const HORIZONTAL_PADDING = '1em';
 const ReplyMarkdown = styled(ReactMarkdown)`
@@ -55,6 +55,8 @@ type ViewReplyProps = {
   thread: Thread;
   category: Category;
   selected?: boolean;
+  onEdit: () => void;
+  onQuote: () => void;
 };
 
 // eslint-disable-next-line react/display-name
@@ -62,7 +64,7 @@ export const ViewReply = React.forwardRef((props: ViewReplyProps, ref: React.Ref
   const { state: { address: myAddress } } = useMyAccount();
   const [showModerateForm, setShowModerateForm] = useState(false);
   const { pathname, search } = useLocation();
-  const { reply, thread, category, selected = false } = props;
+  const { reply, thread, category, selected = false, onEdit, onQuote } = props;
   const { id } = reply;
 
   if (reply.isEmpty) {
@@ -91,7 +93,7 @@ export const ViewReply = React.forwardRef((props: ViewReplyProps, ref: React.Ref
     return <ReplyFooterActionsRow>
       <div>
         {isMyPost &&
-          <Button as={Link} to={`/forum/replies/${id.toString()}/edit`} size="mini">
+          <Button onClick={onEdit} size="mini">
             <Icon name="pencil" />
             Edit
           </Button>
@@ -106,7 +108,7 @@ export const ViewReply = React.forwardRef((props: ViewReplyProps, ref: React.Ref
           </Button>
         </IfIAmForumSudo>
       </div>
-      <Button size="mini">
+      <Button onClick={onQuote} size="mini">
         <Icon name="quote left" />
         Quote
       </Button>
@@ -114,7 +116,7 @@ export const ViewReply = React.forwardRef((props: ViewReplyProps, ref: React.Ref
   };
 
   const replyLinkSearch = new URLSearchParams(search);
-  replyLinkSearch.set('replyIdx', reply.nr_in_thread.toString());
+  replyLinkSearch.set(ReplyIdxQueryParam, reply.nr_in_thread.toString());
 
   return (
     <ReplyContainer className="ui segment" ref={ref} selected={selected}>

--- a/pioneer/packages/joy-forum/src/ViewReply.tsx
+++ b/pioneer/packages/joy-forum/src/ViewReply.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
-import { Segment, Button, Icon } from 'semantic-ui-react';
+import { Button, Icon } from 'semantic-ui-react';
 
 import { Post, Category, Thread } from '@joystream/types/forum';
 import { Moderate } from './Moderate';
@@ -16,9 +16,11 @@ const HORIZONTAL_PADDING = '1em';
 const ReplyMarkdown = styled(ReactMarkdown)`
   font-size: 1.15rem;
 `;
-const ReplyContainer = styled(Segment)`
+const ReplyContainer = styled.div<{ selected?: boolean }>`
   && {
     padding: 0;
+
+    outline: ${({ selected }) => selected ? '2px solid #ffc87b' : 'none'};
   }
   overflow: hidden;
 `;
@@ -52,12 +54,15 @@ type ViewReplyProps = {
   reply: Post;
   thread: Thread;
   category: Category;
+  selected?: boolean;
 };
 
-export function ViewReply (props: ViewReplyProps) {
+// eslint-disable-next-line react/display-name
+export const ViewReply = React.forwardRef((props: ViewReplyProps, ref: React.Ref<HTMLDivElement>) => {
   const { state: { address: myAddress } } = useMyAccount();
   const [showModerateForm, setShowModerateForm] = useState(false);
-  const { reply, thread, category } = props;
+  const { pathname, search } = useLocation();
+  const { reply, thread, category, selected = false } = props;
   const { id } = reply;
 
   if (reply.isEmpty) {
@@ -108,17 +113,20 @@ export function ViewReply (props: ViewReplyProps) {
     </ReplyFooterActionsRow>;
   };
 
+  const replyLinkSearch = new URLSearchParams(search);
+  replyLinkSearch.set('replyIdx', reply.nr_in_thread.toString());
+
   return (
-    <ReplyContainer>
+    <ReplyContainer className="ui segment" ref={ref} selected={selected}>
       <ReplyHeader>
         <ReplyHeaderAuthorRow>
           <MemberPreview accountId={reply.author_id} />
         </ReplyHeaderAuthorRow>
         <ReplyHeaderDetailsRow>
           <TimeAgoDate date={reply.created_at.momentDate} id={reply.id} />
-          <a>
+          <Link to={{ pathname, search: replyLinkSearch.toString() }}>
             #{reply.nr_in_thread.toNumber()}
-          </a>
+          </Link>
         </ReplyHeaderDetailsRow>
       </ReplyHeader>
 
@@ -137,4 +145,4 @@ export function ViewReply (props: ViewReplyProps) {
       </ReplyFooter>
     </ReplyContainer>
   );
-}
+});

--- a/pioneer/packages/joy-forum/src/ViewReply.tsx
+++ b/pioneer/packages/joy-forum/src/ViewReply.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
-import Tooltip from 'react-tooltip';
 import { Segment, Button, Icon } from 'semantic-ui-react';
 
 import { Post, Category, Thread } from '@joystream/types/forum';
@@ -11,6 +10,7 @@ import { JoyWarn } from '@polkadot/joy-utils/JoyStatus';
 import { useMyAccount } from '@polkadot/joy-utils/MyAccountContext';
 import { IfIAmForumSudo } from './ForumSudo';
 import { MemberPreview } from '@polkadot/joy-members/MemberPreview';
+import { TimeAgoDate } from './utils';
 
 const HORIZONTAL_PADDING = '1em';
 const ReplyMarkdown = styled(ReactMarkdown)`
@@ -41,7 +41,7 @@ const ReplyContent = styled.div`
 const ReplyFooter = styled.div`
   border-top: 1px solid rgba(34, 36, 38, .15);
   background-color: #fafcfc;
-  padding: 0.5em ${HORIZONTAL_PADDING};
+  padding: 0.35em ${HORIZONTAL_PADDING};
 `;
 const ReplyFooterActionsRow = styled.div`
   display: flex;
@@ -108,8 +108,6 @@ export function ViewReply (props: ViewReplyProps) {
     </ReplyFooterActionsRow>;
   };
 
-  const replyDate = reply.created_at.momentDate;
-
   return (
     <ReplyContainer>
       <ReplyHeader>
@@ -117,12 +115,7 @@ export function ViewReply (props: ViewReplyProps) {
           <MemberPreview accountId={reply.author_id} />
         </ReplyHeaderAuthorRow>
         <ReplyHeaderDetailsRow>
-          <span data-tip data-for="reply-full-date">
-            {replyDate.fromNow()}
-          </span>
-          <Tooltip id="reply-full-date" place="top" effect="solid">
-            {replyDate.toLocaleString()}
-          </Tooltip>
+          <TimeAgoDate date={reply.created_at.momentDate} id={reply.id} />
           <a>
             #{reply.nr_in_thread.toNumber()}
           </a>

--- a/pioneer/packages/joy-forum/src/ViewThread.tsx
+++ b/pioneer/packages/joy-forum/src/ViewThread.tsx
@@ -69,6 +69,11 @@ const ThreadInfo = styled.span`
 const ThreadInfoMemberPreview = styled(MemberPreview)`
   && {
     margin: 0 .2rem;
+
+    .PrefixLabel {
+      color: inherit;
+      margin-right: .2rem;
+    }
   }
 `;
 
@@ -256,8 +261,8 @@ function InnerViewThread (props: ViewThreadProps) {
       </h1>
       <ThreadInfoAndActions>
         <ThreadInfo>
-          Created by
-          <ThreadInfoMemberPreview accountId={thread.author_id} inline />
+          Created
+          <ThreadInfoMemberPreview accountId={thread.author_id} inline prefixLabel="by" />
           <TimeAgoDate date={thread.created_at.momentDate} id="thread" />
         </ThreadInfo>
         {renderActions()}

--- a/pioneer/packages/joy-forum/src/ViewThread.tsx
+++ b/pioneer/packages/joy-forum/src/ViewThread.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
+import styled from 'styled-components';
 import { Table, Button, Label } from 'semantic-ui-react';
 import { History } from 'history';
 import BN from 'bn.js';
 
 import { Category, Thread, ThreadId, Post, PostId } from '@joystream/types/forum';
-import { Pagination, RepliesPerPage, CategoryCrumbs } from './utils';
+import { Pagination, RepliesPerPage, CategoryCrumbs, TimeAgoDate } from './utils';
 import { ViewReply } from './ViewReply';
 import { Moderate } from './Moderate';
 import { MutedSpan } from '@polkadot/joy-utils/MutedText';
@@ -18,6 +19,7 @@ import { orderBy } from 'lodash';
 import { bnToStr } from '@polkadot/joy-utils/index';
 import { IfIAmForumSudo } from './ForumSudo';
 import { MemberPreview } from '@polkadot/joy-members/MemberPreview';
+import { formatDate } from '@polkadot/joy-utils/functions/date';
 
 type ThreadTitleProps = {
   thread: Thread;
@@ -35,6 +37,40 @@ function ThreadTitle (props: ThreadTitleProps) {
     {thread.title}
   </span>;
 }
+
+const ThreadHeader = styled.div`
+  margin: 1rem 0;
+
+  h1 {
+    margin: 0;
+  }
+`;
+
+const ThreadInfoAndActions = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  margin-top: .3rem;
+
+  h1 {
+    margin: 0;
+  }
+`;
+
+const ThreadInfo = styled.span`
+  display: inline-flex;
+  align-items: center;
+
+  font-size: .85rem;
+  color: rgba(0, 0, 0, 0.5);
+`;
+
+const ThreadInfoMemberPreview = styled(MemberPreview)`
+  && {
+    margin: 0 .2rem;
+  }
+`;
 
 type InnerViewThreadProps = {
   category: Category;
@@ -89,6 +125,9 @@ function InnerViewThread (props: ViewThreadProps) {
         </Table.Cell>
         <Table.Cell>
           <MemberPreview accountId={thread.author_id} />
+        </Table.Cell>
+        <Table.Cell>
+          {formatDate(thread.created_at.momentDate)}
         </Table.Cell>
       </Table.Row>
     );
@@ -211,10 +250,20 @@ function InnerViewThread (props: ViewThreadProps) {
 
   return <div style={{ marginBottom: '1rem' }}>
     <CategoryCrumbs categoryId={thread.category_id} />
-    <h1 className='ForumPageTitle'>
-      <ThreadTitle thread={thread} className='TitleText' />
-      {renderActions()}
-    </h1>
+    <ThreadHeader>
+      <h1 className='ForumPageTitle'>
+        <ThreadTitle thread={thread} className='TitleText' />
+      </h1>
+      <ThreadInfoAndActions>
+        <ThreadInfo>
+          Created by
+          <ThreadInfoMemberPreview accountId={thread.author_id} inline />
+          <TimeAgoDate date={thread.created_at.momentDate} id="thread" />
+        </ThreadInfo>
+        {renderActions()}
+      </ThreadInfoAndActions>
+    </ThreadHeader>
+
     {category.archived &&
       <JoyWarn title={'This thread is in archived category.'}>
         No new replies can be posted.

--- a/pioneer/packages/joy-forum/src/ViewThread.tsx
+++ b/pioneer/packages/joy-forum/src/ViewThread.tsx
@@ -131,15 +131,19 @@ type ViewThreadProps = ApiProps & InnerViewThreadProps & {
 function InnerViewThread (props: ViewThreadProps) {
   const [showModerateForm, setShowModerateForm] = useState(false);
   const [displayedPosts, setDisplayedPosts] = useState<Post[]>([]);
+  const [quotedPost, setQuotedPost] = useState<Post | null>(null);
+
   const postsRefs = useRef<Record<number, React.RefObject<HTMLDivElement>>>({});
-  const { category, thread, preview = false } = props;
   const replyFormRef = useRef<HTMLDivElement>(null);
+
   const [rawSelectedPostIdx, setSelectedPostIdx] = useQueryParam(ReplyIdxQueryParam);
   const [rawEditedPostId, setEditedPostId] = useQueryParam(ReplyEditIdQueryParam);
   const [currentPage, setCurrentPage] = usePagination();
 
   const parsedSelectedPostIdx = rawSelectedPostIdx ? parseInt(rawSelectedPostIdx) : null;
   const selectedPostIdx = (parsedSelectedPostIdx && !Number.isNaN(parsedSelectedPostIdx)) ? parsedSelectedPostIdx : null;
+
+  const { category, thread, preview = false } = props;
 
   const editedPostId = rawEditedPostId && new PostId(rawEditedPostId);
 
@@ -264,6 +268,7 @@ function InnerViewThread (props: ViewThreadProps) {
 
   const onThreadReplyClick = () => {
     clearEditedPost();
+    setQuotedPost(null);
     scrollToReplyForm();
   };
 
@@ -304,6 +309,11 @@ function InnerViewThread (props: ViewThreadProps) {
         scrollToReplyForm();
       };
 
+      const onReplyQuoteClick = () => {
+        setQuotedPost(reply);
+        scrollToReplyForm();
+      };
+
       return (
         <ViewReply
           ref={postsRefs.current[replyIdx]}
@@ -313,7 +323,7 @@ function InnerViewThread (props: ViewThreadProps) {
           reply={reply}
           selected={selectedPostIdx === replyIdx}
           onEdit={onReplyEditClick}
-          onQuote={() => {}}
+          onQuote={onReplyQuoteClick}
         />
       );
     });
@@ -398,7 +408,7 @@ function InnerViewThread (props: ViewThreadProps) {
         editedPostId ? (
           <EditReply id={editedPostId} key={editedPostId.toString()} onEditSuccess={onPostEditSuccess} onEditCancel={clearEditedPost} />
         ) : (
-          <NewReply threadId={thread.id} />
+          <NewReply threadId={thread.id} key={quotedPost?.id.toString()} quotedPost={quotedPost} />
         )
       }
     </ReplyEditContainer>

--- a/pioneer/packages/joy-forum/src/index.tsx
+++ b/pioneer/packages/joy-forum/src/index.tsx
@@ -15,6 +15,7 @@ import { NewThread, EditThread } from './EditThread';
 import { NewReply, EditReply } from './EditReply';
 import { CategoryList, ViewCategoryById } from './CategoryList';
 import { ViewThreadById } from './ViewThread';
+import { LegacyPagingRedirect } from './LegacyPagingRedirect';
 
 const ForumContentWrapper = styled.main`
   padding-top: 1.5rem;
@@ -30,22 +31,25 @@ class App extends React.PureComponent<Props> {
         <ForumSudoProvider>
           <ForumContentWrapper className='forum--App'>
             <Switch>
+              {/* routes for handling legacy format of forum paging within the routing path */}
+              {/* translate page param to search query */}
+              <Route path={`${basePath}/categories/:id/page/:page`} component={LegacyPagingRedirect} />
+              <Route path={`${basePath}/threads/:id/page/:page`} component={LegacyPagingRedirect} />
+
               {/* <Route path={`${basePath}/sudo`} component={EditForumSudo} /> */}
               {/* <Route path={`${basePath}/categories/new`} component={NewCategory} /> */}
+
               <Route path={`${basePath}/categories/:id/newSubcategory`} component={NewSubcategory} />
               <Route path={`${basePath}/categories/:id/newThread`} component={NewThread} />
               <Route path={`${basePath}/categories/:id/edit`} component={EditCategory} />
-              <Route path={`${basePath}/categories/:id/page/:page`} component={ViewCategoryById} />
               <Route path={`${basePath}/categories/:id`} component={ViewCategoryById} />
               <Route path={`${basePath}/categories`} component={CategoryList} />
 
               <Route path={`${basePath}/threads/:id/reply`} component={NewReply} />
               <Route path={`${basePath}/threads/:id/edit`} component={EditThread} />
-              <Route path={`${basePath}/threads/:id/page/:page`} component={ViewThreadById} />
               <Route path={`${basePath}/threads/:id`} component={ViewThreadById} />
 
               <Route path={`${basePath}/replies/:id/edit`} component={EditReply} />
-              {/* <Route path={`${basePath}/replies/:id`} component={ViewReplyById} /> */}
 
               <Route component={CategoryList} />
             </Switch>

--- a/pioneer/packages/joy-forum/src/index.tsx
+++ b/pioneer/packages/joy-forum/src/index.tsx
@@ -12,10 +12,10 @@ import { ForumProvider } from './Context';
 import { ForumSudoProvider } from './ForumSudo';
 import { NewSubcategory, EditCategory } from './EditCategory';
 import { NewThread, EditThread } from './EditThread';
-import { NewReply, EditReply } from './EditReply';
 import { CategoryList, ViewCategoryById } from './CategoryList';
 import { ViewThreadById } from './ViewThread';
 import { LegacyPagingRedirect } from './LegacyPagingRedirect';
+import ForumRoot from './ForumRoot';
 
 const ForumContentWrapper = styled.main`
   padding-top: 1.5rem;
@@ -48,7 +48,7 @@ class App extends React.PureComponent<Props> {
               <Route path={`${basePath}/threads/:id/edit`} component={EditThread} />
               <Route path={`${basePath}/threads/:id`} component={ViewThreadById} />
 
-              <Route component={CategoryList} />
+              <Route component={ForumRoot} />
             </Switch>
           </ForumContentWrapper>
         </ForumSudoProvider>

--- a/pioneer/packages/joy-forum/src/index.tsx
+++ b/pioneer/packages/joy-forum/src/index.tsx
@@ -1,9 +1,9 @@
 
 import React from 'react';
 import { Route, Switch } from 'react-router';
+import styled from 'styled-components';
 
 import { AppProps, I18nProps } from '@polkadot/react-components/types';
-import Tabs, { TabItem } from '@polkadot/react-components/Tabs';
 
 import './index.css';
 
@@ -16,43 +16,22 @@ import { NewReply, EditReply } from './EditReply';
 import { CategoryList, ViewCategoryById } from './CategoryList';
 import { ViewThreadById } from './ViewThread';
 
+const ForumContentWrapper = styled.main`
+  padding-top: 1.5rem;
+`;
+
 type Props = AppProps & I18nProps & {};
 
 class App extends React.PureComponent<Props> {
-  private buildTabs (): TabItem[] {
-    const { t } = this.props;
-    return [
-      {
-        isRoot: true,
-        name: 'forum',
-        text: t('Forum')
-      },
-      {
-        // TODO show this tab only if current user is the sudo:
-        name: 'categories/new',
-        text: t('New category')
-      },
-      {
-        name: 'sudo',
-        text: t('Forum sudo')
-      }
-    ];
-  }
-
   render () {
     const { basePath } = this.props;
-    const tabs = this.buildTabs();
     return (
       <ForumProvider>
         <ForumSudoProvider>
-          <main className='forum--App'>
-            <header>
-              <Tabs basePath={basePath} items={tabs} />
-            </header>
+          <ForumContentWrapper className='forum--App'>
             <Switch>
-              <Route path={`${basePath}/sudo`} component={EditForumSudo} />
-
-              <Route path={`${basePath}/categories/new`} component={NewCategory} />
+              {/* <Route path={`${basePath}/sudo`} component={EditForumSudo} /> */}
+              {/* <Route path={`${basePath}/categories/new`} component={NewCategory} /> */}
               <Route path={`${basePath}/categories/:id/newSubcategory`} component={NewSubcategory} />
               <Route path={`${basePath}/categories/:id/newThread`} component={NewThread} />
               <Route path={`${basePath}/categories/:id/edit`} component={EditCategory} />
@@ -70,7 +49,7 @@ class App extends React.PureComponent<Props> {
 
               <Route component={CategoryList} />
             </Switch>
-          </main>
+          </ForumContentWrapper>
         </ForumSudoProvider>
       </ForumProvider>
     );

--- a/pioneer/packages/joy-forum/src/index.tsx
+++ b/pioneer/packages/joy-forum/src/index.tsx
@@ -9,8 +9,8 @@ import './index.css';
 
 import translate from './translate';
 import { ForumProvider } from './Context';
-import { EditForumSudo, ForumSudoProvider } from './ForumSudo';
-import { NewCategory, NewSubcategory, EditCategory } from './EditCategory';
+import { ForumSudoProvider } from './ForumSudo';
+import { NewSubcategory, EditCategory } from './EditCategory';
 import { NewThread, EditThread } from './EditThread';
 import { NewReply, EditReply } from './EditReply';
 import { CategoryList, ViewCategoryById } from './CategoryList';

--- a/pioneer/packages/joy-forum/src/index.tsx
+++ b/pioneer/packages/joy-forum/src/index.tsx
@@ -45,11 +45,8 @@ class App extends React.PureComponent<Props> {
               <Route path={`${basePath}/categories/:id`} component={ViewCategoryById} />
               <Route path={`${basePath}/categories`} component={CategoryList} />
 
-              <Route path={`${basePath}/threads/:id/reply`} component={NewReply} />
               <Route path={`${basePath}/threads/:id/edit`} component={EditThread} />
               <Route path={`${basePath}/threads/:id`} component={ViewThreadById} />
-
-              <Route path={`${basePath}/replies/:id/edit`} component={EditReply} />
 
               <Route component={CategoryList} />
             </Switch>

--- a/pioneer/packages/joy-forum/src/utils.tsx
+++ b/pioneer/packages/joy-forum/src/utils.tsx
@@ -12,6 +12,7 @@ import { withMulti } from '@polkadot/react-api';
 
 export const ThreadsPerPage = 10;
 export const RepliesPerPage = 10;
+export const RecentActivityPostsCount = 7;
 export const ReplyIdxQueryParam = 'replyIdx';
 export const ReplyEditIdQueryParam = 'editReplyId';
 export const PagingQueryParam = 'page';

--- a/pioneer/packages/joy-forum/src/utils.tsx
+++ b/pioneer/packages/joy-forum/src/utils.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Breadcrumb, Pagination as SuiPagination } from 'semantic-ui-react';
 import styled from 'styled-components';
+import moment from 'moment';
+import Tooltip from 'react-tooltip';
 
 import { Category, CategoryId, Thread, ThreadId } from '@joystream/types/forum';
 import { withForumCalls } from './calls';
@@ -114,6 +116,22 @@ export const CategoryCrumbs = ({ categoryId, threadId, root }: CategoryCrumbsPro
     </StyledBreadcrumbs>
   );
 };
+
+type TimeAgoDateProps = {
+  date: moment.Moment;
+  id: any;
+};
+
+export const TimeAgoDate: React.FC<TimeAgoDateProps> = ({ date, id }) => (
+  <>
+    <span data-tip data-for={`${id}-date-tooltip`}>
+      {date.fromNow()}
+    </span>
+    <Tooltip id={`${id}-date-tooltip`} place="top" effect="solid">
+      {date.toLocaleString()}
+    </Tooltip>
+  </>
+);
 
 // It's used on such routes as:
 //   /categories/:id

--- a/pioneer/packages/joy-forum/src/utils.tsx
+++ b/pioneer/packages/joy-forum/src/utils.tsx
@@ -12,6 +12,9 @@ import { withMulti } from '@polkadot/react-api';
 
 export const ThreadsPerPage = 10;
 export const RepliesPerPage = 10;
+export const ReplyIdxQueryParam = 'replyIdx';
+export const ReplyEditIdQueryParam = 'editReplyId';
+export const PagingQueryParam = 'page';
 
 type PaginationProps = {
   currentPage?: number;
@@ -148,7 +151,7 @@ export type UrlHasIdProps = {
 };
 
 type QueryValueType = string | null;
-type QuerySetValueType = (value?: QueryValueType | number, clear?: boolean) => void;
+type QuerySetValueType = (value?: QueryValueType | number, paramsToReset?: string[]) => void;
 type QueryReturnType = [QueryValueType, QuerySetValueType];
 
 export const useQueryParam = (queryParam: string): QueryReturnType => {
@@ -164,7 +167,7 @@ export const useQueryParam = (queryParam: string): QueryReturnType => {
     }
   }, [search, setValue, queryParam]);
 
-  const setParam: QuerySetValueType = (rawValue, clear = false) => {
+  const setParam: QuerySetValueType = (rawValue, paramsToReset = []) => {
     let parsedValue: string | null;
     if (!rawValue && rawValue !== 0) {
       parsedValue = null;
@@ -172,12 +175,14 @@ export const useQueryParam = (queryParam: string): QueryReturnType => {
       parsedValue = rawValue.toString();
     }
 
-    const params = new URLSearchParams(!clear ? search : '');
+    const params = new URLSearchParams(search);
     if (parsedValue) {
       params.set(queryParam, parsedValue);
     } else {
       params.delete(queryParam);
     }
+
+    paramsToReset.forEach(p => params.delete(p));
 
     setValue(parsedValue);
     history.push({ pathname, search: params.toString() });
@@ -187,7 +192,7 @@ export const useQueryParam = (queryParam: string): QueryReturnType => {
 };
 
 export const usePagination = (): [number, QuerySetValueType] => {
-  const [rawCurrentPage, setCurrentPage] = useQueryParam('page');
+  const [rawCurrentPage, setCurrentPage] = useQueryParam(PagingQueryParam);
 
   let currentPage = 1;
   if (rawCurrentPage) {

--- a/pioneer/packages/joy-forum/src/utils.tsx
+++ b/pioneer/packages/joy-forum/src/utils.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Pagination as SuiPagination } from 'semantic-ui-react';
+import { Breadcrumb, Pagination as SuiPagination } from 'semantic-ui-react';
+import styled from 'styled-components';
 
 import { Category, CategoryId, Thread, ThreadId } from '@joystream/types/forum';
 import { withForumCalls } from './calls';
@@ -36,6 +37,7 @@ type CategoryCrumbsProps = {
   category?: Category;
   threadId?: ThreadId;
   thread?: Thread;
+  root?: boolean;
 };
 
 function InnerCategoryCrumb (p: CategoryCrumbsProps) {
@@ -46,8 +48,8 @@ function InnerCategoryCrumb (p: CategoryCrumbsProps) {
       const url = `/forum/categories/${category.id.toString()}`;
       return <>
         {category.parent_id ? <CategoryCrumb categoryId={category.parent_id} /> : null}
-        <i className='right angle icon divider'></i>
-        <Link className='section' to={url}>{category.title}</Link>
+        <Breadcrumb.Divider icon="right angle" />
+        <Breadcrumb.Section as={Link} to={url}>{category.title}</Breadcrumb.Section>
       </>;
     } catch (err) {
       console.log('Failed to create a category breadcrumb', err);
@@ -72,8 +74,8 @@ function InnerThreadCrumb (p: CategoryCrumbsProps) {
       const url = `/forum/threads/${thread.id.toString()}`;
       return <>
         <CategoryCrumb categoryId={thread.category_id} />
-        <i className='right angle icon divider'></i>
-        <Link className='section' to={url}>{thread.title}</Link>
+        <Breadcrumb.Divider icon="right angle" />
+        <Breadcrumb.Section as={Link} to={url}>{thread.title}</Breadcrumb.Section>
       </>;
     } catch (err) {
       console.log('Failed to create a thread breadcrumb', err);
@@ -90,13 +92,26 @@ const ThreadCrumb = withMulti(
   )
 );
 
-export const CategoryCrumbs = (p: CategoryCrumbsProps) => {
+const StyledBreadcrumbs = styled(Breadcrumb)`
+  && {
+    font-size: 1.3rem;
+    line-height: 1.2;
+  }
+`;
+
+export const CategoryCrumbs = ({ categoryId, threadId, root }: CategoryCrumbsProps) => {
   return (
-    <div className='ui breadcrumb'>
-      <Link className='section' to='/forum'>Top categories</Link>
-      <CategoryCrumb categoryId={p.categoryId} />
-      <ThreadCrumb threadId={p.threadId} />
-    </div>
+    <StyledBreadcrumbs>
+      <Breadcrumb.Section>Forum</Breadcrumb.Section>
+      {!root && (
+        <>
+          <Breadcrumb.Divider icon="right angle" />
+          <Breadcrumb.Section as={Link} to="/forum">Top categories</Breadcrumb.Section>
+          <CategoryCrumb categoryId={categoryId} />
+          <ThreadCrumb threadId={threadId} />
+        </>
+      )}
+    </StyledBreadcrumbs>
   );
 };
 

--- a/pioneer/packages/joy-forum/src/utils.tsx
+++ b/pioneer/packages/joy-forum/src/utils.tsx
@@ -148,7 +148,7 @@ export type UrlHasIdProps = {
 };
 
 type QueryValueType = string | null;
-type QuerySetValueType = (value?: QueryValueType | number) => void;
+type QuerySetValueType = (value?: QueryValueType | number, clear?: boolean) => void;
 type QueryReturnType = [QueryValueType, QuerySetValueType];
 
 export const useQueryParam = (queryParam: string): QueryReturnType => {
@@ -164,7 +164,7 @@ export const useQueryParam = (queryParam: string): QueryReturnType => {
     }
   }, [search, setValue, queryParam]);
 
-  const setParam: QuerySetValueType = (rawValue) => {
+  const setParam: QuerySetValueType = (rawValue, clear = false) => {
     let parsedValue: string | null;
     if (!rawValue && rawValue !== 0) {
       parsedValue = null;
@@ -172,7 +172,7 @@ export const useQueryParam = (queryParam: string): QueryReturnType => {
       parsedValue = rawValue.toString();
     }
 
-    const params = new URLSearchParams(search);
+    const params = new URLSearchParams(!clear ? search : '');
     if (parsedValue) {
       params.set(queryParam, parsedValue);
     } else {

--- a/pioneer/packages/joy-members/src/MemberPreview.tsx
+++ b/pioneer/packages/joy-members/src/MemberPreview.tsx
@@ -24,6 +24,7 @@ type MemberPreviewProps = ApiProps & I18nProps & {
   memberProfile?: Option<any>; // TODO refactor to Option<Profile>
   activeCouncil?: Seat[];
   prefixLabel?: string;
+  inline?: boolean;
   className?: string;
   style?: React.CSSProperties;
 };
@@ -37,7 +38,7 @@ class InnerMemberPreview extends React.PureComponent<MemberPreviewProps> {
   }
 
   private renderProfile (memberProfile: Profile) {
-    const { activeCouncil = [], accountId, prefixLabel, className, style } = this.props;
+    const { activeCouncil = [], accountId, prefixLabel, inline, className, style } = this.props;
     const { handle, avatar_uri } = memberProfile;
 
     const hasAvatar = avatar_uri && nonEmptyStr(avatar_uri.toString());
@@ -48,21 +49,26 @@ class InnerMemberPreview extends React.PureComponent<MemberPreviewProps> {
         {prefixLabel &&
           <MutedSpan className='PrefixLabel'>{prefixLabel}</MutedSpan>
         }
-        {hasAvatar
-          ? <img className='Avatar' src={avatar_uri.toString()} width={AvatarSizePx} height={AvatarSizePx} />
-          : <IdentityIcon className='Avatar' value={accountId} size={AvatarSizePx} />
-        }
+        {!inline && (
+          hasAvatar ? (
+            <img className="Avatar" src={avatar_uri.toString()} width={AvatarSizePx} height={AvatarSizePx} />
+          ) : (
+            <IdentityIcon className="Avatar" value={accountId} size={AvatarSizePx} />
+          )
+        )}
         <div className='Content'>
           <div className='Username'>
             <Link to={`/members/${handle.toString()}`} className='handle'>{handle.toString()}</Link>
           </div>
-          <div className='Details'>
-            {isCouncilor &&
-              <b className='muted text' style={{ color: '#607d8b' }}>
-                <i className='university icon'></i>
-                Council member
-              </b>}
-          </div>
+          {!inline && (
+            <div className='Details'>
+              {isCouncilor &&
+                <b className='muted text' style={{ color: '#607d8b' }}>
+                  <i className='university icon'></i>
+                  Council member
+                </b>}
+            </div>
+          )}
         </div>
       </FlexCenter>
     </div>;

--- a/pioneer/packages/joy-members/src/MemberPreview.tsx
+++ b/pioneer/packages/joy-members/src/MemberPreview.tsx
@@ -17,6 +17,7 @@ import { FlexCenter } from '@polkadot/joy-utils/FlexCenter';
 import { MutedSpan } from '@polkadot/joy-utils/MutedText';
 
 const AvatarSizePx = 36;
+const InlineAvatarSizePx = 24;
 
 type MemberPreviewProps = ApiProps & I18nProps & {
   accountId: AccountId;
@@ -44,18 +45,19 @@ class InnerMemberPreview extends React.PureComponent<MemberPreviewProps> {
     const hasAvatar = avatar_uri && nonEmptyStr(avatar_uri.toString());
     const isCouncilor: boolean = accountId !== undefined && activeCouncil.find(x => accountId.eq(x.member)) !== undefined;
 
+    const avatarSize = inline ? InlineAvatarSizePx : AvatarSizePx;
+
     return <div className={`JoyMemberPreview ${className}`} style={style}>
       <FlexCenter>
         {prefixLabel &&
           <MutedSpan className='PrefixLabel'>{prefixLabel}</MutedSpan>
         }
-        {!inline && (
-          hasAvatar ? (
-            <img className="Avatar" src={avatar_uri.toString()} width={AvatarSizePx} height={AvatarSizePx} />
-          ) : (
-            <IdentityIcon className="Avatar" value={accountId} size={AvatarSizePx} />
-          )
-        )}
+        {hasAvatar ? (
+          <img className="Avatar" src={avatar_uri.toString()} width={avatarSize} height={avatarSize} />
+        ) : (
+          <IdentityIcon className="Avatar" value={accountId} size={avatarSize} />
+        )
+        }
         <div className='Content'>
           <div className='Username'>
             <Link to={`/members/${handle.toString()}`} className='handle'>{handle.toString()}</Link>

--- a/pioneer/packages/joy-utils/src/functions/date.ts
+++ b/pioneer/packages/joy-utils/src/functions/date.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
 
 export function formatDate (date: moment.Moment): string {
-  return date.format('YYYY/MM/DD LT');
+  return date.format('DD/MM/YYYY LT');
 }

--- a/pioneer/packages/joy-utils/src/functions/date.ts
+++ b/pioneer/packages/joy-utils/src/functions/date.ts
@@ -1,0 +1,5 @@
+import moment from 'moment';
+
+export function formatDate (date: moment.Moment): string {
+  return date.format('YYYY/MM/DD LT');
+}

--- a/pioneer/packages/react-components/src/styles/index.ts
+++ b/pioneer/packages/react-components/src/styles/index.ts
@@ -124,10 +124,7 @@ export default createGlobalStyle`
     font-weight: 100;
   }
 
-  h1 {
-    text-transform: lowercase;
-
-    em {
+  h1 em {
       font-style: normal;
       text-transform: none;
     }

--- a/types/src/forum.ts
+++ b/types/src/forum.ts
@@ -1,6 +1,7 @@
 import { getTypeRegistry, bool, u16, u32, u64, Text, Option, Vec as Vector} from '@polkadot/types';
 import { AccountId, Moment, BlockNumber } from '@polkadot/types/interfaces';
 import { GenericAccountId } from '@polkadot/types';
+import moment from 'moment';
 
 import { JoyStruct } from './JoyStruct';
 
@@ -25,6 +26,10 @@ export class BlockchainTimestamp extends JoyStruct<BlockchainTimestampType> {
 
   get time (): Moment {
     return this.getField('time');
+  }
+
+  get momentDate (): moment.Moment {
+    return moment(this.time.toNumber());
   }
 
   static newEmpty (): BlockchainTimestamp {

--- a/types/src/forum.ts
+++ b/types/src/forum.ts
@@ -29,7 +29,20 @@ export class BlockchainTimestamp extends JoyStruct<BlockchainTimestampType> {
   }
 
   get momentDate (): moment.Moment {
-    return moment(this.time.toNumber());
+    const YEAR_2000_MILLISECONDS = 946684801000;
+
+    // overflowing in ~270,000 years
+    const timestamp = this.time.toNumber();
+
+    // TODO: remove once https://github.com/Joystream/joystream/issues/705 is resolved
+    // due to a bug, timestamp can be either in seconds or milliseconds
+    let timestampInMillis = timestamp;
+    if (timestamp < YEAR_2000_MILLISECONDS) {
+      // timestamp is in seconds
+      timestampInMillis = timestamp * 1000;
+    }
+
+    return moment(timestampInMillis);
   }
 
   static newEmpty (): BlockchainTimestamp {


### PR DESCRIPTION
This PR tackles all the forum improvements requested in #558.

### Notable changes

- Categories list columns were updated and recent activity (in unique threads) was added to the top-level categories.
<img width="983" alt="Screenshot 2020-06-19 at 12 30 44 PM" src="https://user-images.githubusercontent.com/12646744/85123533-b696e600-b228-11ea-802a-949a1ca266cf.png">

- Thread view got refreshed so that:
  - Thread creator and timestamp are presented
  - Each post has a timestamp and post number
  - Post actions are in a separate row
<img width="988" alt="Screenshot 2020-06-19 at 12 33 58 PM" src="https://user-images.githubusercontent.com/12646744/85123875-4b99df00-b229-11ea-97a6-82fdb606b89d.png">

- Thread reply form was moved inside the thread view and it supports both new reply and editing.
<img width="971" alt="Screenshot 2020-06-19 at 12 37 37 PM" src="https://user-images.githubusercontent.com/12646744/85124128-afbca300-b229-11ea-8da2-0f894c8af27d.png">

- Each post can be quoted using the button in the action row. At the moment, quoting supports only post text, adding author name, for example, would require some async fetching and additional work that may not be worth at the time.
<img width="971" alt="Screenshot 2020-06-19 at 12 38 44 PM" src="https://user-images.githubusercontent.com/12646744/85124303-f9a58900-b229-11ea-8e1c-754318532a49.png">

- Each post has a linkable number that once clicked, selects the post, and inserts its ID into the URL. This URL can be shared with others so that they will be taken directly to this specific reply.

- Threads list now lists the thread creation date.
<img width="977" alt="Screenshot 2020-06-19 at 12 31 47 PM" src="https://user-images.githubusercontent.com/12646744/85123614-db8b5900-b228-11ea-85a9-8d30cf065df5.png">

- Forum tabs were removed and replaced with breadcrumbs.
<img width="443" alt="Screenshot 2020-06-19 at 12 29 41 PM" src="https://user-images.githubusercontent.com/12646744/85123442-91a27300-b228-11ea-9dff-5e6411d85839.png">

- Some visual tweaks were performed:
  - Increasing font size for forum texts
  - Displaying properly-cased thread title
  - Styling of markdown blockquotes

### Items that weren't resolved

- Incorrect display of manual linebreaks was reported in the issue but that's expected behavior of Markdown (double new line is required). To keep the syntax standard, no changes were made.

- Lack of support for intended lists was reported as well, but that's something I couldn't reproduce:
<img width="217" alt="Screenshot 2020-06-19 at 12 48 50 PM" src="https://user-images.githubusercontent.com/12646744/85125055-3e7def80-b22b-11ea-9b6c-6fef44d2e7aa.png">
@bedeho do you have any more details on that specific item?

### Rationale behind some changes
So that some specific actions/items can be linked, query params in the URL were used. However, for some reason, current forum paging (threads and replies) wasn't using query params but page number inside the path itself (e.g. `forum/threads/1/page/2`). That is a pretty non-standard approach.

To make the paging more predictable and to enable easier integration with other features, paging was switched to query param based one (e.g. `forum/thread/1?page=2`). So that old links (in proposals for example) still work properly, a redirect component was added that will translate previous paging schema to a new one.