### PR TITLE
make all FTS selects in a single transaction

### DIFF
--- a/query-node/substrate-query-framework/cli/src/templates/textsearch/service.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/textsearch/service.ts.mst
@@ -4,7 +4,7 @@ import { {{type}} } from '../{{model}}/{{model}}.model';
 {{/entities}}  
 
 import { InjectRepository } from 'typeorm-typedi-extensions';
-import { Repository, getManager } from 'typeorm';
+import { Repository, getConnection } from 'typeorm';
 
 import { {{query.typePrefix}}FTSOutput } from './{{query.typePrefix}}.resolver';
 
@@ -29,7 +29,14 @@ export class {{query.typePrefix}}FTSService {
     }
 
     async search(text: string, limit:number = 5): Promise<{{query.typePrefix}}FTSOutput[]> {
-        const query = `
+        const connection = getConnection();
+		const queryRunner = connection.createQueryRunner();
+        // establish real database connection using our new query runner
+		await queryRunner.connect();
+        await queryRunner.startTransaction('REPEATABLE READ');
+
+        try {    
+            const query = `
             SELECT origin_table, id, 
                 ts_rank(tsv, phraseto_tsquery('{{query.language}}', $1)) as rank,
                 ts_headline(document, phraseto_tsquery('{{query.language}}', $1)) as highlight
@@ -38,33 +45,36 @@ export class {{query.typePrefix}}FTSService {
             ORDER BY rank DESC
             LIMIT $2`;
 
-        const results = await getManager().query(query, [text, limit]) as RawSQLResult[];
+            const results = await queryRunner.query(query, [text, limit]) as RawSQLResult[];
 
-        if (results.length == 0) {
-            return [];
-        }
-
-        const idMap:{ [id:string]: RawSQLResult } = {};
-        results.forEach(item => idMap[item.id] = item);
-        const ids: string[] = results.map(item => item.id);
-        
-        {{#entities}}
-        const {{arrayName}}: {{type}}[] = await this.{{fieldName}}Repository.createQueryBuilder()
-                    .where("id IN (:...ids)", { ids }).getMany();
-        {{/entities}}
-
-        const enhancedEntities = [{{#entities}}...{{arrayName}} {{^last}},{{/last}}{{/entities}}].map((e) => {
-            return { item: e, 
-                rank: idMap[e.id].rank, 
-                highlight: idMap[e.id].highlight,
-                isTypeOf: idMap[e.id].origin_table } as {{query.typePrefix}}FTSOutput;
-        });
-          
-        return enhancedEntities.reduce((accum: {{query.typePrefix}}FTSOutput[], entity) => {
-            if (entity.rank > 0) {
-                accum.push(entity);
+            if (results.length == 0) {
+                return [];
             }
-            return accum;
-        }, []).sort((a,b) => b.rank - a.rank);
+
+            const idMap:{ [id:string]: RawSQLResult } = {};
+            results.forEach(item => idMap[item.id] = item);
+            const ids: string[] = results.map(item => item.id);
+            
+            {{#entities}}
+            const {{arrayName}}: {{type}}[] = await this.{{fieldName}}Repository.createQueryBuilder()
+                        .where("id IN (:...ids)", { ids }).getMany();
+            {{/entities}}
+
+            const enhancedEntities = [{{#entities}}...{{arrayName}} {{^last}},{{/last}}{{/entities}}].map((e) => {
+                return { item: e, 
+                    rank: idMap[e.id].rank, 
+                    highlight: idMap[e.id].highlight,
+                    isTypeOf: idMap[e.id].origin_table } as {{query.typePrefix}}FTSOutput;
+            });
+            
+            return enhancedEntities.reduce((accum: {{query.typePrefix}}FTSOutput[], entity) => {
+                if (entity.rank > 0) {
+                    accum.push(entity);
+                }
+                return accum;
+            }, []).sort((a,b) => b.rank - a.rank);
+        } finally {
+            await queryRunner.commitTransaction();
+        }
     }
 }


### PR DESCRIPTION
This PR puts all SELECT db queries made by the FTS service into a single transaction with `REPEATABLE READ` isolation level. This prevents inconsistent reads when the database is simultaneously updated by the indexer.  