### PR TITLE
Forum category to moderator type

### DIFF
--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -407,7 +407,7 @@ pub fn set_moderator_category_mock(
     );
     if result.is_ok() {
         assert_eq!(
-            TestForumModule::category_by_moderator(category_id, moderator_id),
+            <CategoryByModerator<Runtime>>::exists(category_id, moderator_id),
             new_value
         );
     };


### PR DESCRIPTION
Solves subtask of #766 - *CategoryByModerator models a set, as such it should just map to an empty type, as the bool value type has no semantic meaning, and can be misleading.*

To minimize merge conflict potential, this PR assumes #827 will be merged first.