### PR TITLE
Remove import of members and old forum posts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "ctrlc",
  "derive_more 0.14.1",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '2.4.0'
+version = '2.4.1'
 default-run = "joystream-node"
 
 [[bin]]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -257,7 +257,7 @@ pub fn testnet_genesis(
         }),
         members: Some(MembersConfig {
             default_paid_membership_fee: 100u128,
-            members: crate::members_config::initial_members(),
+            members: vec![],
         }),
         forum: Some(crate::forum_config::from_serialized::create(
             endowed_accounts[0].clone(),

--- a/node/src/forum_config/from_serialized.rs
+++ b/node/src/forum_config/from_serialized.rs
@@ -19,7 +19,7 @@ struct ForumData {
 }
 
 fn parse_forum_json() -> Result<ForumData> {
-    let data = include_str!("../../res/forum_data_acropolis_serialized.json");
+    let data = include_str!("../../res/forum_data_empty.json");
     serde_json::from_str(data)
 }
 


### PR DESCRIPTION
Its cleaner to start a new chain without members or forum posts, at least for development its not required. And the member imports were initially done when we launched a new testnet.

I'm not sure if there is an assumption that Alice is already a member in the network integration tests @gleb-urvanov (there is a member on testnet who chose to use this well known key which is odd)
