### PR TITLE
Changes to the working group: make leader hireable.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "6.16.0"
+version = "6.17.0"
 dependencies = [
  "parity-scale-codec",
  "safe-mix",

--- a/runtime-modules/common/src/lib.rs
+++ b/runtime-modules/common/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub mod constraints;
 pub mod currency;
-pub mod origin_validator;
+pub mod origin;
 
 use codec::{Decode, Encode};
 #[cfg(feature = "std")]

--- a/runtime-modules/common/src/origin.rs
+++ b/runtime-modules/common/src/origin.rs
@@ -1,0 +1,26 @@
+use system::RawOrigin;
+
+/// Abstract validator for the origin(account_id) and actor_id (eg.: thread author id).
+pub trait ActorOriginValidator<Origin, ActorId, AccountId> {
+    /// Check for valid combination of origin and actor_id.
+    fn ensure_actor_origin(origin: Origin, actor_id: ActorId) -> Result<AccountId, &'static str>;
+}
+
+// Multiplies the T::Origin.
+// In our current substrate version system::Origin doesn't support clone(),
+// but it will be supported in latest up-to-date substrate version.
+// TODO: delete when T::Origin will support the clone()
+pub fn double_origin<T: system::Trait>(origin: T::Origin) -> (T::Origin, T::Origin) {
+    let coerced_origin = origin.into().ok().unwrap_or(RawOrigin::None);
+
+    let (cloned_origin1, cloned_origin2) = match coerced_origin {
+        RawOrigin::None => (RawOrigin::None, RawOrigin::None),
+        RawOrigin::Root => (RawOrigin::Root, RawOrigin::Root),
+        RawOrigin::Signed(account_id) => (
+            RawOrigin::Signed(account_id.clone()),
+            RawOrigin::Signed(account_id),
+        ),
+    };
+
+    (cloned_origin1.into(), cloned_origin2.into())
+}

--- a/runtime-modules/common/src/origin_validator.rs
+++ b/runtime-modules/common/src/origin_validator.rs
@@ -1,5 +1,0 @@
-/// Abstract validator for the origin(account_id) and actor_id (eg.: thread author id).
-pub trait ActorOriginValidator<Origin, ActorId, AccountId> {
-    /// Check for valid combination of origin and actor_id.
-    fn ensure_actor_origin(origin: Origin, actor_id: ActorId) -> Result<AccountId, &'static str>;
-}

--- a/runtime-modules/hiring/src/hiring/staking_policy.rs
+++ b/runtime-modules/hiring/src/hiring/staking_policy.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// Policy for staking
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Debug, Eq, PartialEq, Clone)]
+#[derive(Encode, Decode, Debug, Eq, PartialEq, Clone, Default)]
 pub struct StakingPolicy<Balance, BlockNumber> {
     /// Staking amount
     pub amount: Balance,
@@ -76,4 +76,10 @@ pub enum StakingAmountLimitMode {
 
     /// Stake should be equal to provided value
     Exact,
+}
+
+impl Default for StakingAmountLimitMode {
+    fn default() -> Self {
+        StakingAmountLimitMode::Exact
+    }
 }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -123,7 +123,7 @@ impl governance::council::Trait for Test {
     type CouncilTermEnded = ();
 }
 
-impl common::origin_validator::ActorOriginValidator<Origin, u64, u64> for () {
+impl common::origin::ActorOriginValidator<Origin, u64, u64> for () {
     fn ensure_actor_origin(origin: Origin, _: u64) -> Result<u64, &'static str> {
         let account_id = system::ensure_signed(origin)?;
 

--- a/runtime-modules/proposals/discussion/src/lib.rs
+++ b/runtime-modules/proposals/discussion/src/lib.rs
@@ -56,7 +56,7 @@ use srml_support::{decl_error, decl_event, decl_module, decl_storage, ensure, Pa
 use srml_support::traits::Get;
 use types::{DiscussionPost, DiscussionThread, ThreadCounter};
 
-use common::origin_validator::ActorOriginValidator;
+use common::origin::ActorOriginValidator;
 use srml_support::dispatch::DispatchResult;
 
 type MemberId<T> = <T as membership::members::Trait>::MemberId;

--- a/runtime-modules/proposals/engine/src/lib.rs
+++ b/runtime-modules/proposals/engine/src/lib.rs
@@ -135,7 +135,7 @@ use srml_support::{
 use system::{ensure_root, RawOrigin};
 
 use crate::types::ApprovedProposalData;
-use common::origin_validator::ActorOriginValidator;
+use common::origin::ActorOriginValidator;
 use srml_support::dispatch::Dispatchable;
 
 type MemberId<T> = <T as membership::members::Trait>::MemberId;

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -124,7 +124,7 @@ impl Default for proposals::Call<Test> {
     }
 }
 
-impl common::origin_validator::ActorOriginValidator<Origin, u64, u64> for () {
+impl common::origin::ActorOriginValidator<Origin, u64, u64> for () {
     fn ensure_actor_origin(origin: Origin, _account_id: u64) -> Result<u64, &'static str> {
         let signed_account_id = system::ensure_signed(origin)?;
 

--- a/runtime-modules/recurring-reward/src/lib.rs
+++ b/runtime-modules/recurring-reward/src/lib.rs
@@ -94,10 +94,10 @@ pub struct RewardRelationship<AccountId, Balance, BlockNumber, MintId, Recipient
     mint_id: MintId,
 
     /// Destination account for reward
-    account: AccountId,
+    pub account: AccountId,
 
     /// The payout amount at the next payout
-    amount_per_payout: Balance,
+    pub amount_per_payout: Balance,
 
     /// When set, identifies block when next payout should be processed,
     /// otherwise there is no pending payout
@@ -146,7 +146,7 @@ decl_storage! {
 
         RecipientsCreated get(recipients_created): T::RecipientId;
 
-        RewardRelationships get(reward_relationships): linked_map T::RewardRelationshipId => RewardRelationship<T::AccountId, BalanceOf<T>, T::BlockNumber, T::MintId, T::RecipientId>;
+        pub RewardRelationships get(reward_relationships): linked_map T::RewardRelationshipId => RewardRelationship<T::AccountId, BalanceOf<T>, T::BlockNumber, T::MintId, T::RecipientId>;
 
         RewardRelationshipsCreated get(reward_relationships_created): T::RewardRelationshipId;
     }

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -130,8 +130,13 @@ impl recurringrewards::Trait for Test {
     type RewardRelationshipId = u64;
 }
 
+parameter_types! {
+    pub const MaxWorkerNumberLimit: u32 = 3;
+}
+
 impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type Event = MetaEvent;
+    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
 }
 
 impl timestamp::Trait for Test {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -158,7 +158,7 @@ pub(crate) fn hire_storage_provider() -> (u64, u64) {
 
     let storage_provider = working_group::Worker {
         member_id: 1,
-        role_account: role_account_id,
+        role_account_id,
         reward_relationship: None,
         role_stake_profile: None,
     };

--- a/runtime-modules/storage/src/data_directory.rs
+++ b/runtime-modules/storage/src/data_directory.rs
@@ -27,7 +27,7 @@ use sr_primitives::traits::{MaybeSerialize, Member};
 use srml_support::{decl_error, decl_event, decl_module, decl_storage, ensure, Parameter};
 use system::{self, ensure_root};
 
-use common::origin_validator::ActorOriginValidator;
+use common::origin::ActorOriginValidator;
 pub(crate) use common::BlockAndTime;
 
 use crate::data_object_type_registry;

--- a/runtime-modules/storage/src/tests/data_object_type_registry.rs
+++ b/runtime-modules/storage/src/tests/data_object_type_registry.rs
@@ -6,6 +6,7 @@ use system::{self, EventRecord, Phase, RawOrigin};
 
 const DEFAULT_LEADER_ACCOUNT_ID: u64 = 1;
 const DEFAULT_LEADER_MEMBER_ID: u64 = 1;
+const DEFAULT_LEADER_WORKER_ID: u32 = 1;
 
 struct SetLeadFixture;
 impl SetLeadFixture {
@@ -14,6 +15,7 @@ impl SetLeadFixture {
         let new_lead = working_group::Lead {
             member_id: DEFAULT_LEADER_MEMBER_ID,
             role_account_id: DEFAULT_LEADER_ACCOUNT_ID,
+            worker_id: DEFAULT_LEADER_WORKER_ID,
         };
 
         // Update current lead

--- a/runtime-modules/storage/src/tests/data_object_type_registry.rs
+++ b/runtime-modules/storage/src/tests/data_object_type_registry.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::mock::*;
-use crate::StorageWorkingGroup;
+use srml_support::StorageValue;
 use system::{self, EventRecord, Phase, RawOrigin};
 
 const DEFAULT_LEADER_ACCOUNT_ID: u64 = 1;
@@ -10,12 +10,14 @@ const DEFAULT_LEADER_MEMBER_ID: u64 = 1;
 struct SetLeadFixture;
 impl SetLeadFixture {
     fn set_default_lead() {
-        let set_lead_result = <StorageWorkingGroup<Test>>::set_lead(
-            RawOrigin::Root.into(),
-            DEFAULT_LEADER_MEMBER_ID,
-            DEFAULT_LEADER_ACCOUNT_ID,
-        );
-        assert!(set_lead_result.is_ok());
+        // Construct lead
+        let new_lead = working_group::Lead {
+            member_id: DEFAULT_LEADER_MEMBER_ID,
+            role_account_id: DEFAULT_LEADER_ACCOUNT_ID,
+        };
+
+        // Update current lead
+        <working_group::CurrentLead<Test, StorageWorkingGroupInstance>>::put(new_lead);
     }
 }
 

--- a/runtime-modules/storage/src/tests/data_object_type_registry.rs
+++ b/runtime-modules/storage/src/tests/data_object_type_registry.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::mock::*;
-use srml_support::StorageValue;
+use srml_support::{StorageLinkedMap, StorageValue};
 use system::{self, EventRecord, Phase, RawOrigin};
 
 const DEFAULT_LEADER_ACCOUNT_ID: u64 = 1;
@@ -11,15 +11,23 @@ const DEFAULT_LEADER_WORKER_ID: u32 = 1;
 struct SetLeadFixture;
 impl SetLeadFixture {
     fn set_default_lead() {
-        // Construct lead
-        let new_lead = working_group::Lead {
+        let worker = working_group::Worker {
             member_id: DEFAULT_LEADER_MEMBER_ID,
             role_account_id: DEFAULT_LEADER_ACCOUNT_ID,
-            worker_id: DEFAULT_LEADER_WORKER_ID,
+            reward_relationship: None,
+            role_stake_profile: None,
         };
 
-        // Update current lead
-        <working_group::CurrentLead<Test, StorageWorkingGroupInstance>>::put(new_lead);
+        // Create the worker.
+        <working_group::WorkerById<Test, StorageWorkingGroupInstance>>::insert(
+            DEFAULT_LEADER_WORKER_ID,
+            worker,
+        );
+
+        // Update current lead.
+        <working_group::CurrentLead<Test, StorageWorkingGroupInstance>>::put(
+            DEFAULT_LEADER_WORKER_ID,
+        );
     }
 }
 

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -304,7 +304,7 @@ pub(crate) fn hire_storage_provider() -> (u64, u32) {
 
     let storage_provider = working_group::Worker {
         member_id: 1,
-        role_account: role_account_id,
+        role_account_id,
         reward_relationship: None,
         role_stake_profile: None,
     };

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -169,7 +169,7 @@ impl crate::data_directory::StorageProviderHelper<Test> for () {
     }
 }
 
-impl common::origin_validator::ActorOriginValidator<Origin, u64, u64> for () {
+impl common::origin::ActorOriginValidator<Origin, u64, u64> for () {
     fn ensure_actor_origin(origin: Origin, _account_id: u64) -> Result<u64, &'static str> {
         let signed_account_id = system::ensure_signed(origin)?;
 

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -146,8 +146,13 @@ impl GovernanceCurrency for Test {
     type Currency = balances::Module<Self>;
 }
 
+parameter_types! {
+    pub const MaxWorkerNumberLimit: u32 = 3;
+}
+
 impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type Event = MetaEvent;
+    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
 }
 
 impl data_object_type_registry::Trait for Test {

--- a/runtime-modules/working-group/src/errors.rs
+++ b/runtime-modules/working-group/src/errors.rs
@@ -244,6 +244,9 @@ decl_error! {
 
         /// Require signed origin in extrinsics.
         RequireSignedOrigin,
+
+        /// Working group size limit exceeded.
+        MaxActiveWorkerNumberExceeded,
     }
 }
 

--- a/runtime-modules/working-group/src/errors.rs
+++ b/runtime-modules/working-group/src/errors.rs
@@ -17,6 +17,9 @@ decl_error! {
         /// There is leader already, cannot hire another one.
         CannotHireLeaderWhenLeaderExists,
 
+        /// Cannot fill opening with several applications.
+        CannotHireSeveralLeader,
+
         /// Not a lead account.
         IsNotLeadAccount,
 

--- a/runtime-modules/working-group/src/errors.rs
+++ b/runtime-modules/working-group/src/errors.rs
@@ -14,6 +14,9 @@ decl_error! {
         /// Current lead is not set.
         CurrentLeadNotSet,
 
+        /// There is leader already, cannot hire another one.
+        CannotHireLeaderWhenLeaderExists,
+
         /// Not a lead account.
         IsNotLeadAccount,
 

--- a/runtime-modules/working-group/src/errors.rs
+++ b/runtime-modules/working-group/src/errors.rs
@@ -241,6 +241,9 @@ decl_error! {
 
         /// Require root origin in extrinsics.
         RequireRootOrigin,
+
+        /// Require signed origin in extrinsics.
+        RequireSignedOrigin,
     }
 }
 
@@ -249,6 +252,7 @@ impl From<system::Error> for Error {
         match error {
             system::Error::Other(msg) => Error::Other(msg),
             system::Error::RequireRootOrigin => Error::RequireRootOrigin,
+            system::Error::RequireSignedOrigin => Error::RequireSignedOrigin,
             _ => Error::Other(error.into()),
         }
     }

--- a/runtime-modules/working-group/src/errors.rs
+++ b/runtime-modules/working-group/src/errors.rs
@@ -17,8 +17,8 @@ decl_error! {
         /// There is leader already, cannot hire another one.
         CannotHireLeaderWhenLeaderExists,
 
-        /// Cannot fill opening with several applications.
-        CannotHireSeveralLeader,
+        /// Cannot fill opening with multiple applications.
+        CannotHireMultipleLeaders,
 
         /// Not a lead account.
         IsNotLeadAccount,

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -41,9 +41,9 @@
 // Do not delete! Cannot be uncommented by default, because of Parity decl_module! issue.
 //#![warn(missing_docs)]
 
-// TODO: terminate role - add 'include slashing' parameter.
 // TODO: leave role - unset lead on success when the leader is leaving.
 // TODO: check all that a leader can set only its own parameters as a worker.
+// TODO: coments
 
 #[cfg(test)]
 mod tests;
@@ -1372,6 +1372,15 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
             ))?;
         }
 
+        // Unset lead if the leader is leaving.
+        let lead = <CurrentLead<T, I>>::get();
+        if let Some(lead) = lead {
+            if lead.worker_id == *worker_id {
+                Self::unset_lead();
+            }
+        }
+
+        // Remove the worker from the storage.
         WorkerById::<T, I>::remove(worker_id);
 
         // Trigger the event
@@ -1386,10 +1395,6 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
                 RawEvent::TerminatedLeader(*worker_id, rationale_text.to_vec())
             }
         };
-
-        if matches!(exit_initiation_origin, ExitInitiationOrigin::Sudo) {
-            Self::unset_lead();
-        }
 
         Self::deposit_event(event);
 

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -44,7 +44,6 @@
 // TODO: terminate role - add 'include slashing' parameter.
 // TODO: terminate role - unset lead on success when the leader is being fired.
 // TODO: leave role - unset lead on success when the leader is leaving.
-// TODO: fill_opening: single application winner.
 // TODO: stakes - disallow zero stake.
 // TODO: check all that a leader can set only its own parameters as a worker.
 

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -112,21 +112,12 @@ pub type HiringApplicationId<T> = <T as hiring::Trait>::ApplicationId;
 
 // Type simplification
 type OpeningInfo<T> = (
-    Opening<
-        <T as hiring::Trait>::OpeningId,
-        <T as system::Trait>::BlockNumber,
-        BalanceOf<T>,
-        ApplicationId<T>,
-    >,
+    OpeningOf<T>,
     hiring::Opening<BalanceOf<T>, <T as system::Trait>::BlockNumber, HiringApplicationId<T>>,
 );
 
 // Type simplification
-type ApplicationInfo<T> = (
-    Application<<T as system::Trait>::AccountId, OpeningId<T>, MemberId<T>, HiringApplicationId<T>>,
-    ApplicationId<T>,
-    OpeningOf<T>,
-);
+type ApplicationInfo<T> = (ApplicationOf<T>, ApplicationId<T>, OpeningOf<T>);
 
 // Type simplification
 type RewardSettings<T> = (
@@ -150,6 +141,10 @@ type OpeningOf<T> = Opening<
     BalanceOf<T>,
     ApplicationId<T>,
 >;
+
+// Type simplification
+type ApplicationOf<T> =
+    Application<<T as system::Trait>::AccountId, OpeningId<T>, MemberId<T>, HiringApplicationId<T>>;
 
 /// The _Working group_ main _Trait_
 pub trait Trait<I: Instance>:
@@ -300,8 +295,7 @@ decl_storage! {
         pub OpeningHumanReadableText get(opening_human_readable_text): InputValidationLengthConstraint;
 
         /// Maps identifier to worker application on opening.
-        pub ApplicationById get(application_by_id) : linked_map ApplicationId<T> =>
-            Application<T::AccountId, OpeningId<T>, T::MemberId, T::ApplicationId>;
+        pub ApplicationById get(application_by_id) : linked_map ApplicationId<T> => ApplicationOf<T>;
 
         /// Next identifier value for new worker application.
         pub NextApplicationId get(next_application_id) : ApplicationId<T>;

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -41,9 +41,6 @@
 // Do not delete! Cannot be uncommented by default, because of Parity decl_module! issue.
 //#![warn(missing_docs)]
 
-// TODO: slash_stake for a leader
-// TODO: decrease_stake for a leader
-// TODO: increase_stake for a leader
 // TODO: comments
 
 #[cfg(test)]
@@ -423,8 +420,8 @@ decl_module! {
             worker_id: WorkerId<T>,
             new_amount: BalanceOfMint<T>
         ) {
-            // Ensure lead is set and is origin signer
-            Self::ensure_origin_is_active_leader(origin)?;
+            // Ensure lead is set and is origin signer or it is the council.
+            Self::ensure_origin_for_leader(origin, worker_id)?;
 
             // Ensuring worker actually exists
             let worker = Self::ensure_worker_exists(&worker_id)?;
@@ -959,7 +956,8 @@ decl_module! {
         /// Decreases the worker/lead stake and returns the remainder to the worker role_account,
         /// demands a leader origin. Can be decreased to zero, no actions on zero stake.
         pub fn decrease_stake(origin, worker_id: WorkerId<T>, balance: BalanceOf<T>) {
-            Self::ensure_origin_is_active_leader(origin)?;
+            // Ensure lead is set or it is the council terminating the leader.
+            Self::ensure_origin_for_leader(origin, worker_id)?;
 
             let worker = Self::ensure_worker_exists(&worker_id)?;
 

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -845,7 +845,7 @@ decl_module! {
 
             // Check for a single application for a leader.
             if matches!(opening.opening_type, OpeningType::Leader) {
-                ensure!(successful_application_ids.len() == 1, Error::CannotHireSeveralLeader);
+                ensure!(successful_application_ids.len() == 1, Error::CannotHireMultipleLeaders);
             }
 
             // NB: Combined ensure check and mutation in hiring module
@@ -1254,8 +1254,8 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
         <NegativeImbalance<T>>::zero()
     }
 
-    /// Checks that provided lead account id belongs to the current working group leader
-    pub fn ensure_is_lead_account(lead_account_id: T::AccountId) -> Result<(), Error> {
+    // Checks that provided lead account id belongs to the current working group leader
+    fn ensure_is_lead_account(lead_account_id: T::AccountId) -> Result<(), Error> {
         let lead = <CurrentLead<T, I>>::get();
 
         if let Some(lead) = lead {

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -516,10 +516,6 @@ decl_module! {
 
             Self::ensure_opening_human_readable_text_is_valid(&human_readable_text)?;
 
-            ensure!(
-                (Self::active_worker_count()) < T::MaxWorkerNumberLimit::get(),
-                Error::MaxActiveWorkerNumberExceeded
-            );
 
             // Add opening
             // NB: This call can in principle fail, because the staking policies
@@ -783,6 +779,14 @@ decl_module! {
             let (opening, _) = Self::ensure_opening_exists(&opening_id)?;
 
             Self::ensure_origin_for_opening_type(origin, opening.opening_type)?;
+
+            let potential_worker_number =
+                Self::active_worker_count() + (successful_application_ids.len() as u32);
+
+            ensure!(
+                potential_worker_number <= T::MaxWorkerNumberLimit::get(),
+                Error::MaxActiveWorkerNumberExceeded
+            );
 
             // Cannot hire a lead when another leader exists.
             if matches!(opening.opening_type, OpeningType::Leader) {

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -753,6 +753,7 @@ decl_module! {
 
             Self::ensure_origin_for_opening_type(origin, opening.opening_type)?;
 
+            // Cannot hire a lead when another leader exists.
             if matches!(opening.opening_type, OpeningType::Leader) {
                 ensure!(!<CurrentLead<T,I>>::exists(), Error::CannotHireLeaderWhenLeaderExists);
             }
@@ -801,6 +802,11 @@ decl_module! {
                                             .clone()
                                             .map(|(successful_application, _, _)| successful_application.hiring_application_id)
                                             .collect::<BTreeSet<_>>();
+
+            // Check for a single application for a leader.
+            if matches!(opening.opening_type, OpeningType::Leader) {
+                ensure!(successful_application_ids.len() == 1, Error::CannotHireSeveralLeader);
+            }
 
             // NB: Combined ensure check and mutation in hiring module
             ensure_on_wrapped_error!(

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -238,17 +238,6 @@ impl UpdateWorkerRoleAccountFixture {
     }
 }
 
-pub struct UnsetLeadFixture;
-impl UnsetLeadFixture {
-    pub fn unset_lead() {
-        TestWorkingGroup::unset_lead();
-    }
-
-    pub fn call_and_assert(origin: RawOrigin<u64>, expected_result: Result<(), Error>) {
-        TestWorkingGroup::unset_lead();
-    }
-}
-
 pub fn set_mint_id(mint_id: u64) {
     <crate::Mint<Test, TestWorkingGroupInstance>>::put(mint_id);
 }
@@ -587,6 +576,10 @@ impl Default for SetLeadFixture {
 }
 
 impl SetLeadFixture {
+    pub fn unset_lead() {
+        TestWorkingGroup::unset_lead();
+    }
+
     pub fn set_lead(self) {
         TestWorkingGroup::set_lead(self.member_id, self.role_account);
     }
@@ -611,13 +604,6 @@ impl Default for HireLeadFixture {
     }
 }
 impl HireLeadFixture {
-    pub fn disable_setup_environment(self) -> Self {
-        HireLeadFixture {
-            setup_environment: false,
-            ..self
-        }
-    }
-
     pub fn hire_lead(self) -> u64 {
         fill_worker_position(
             None,

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -289,14 +289,21 @@ impl FillWorkerOpeningFixture {
         }
     }
 
-    pub fn call_and_assert(&self, expected_result: Result<(), Error>) -> u64 {
+    pub fn call(&self) -> Result<u64, Error> {
         let saved_worker_next_id = TestWorkingGroup::next_worker_id();
-        let actual_result = TestWorkingGroup::fill_opening(
+        TestWorkingGroup::fill_opening(
             self.origin.clone().into(),
             self.opening_id,
             self.successful_application_ids.clone(),
             self.reward_policy.clone(),
-        );
+        )?;
+
+        Ok(saved_worker_next_id)
+    }
+
+    pub fn call_and_assert(&self, expected_result: Result<(), Error>) -> u64 {
+        let saved_worker_next_id = TestWorkingGroup::next_worker_id();
+        let actual_result = self.call().map(|_| ());
         assert_eq!(actual_result.clone(), expected_result);
 
         if actual_result.is_ok() {
@@ -460,28 +467,36 @@ pub struct ApplyOnWorkerOpeningFixture {
 
 impl ApplyOnWorkerOpeningFixture {
     pub fn with_text(self, text: Vec<u8>) -> Self {
-        ApplyOnWorkerOpeningFixture {
+        Self {
             human_readable_text: text,
             ..self
         }
     }
 
-    pub fn with_role_stake(self, stake: u64) -> Self {
-        ApplyOnWorkerOpeningFixture {
-            opt_role_stake_balance: Some(stake),
+    pub fn with_origin(self, origin: RawOrigin<u64>, member_id: u64) -> Self {
+        Self {
+            origin,
+            member_id,
+            ..self
+        }
+    }
+
+    pub fn with_role_stake(self, stake: Option<u64>) -> Self {
+        Self {
+            opt_role_stake_balance: stake,
             ..self
         }
     }
 
     pub fn with_application_stake(self, stake: u64) -> Self {
-        ApplyOnWorkerOpeningFixture {
+        Self {
             opt_application_stake_balance: Some(stake),
             ..self
         }
     }
 
     pub fn default_for_opening_id(opening_id: u64) -> Self {
-        ApplyOnWorkerOpeningFixture {
+        Self {
             origin: RawOrigin::Signed(1),
             member_id: 1,
             worker_opening_id: opening_id,

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -338,10 +338,8 @@ impl FillWorkerOpeningFixture {
                     &stake_id,
                     &opening
                         .policy_commitment
-                        .terminate_worker_role_stake_unstaking_period,
-                    &opening
-                        .policy_commitment
-                        .exit_worker_role_stake_unstaking_period,
+                        .terminate_role_stake_unstaking_period,
+                    &opening.policy_commitment.exit_role_stake_unstaking_period,
                 ))
             } else {
                 None
@@ -716,7 +714,7 @@ impl AddWorkerOpeningFixture {
             let actual_opening = TestWorkingGroup::opening_by_id(opening_id);
 
             let expected_opening = Opening::<u64, u64, u64, u64> {
-                opening_id,
+                hiring_opening_id: opening_id,
                 applications: BTreeSet::new(),
                 policy_commitment: self.commitment.clone(),
                 opening_type: self.opening_type,

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -23,7 +23,7 @@ pub struct IncreaseWorkerStakeFixture {
 impl IncreaseWorkerStakeFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
         let account_id = 1;
-        IncreaseWorkerStakeFixture {
+        Self {
             origin: RawOrigin::Signed(1),
             worker_id,
             balance: 10,
@@ -31,11 +31,11 @@ impl IncreaseWorkerStakeFixture {
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        IncreaseWorkerStakeFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn with_balance(self, balance: u64) -> Self {
-        IncreaseWorkerStakeFixture { balance, ..self }
+        Self { balance, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) {
@@ -72,11 +72,12 @@ pub struct TerminateWorkerRoleFixture {
     origin: RawOrigin<u64>,
     text: Vec<u8>,
     constraint: InputValidationLengthConstraint,
+    slash_stake: bool,
 }
 
 impl TerminateWorkerRoleFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
-        TerminateWorkerRoleFixture {
+        Self {
             worker_id,
             origin: RawOrigin::Signed(1),
             text: b"rationale_text".to_vec(),
@@ -84,14 +85,22 @@ impl TerminateWorkerRoleFixture {
                 min: 1,
                 max_min_diff: 20,
             },
+            slash_stake: false,
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        TerminateWorkerRoleFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn with_text(self, text: Vec<u8>) -> Self {
-        TerminateWorkerRoleFixture { text, ..self }
+        Self { text, ..self }
+    }
+
+    pub fn with_slashing(self) -> Self {
+        Self {
+            slash_stake: true,
+            ..self
+        }
     }
 
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) {
@@ -101,6 +110,7 @@ impl TerminateWorkerRoleFixture {
             self.origin.clone().into(),
             self.worker_id,
             self.text.clone(),
+            self.slash_stake,
         );
         assert_eq!(actual_result, expected_result);
 
@@ -121,13 +131,13 @@ pub(crate) struct LeaveWorkerRoleFixture {
 
 impl LeaveWorkerRoleFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
-        LeaveWorkerRoleFixture {
+        Self {
             worker_id,
             origin: RawOrigin::Signed(1),
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        LeaveWorkerRoleFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) {
@@ -153,14 +163,14 @@ pub struct UpdateWorkerRewardAmountFixture {
 
 impl UpdateWorkerRewardAmountFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
-        UpdateWorkerRewardAmountFixture {
+        Self {
             worker_id,
             amount: 100,
             origin: RawOrigin::Signed(1),
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        UpdateWorkerRewardAmountFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) {
@@ -182,14 +192,14 @@ pub struct UpdateWorkerRewardAccountFixture {
 
 impl UpdateWorkerRewardAccountFixture {
     pub fn default_with_ids(worker_id: u64, new_reward_account_id: u64) -> Self {
-        UpdateWorkerRewardAccountFixture {
+        Self {
             worker_id,
             new_reward_account_id,
             origin: RawOrigin::Signed(1),
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        UpdateWorkerRewardAccountFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) {
@@ -212,14 +222,14 @@ pub struct UpdateWorkerRoleAccountFixture {
 
 impl UpdateWorkerRoleAccountFixture {
     pub fn default_with_ids(worker_id: u64, new_role_account_id: u64) -> Self {
-        UpdateWorkerRoleAccountFixture {
+        Self {
             worker_id,
             new_role_account_id,
             origin: RawOrigin::Signed(1),
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        UpdateWorkerRoleAccountFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) {
@@ -258,7 +268,7 @@ impl FillWorkerOpeningFixture {
     pub fn default_for_ids(opening_id: u64, application_ids: Vec<u64>) -> Self {
         let application_ids: BTreeSet<u64> = application_ids.iter().map(|x| *x).collect();
 
-        FillWorkerOpeningFixture {
+        Self {
             origin: RawOrigin::Signed(1),
             opening_id,
             successful_application_ids: application_ids,
@@ -268,11 +278,11 @@ impl FillWorkerOpeningFixture {
     }
 
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        FillWorkerOpeningFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn with_reward_policy(self, reward_policy: RewardPolicy<u64, u64>) -> Self {
-        FillWorkerOpeningFixture {
+        Self {
             reward_policy: Some(reward_policy),
             ..self
         }
@@ -345,13 +355,13 @@ pub struct BeginReviewWorkerApplicationsFixture {
 
 impl BeginReviewWorkerApplicationsFixture {
     pub fn default_for_opening_id(opening_id: u64) -> Self {
-        BeginReviewWorkerApplicationsFixture {
+        Self {
             origin: RawOrigin::Signed(1),
             opening_id,
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        BeginReviewWorkerApplicationsFixture { origin, ..self }
+        Self { origin, ..self }
     }
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) {
         let actual_result =
@@ -367,16 +377,16 @@ pub struct TerminateApplicationFixture {
 
 impl TerminateApplicationFixture {
     pub fn with_signer(self, account_id: u64) -> Self {
-        TerminateApplicationFixture {
+        Self {
             origin: RawOrigin::Signed(account_id),
             ..self
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        TerminateApplicationFixture { origin, ..self }
+        Self { origin, ..self }
     }
     pub fn default_for_application_id(application_id: u64) -> Self {
-        TerminateApplicationFixture {
+        Self {
             origin: RawOrigin::Signed(1),
             worker_application_id: application_id,
         }
@@ -396,16 +406,16 @@ pub struct WithdrawApplicationFixture {
 
 impl WithdrawApplicationFixture {
     pub fn with_signer(self, account_id: u64) -> Self {
-        WithdrawApplicationFixture {
+        Self {
             origin: RawOrigin::Signed(account_id),
             ..self
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        WithdrawApplicationFixture { origin, ..self }
+        Self { origin, ..self }
     }
     pub fn default_for_application_id(application_id: u64) -> Self {
-        WithdrawApplicationFixture {
+        Self {
             origin: RawOrigin::Signed(1),
             worker_application_id: application_id,
         }
@@ -422,6 +432,10 @@ impl WithdrawApplicationFixture {
 pub fn increase_total_balance_issuance_using_account_id(account_id: u64, balance: u64) {
     let _ =
         <Balances as srml_support::traits::Currency<u64>>::deposit_creating(&account_id, balance);
+}
+
+pub fn get_balance(account_id: u64) -> u64 {
+    <super::mock::Balances as srml_support::traits::Currency<u64>>::total_balance(&account_id)
 }
 
 pub fn setup_members(count: u8) {
@@ -549,7 +563,7 @@ pub struct AcceptWorkerApplicationsFixture {
 
 impl AcceptWorkerApplicationsFixture {
     pub fn default_for_opening_id(opening_id: u64) -> Self {
-        AcceptWorkerApplicationsFixture {
+        Self {
             origin: RawOrigin::Signed(1),
             opening_id,
         }
@@ -586,7 +600,7 @@ impl SetLeadFixture {
         TestWorkingGroup::set_lead(self.member_id, self.role_account, self.worker_id);
     }
     pub fn set_lead_with_ids(member_id: u64, role_account: u64, worker_id: u64) {
-        SetLeadFixture {
+        Self {
             member_id,
             role_account,
             worker_id,
@@ -601,7 +615,7 @@ pub struct HireLeadFixture {
 
 impl Default for HireLeadFixture {
     fn default() -> Self {
-        HireLeadFixture {
+        Self {
             setup_environment: true,
         }
     }
@@ -632,7 +646,7 @@ pub struct AddWorkerOpeningFixture {
 
 impl Default for AddWorkerOpeningFixture {
     fn default() -> Self {
-        AddWorkerOpeningFixture {
+        Self {
             origin: RawOrigin::Signed(1),
             activate_at: hiring::ActivateOpeningAt::CurrentBlock,
             commitment: <OpeningPolicyCommitment<u64, u64>>::default(),
@@ -647,7 +661,7 @@ impl AddWorkerOpeningFixture {
         self,
         policy_commitment: OpeningPolicyCommitment<u64, u64>,
     ) -> Self {
-        AddWorkerOpeningFixture {
+        Self {
             commitment: policy_commitment,
             ..self
         }
@@ -695,25 +709,25 @@ impl AddWorkerOpeningFixture {
     }
 
     pub fn with_text(self, text: Vec<u8>) -> Self {
-        AddWorkerOpeningFixture {
+        Self {
             human_readable_text: text,
             ..self
         }
     }
 
     pub fn with_opening_type(self, opening_type: OpeningType) -> Self {
-        AddWorkerOpeningFixture {
+        Self {
             opening_type,
             ..self
         }
     }
 
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        AddWorkerOpeningFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn with_activate_at(self, activate_at: hiring::ActivateOpeningAt<u64>) -> Self {
-        AddWorkerOpeningFixture {
+        Self {
             activate_at,
             ..self
         }
@@ -763,7 +777,7 @@ pub struct DecreaseWorkerStakeFixture {
 impl DecreaseWorkerStakeFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
         let account_id = 1;
-        DecreaseWorkerStakeFixture {
+        Self {
             origin: RawOrigin::Signed(account_id),
             worker_id,
             balance: 10,
@@ -771,11 +785,11 @@ impl DecreaseWorkerStakeFixture {
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        DecreaseWorkerStakeFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn with_balance(self, balance: u64) -> Self {
-        DecreaseWorkerStakeFixture { balance, ..self }
+        Self { balance, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) {
@@ -807,7 +821,7 @@ impl DecreaseWorkerStakeFixture {
     }
 }
 
-fn get_stake_balance(stake: stake::Stake<u64, u64, u64>) -> u64 {
+pub(crate) fn get_stake_balance(stake: stake::Stake<u64, u64, u64>) -> u64 {
     if let stake::StakingStatus::Staked(stake) = stake.staking_status {
         return stake.staked_amount;
     }
@@ -825,7 +839,7 @@ pub struct SlashWorkerStakeFixture {
 impl SlashWorkerStakeFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
         let account_id = 1;
-        SlashWorkerStakeFixture {
+        Self {
             origin: RawOrigin::Signed(account_id),
             worker_id,
             balance: 10,
@@ -833,11 +847,11 @@ impl SlashWorkerStakeFixture {
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        SlashWorkerStakeFixture { origin, ..self }
+        Self { origin, ..self }
     }
 
     pub fn with_balance(self, balance: u64) -> Self {
-        SlashWorkerStakeFixture { balance, ..self }
+        Self { balance, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) {

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -565,12 +565,14 @@ impl AcceptWorkerApplicationsFixture {
 pub struct SetLeadFixture {
     pub member_id: u64,
     pub role_account: u64,
+    pub worker_id: u64,
 }
 impl Default for SetLeadFixture {
     fn default() -> Self {
         SetLeadFixture {
             member_id: 1,
             role_account: 1,
+            worker_id: 1,
         }
     }
 }
@@ -581,12 +583,13 @@ impl SetLeadFixture {
     }
 
     pub fn set_lead(self) {
-        TestWorkingGroup::set_lead(self.member_id, self.role_account);
+        TestWorkingGroup::set_lead(self.member_id, self.role_account, self.worker_id);
     }
-    pub fn set_lead_with_ids(member_id: u64, role_account: u64) {
+    pub fn set_lead_with_ids(member_id: u64, role_account: u64, worker_id: u64) {
         SetLeadFixture {
             member_id,
             role_account,
+            worker_id,
         }
         .set_lead();
     }

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -492,9 +492,9 @@ impl ApplyOnWorkerOpeningFixture {
         }
     }
 
-    pub fn call_and_assert(&self, expected_result: Result<(), Error>) -> u64 {
+    pub fn call(&self) -> Result<u64, Error> {
         let saved_application_next_id = TestWorkingGroup::next_application_id();
-        let actual_result = TestWorkingGroup::apply_on_opening(
+        TestWorkingGroup::apply_on_opening(
             self.origin.clone().into(),
             self.member_id,
             self.worker_opening_id,
@@ -502,7 +502,14 @@ impl ApplyOnWorkerOpeningFixture {
             self.opt_role_stake_balance,
             self.opt_application_stake_balance,
             self.human_readable_text.clone(),
-        );
+        )?;
+
+        Ok(saved_application_next_id)
+    }
+    pub fn call_and_assert(&self, expected_result: Result<(), Error>) -> u64 {
+        let saved_application_next_id = TestWorkingGroup::next_application_id();
+
+        let actual_result = self.call().map(|_| ());
         assert_eq!(actual_result.clone(), expected_result);
 
         if actual_result.is_ok() {
@@ -644,13 +651,8 @@ impl AddWorkerOpeningFixture {
 
     pub fn call_and_assert(&self, expected_result: Result<(), Error>) -> u64 {
         let saved_opening_next_id = TestWorkingGroup::next_opening_id();
-        let actual_result = TestWorkingGroup::add_opening(
-            self.origin.clone().into(),
-            self.activate_at.clone(),
-            self.commitment.clone(),
-            self.human_readable_text.clone(),
-            self.opening_type,
-        );
+        let actual_result = self.call().map(|_| ());
+
         assert_eq!(actual_result.clone(), expected_result);
 
         if actual_result.is_ok() {
@@ -673,6 +675,19 @@ impl AddWorkerOpeningFixture {
         }
 
         saved_opening_next_id
+    }
+
+    pub fn call(&self) -> Result<u64, Error> {
+        let saved_opening_next_id = TestWorkingGroup::next_opening_id();
+        TestWorkingGroup::add_opening(
+            self.origin.clone().into(),
+            self.activate_at.clone(),
+            self.commitment.clone(),
+            self.human_readable_text.clone(),
+            self.opening_type,
+        )?;
+
+        Ok(saved_opening_next_id)
     }
 
     pub fn with_text(self, text: Vec<u8>) -> Self {

--- a/runtime-modules/working-group/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-group/src/tests/hiring_workflow.rs
@@ -1,0 +1,170 @@
+use crate::tests::fixtures::{
+    create_mint, increase_total_balance_issuance_using_account_id, set_mint_id, setup_members,
+    AddWorkerOpeningFixture, ApplyOnWorkerOpeningFixture, BeginReviewWorkerApplicationsFixture,
+    FillWorkerOpeningFixture, SetLeadFixture,
+};
+use crate::Error;
+use crate::{OpeningPolicyCommitment, OpeningType, RewardPolicy};
+use system::RawOrigin;
+
+#[derive(Clone)]
+struct HiringWorkflowApplication {
+    stake: Option<u64>,
+    worker_handle: Vec<u8>,
+}
+
+pub struct HiringWorkflow {
+    opening_type: OpeningType,
+    expected_result: Result<(), Error>,
+    role_stake: Option<u64>,
+    applications: Vec<HiringWorkflowApplication>,
+    setup_environment: bool,
+    reward_policy: Option<RewardPolicy<u64, u64>>,
+}
+
+impl Default for HiringWorkflow {
+    fn default() -> Self {
+        Self {
+            opening_type: OpeningType::Worker,
+            expected_result: Ok(()),
+            role_stake: None,
+            applications: Vec::new(),
+            setup_environment: true,
+            reward_policy: None,
+        }
+        .add_default_application()
+    }
+}
+
+impl HiringWorkflow {
+    fn expect(self, result: Result<(), Error>) -> Self {
+        Self {
+            expected_result: result,
+            ..self
+        }
+    }
+
+    fn disable_setup_environment(self) -> Self {
+        Self {
+            setup_environment: false,
+            ..self
+        }
+    }
+
+    fn with_role_stake(self, role_stake: u64) -> Self {
+        Self {
+            role_stake: Some(role_stake),
+            ..self
+        }
+    }
+
+    fn with_reward_policy(self, reward_policy: RewardPolicy<u64, u64>) -> Self {
+        Self {
+            reward_policy: Some(reward_policy),
+            ..self
+        }
+    }
+
+    pub fn add_default_application(self) -> Self {
+        let worker_handle = b"default worker handle".to_vec();
+
+        let mut applications = self.applications;
+        applications.push(HiringWorkflowApplication {
+            worker_handle,
+            stake: self.role_stake.clone(),
+        });
+
+        Self {
+            applications,
+            ..self
+        }
+    }
+
+    fn setup_environment(&self) {
+        if matches!(self.opening_type, OpeningType::Worker) {
+            SetLeadFixture::default().set_lead();
+        }
+        increase_total_balance_issuance_using_account_id(1, 10000);
+        setup_members(2);
+        set_mint_id(create_mint());
+    }
+
+    pub fn execute(&self) -> Option<u64> {
+        if self.setup_environment {
+            self.setup_environment()
+        }
+
+        let result = self.fill_worker_position();
+
+        let check_result = result.clone().map(|_| ());
+
+        assert_eq!(check_result, self.expected_result);
+
+        result.ok()
+    }
+
+    fn fill_worker_position(
+        &self,
+
+    ) -> Result<u64, Error> {
+        let lead_account_id = 1;
+
+        let origin = match self.opening_type {
+            OpeningType::Leader => RawOrigin::Root,
+            OpeningType::Worker => RawOrigin::Signed(lead_account_id),
+        };
+
+        // create the opening
+        let mut add_worker_opening_fixture = AddWorkerOpeningFixture::default()
+            .with_opening_type(self.opening_type)
+            .with_origin(origin.clone());
+
+        if let Some(stake) = self.role_stake.clone() {
+            add_worker_opening_fixture =
+                add_worker_opening_fixture.with_policy_commitment(OpeningPolicyCommitment {
+                    role_staking_policy: Some(hiring::StakingPolicy {
+                        amount: stake,
+                        amount_mode: hiring::StakingAmountLimitMode::AtLeast,
+                        crowded_out_unstaking_period_length: None,
+                        review_period_expired_unstaking_period_length: None,
+                    }),
+                    ..OpeningPolicyCommitment::default()
+                });
+        }
+
+        let opening_id = add_worker_opening_fixture.call()?;
+
+        // fill applications
+        let mut application_ids = Vec::new();
+        for application in self.applications.clone(){
+            let mut apply_on_worker_opening_fixture = ApplyOnWorkerOpeningFixture::default_for_opening_id(opening_id).with_text(application.worker_handle);
+            if let Some(stake) = self.role_stake.clone() {
+                apply_on_worker_opening_fixture = apply_on_worker_opening_fixture.with_role_stake(stake);
+            }
+
+            let application_id = apply_on_worker_opening_fixture.call()?;
+            application_ids.push(application_id);
+        }
+
+        // begin application review
+
+        let begin_review_worker_applications_fixture =
+            BeginReviewWorkerApplicationsFixture::default_for_opening_id(opening_id)
+                .with_origin(origin.clone());
+        begin_review_worker_applications_fixture.call_and_assert(Ok(()));
+
+        // fill opening
+        let mut fill_worker_opening_fixture =
+            FillWorkerOpeningFixture::default_for_ids(opening_id, application_ids)
+                .with_origin(origin.clone());
+
+        if let Some(reward_policy) = self.reward_policy.clone() {
+            fill_worker_opening_fixture =
+                fill_worker_opening_fixture.with_reward_policy(reward_policy);
+        }
+
+        let worker_id = fill_worker_opening_fixture.call_and_assert(Ok(()));
+
+        Ok(worker_id)
+    }
+}

--- a/runtime-modules/working-group/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-group/src/tests/hiring_workflow.rs
@@ -11,6 +11,8 @@ use system::RawOrigin;
 struct HiringWorkflowApplication {
     stake: Option<u64>,
     worker_handle: Vec<u8>,
+    origin: RawOrigin<u64>,
+    member_id: u64,
 }
 
 pub struct HiringWorkflow {
@@ -32,35 +34,45 @@ impl Default for HiringWorkflow {
             setup_environment: true,
             reward_policy: None,
         }
-        .add_default_application()
     }
 }
 
 impl HiringWorkflow {
-    fn expect(self, result: Result<(), Error>) -> Self {
+    pub fn expect(self, result: Result<(), Error>) -> Self {
         Self {
             expected_result: result,
             ..self
         }
     }
 
-    fn disable_setup_environment(self) -> Self {
+    pub fn disable_setup_environment(self) -> Self {
         Self {
             setup_environment: false,
             ..self
         }
     }
 
-    fn with_role_stake(self, role_stake: u64) -> Self {
+    pub fn with_setup_environment(self, setup_environment: bool) -> Self {
         Self {
-            role_stake: Some(role_stake),
+            setup_environment,
             ..self
         }
     }
 
-    fn with_reward_policy(self, reward_policy: RewardPolicy<u64, u64>) -> Self {
+    pub fn with_opening_type(self, opening_type: OpeningType) -> Self {
         Self {
-            reward_policy: Some(reward_policy),
+            opening_type,
+            ..self
+        }
+    }
+
+    pub fn with_role_stake(self, role_stake: Option<u64>) -> Self {
+        Self { role_stake, ..self }
+    }
+
+    pub fn with_reward_policy(self, reward_policy: Option<RewardPolicy<u64, u64>>) -> Self {
+        Self {
+            reward_policy,
             ..self
         }
     }
@@ -68,10 +80,25 @@ impl HiringWorkflow {
     pub fn add_default_application(self) -> Self {
         let worker_handle = b"default worker handle".to_vec();
 
+        self.add_application(worker_handle)
+    }
+
+    pub fn add_application(self, worker_handle: Vec<u8>) -> Self {
+        self.add_application_with_origin(worker_handle, RawOrigin::Signed(1), 1)
+    }
+
+    pub fn add_application_with_origin(
+        self,
+        worker_handle: Vec<u8>,
+        origin: RawOrigin<u64>,
+        member_id: u64,
+    ) -> Self {
         let mut applications = self.applications;
         applications.push(HiringWorkflowApplication {
             worker_handle,
             stake: self.role_stake.clone(),
+            origin,
+            member_id,
         });
 
         Self {
@@ -85,7 +112,7 @@ impl HiringWorkflow {
             SetLeadFixture::default().set_lead();
         }
         increase_total_balance_issuance_using_account_id(1, 10000);
-        setup_members(2);
+        setup_members(3);
         set_mint_id(create_mint());
     }
 
@@ -103,11 +130,8 @@ impl HiringWorkflow {
         result.ok()
     }
 
-    fn fill_worker_position(
-        &self,
-
-    ) -> Result<u64, Error> {
-        let lead_account_id = 1;
+    fn fill_worker_position(&self) -> Result<u64, Error> {
+        let lead_account_id = SetLeadFixture::default().role_account;
 
         let origin = match self.opening_type {
             OpeningType::Leader => RawOrigin::Root,
@@ -136,11 +160,12 @@ impl HiringWorkflow {
 
         // fill applications
         let mut application_ids = Vec::new();
-        for application in self.applications.clone(){
-            let mut apply_on_worker_opening_fixture = ApplyOnWorkerOpeningFixture::default_for_opening_id(opening_id).with_text(application.worker_handle);
-            if let Some(stake) = self.role_stake.clone() {
-                apply_on_worker_opening_fixture = apply_on_worker_opening_fixture.with_role_stake(stake);
-            }
+        for application in self.applications.clone() {
+            let apply_on_worker_opening_fixture =
+                ApplyOnWorkerOpeningFixture::default_for_opening_id(opening_id)
+                    .with_text(application.worker_handle)
+                    .with_origin(application.origin, application.member_id)
+                    .with_role_stake(self.role_stake);
 
             let application_id = apply_on_worker_opening_fixture.call()?;
             application_ids.push(application_id);
@@ -163,7 +188,7 @@ impl HiringWorkflow {
                 fill_worker_opening_fixture.with_reward_policy(reward_policy);
         }
 
-        let worker_id = fill_worker_opening_fixture.call_and_assert(Ok(()));
+        let worker_id = fill_worker_opening_fixture.call()?;
 
         Ok(worker_id)
     }

--- a/runtime-modules/working-group/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-group/src/tests/hiring_workflow.rs
@@ -158,7 +158,7 @@ impl HiringWorkflow {
 
         let opening_id = add_worker_opening_fixture.call()?;
 
-        // fill applications
+        // Fill applications.
         let mut application_ids = Vec::new();
         for application in self.applications.clone() {
             let apply_on_worker_opening_fixture =

--- a/runtime-modules/working-group/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-group/src/tests/hiring_workflow.rs
@@ -3,6 +3,7 @@ use crate::tests::fixtures::{
     AddWorkerOpeningFixture, ApplyOnWorkerOpeningFixture, BeginReviewWorkerApplicationsFixture,
     FillWorkerOpeningFixture, SetLeadFixture,
 };
+use crate::tests::mock::TestWorkingGroup;
 use crate::Error;
 use crate::{OpeningPolicyCommitment, OpeningType, RewardPolicy};
 use system::RawOrigin;
@@ -131,11 +132,15 @@ impl HiringWorkflow {
     }
 
     fn fill_worker_position(&self) -> Result<u64, Error> {
-        let lead_account_id = SetLeadFixture::default().role_account;
-
         let origin = match self.opening_type {
             OpeningType::Leader => RawOrigin::Root,
-            OpeningType::Worker => RawOrigin::Signed(lead_account_id),
+            OpeningType::Worker => {
+                let leader_worker_id = TestWorkingGroup::current_lead().unwrap();
+                let leader = TestWorkingGroup::worker_by_id(leader_worker_id);
+                let lead_account_id = leader.role_account_id;
+
+                RawOrigin::Signed(lead_account_id)
+            }
         };
 
         // create the opening

--- a/runtime-modules/working-group/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-group/src/tests/hiring_workflow.rs
@@ -113,7 +113,7 @@ impl HiringWorkflow {
             SetLeadFixture::default().set_lead();
         }
         increase_total_balance_issuance_using_account_id(1, 10000);
-        setup_members(3);
+        setup_members(4);
         set_mint_id(create_mint());
     }
 

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -127,8 +127,13 @@ impl recurringrewards::Trait for Test {
 pub type Balances = balances::Module<Test>;
 pub type System = system::Module<Test>;
 
+parameter_types! {
+    pub const MaxWorkerNumberLimit: u32 = 3;
+}
+
 impl Trait<TestWorkingGroupInstance> for Test {
     type Event = TestEvent;
+    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
 }
 
 pub type Membership = membership::members::Module<Test>;

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -1187,6 +1187,11 @@ fn terminate_worker_role_succeeds_with_stakes() {
             total_balance - stake_balance
         );
 
+        let stake_id = 0;
+        let old_stake = <stake::Module<Test>>::stakes(stake_id);
+
+        assert_eq!(get_stake_balance(old_stake), stake_balance);
+
         let terminate_worker_role_fixture =
             TerminateWorkerRoleFixture::default_for_worker_id(worker_id);
 
@@ -1195,6 +1200,16 @@ fn terminate_worker_role_succeeds_with_stakes() {
         EventFixture::assert_last_crate_event(RawEvent::TerminatedWorker(
             worker_id,
             b"rationale_text".to_vec(),
+        ));
+
+        // Balance was restored.
+
+        assert_eq!(get_balance(worker_account_id), total_balance);
+
+        let new_stake = <stake::Module<Test>>::stakes(stake_id);
+        assert!(matches!(
+            new_stake.staking_status,
+            stake::StakingStatus::NotStaked
         ));
     });
 }

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -50,7 +50,7 @@ fn hire_lead_fails_multiple_applications() {
             .with_opening_type(OpeningType::Leader)
             .add_application_with_origin(b"leader_handle".to_vec(), RawOrigin::Signed(1), 1)
             .add_application_with_origin(b"leader_handle2".to_vec(), RawOrigin::Signed(2), 2)
-            .expect(Err(Error::CannotHireSeveralLeader));
+            .expect(Err(Error::CannotHireMultipleLeaders));
 
         hiring_workflow.execute();
     });

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod fixtures;
+mod hiring_workflow;
 mod mock;
 
 use crate::types::{OpeningPolicyCommitment, OpeningType, RewardPolicy};

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -1872,3 +1872,59 @@ fn ensure_setting_genesis_constraints_succeeds() {
         assert_eq!(worker_exit_text_constraint, default_constraint);
     });
 }
+
+#[test]
+fn active_worker_counter_works_successfully() {
+    build_test_externalities().execute_with(|| {
+        assert_eq!(TestWorkingGroup::active_worker_count(), 0);
+
+        let leader_id = HireLeadFixture::default().hire_lead();
+        assert_eq!(TestWorkingGroup::active_worker_count(), 1);
+
+        let worker_id1 = fill_worker_position(
+            None,
+            None,
+            false,
+            OpeningType::Worker,
+            Some(b"worker1".to_vec()),
+        );
+        assert_eq!(TestWorkingGroup::active_worker_count(), 2);
+
+        let worker_id2 = fill_worker_position(
+            None,
+            None,
+            false,
+            OpeningType::Worker,
+            Some(b"worker1".to_vec()),
+        );
+        assert_eq!(TestWorkingGroup::active_worker_count(), 3);
+
+        TerminateWorkerRoleFixture::default_for_worker_id(worker_id1).call_and_assert(Ok(()));
+        assert_eq!(TestWorkingGroup::active_worker_count(), 2);
+
+        TerminateWorkerRoleFixture::default_for_worker_id(worker_id2).call_and_assert(Ok(()));
+        assert_eq!(TestWorkingGroup::active_worker_count(), 1);
+
+        TerminateWorkerRoleFixture::default_for_worker_id(leader_id)
+            .with_origin(RawOrigin::Root)
+            .call_and_assert(Ok(()));
+        assert_eq!(TestWorkingGroup::active_worker_count(), 0);
+    });
+}
+
+#[test]
+fn adding_too_much_workers_fails() {
+    build_test_externalities().execute_with(|| {
+        HireLeadFixture::default().hire_lead();
+
+        fill_worker_position(None, None, false, OpeningType::Worker, None);
+        fill_worker_position(None, None, false, OpeningType::Worker, None);
+
+        let hiring_workflow = HiringWorkflow::default()
+            .disable_setup_environment()
+            .add_default_application()
+            .expect(Err(Error::MaxActiveWorkerNumberExceeded));
+
+        hiring_workflow.execute()
+    });
+}

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -3,7 +3,7 @@ mod hiring_workflow;
 mod mock;
 
 use crate::types::{OpeningPolicyCommitment, OpeningType, RewardPolicy};
-use crate::{Error, Lead, RawEvent};
+use crate::{Error, RawEvent, Worker};
 use common::constraints::InputValidationLengthConstraint;
 use mock::{
     build_test_externalities, Test, TestWorkingGroup, TestWorkingGroupInstance,
@@ -59,7 +59,7 @@ fn hire_lead_fails_multiple_applications() {
 #[test]
 fn add_worker_opening_succeeds() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
 
@@ -72,7 +72,7 @@ fn add_worker_opening_succeeds() {
 #[test]
 fn add_leader_opening_succeeds_fails_with_incorrect_origin_for_opening_type() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture =
             AddWorkerOpeningFixture::default().with_opening_type(OpeningType::Leader);
@@ -84,7 +84,7 @@ fn add_leader_opening_succeeds_fails_with_incorrect_origin_for_opening_type() {
 #[test]
 fn add_leader_opening_succeeds() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default()
             .with_opening_type(OpeningType::Leader)
@@ -106,7 +106,7 @@ fn add_worker_opening_fails_with_lead_is_not_set() {
 #[test]
 fn add_worker_opening_fails_with_invalid_human_readable_text() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         <crate::OpeningHumanReadableText<TestWorkingGroupInstance>>::put(
             InputValidationLengthConstraint {
@@ -129,7 +129,7 @@ fn add_worker_opening_fails_with_invalid_human_readable_text() {
 #[test]
 fn add_worker_opening_fails_with_hiring_error() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default()
             .with_activate_at(hiring::ActivateOpeningAt::ExactBlock(0));
@@ -141,7 +141,7 @@ fn add_worker_opening_fails_with_hiring_error() {
 #[test]
 fn accept_worker_applications_succeeds() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default()
             .with_activate_at(hiring::ActivateOpeningAt::ExactBlock(5));
@@ -158,7 +158,7 @@ fn accept_worker_applications_succeeds() {
 #[test]
 fn accept_worker_applications_fails_for_invalid_opening_type() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default()
             .with_origin(RawOrigin::Root)
@@ -175,7 +175,7 @@ fn accept_worker_applications_fails_for_invalid_opening_type() {
 #[test]
 fn accept_worker_applications_fails_with_hiring_error() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -191,7 +191,7 @@ fn accept_worker_applications_fails_with_hiring_error() {
 #[test]
 fn accept_worker_applications_fails_with_not_lead() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -207,7 +207,7 @@ fn accept_worker_applications_fails_with_not_lead() {
 #[test]
 fn accept_worker_applications_fails_with_no_opening() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let opening_id = 55; // random opening id
 
@@ -220,8 +220,7 @@ fn accept_worker_applications_fails_with_no_opening() {
 #[test]
 fn apply_on_worker_opening_succeeds() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -240,10 +239,9 @@ fn apply_on_worker_opening_succeeds() {
 #[test]
 fn apply_on_worker_opening_fails_with_no_opening() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
-        let opening_id = 0; // random opening id
+        let opening_id = 123; // random opening id
 
         let appy_on_worker_opening_fixture =
             ApplyOnWorkerOpeningFixture::default_for_opening_id(opening_id);
@@ -254,13 +252,14 @@ fn apply_on_worker_opening_fails_with_no_opening() {
 #[test]
 fn apply_on_worker_opening_fails_with_not_set_members() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
 
         let appy_on_worker_opening_fixture =
-            ApplyOnWorkerOpeningFixture::default_for_opening_id(opening_id);
+            ApplyOnWorkerOpeningFixture::default_for_opening_id(opening_id)
+                .with_origin(RawOrigin::Signed(55), 55);
         appy_on_worker_opening_fixture
             .call_and_assert(Err(Error::OriginIsNeitherMemberControllerOrRoot));
     });
@@ -270,8 +269,7 @@ fn apply_on_worker_opening_fails_with_not_set_members() {
 fn apply_on_worker_opening_fails_with_hiring_error() {
     build_test_externalities().execute_with(|| {
         increase_total_balance_issuance_using_account_id(1, 500000);
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -287,15 +285,24 @@ fn apply_on_worker_opening_fails_with_hiring_error() {
 #[test]
 fn apply_on_worker_opening_fails_with_invalid_application_stake() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
-        let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
+        let stake = 100;
+
+        let add_worker_opening_fixture =
+            AddWorkerOpeningFixture::default().with_policy_commitment(OpeningPolicyCommitment {
+                application_staking_policy: Some(hiring::StakingPolicy {
+                    amount: stake,
+                    ..hiring::StakingPolicy::default()
+                }),
+                ..OpeningPolicyCommitment::default()
+            });
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
 
         let appy_on_worker_opening_fixture =
             ApplyOnWorkerOpeningFixture::default_for_opening_id(opening_id)
-                .with_application_stake(100);
+                .with_origin(RawOrigin::Signed(2), 2)
+                .with_application_stake(stake);
         appy_on_worker_opening_fixture.call_and_assert(Err(Error::InsufficientBalanceToApply));
     });
 }
@@ -303,15 +310,24 @@ fn apply_on_worker_opening_fails_with_invalid_application_stake() {
 #[test]
 fn apply_on_worker_opening_fails_with_invalid_role_stake() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
-        let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
+        let stake = 100;
+
+        let add_worker_opening_fixture =
+            AddWorkerOpeningFixture::default().with_policy_commitment(OpeningPolicyCommitment {
+                role_staking_policy: Some(hiring::StakingPolicy {
+                    amount: stake,
+                    ..hiring::StakingPolicy::default()
+                }),
+                ..OpeningPolicyCommitment::default()
+            });
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
 
         let appy_on_worker_opening_fixture =
             ApplyOnWorkerOpeningFixture::default_for_opening_id(opening_id)
-                .with_role_stake(Some(100));
+                .with_role_stake(Some(stake))
+                .with_origin(RawOrigin::Signed(2), 2);
         appy_on_worker_opening_fixture.call_and_assert(Err(Error::InsufficientBalanceToApply));
     });
 }
@@ -319,8 +335,7 @@ fn apply_on_worker_opening_fails_with_invalid_role_stake() {
 #[test]
 fn apply_on_worker_opening_fails_with_invalid_text() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -348,8 +363,7 @@ fn apply_on_worker_opening_fails_with_invalid_text() {
 #[test]
 fn apply_on_worker_opening_fails_with_already_active_application() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -366,8 +380,7 @@ fn apply_on_worker_opening_fails_with_already_active_application() {
 #[test]
 fn withdraw_worker_application_succeeds() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -398,8 +411,7 @@ fn withdraw_worker_application_fails_invalid_application_id() {
 #[test]
 fn withdraw_worker_application_fails_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -418,8 +430,7 @@ fn withdraw_worker_application_fails_invalid_origin() {
 #[test]
 fn withdraw_worker_application_fails_with_invalid_application_author() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -439,8 +450,7 @@ fn withdraw_worker_application_fails_with_invalid_application_author() {
 #[test]
 fn withdraw_worker_application_fails_with_hiring_error() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -460,8 +470,7 @@ fn withdraw_worker_application_fails_with_hiring_error() {
 #[test]
 fn terminate_worker_application_succeeds() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -481,8 +490,7 @@ fn terminate_worker_application_succeeds() {
 #[test]
 fn terminate_worker_application_fails_with_invalid_application_author() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -502,8 +510,7 @@ fn terminate_worker_application_fails_with_invalid_application_author() {
 #[test]
 fn terminate_worker_application_fails_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
-        setup_members(2);
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -522,7 +529,7 @@ fn terminate_worker_application_fails_invalid_origin() {
 #[test]
 fn terminate_worker_application_fails_invalid_application_id() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let invalid_application_id = 6;
 
@@ -535,8 +542,7 @@ fn terminate_worker_application_fails_invalid_application_id() {
 #[test]
 fn terminate_worker_application_fails_with_hiring_error() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
-        setup_members(2);
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -556,7 +562,7 @@ fn terminate_worker_application_fails_with_hiring_error() {
 #[test]
 fn begin_review_worker_applications_succeeds() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -572,7 +578,7 @@ fn begin_review_worker_applications_succeeds() {
 #[test]
 fn begin_review_worker_applications_fails_with_invalid_origin_for_opening_type() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default()
             .with_origin(RawOrigin::Root)
@@ -588,7 +594,7 @@ fn begin_review_worker_applications_fails_with_invalid_origin_for_opening_type()
 #[test]
 fn begin_review_worker_applications_fails_with_not_a_lead() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -604,7 +610,7 @@ fn begin_review_worker_applications_fails_with_not_a_lead() {
 #[test]
 fn begin_review_worker_applications_fails_with_invalid_opening() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let invalid_opening_id = 6;
 
@@ -617,7 +623,7 @@ fn begin_review_worker_applications_fails_with_invalid_opening() {
 #[test]
 fn begin_review_worker_applications_with_hiring_error() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -634,7 +640,7 @@ fn begin_review_worker_applications_with_hiring_error() {
 #[test]
 fn begin_review_worker_applications_fails_with_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -649,8 +655,7 @@ fn begin_review_worker_applications_fails_with_invalid_origin() {
 #[test]
 fn fill_worker_opening_succeeds() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
         increase_total_balance_issuance_using_account_id(1, 10000);
 
         let add_worker_opening_fixture =
@@ -699,8 +704,7 @@ fn fill_worker_opening_succeeds() {
 #[test]
 fn fill_worker_opening_fails_with_invalid_origin_for_opening_type() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
         increase_total_balance_issuance_using_account_id(1, 10000);
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default()
@@ -743,7 +747,7 @@ fn fill_worker_opening_fails_with_invalid_origin_for_opening_type() {
 #[test]
 fn fill_worker_opening_fails_with_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -758,7 +762,7 @@ fn fill_worker_opening_fails_with_invalid_origin() {
 #[test]
 fn fill_worker_opening_fails_with_not_a_lead() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -774,7 +778,7 @@ fn fill_worker_opening_fails_with_not_a_lead() {
 #[test]
 fn fill_worker_opening_fails_with_invalid_opening() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let invalid_opening_id = 6;
 
@@ -787,8 +791,7 @@ fn fill_worker_opening_fails_with_invalid_opening() {
 #[test]
 fn fill_worker_opening_fails_with_invalid_application_list() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -814,7 +817,7 @@ fn fill_worker_opening_fails_with_invalid_application_list() {
 #[test]
 fn fill_worker_opening_fails_with_invalid_application_with_hiring_error() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -829,8 +832,7 @@ fn fill_worker_opening_fails_with_invalid_application_with_hiring_error() {
 #[test]
 fn fill_worker_opening_fails_with_invalid_reward_policy() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
 
         let add_worker_opening_fixture = AddWorkerOpeningFixture::default();
         let opening_id = add_worker_opening_fixture.call_and_assert(Ok(()));
@@ -879,26 +881,22 @@ fn update_worker_role_account_by_leader_succeeds() {
         let new_account_id = 10;
         let worker_id = HireLeadFixture::default().hire_lead();
 
-        // Default ids.
-        let mut lead = Lead {
-            member_id: 1,
-            role_account_id: 1,
-            worker_id: 0,
-        };
-
-        assert_eq!(TestWorkingGroup::current_lead(), Some(lead));
+        let old_lead = TestWorkingGroup::worker_by_id(worker_id);
 
         let update_worker_account_fixture =
             UpdateWorkerRoleAccountFixture::default_with_ids(worker_id, new_account_id);
 
         update_worker_account_fixture.call_and_assert(Ok(()));
 
-        lead = Lead {
-            role_account_id: new_account_id,
-            ..lead
-        };
+        let new_lead = TestWorkingGroup::worker_by_id(worker_id);
 
-        assert_eq!(TestWorkingGroup::current_lead(), Some(lead));
+        assert_eq!(
+            new_lead,
+            Worker {
+                role_account_id: new_account_id,
+                ..old_lead
+            }
+        );
     });
 }
 
@@ -969,7 +967,7 @@ fn update_worker_reward_account_fails_with_invalid_origin_signed_account() {
 
         let invalid_role_account = 23333;
         let update_worker_account_fixture =
-            UpdateWorkerRewardAccountFixture::default_with_ids(worker_id, worker.role_account)
+            UpdateWorkerRewardAccountFixture::default_with_ids(worker_id, worker.role_account_id)
                 .with_origin(RawOrigin::Signed(invalid_role_account));
 
         update_worker_account_fixture.call_and_assert(Err(Error::SignerIsNotWorkerRoleAccount));
@@ -1634,7 +1632,7 @@ fn decrease_worker_stake_fails_with_zero_balance() {
 #[test]
 fn decrease_worker_stake_fails_with_invalid_worker_id() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
         let invalid_worker_id = 11;
 
         let decrease_stake_fixture =
@@ -1751,7 +1749,7 @@ fn slash_worker_stake_fails_with_zero_balance() {
 #[test]
 fn slash_worker_stake_fails_with_invalid_worker_id() {
     build_test_externalities().execute_with(|| {
-        SetLeadFixture::default().set_lead();
+        HireLeadFixture::default().hire_lead();
         let invalid_worker_id = 11;
 
         let slash_stake_fixture = SlashWorkerStakeFixture::default_for_worker_id(invalid_worker_id);

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -1913,7 +1913,7 @@ fn active_worker_counter_works_successfully() {
 }
 
 #[test]
-fn adding_too_much_workers_fails() {
+fn adding_too_much_workers_fails_with_single_application_out_of_limit() {
     build_test_externalities().execute_with(|| {
         HireLeadFixture::default().hire_lead();
 
@@ -1923,6 +1923,23 @@ fn adding_too_much_workers_fails() {
         let hiring_workflow = HiringWorkflow::default()
             .disable_setup_environment()
             .add_default_application()
+            .expect(Err(Error::MaxActiveWorkerNumberExceeded));
+
+        hiring_workflow.execute()
+    });
+}
+
+#[test]
+fn fill_opening_cannot_hire_more_workers_using_several_applicationst_han_allows_worker_limit() {
+    build_test_externalities().execute_with(|| {
+        HireLeadFixture::default().hire_lead();
+
+        fill_worker_position(None, None, false, OpeningType::Worker, None);
+
+        let hiring_workflow = HiringWorkflow::default()
+            .disable_setup_environment()
+            .add_application_with_origin(b"Some1".to_vec(), RawOrigin::Signed(2), 2)
+            .add_application_with_origin(b"Some2".to_vec(), RawOrigin::Signed(3), 3)
             .expect(Err(Error::MaxActiveWorkerNumberExceeded));
 
         hiring_workflow.execute()

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -1092,6 +1092,23 @@ fn leave_worker_role_succeeds() {
 }
 
 #[test]
+fn leave_worker_role_by_leader_succeeds() {
+    build_test_externalities().execute_with(|| {
+        // Ensure that lead is default
+        assert_eq!(TestWorkingGroup::current_lead(), None);
+        let worker_id = HireLeadFixture::default().hire_lead();
+
+        assert!(TestWorkingGroup::current_lead().is_some());
+
+        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
+
+        leave_worker_role_fixture.call_and_assert(Ok(()));
+
+        assert_eq!(TestWorkingGroup::current_lead(), None);
+    });
+}
+
+#[test]
 fn leave_worker_role_fails_with_invalid_origin() {
     build_test_externalities().execute_with(|| {
         let leave_worker_role_fixture =

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -3,7 +3,7 @@ mod hiring_workflow;
 mod mock;
 
 use crate::types::{OpeningPolicyCommitment, OpeningType, RewardPolicy};
-use crate::{Error, RawEvent};
+use crate::{Error, Lead, RawEvent};
 use common::constraints::InputValidationLengthConstraint;
 use mock::{
     build_test_externalities, Test, TestWorkingGroup, TestWorkingGroupInstance,
@@ -871,6 +871,35 @@ fn update_worker_role_account_succeeds() {
             worker_id,
             new_account_id,
         ));
+    });
+}
+
+#[test]
+fn update_worker_role_account_by_leader_succeeds() {
+    build_test_externalities().execute_with(|| {
+        let new_account_id = 10;
+        let worker_id = HireLeadFixture::default().hire_lead();
+
+        // Default ids.
+        let mut lead = Lead {
+            member_id: 1,
+            role_account_id: 1,
+            worker_id: 0,
+        };
+
+        assert_eq!(TestWorkingGroup::current_lead(), Some(lead));
+
+        let update_worker_account_fixture =
+            UpdateWorkerRoleAccountFixture::default_with_ids(worker_id, new_account_id);
+
+        update_worker_account_fixture.call_and_assert(Ok(()));
+
+        lead = Lead {
+            role_account_id: new_account_id,
+            ..lead
+        };
+
+        assert_eq!(TestWorkingGroup::current_lead(), Some(lead));
     });
 }
 

--- a/runtime-modules/working-group/src/types.rs
+++ b/runtime-modules/working-group/src/types.rs
@@ -234,12 +234,14 @@ impl<
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, Clone, PartialEq)]
 pub enum ExitInitiationOrigin {
-    /// Lead is origin.
+    /// Lead fires the worker.
     Lead,
 
-    /// The curator exiting is the origin.
+    /// Worker leaves the position.
     Worker,
-    //TODO council ?
+
+    /// Council fires the leader.
+    Sudo,
 }
 
 /// The recurring reward if any to be assigned to an actor when filling in the position.

--- a/runtime-modules/working-group/src/types.rs
+++ b/runtime-modules/working-group/src/types.rs
@@ -6,7 +6,7 @@ use rstd::collections::btree_set::BTreeSet;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
-/// Terms for slashings applied to a given role.
+/// Terms for slashes applied to a given role.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, Clone, PartialEq, Eq)]
 pub struct SlashableTerms {
@@ -28,7 +28,7 @@ pub enum SlashingTerms {
     Slashable(SlashableTerms),
 }
 
-/// Must be default constructible because it indirectly is a value in a storage map.
+/// Must be default constructable because it indirectly is a value in a storage map.
 /// ***SHOULD NEVER ACTUALLY GET CALLED, IS REQUIRED TO DUE BAD STORAGE MODEL IN SUBSTRATE***
 impl Default for SlashingTerms {
     fn default() -> Self {
@@ -69,14 +69,14 @@ pub struct OpeningPolicyCommitment<BlockNumber, Balance> {
     /// When terminating a worker: unstaking period for application stake.
     pub terminate_application_stake_unstaking_period: Option<BlockNumber>,
 
-    /// When terminating a worker: unstaking period for role stake.
-    pub terminate_worker_role_stake_unstaking_period: Option<BlockNumber>,
+    /// When terminating a worke/leadr: unstaking period for role stake.
+    pub terminate_role_stake_unstaking_period: Option<BlockNumber>,
 
-    /// When a worker exists: unstaking period for application stake.
-    pub exit_worker_role_application_stake_unstaking_period: Option<BlockNumber>,
+    /// When a worker/lead exists: unstaking period for application stake.
+    pub exit_role_application_stake_unstaking_period: Option<BlockNumber>,
 
-    /// When a worker exists: unstaking period for role stake.
-    pub exit_worker_role_stake_unstaking_period: Option<BlockNumber>,
+    /// When a worker/lead exists: unstaking period for role stake.
+    pub exit_role_stake_unstaking_period: Option<BlockNumber>,
 }
 
 /// An opening for a worker or lead role.
@@ -84,7 +84,7 @@ pub struct OpeningPolicyCommitment<BlockNumber, Balance> {
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq)]
 pub struct Opening<OpeningId, BlockNumber, Balance, WorkerApplicationId: core::cmp::Ord> {
     /// Identifier for underlying opening in the hiring module.
-    pub opening_id: OpeningId,
+    pub hiring_opening_id: OpeningId,
 
     /// Set of identifiers for all worker applications ever added.
     pub applications: BTreeSet<WorkerApplicationId>,
@@ -115,7 +115,7 @@ impl Default for OpeningType {
     }
 }
 
-/// Working group lead: worker lead.
+/// Working group lead.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq, Copy)]
 pub struct Lead<MemberId, AccountId, WorkerId> {
@@ -129,7 +129,7 @@ pub struct Lead<MemberId, AccountId, WorkerId> {
     pub worker_id: WorkerId,
 }
 
-/// An application for the worker role.
+/// An application for the worker/lead role.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq)]
 pub struct Application<AccountId, OpeningId, MemberId, ApplicationId> {
@@ -165,7 +165,7 @@ impl<AccountId: Clone, OpeningId: Clone, MemberId: Clone, ApplicationId: Clone>
     }
 }
 
-/// Role stake information for a worker/ledd.
+/// Role stake information for a worker/lead.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq)]
 pub struct RoleStakeProfile<StakeId, BlockNumber> {
@@ -180,7 +180,7 @@ pub struct RoleStakeProfile<StakeId, BlockNumber> {
 }
 
 impl<StakeId: Clone, BlockNumber: Clone> RoleStakeProfile<StakeId, BlockNumber> {
-    /// Creates a new worker role stake profile using stake parameters.
+    /// Creates a new worker/lead role stake profile using stake parameters.
     pub fn new(
         stake_id: &StakeId,
         termination_unstaking_period: &Option<BlockNumber>,
@@ -199,13 +199,16 @@ impl<StakeId: Clone, BlockNumber: Clone> RoleStakeProfile<StakeId, BlockNumber> 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq)]
 pub struct Worker<AccountId, RewardRelationshipId, StakeId, BlockNumber, MemberId> {
-    /// Member id related to the worker
+    /// Member id related to the worker/lead.
     pub member_id: MemberId,
+
     /// Account used to authenticate in this role.
     pub role_account: AccountId,
+
     /// Whether the role has recurring reward, and if so an identifier for this.
     pub reward_relationship: Option<RewardRelationshipId>,
-    /// When set, describes role stake of worker.
+
+    /// When set, describes role stake of the worker/lead.
     pub role_stake_profile: Option<RoleStakeProfile<StakeId, BlockNumber>>,
 }
 
@@ -233,7 +236,7 @@ impl<
     }
 }
 
-/// Origin of exit initiation on behalf of a curator.'
+/// Origin of exit initiation.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, Clone, PartialEq)]
 pub enum ExitInitiationOrigin {

--- a/runtime-modules/working-group/src/types.rs
+++ b/runtime-modules/working-group/src/types.rs
@@ -115,26 +115,12 @@ impl Default for OpeningType {
     }
 }
 
-/// Working group lead.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Default, Debug, Clone, PartialEq, Copy)]
-pub struct Lead<MemberId, AccountId, WorkerId> {
-    /// Member id of the leader.
-    pub member_id: MemberId,
-
-    /// Account used to authenticate in this role.
-    pub role_account_id: AccountId,
-
-    /// Leader worker id.
-    pub worker_id: WorkerId,
-}
-
 /// An application for the worker/lead role.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq)]
 pub struct Application<AccountId, OpeningId, MemberId, ApplicationId> {
     /// Account used to authenticate in this role.
-    pub role_account: AccountId,
+    pub role_account_id: AccountId,
 
     /// Opening on which this application applies.
     pub opening_id: OpeningId,
@@ -151,13 +137,13 @@ impl<AccountId: Clone, OpeningId: Clone, MemberId: Clone, ApplicationId: Clone>
 {
     /// Creates a new worker application using parameters.
     pub fn new(
-        role_account: &AccountId,
+        role_account_id: &AccountId,
         opening_id: &OpeningId,
         member_id: &MemberId,
         application_id: &ApplicationId,
     ) -> Self {
         Application {
-            role_account: role_account.clone(),
+            role_account_id: role_account_id.clone(),
             opening_id: opening_id.clone(),
             member_id: member_id.clone(),
             hiring_application_id: application_id.clone(),
@@ -203,7 +189,7 @@ pub struct Worker<AccountId, RewardRelationshipId, StakeId, BlockNumber, MemberI
     pub member_id: MemberId,
 
     /// Account used to authenticate in this role.
-    pub role_account: AccountId,
+    pub role_account_id: AccountId,
 
     /// Whether the role has recurring reward, and if so an identifier for this.
     pub reward_relationship: Option<RewardRelationshipId>,
@@ -223,13 +209,13 @@ impl<
     /// Creates a new _Worker_ using parameters.
     pub fn new(
         member_id: &MemberId,
-        role_account: &AccountId,
+        role_account_id: &AccountId,
         reward_relationship: &Option<RewardRelationshipId>,
         role_stake_profile: &Option<RoleStakeProfile<StakeId, BlockNumber>>,
     ) -> Self {
         Worker {
             member_id: member_id.clone(),
-            role_account: role_account.clone(),
+            role_account_id: role_account_id.clone(),
             reward_relationship: reward_relationship.clone(),
             role_stake_profile: role_stake_profile.clone(),
         }

--- a/runtime-modules/working-group/src/types.rs
+++ b/runtime-modules/working-group/src/types.rs
@@ -118,12 +118,15 @@ impl Default for OpeningType {
 /// Working group lead: worker lead.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Debug, Clone, PartialEq, Copy)]
-pub struct Lead<MemberId, AccountId> {
+pub struct Lead<MemberId, AccountId, WorkerId> {
     /// Member id of the leader.
     pub member_id: MemberId,
 
     /// Account used to authenticate in this role.
     pub role_account_id: AccountId,
+
+    /// Leader worker id.
+    pub worker_id: WorkerId,
 }
 
 /// An application for the worker role.

--- a/runtime-modules/working-group/src/types.rs
+++ b/runtime-modules/working-group/src/types.rs
@@ -117,7 +117,7 @@ impl Default for OpeningType {
 
 /// Working group lead: worker lead.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Default, Debug, Clone, PartialEq)]
+#[derive(Encode, Decode, Default, Debug, Clone, PartialEq, Copy)]
 pub struct Lead<MemberId, AccountId> {
     /// Member id of the leader.
     pub member_id: MemberId,
@@ -239,7 +239,7 @@ pub enum ExitInitiationOrigin {
 
     /// The curator exiting is the origin.
     Worker,
-    //TODO
+    //TODO council ?
 }
 
 /// The recurring reward if any to be assigned to an actor when filling in the position.

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,11 +1,10 @@
-
 [package]
 authors = ['Joystream contributors']
 edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '6.16.0'
+version = '6.17.0'
 
 [features]
 default = ['std']

--- a/runtime/src/integration/content_working_group.rs
+++ b/runtime/src/integration/content_working_group.rs
@@ -1,0 +1,141 @@
+use crate::{AccountId, Credential, Runtime};
+
+use srml_support::traits::{Currency, Imbalance};
+use srml_support::{parameter_types, StorageLinkedMap, StorageMap};
+
+parameter_types! {
+    pub const CurrentLeadCredential: Credential = 0;
+    pub const AnyActiveCuratorCredential: Credential = 1;
+    pub const AnyActiveChannelOwnerCredential: Credential = 2;
+    pub const PrincipalIdMappingStartsAtCredential: Credential = 1000;
+}
+
+pub struct ContentWorkingGroupCredentials {}
+impl versioned_store_permissions::CredentialChecker<Runtime> for ContentWorkingGroupCredentials {
+    fn account_has_credential(
+        account: &AccountId,
+        credential: <Runtime as versioned_store_permissions::Trait>::Credential,
+    ) -> bool {
+        match credential {
+            // Credentials from 0..999 represents groups or more complex requirements
+            // Current Lead if set
+            credential if credential == CurrentLeadCredential::get() => {
+                match <content_working_group::Module<Runtime>>::ensure_lead_is_set() {
+                    Ok((_, lead)) => lead.role_account == *account,
+                    _ => false,
+                }
+            }
+            // Any Active Curator
+            credential if credential == AnyActiveCuratorCredential::get() => {
+                // Look for a Curator with a matching role account
+                for (_principal_id, principal) in
+                    <content_working_group::PrincipalById<Runtime>>::enumerate()
+                {
+                    if let content_working_group::Principal::Curator(curator_id) = principal {
+                        let curator =
+                            <content_working_group::CuratorById<Runtime>>::get(curator_id);
+                        if curator.role_account == *account
+                            && curator.stage == content_working_group::CuratorRoleStage::Active
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                false
+            }
+            // Any Active Channel Owner
+            credential if credential == AnyActiveChannelOwnerCredential::get() => {
+                // Look for a ChannelOwner with a matching role account
+                for (_principal_id, principal) in
+                    <content_working_group::PrincipalById<Runtime>>::enumerate()
+                {
+                    if let content_working_group::Principal::ChannelOwner(channel_id) = principal {
+                        let channel =
+                            <content_working_group::ChannelById<Runtime>>::get(channel_id);
+                        if channel.role_account == *account {
+                            return true; // should we also take publishing_status/curation_status into account ?
+                        }
+                    }
+                }
+
+                false
+            }
+            // mapping to working group principal id
+            n if n >= PrincipalIdMappingStartsAtCredential::get() => {
+                <content_working_group::Module<Runtime>>::account_has_credential(
+                    account,
+                    n - PrincipalIdMappingStartsAtCredential::get(),
+                )
+            }
+            _ => false,
+        }
+    }
+}
+
+pub struct ContentWorkingGroupStakingEventHandler {}
+impl stake::StakingEventsHandler<Runtime> for ContentWorkingGroupStakingEventHandler {
+    fn unstaked(
+        stake_id: &<Runtime as stake::Trait>::StakeId,
+        _unstaked_amount: stake::BalanceOf<Runtime>,
+        remaining_imbalance: stake::NegativeImbalance<Runtime>,
+    ) -> stake::NegativeImbalance<Runtime> {
+        if !hiring::ApplicationIdByStakingId::<Runtime>::exists(stake_id) {
+            // Stake not related to a staked role managed by the hiring module
+            return remaining_imbalance;
+        }
+
+        let application_id = hiring::ApplicationIdByStakingId::<Runtime>::get(stake_id);
+
+        if !content_working_group::CuratorApplicationById::<Runtime>::exists(application_id) {
+            // Stake not for a Curator
+            return remaining_imbalance;
+        }
+
+        // Notify the Hiring module - is there a potential re-entrancy bug if
+        // instant unstaking is occuring?
+        hiring::Module::<Runtime>::unstaked(*stake_id);
+
+        // Only notify working group module if non instantaneous unstaking occured
+        if content_working_group::UnstakerByStakeId::<Runtime>::exists(stake_id) {
+            content_working_group::Module::<Runtime>::unstaked(*stake_id);
+        }
+
+        // Determine member id of the curator
+        let curator_application =
+            content_working_group::CuratorApplicationById::<Runtime>::get(application_id);
+        let member_id = curator_application.member_id;
+
+        // get member's profile
+        let member_profile = membership::members::MemberProfile::<Runtime>::get(member_id).unwrap();
+
+        // deposit funds to member's root_account
+        // The application doesn't recorded the original source_account from which staked funds were
+        // provided, so we don't really have another option at the moment.
+        <Runtime as stake::Trait>::Currency::resolve_creating(
+            &member_profile.root_account,
+            remaining_imbalance,
+        );
+
+        stake::NegativeImbalance::<Runtime>::zero()
+    }
+
+    // Handler for slashing event
+    fn slashed(
+        _id: &<Runtime as stake::Trait>::StakeId,
+        _slash_id: Option<<Runtime as stake::Trait>::SlashId>,
+        _slashed_amount: stake::BalanceOf<Runtime>,
+        _remaining_stake: stake::BalanceOf<Runtime>,
+        remaining_imbalance: stake::NegativeImbalance<Runtime>,
+    ) -> stake::NegativeImbalance<Runtime> {
+        // Check if the stake is associated with a hired curator or applicant
+        // if their stake goes below minimum required for the role,
+        // they should get deactivated.
+        // Since we don't currently implement any slash initiation in working group,
+        // there is nothing to do for now.
+
+        // Not interested in transfering the slashed amount anywhere for now,
+        // so return it to next handler.
+        remaining_imbalance
+    }
+}

--- a/runtime/src/integration/mod.rs
+++ b/runtime/src/integration/mod.rs
@@ -1,3 +1,4 @@
+pub mod content_working_group;
 pub mod proposals;
 pub mod storage;
 pub mod working_group;

--- a/runtime/src/integration/mod.rs
+++ b/runtime/src/integration/mod.rs
@@ -1,2 +1,3 @@
 pub mod proposals;
 pub mod storage;
+pub mod working_group;

--- a/runtime/src/integration/proposals/council_origin_validator.rs
+++ b/runtime/src/integration/proposals/council_origin_validator.rs
@@ -2,7 +2,7 @@
 
 use rstd::marker::PhantomData;
 
-use common::origin_validator::ActorOriginValidator;
+use common::origin::ActorOriginValidator;
 use proposals_engine::VotersParameters;
 
 use super::{MemberId, MembershipOriginValidator};
@@ -44,7 +44,7 @@ impl<T: governance::council::Trait> VotersParameters for CouncilManager<T> {
 mod tests {
     use super::CouncilManager;
     use crate::Runtime;
-    use common::origin_validator::ActorOriginValidator;
+    use common::origin::ActorOriginValidator;
     use membership::members::UserInfo;
     use proposals_engine::VotersParameters;
     use sr_primitives::AccountId32;

--- a/runtime/src/integration/proposals/membership_origin_validator.rs
+++ b/runtime/src/integration/proposals/membership_origin_validator.rs
@@ -2,7 +2,7 @@
 
 use rstd::marker::PhantomData;
 
-use common::origin_validator::ActorOriginValidator;
+use common::origin::ActorOriginValidator;
 use system::ensure_signed;
 
 /// Member of the Joystream organization
@@ -46,7 +46,7 @@ impl<T: crate::members::Trait>
 mod tests {
     use super::MembershipOriginValidator;
     use crate::Runtime;
-    use common::origin_validator::ActorOriginValidator;
+    use common::origin::ActorOriginValidator;
     use membership::members::UserInfo;
     use sr_primitives::AccountId32;
     use system::RawOrigin;

--- a/runtime/src/integration/storage.rs
+++ b/runtime/src/integration/storage.rs
@@ -8,7 +8,7 @@ pub struct StorageProviderHelper;
 
 impl storage::data_directory::StorageProviderHelper<Runtime> for StorageProviderHelper {
     fn get_random_storage_provider() -> Result<ActorId, &'static str> {
-        let ids = crate::StorageWorkingGroup::get_all_worker_ids();
+        let ids = crate::StorageWorkingGroup::get_regular_worker_ids();
 
         let live_ids: Vec<ActorId> = ids
             .into_iter()

--- a/runtime/src/integration/working_group.rs
+++ b/runtime/src/integration/working_group.rs
@@ -1,0 +1,49 @@
+use rstd::marker::PhantomData;
+use srml_support::{StorageLinkedMap, StorageMap};
+
+use crate::StorageWorkingGroupInstance;
+use stake::{BalanceOf, NegativeImbalance};
+
+pub struct StakingEventsHandler<T> {
+    pub marker: PhantomData<T>,
+}
+
+impl<T: stake::Trait + working_group::Trait<StorageWorkingGroupInstance>>
+    stake::StakingEventsHandler<T> for StakingEventsHandler<T>
+{
+    /// Unstake remaining sum back to the source_account_id
+    fn unstaked(
+        stake_id: &<T as stake::Trait>::StakeId,
+        _unstaked_amount: BalanceOf<T>,
+        remaining_imbalance: NegativeImbalance<T>,
+    ) -> NegativeImbalance<T> {
+        // Stake not related to a staked role managed by the hiring module.
+        if !hiring::ApplicationIdByStakingId::<T>::exists(*stake_id) {
+            return remaining_imbalance;
+        }
+
+        let hiring_application_id = hiring::ApplicationIdByStakingId::<T>::get(*stake_id);
+
+        if working_group::MemberIdByHiringApplicationId::<T, StorageWorkingGroupInstance>::exists(
+            hiring_application_id,
+        ) {
+            return <working_group::Module<T, StorageWorkingGroupInstance>>::refund_working_group_stake(
+				*stake_id,
+				remaining_imbalance,
+			);
+        }
+
+        remaining_imbalance
+    }
+
+    /// Empty handler for the slashing.
+    fn slashed(
+        _: &<T as stake::Trait>::StakeId,
+        _: Option<<T as stake::Trait>::SlashId>,
+        _: BalanceOf<T>,
+        _: BalanceOf<T>,
+        remaining_imbalance: NegativeImbalance<T>,
+    ) -> NegativeImbalance<T> {
+        remaining_imbalance
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -447,7 +447,10 @@ impl versioned_store::Trait for Runtime {
 
 impl versioned_store_permissions::Trait for Runtime {
     type Credential = Credential;
-    type CredentialChecker = (ContentWorkingGroupCredentials, SudoKeyHasAllCredentials);
+    type CredentialChecker = (
+        integration::content_working_group::ContentWorkingGroupCredentials,
+        SudoKeyHasAllCredentials,
+    );
     type CreateClassPermissionsChecker = ContentLeadOrSudoKeyCanCreateClasses;
 }
 
@@ -459,72 +462,6 @@ impl versioned_store_permissions::CredentialChecker<Runtime> for SudoKeyHasAllCr
         _credential: <Runtime as versioned_store_permissions::Trait>::Credential,
     ) -> bool {
         <sudo::Module<Runtime>>::key() == *account
-    }
-}
-
-parameter_types! {
-    pub const CurrentLeadCredential: Credential = 0;
-    pub const AnyActiveCuratorCredential: Credential = 1;
-    pub const AnyActiveChannelOwnerCredential: Credential = 2;
-    pub const PrincipalIdMappingStartsAtCredential: Credential = 1000;
-}
-
-pub struct ContentWorkingGroupCredentials {}
-impl versioned_store_permissions::CredentialChecker<Runtime> for ContentWorkingGroupCredentials {
-    fn account_has_credential(
-        account: &AccountId,
-        credential: <Runtime as versioned_store_permissions::Trait>::Credential,
-    ) -> bool {
-        match credential {
-            // Credentials from 0..999 represents groups or more complex requirements
-            // Current Lead if set
-            credential if credential == CurrentLeadCredential::get() => {
-                match <content_wg::Module<Runtime>>::ensure_lead_is_set() {
-                    Ok((_, lead)) => lead.role_account == *account,
-                    _ => false,
-                }
-            }
-            // Any Active Curator
-            credential if credential == AnyActiveCuratorCredential::get() => {
-                // Look for a Curator with a matching role account
-                for (_principal_id, principal) in <content_wg::PrincipalById<Runtime>>::enumerate()
-                {
-                    if let content_wg::Principal::Curator(curator_id) = principal {
-                        let curator = <content_wg::CuratorById<Runtime>>::get(curator_id);
-                        if curator.role_account == *account
-                            && curator.stage == content_wg::CuratorRoleStage::Active
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                false
-            }
-            // Any Active Channel Owner
-            credential if credential == AnyActiveChannelOwnerCredential::get() => {
-                // Look for a ChannelOwner with a matching role account
-                for (_principal_id, principal) in <content_wg::PrincipalById<Runtime>>::enumerate()
-                {
-                    if let content_wg::Principal::ChannelOwner(channel_id) = principal {
-                        let channel = <content_wg::ChannelById<Runtime>>::get(channel_id);
-                        if channel.role_account == *account {
-                            return true; // should we also take publishing_status/curation_status into account ?
-                        }
-                    }
-                }
-
-                false
-            }
-            // mapping to workging group principal id
-            n if n >= PrincipalIdMappingStartsAtCredential::get() => {
-                <content_wg::Module<Runtime>>::account_has_credential(
-                    account,
-                    n - PrincipalIdMappingStartsAtCredential::get(),
-                )
-            }
-            _ => false,
-        }
     }
 }
 
@@ -591,7 +528,7 @@ impl stake::Trait for Runtime {
     type Currency = <Self as common::currency::GovernanceCurrency>::Currency;
     type StakePoolId = StakePoolId;
     type StakingEventsHandler = (
-        ContentWorkingGroupStakingEventHandler,
+        crate::integration::content_working_group::ContentWorkingGroupStakingEventHandler,
         (
             crate::integration::proposals::StakingEventsHandler<Self>,
             crate::integration::working_group::StakingEventsHandler<Self>,
@@ -599,73 +536,6 @@ impl stake::Trait for Runtime {
     );
     type StakeId = u64;
     type SlashId = u64;
-}
-
-pub struct ContentWorkingGroupStakingEventHandler {}
-impl stake::StakingEventsHandler<Runtime> for ContentWorkingGroupStakingEventHandler {
-    fn unstaked(
-        stake_id: &<Runtime as stake::Trait>::StakeId,
-        _unstaked_amount: stake::BalanceOf<Runtime>,
-        remaining_imbalance: stake::NegativeImbalance<Runtime>,
-    ) -> stake::NegativeImbalance<Runtime> {
-        if !hiring::ApplicationIdByStakingId::<Runtime>::exists(stake_id) {
-            // Stake not related to a staked role managed by the hiring module
-            return remaining_imbalance;
-        }
-
-        let application_id = hiring::ApplicationIdByStakingId::<Runtime>::get(stake_id);
-
-        if !content_wg::CuratorApplicationById::<Runtime>::exists(application_id) {
-            // Stake not for a Curator
-            return remaining_imbalance;
-        }
-
-        // Notify the Hiring module - is there a potential re-entrancy bug if
-        // instant unstaking is occuring?
-        hiring::Module::<Runtime>::unstaked(*stake_id);
-
-        // Only notify working group module if non instantaneous unstaking occured
-        if content_wg::UnstakerByStakeId::<Runtime>::exists(stake_id) {
-            content_wg::Module::<Runtime>::unstaked(*stake_id);
-        }
-
-        // Determine member id of the curator
-        let curator_application =
-            content_wg::CuratorApplicationById::<Runtime>::get(application_id);
-        let member_id = curator_application.member_id;
-
-        // get member's profile
-        let member_profile = membership::members::MemberProfile::<Runtime>::get(member_id).unwrap();
-
-        // deposit funds to member's root_account
-        // The application doesn't recorded the original source_account from which staked funds were
-        // provided, so we don't really have another option at the moment.
-        <Runtime as stake::Trait>::Currency::resolve_creating(
-            &member_profile.root_account,
-            remaining_imbalance,
-        );
-
-        stake::NegativeImbalance::<Runtime>::zero()
-    }
-
-    // Handler for slashing event
-    fn slashed(
-        _id: &<Runtime as stake::Trait>::StakeId,
-        _slash_id: Option<<Runtime as stake::Trait>::SlashId>,
-        _slashed_amount: stake::BalanceOf<Runtime>,
-        _remaining_stake: stake::BalanceOf<Runtime>,
-        remaining_imbalance: stake::NegativeImbalance<Runtime>,
-    ) -> stake::NegativeImbalance<Runtime> {
-        // Check if the stake is associated with a hired curator or applicant
-        // if their stake goes below minimum required for the role,
-        // they should get deactivated.
-        // Since we don't currently implement any slash initiation in working group,
-        // there is nothing to do for now.
-
-        // Not interested in transfering the slashed amount anywhere for now,
-        // so return it to next handler.
-        remaining_imbalance
-    }
 }
 
 impl content_wg::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -161,7 +161,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 6,
-    spec_version: 16,
+    spec_version: 17,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
 };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -592,7 +592,10 @@ impl stake::Trait for Runtime {
     type StakePoolId = StakePoolId;
     type StakingEventsHandler = (
         ContentWorkingGroupStakingEventHandler,
-        crate::integration::proposals::StakingEventsHandler<Self>,
+        (
+            crate::integration::proposals::StakingEventsHandler<Self>,
+            crate::integration::working_group::StakingEventsHandler<Self>,
+        ),
     );
     type StakeId = u64;
     type SlashId = u64;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -319,7 +319,7 @@ impl transaction_payment::Trait for Runtime {
     type TransactionBaseFee = TransactionBaseFee;
     type TransactionByteFee = TransactionByteFee;
     type WeightToFee = ();
-    type FeeMultiplierUpdate = (); // FeeMultiplierUpdateHandler;
+    type FeeMultiplierUpdate = ();
 }
 
 impl sudo::Trait for Runtime {
@@ -593,7 +593,7 @@ impl members::Trait for Runtime {
  *
  * ForumUserRegistry could have been implemented directly on
  * the membership module, and likewise ForumUser on Profile,
- * however this approach is more loosley coupled.
+ * however this approach is more loosely coupled.
  *
  * Further exploration required to decide what the long
  * run convention should be.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -631,8 +631,13 @@ impl migration::Trait for Runtime {
 // The storage working group instance alias.
 pub type StorageWorkingGroupInstance = working_group::Instance2;
 
+parameter_types! {
+    pub const MaxWorkerNumberLimit: u32 = 100;
+}
+
 impl working_group::Trait<StorageWorkingGroupInstance> for Runtime {
     type Event = Event;
+    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
 }
 
 impl service_discovery::Trait for Runtime {


### PR DESCRIPTION
The working group leader should be hirable like a regular worker. All working group operations should be applicable to the leader. Only the council is allowed to invoke operations with the leader.

### Changes
- hiring workflow
- roles operations
- stake management
- improve comments
- stake refunding
- move out content working group structs to the separate file in the runtime
- optional slashing on the role termination
- changed get_worker_ids() (excluded the leader and renamed)
- new extrinsic added (update_reward_amount)