### PR TITLE
Content directory 2.0 tests: update_entity_permissions full coverage

### DIFF
--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -51,7 +51,7 @@ pub const FIRST_ENTITY_ID: EntityId = 1;
 pub const SECOND_ENTITY_ID: EntityId = 2;
 
 pub const UNKNOWN_CLASS_ID: ClassId = 111;
-// pub const UNKNOWN_ENTITY_ID: EntityId = 222;
+pub const UNKNOWN_ENTITY_ID: EntityId = 222;
 pub const UNKNOWN_PROPERTY_ID: PropertyId = 333;
 pub const UNKNOWN_SCHEMA_ID: SchemaId = 444;
 

--- a/runtime-modules/content-directory/src/tests/update_entity_permissions.rs
+++ b/runtime-modules/content-directory/src/tests/update_entity_permissions.rs
@@ -49,3 +49,56 @@ fn update_entity_permissions_success() {
         );
     })
 }
+
+#[test]
+fn update_entity_permissions_lead_auth_failed() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to update entity permissions for chosen entity under non lead origin
+        let update_entity_permissions_result =
+            update_entity_permissions(FIRST_MEMBER_ORIGIN, FIRST_ENTITY_ID, None, Some(false));
+
+        // Failure checked
+        assert_failure(
+            update_entity_permissions_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_permissions_of_non_existent_entity() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to update entity permissions for chosen entity under non lead origin
+        let update_entity_permissions_result =
+            update_entity_permissions(FIRST_MEMBER_ORIGIN, UNKNOWN_ENTITY_ID, None, Some(false));
+
+        // Failure checked
+        assert_failure(
+            update_entity_permissions_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}

--- a/runtime-modules/content-directory/src/tests/update_entity_permissions.rs
+++ b/runtime-modules/content-directory/src/tests/update_entity_permissions.rs
@@ -92,12 +92,12 @@ fn update_entity_permissions_of_non_existent_entity() {
 
         // Make an attempt to update entity permissions for chosen entity under non lead origin
         let update_entity_permissions_result =
-            update_entity_permissions(FIRST_MEMBER_ORIGIN, UNKNOWN_ENTITY_ID, None, Some(false));
+            update_entity_permissions(LEAD_ORIGIN, UNKNOWN_ENTITY_ID, None, Some(false));
 
         // Failure checked
         assert_failure(
             update_entity_permissions_result,
-            ERROR_LEAD_AUTH_FAILED,
+            ERROR_ENTITY_NOT_FOUND,
             number_of_events_before_call,
         );
     })


### PR DESCRIPTION
Closes https://github.com/Joystream/joystream/issues/790
Depends on: #841, #822, #817