### PR TITLE
Forum archival state removal 1

### DIFF
--- a/node/src/forum_config/from_serialized.rs
+++ b/node/src/forum_config/from_serialized.rs
@@ -48,12 +48,6 @@ pub fn create() -> ForumConfig {
         next_category_id,
         next_thread_id,
         next_post_id,
-        category_title_constraint: new_validation(10, 90),
-        category_description_constraint: new_validation(10, 490),
-        thread_title_constraint: new_validation(10, 90),
-        post_text_constraint: new_validation(10, 990),
-        thread_moderation_rationale_constraint: new_validation(10, 290),
-        post_moderation_rationale_constraint: new_validation(10, 290),
 
         // TODO: get rid of mocks and setup valid values
         max_category_depth: 10,

--- a/node/src/forum_config/from_serialized.rs
+++ b/node/src/forum_config/from_serialized.rs
@@ -3,7 +3,7 @@
 use super::new_validation;
 use node_runtime::{
     forum::{Category, Post, Thread},
-    BlockNumber, CategoryId, ForumConfig, ForumUserId, ModeratorId, Moment, PostId, ThreadId,
+    BlockNumber, CategoryId, ForumConfig, ForumUserId, Hash, ModeratorId, Moment, PostId, ThreadId,
 };
 use serde::Deserialize;
 use serde_json::Result;
@@ -12,15 +12,15 @@ use serde_json::Result;
 struct ForumData {
     categories: Vec<(
         CategoryId,
-        Category<CategoryId, ThreadId, BlockNumber, Moment>,
+        Category<CategoryId, ThreadId, BlockNumber, Moment, Hash>,
     )>,
     posts: Vec<(
         PostId,
-        Post<ForumUserId, ModeratorId, ThreadId, BlockNumber, Moment>,
+        Post<ForumUserId, ModeratorId, ThreadId, BlockNumber, Moment, Hash>,
     )>,
     threads: Vec<(
         ThreadId,
-        Thread<ForumUserId, ModeratorId, CategoryId, BlockNumber, Moment>,
+        Thread<ForumUserId, ModeratorId, CategoryId, BlockNumber, Moment, Hash>,
     )>,
 }
 

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -112,16 +112,17 @@ pub const INVLAID_CATEGORY_ID: <Runtime as Trait>::CategoryId = 333;
 
 pub const NOT_REGISTER_MODERATOR_ID: <Runtime as Trait>::ModeratorId = 666;
 
-pub fn generate_poll() -> Poll<<Runtime as timestamp::Trait>::Moment> {
+pub fn generate_poll(
+) -> Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash> {
     Poll {
-        poll_description: b"poll description".to_vec(),
+        hash: generate_hash(),
         start_time: Timestamp::now(),
         end_time: Timestamp::now() + 10,
         poll_alternatives: {
             let mut alternatives = vec![];
             for _ in 0..5 {
                 alternatives.push(PollAlternative {
-                    alternative_text: b"poll alternative".to_vec(),
+                    hash: generate_hash(),
                     vote_count: 0,
                 });
             }
@@ -130,17 +131,19 @@ pub fn generate_poll() -> Poll<<Runtime as timestamp::Trait>::Moment> {
     }
 }
 
-pub fn generate_poll_timestamp_cases(index: usize) -> Poll<<Runtime as timestamp::Trait>::Moment> {
+pub fn generate_poll_timestamp_cases(
+    index: usize,
+) -> Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash> {
     let test_cases = vec![
         Poll {
-            poll_description: b"poll description".to_vec(),
+            hash: generate_hash(),
             start_time: Timestamp::now(),
             end_time: Timestamp::now() + 10,
             poll_alternatives: {
                 let mut alternatives = vec![];
                 for _ in 0..5 {
                     alternatives.push(PollAlternative {
-                        alternative_text: b"poll alternative".to_vec(),
+                        hash: generate_hash(),
                         vote_count: 0,
                     });
                 }
@@ -148,14 +151,14 @@ pub fn generate_poll_timestamp_cases(index: usize) -> Poll<<Runtime as timestamp
             },
         },
         Poll {
-            poll_description: b"poll description".to_vec(),
+            hash: generate_hash(),
             start_time: Timestamp::now() + 10,
             end_time: Timestamp::now(),
             poll_alternatives: {
                 let mut alternatives = vec![];
                 for _ in 0..5 {
                     alternatives.push(PollAlternative {
-                        alternative_text: b"poll alternative".to_vec(),
+                        hash: generate_hash(),
                         vote_count: 0,
                     });
                 }
@@ -192,7 +195,9 @@ pub fn create_thread_mock(
     forum_user_id: <Runtime as Trait>::ForumUserId,
     category_id: <Runtime as Trait>::CategoryId,
     hash: <Runtime as system::Trait>::Hash,
-    poll_data: Option<Poll<<Runtime as timestamp::Trait>::Moment>>,
+    poll_data: Option<
+        Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash>,
+    >,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::ThreadId {
     let thread_id = TestForumModule::next_thread_id();

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -8,7 +8,7 @@ use crate::{GenesisConfig, Module, Trait};
 
 use runtime_primitives::{
     testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, Hash, IdentityLookup},
     Perbill,
 };
 use srml_support::{impl_outer_event, impl_outer_origin, parameter_types};
@@ -85,6 +85,10 @@ impl Trait for Runtime {
     fn is_moderator(account_id: &Self::AccountId, moderator_id: &Self::ModeratorId) -> bool {
         *account_id == FORUM_LEAD_ORIGIN_ID && *moderator_id != NOT_REGISTER_MODERATOR_ID
     }
+
+    fn calculate_hash(text: &[u8]) -> Self::Hash {
+        Self::Hashing::hash(text)
+    }
 }
 
 #[derive(Clone)]
@@ -112,17 +116,37 @@ pub const INVLAID_CATEGORY_ID: <Runtime as Trait>::CategoryId = 333;
 
 pub const NOT_REGISTER_MODERATOR_ID: <Runtime as Trait>::ModeratorId = 666;
 
+pub fn good_category_title() -> Vec<u8> {
+    b"Great new category".to_vec()
+}
+
+pub fn good_category_description() -> Vec<u8> {
+    b"This is a great new category for the forum".to_vec()
+}
+
+pub fn good_thread_title() -> Vec<u8> {
+    b"Great new thread".to_vec()
+}
+
+pub fn good_thread_text() -> Vec<u8> {
+    b"The first post in this thread".to_vec()
+}
+
+pub fn good_post_text() -> Vec<u8> {
+    b"A response in the thread".to_vec()
+}
+
 pub fn generate_poll(
 ) -> Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash> {
     Poll {
-        hash: generate_hash(),
+        description_hash: generate_hash(),
         start_time: Timestamp::now(),
         end_time: Timestamp::now() + 10,
         poll_alternatives: {
             let mut alternatives = vec![];
             for _ in 0..5 {
                 alternatives.push(PollAlternative {
-                    hash: generate_hash(),
+                    alternative_text_hash: generate_hash(),
                     vote_count: 0,
                 });
             }
@@ -136,14 +160,14 @@ pub fn generate_poll_timestamp_cases(
 ) -> Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash> {
     let test_cases = vec![
         Poll {
-            hash: generate_hash(),
+            description_hash: generate_hash(),
             start_time: Timestamp::now(),
             end_time: Timestamp::now() + 10,
             poll_alternatives: {
                 let mut alternatives = vec![];
                 for _ in 0..5 {
                     alternatives.push(PollAlternative {
-                        hash: generate_hash(),
+                        alternative_text_hash: generate_hash(),
                         vote_count: 0,
                     });
                 }
@@ -151,14 +175,14 @@ pub fn generate_poll_timestamp_cases(
             },
         },
         Poll {
-            hash: generate_hash(),
+            description_hash: generate_hash(),
             start_time: Timestamp::now() + 10,
             end_time: Timestamp::now(),
             poll_alternatives: {
                 let mut alternatives = vec![];
                 for _ in 0..5 {
                     alternatives.push(PollAlternative {
-                        hash: generate_hash(),
+                        alternative_text_hash: generate_hash(),
                         vote_count: 0,
                     });
                 }
@@ -172,12 +196,18 @@ pub fn generate_poll_timestamp_cases(
 pub fn create_category_mock(
     origin: OriginType,
     parent: Option<<Runtime as Trait>::CategoryId>,
-    hash: <Runtime as system::Trait>::Hash,
+    title: Vec<u8>,
+    description: Vec<u8>,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::CategoryId {
     let category_id = TestForumModule::next_category_id();
     assert_eq!(
-        TestForumModule::create_category(mock_origin(origin), parent, hash,),
+        TestForumModule::create_category(
+            mock_origin(origin),
+            parent,
+            title.clone(),
+            description.clone(),
+        ),
         result
     );
     if result.is_ok() {
@@ -194,7 +224,8 @@ pub fn create_thread_mock(
     origin: OriginType,
     forum_user_id: <Runtime as Trait>::ForumUserId,
     category_id: <Runtime as Trait>::CategoryId,
-    hash: <Runtime as system::Trait>::Hash,
+    title: Vec<u8>,
+    text: Vec<u8>,
     poll_data: Option<
         Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash>,
     >,
@@ -206,7 +237,8 @@ pub fn create_thread_mock(
             mock_origin(origin.clone()),
             forum_user_id,
             category_id,
-            hash,
+            title,
+            text,
             poll_data.clone(),
         ),
         result
@@ -225,12 +257,12 @@ pub fn create_post_mock(
     origin: OriginType,
     forum_user_id: <Runtime as Trait>::ForumUserId,
     thread_id: <Runtime as Trait>::ThreadId,
-    hash: <Runtime as system::Trait>::Hash,
+    text: Vec<u8>,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::PostId {
     let post_id = TestForumModule::next_post_id();
     assert_eq!(
-        TestForumModule::add_post(mock_origin(origin.clone()), forum_user_id, thread_id, hash,),
+        TestForumModule::add_post(mock_origin(origin.clone()), forum_user_id, thread_id, text),
         result
     );
     if result.is_ok() {

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -136,17 +136,27 @@ pub fn good_post_text() -> Vec<u8> {
     b"A response in the thread".to_vec()
 }
 
+pub fn good_poll_description() -> Vec<u8> {
+    b"poll description".to_vec()
+}
+
+pub fn good_poll_alternative_text() -> Vec<u8> {
+    b"poll alternative".to_vec()
+}
+
 pub fn generate_poll(
 ) -> Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash> {
     Poll {
-        description_hash: generate_hash(),
+        description_hash: Runtime::calculate_hash(good_poll_description().as_slice()),
         start_time: Timestamp::now(),
         end_time: Timestamp::now() + 10,
         poll_alternatives: {
             let mut alternatives = vec![];
             for _ in 0..5 {
                 alternatives.push(PollAlternative {
-                    alternative_text_hash: generate_hash(),
+                    alternative_text_hash: Runtime::calculate_hash(
+                        good_poll_alternative_text().as_slice(),
+                    ),
                     vote_count: 0,
                 });
             }
@@ -160,14 +170,16 @@ pub fn generate_poll_timestamp_cases(
 ) -> Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash> {
     let test_cases = vec![
         Poll {
-            description_hash: generate_hash(),
+            description_hash: Runtime::calculate_hash(good_poll_description().as_slice()),
             start_time: Timestamp::now(),
             end_time: Timestamp::now() + 10,
             poll_alternatives: {
                 let mut alternatives = vec![];
                 for _ in 0..5 {
                     alternatives.push(PollAlternative {
-                        alternative_text_hash: generate_hash(),
+                        alternative_text_hash: Runtime::calculate_hash(
+                            good_poll_alternative_text().as_slice(),
+                        ),
                         vote_count: 0,
                     });
                 }
@@ -175,14 +187,16 @@ pub fn generate_poll_timestamp_cases(
             },
         },
         Poll {
-            description_hash: generate_hash(),
+            description_hash: Runtime::calculate_hash(good_poll_description().as_slice()),
             start_time: Timestamp::now() + 10,
             end_time: Timestamp::now(),
             poll_alternatives: {
                 let mut alternatives = vec![];
                 for _ in 0..5 {
                     alternatives.push(PollAlternative {
-                        alternative_text_hash: generate_hash(),
+                        alternative_text_hash: Runtime::calculate_hash(
+                            good_poll_alternative_text().as_slice(),
+                        ),
                         vote_count: 0,
                     });
                 }
@@ -465,12 +479,6 @@ pub fn default_genesis_config() -> GenesisConfig<Runtime> {
 
 pub fn migration_not_done_config() -> GenesisConfig<Runtime> {
     create_genesis_config(false)
-}
-
-pub fn generate_hash() -> <Runtime as system::Trait>::Hash {
-    let hash = <Runtime as system::Trait>::Hash::random();
-
-    hash
 }
 
 pub fn create_genesis_config(data_migration_done: bool) -> GenesisConfig<Runtime> {

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -112,14 +112,6 @@ pub const INVLAID_CATEGORY_ID: <Runtime as Trait>::CategoryId = 333;
 
 pub const NOT_REGISTER_MODERATOR_ID: <Runtime as Trait>::ModeratorId = 666;
 
-pub fn generate_text(len: usize) -> Vec<u8> {
-    vec![b'x'; len]
-}
-
-pub fn good_rationale() -> Vec<u8> {
-    b"This post violates our community rules".to_vec()
-}
-
 pub fn generate_poll() -> Poll<<Runtime as timestamp::Trait>::Moment> {
     Poll {
         poll_description: b"poll description".to_vec(),
@@ -353,11 +345,10 @@ pub fn moderate_thread_mock(
     origin: OriginType,
     moderator_id: <Runtime as Trait>::ModeratorId,
     thread_id: <Runtime as Trait>::ThreadId,
-    rationale: Vec<u8>,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::ThreadId {
     assert_eq!(
-        TestForumModule::moderate_thread(mock_origin(origin), moderator_id, thread_id, rationale),
+        TestForumModule::moderate_thread(mock_origin(origin), moderator_id, thread_id),
         result
     );
     if result.is_ok() {
@@ -379,11 +370,10 @@ pub fn moderate_post_mock(
     origin: OriginType,
     moderator_id: <Runtime as Trait>::ModeratorId,
     post_id: <Runtime as Trait>::PostId,
-    rationale: Vec<u8>,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::PostId {
     assert_eq!(
-        TestForumModule::moderate_post(mock_origin(origin), moderator_id, post_id, rationale),
+        TestForumModule::moderate_post(mock_origin(origin), moderator_id, post_id),
         result
     );
     if result.is_ok() {
@@ -459,35 +449,6 @@ pub fn create_genesis_config(data_migration_done: bool) -> GenesisConfig<Runtime
         max_category_depth: 5,
         reaction_by_post: vec![],
 
-        category_title_constraint: InputValidationLengthConstraint {
-            min: 10,
-            max_min_diff: 140,
-        },
-
-        category_description_constraint: InputValidationLengthConstraint {
-            min: 10,
-            max_min_diff: 140,
-        },
-
-        thread_title_constraint: InputValidationLengthConstraint {
-            min: 3,
-            max_min_diff: 43,
-        },
-
-        post_text_constraint: InputValidationLengthConstraint {
-            min: 1,
-            max_min_diff: 1001,
-        },
-
-        thread_moderation_rationale_constraint: InputValidationLengthConstraint {
-            min: 10,
-            max_min_diff: 2000,
-        },
-
-        post_moderation_rationale_constraint: InputValidationLengthConstraint {
-            min: 10,
-            max_min_diff: 2000,
-        }, // JUST GIVING UP ON ALL THIS FOR NOW BECAUSE ITS TAKING TOO LONG
         poll_desc_constraint: InputValidationLengthConstraint {
             min: 10,
             max_min_diff: 200,

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -31,7 +31,13 @@ fn set_moderator_category_origin() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         set_moderator_category_mock(origin, moderator_id, category_id, true, Ok(()));
         set_moderator_category_mock(
             NOT_FORUM_LEAD_ORIGIN,
@@ -51,7 +57,13 @@ fn set_moderator_category_category() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         set_moderator_category_mock(
             origin.clone(),
@@ -70,7 +82,13 @@ fn set_moderator_category_account_id() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(default_genesis_config()).execute_with(|| {
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         set_moderator_category_mock(
             origin.clone(),
             NOT_REGISTER_MODERATOR_ID,
@@ -82,7 +100,13 @@ fn set_moderator_category_account_id() {
 
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         set_moderator_category_mock(origin, moderator_id, category_id, true, Ok(()));
     });
 }
@@ -98,7 +122,8 @@ fn create_category_origin() {
             create_category_mock(
                 origins[index].clone(),
                 None,
-                generate_hash(),
+                good_category_title(),
+                good_category_description(),
                 results[index],
             );
         });
@@ -121,15 +146,34 @@ fn create_category_parent() {
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
-            create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
-            create_category_mock(origin.clone(), Some(1), generate_hash(), Ok(()));
-            create_category_mock(origin.clone(), Some(2), generate_hash(), Ok(()));
+            create_category_mock(
+                origin.clone(),
+                None,
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
+            create_category_mock(
+                origin.clone(),
+                Some(1),
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
+            create_category_mock(
+                origin.clone(),
+                Some(2),
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
             update_category_mock(origin.clone(), 3, Some(true), None, Ok(()));
             update_category_mock(origin.clone(), 2, None, Some(true), Ok(()));
             create_category_mock(
                 origin.clone(),
                 parents[index],
-                generate_hash(),
+                good_category_title(),
+                good_category_description(),
                 results[index],
             );
         });
@@ -143,14 +187,39 @@ fn create_category_depth() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
-        create_category_mock(origin.clone(), Some(1), generate_hash(), Ok(()));
-        create_category_mock(origin.clone(), Some(2), generate_hash(), Ok(()));
-        create_category_mock(origin.clone(), Some(3), generate_hash(), Ok(()));
+        create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
+        create_category_mock(
+            origin.clone(),
+            Some(1),
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
+        create_category_mock(
+            origin.clone(),
+            Some(2),
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
+        create_category_mock(
+            origin.clone(),
+            Some(3),
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         create_category_mock(
             origin.clone(),
             Some(4),
-            generate_hash(),
+            good_category_title(),
+            good_category_description(),
             Err(ERROR_MAX_VALID_CATEGORY_DEPTH_EXCEEDED),
         );
     });
@@ -170,7 +239,13 @@ fn update_category_origin() {
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
-            create_category_mock(origin, None, generate_hash(), Ok(()));
+            create_category_mock(
+                origin,
+                None,
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
             update_category_mock(origins[index].clone(), 1, Some(true), None, results[index]);
         });
     }
@@ -182,7 +257,13 @@ fn update_category_without_updates() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         update_category_mock(origin, 1, None, None, Err(ERROR_CATEGORY_NOT_BEING_UPDATED));
     });
 }
@@ -193,7 +274,13 @@ fn update_category_without_updates_two() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         update_category_mock(
             origin,
             1,
@@ -211,7 +298,13 @@ fn update_category_without_updates_three() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         update_category_mock(origin.clone(), 1, Some(false), Some(true), Ok(()));
         update_category_mock(
             origin.clone(),
@@ -230,7 +323,13 @@ fn update_category_deleted_then_unarchived() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         update_category_mock(origin.clone(), 1, Some(true), Some(true), Ok(()));
         update_category_mock(
             origin.clone(),
@@ -254,15 +353,20 @@ fn create_thread_origin() {
         let config = default_genesis_config();
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
-        let hash_category = generate_hash();
-        let hash_thread = generate_hash();
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(origin, None, hash_category, Ok(()));
+            let category_id = create_category_mock(
+                origin,
+                None,
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
             create_thread_mock(
                 origins[index].clone(),
                 forum_lead,
                 category_id,
-                hash_thread,
+                good_thread_title(),
+                good_thread_text(),
                 None,
                 results[index],
             );
@@ -284,13 +388,20 @@ fn create_thread_poll_timestamp() {
         let origin = OriginType::Signed(forum_lead);
 
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+            let category_id = create_category_mock(
+                origin.clone(),
+                None,
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
 
             create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                generate_hash(),
+                good_thread_title(),
+                good_thread_text(),
                 Some(generate_poll_timestamp_cases(index)),
                 results[index],
             );
@@ -311,12 +422,19 @@ fn vote_on_poll_origin() {
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+            let category_id = create_category_mock(
+                origin.clone(),
+                None,
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                generate_hash(),
+                good_thread_title(),
+                good_thread_text(),
                 Some(generate_poll()),
                 Ok(()),
             );
@@ -339,12 +457,19 @@ fn vote_on_poll_exists() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            generate_hash(),
+            good_thread_title(),
+            good_thread_text(),
             None,
             Ok(()),
         );
@@ -365,12 +490,19 @@ fn vote_on_poll_expired() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            generate_hash(),
+            good_thread_title(),
+            good_thread_text(),
             Some(generate_poll()),
             Ok(()),
         );
@@ -392,13 +524,20 @@ fn moderate_thread_origin_ok() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            generate_hash(),
+            good_thread_title(),
+            good_thread_text(),
             None,
             Ok(()),
         );
@@ -420,13 +559,20 @@ fn add_post_origin() {
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+            let category_id = create_category_mock(
+                origin.clone(),
+                None,
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
 
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                generate_hash(),
+                good_thread_title(),
+                good_thread_text(),
                 None,
                 Ok(()),
             );
@@ -434,7 +580,7 @@ fn add_post_origin() {
                 origins[index].clone(),
                 forum_lead,
                 thread_id,
-                generate_hash(),
+                good_post_text(),
                 results[index],
             );
         });
@@ -459,13 +605,20 @@ fn react_post() {
         let origin = FORUM_LEAD_ORIGIN;
 
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+            let category_id = create_category_mock(
+                origin.clone(),
+                None,
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
 
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                generate_hash(),
+                good_thread_title(),
+                good_thread_text(),
                 None,
                 Ok(()),
             );
@@ -473,7 +626,7 @@ fn react_post() {
                 origin.clone(),
                 forum_lead,
                 thread_id,
-                generate_hash(),
+                good_post_text(),
                 Ok(()),
             );
             assert_eq!(
@@ -509,14 +662,21 @@ fn moderate_post_origin() {
         build_test_externalities(config).execute_with(|| {
             let moderator_id = forum_lead;
 
-            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+            let category_id = create_category_mock(
+                origin.clone(),
+                None,
+                good_category_title(),
+                good_category_description(),
+                Ok(()),
+            );
             set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
 
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                generate_hash(),
+                good_thread_title(),
+                good_thread_text(),
                 None,
                 Ok(()),
             );
@@ -524,7 +684,7 @@ fn moderate_post_origin() {
                 origin.clone(),
                 forum_lead,
                 thread_id,
-                generate_hash(),
+                good_post_text(),
                 Ok(()),
             );
             moderate_post_mock(
@@ -544,13 +704,20 @@ fn set_stickied_threads_ok() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            generate_hash(),
+            good_thread_title(),
+            good_thread_text(),
             None,
             Ok(()),
         );
@@ -565,13 +732,20 @@ fn set_stickied_threads_wrong_moderator() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
 
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            generate_hash(),
+            good_thread_title(),
+            good_thread_text(),
             None,
             Ok(()),
         );
@@ -592,13 +766,20 @@ fn set_stickied_threads_thread_not_exists() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            generate_hash(),
+            good_thread_title(),
+            good_thread_text(),
             None,
             Ok(()),
         );
@@ -620,22 +801,36 @@ fn set_stickied_threads_wrong_category() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         let _ = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            generate_hash(),
+            good_thread_title(),
+            good_thread_text(),
             None,
             Ok(()),
         );
-        let category_id_2 = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        let category_id_2 = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id_2,
-            generate_hash(),
+            good_thread_title(),
+            good_thread_text(),
             None,
             Ok(()),
         );
@@ -662,7 +857,12 @@ fn test_migration_not_done() {
         let post_id = 1;
 
         assert_eq!(
-            TestForumModule::create_category(mock_origin(origin.clone()), None, generate_hash(),),
+            TestForumModule::create_category(
+                mock_origin(origin.clone()),
+                None,
+                good_category_title(),
+                good_category_description()
+            ),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );
 
@@ -671,7 +871,8 @@ fn test_migration_not_done() {
                 mock_origin(origin.clone()),
                 forum_user_id,
                 category_id,
-                generate_hash(),
+                good_thread_title(),
+                good_thread_text(),
                 None,
             ),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
@@ -682,7 +883,7 @@ fn test_migration_not_done() {
                 mock_origin(origin.clone()),
                 forum_user_id,
                 thread_id,
-                generate_hash(),
+                good_post_text(),
             ),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -29,16 +29,9 @@ fn set_moderator_category_origin() {
     let config = default_genesis_config();
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
-
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         set_moderator_category_mock(origin, moderator_id, category_id, true, Ok(()));
         set_moderator_category_mock(
             NOT_FORUM_LEAD_ORIGIN,
@@ -58,13 +51,7 @@ fn set_moderator_category_category() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         set_moderator_category_mock(
             origin.clone(),
@@ -83,13 +70,7 @@ fn set_moderator_category_account_id() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(default_genesis_config()).execute_with(|| {
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         set_moderator_category_mock(
             origin.clone(),
             NOT_REGISTER_MODERATOR_ID,
@@ -101,13 +82,7 @@ fn set_moderator_category_account_id() {
 
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         set_moderator_category_mock(origin, moderator_id, category_id, true, Ok(()));
     });
 }
@@ -123,8 +98,7 @@ fn create_category_origin() {
             create_category_mock(
                 origins[index].clone(),
                 None,
-                good_category_title(),
-                good_category_description(),
+                generate_hash(),
                 results[index],
             );
         });
@@ -147,34 +121,15 @@ fn create_category_parent() {
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
-            create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
-            create_category_mock(
-                origin.clone(),
-                Some(1),
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
-            create_category_mock(
-                origin.clone(),
-                Some(2),
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+            create_category_mock(origin.clone(), Some(1), generate_hash(), Ok(()));
+            create_category_mock(origin.clone(), Some(2), generate_hash(), Ok(()));
             update_category_mock(origin.clone(), 3, Some(true), None, Ok(()));
             update_category_mock(origin.clone(), 2, None, Some(true), Ok(()));
             create_category_mock(
                 origin.clone(),
                 parents[index],
-                good_category_title(),
-                good_category_description(),
+                generate_hash(),
                 results[index],
             );
         });
@@ -188,102 +143,17 @@ fn create_category_depth() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
-        create_category_mock(
-            origin.clone(),
-            Some(1),
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
-        create_category_mock(
-            origin.clone(),
-            Some(2),
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
-        create_category_mock(
-            origin.clone(),
-            Some(3),
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
+        create_category_mock(origin.clone(), Some(1), generate_hash(), Ok(()));
+        create_category_mock(origin.clone(), Some(2), generate_hash(), Ok(()));
+        create_category_mock(origin.clone(), Some(3), generate_hash(), Ok(()));
         create_category_mock(
             origin.clone(),
             Some(4),
-            good_category_title(),
-            good_category_description(),
+            generate_hash(),
             Err(ERROR_MAX_VALID_CATEGORY_DEPTH_EXCEEDED),
         );
     });
-}
-
-#[test]
-// test category title length
-fn create_category_title() {
-    let config = default_genesis_config();
-    let forum_lead = FORUM_LEAD_ORIGIN_ID;
-    let origin = OriginType::Signed(forum_lead);
-    let titles = vec![
-        generate_text(config.category_title_constraint.min as usize),
-        generate_text((config.category_title_constraint.min - 1) as usize),
-        generate_text((config.category_title_constraint.max() + 1) as usize),
-    ];
-    let results = vec![
-        Ok(()),
-        Err(ERROR_CATEGORY_TITLE_TOO_SHORT),
-        Err(ERROR_CATEGORY_TITLE_TOO_LONG),
-    ];
-    for index in 0..titles.len() {
-        let config = default_genesis_config();
-        build_test_externalities(config).execute_with(|| {
-            create_category_mock(
-                origin.clone(),
-                None,
-                titles[index].clone(),
-                good_category_description(),
-                results[index],
-            );
-        });
-    }
-}
-
-#[test]
-// test for category description text length
-fn create_category_description() {
-    let config = default_genesis_config();
-    let forum_lead = FORUM_LEAD_ORIGIN_ID;
-    let origin = OriginType::Signed(forum_lead);
-    let descriptions = vec![
-        generate_text(config.category_description_constraint.min as usize),
-        generate_text((config.category_description_constraint.min - 1) as usize),
-        generate_text((config.category_description_constraint.max() + 1) as usize),
-    ];
-    let results = vec![
-        Ok(()),
-        Err(ERROR_CATEGORY_DESCRIPTION_TOO_SHORT),
-        Err(ERROR_CATEGORY_DESCRIPTION_TOO_LONG),
-    ];
-    for index in 0..descriptions.len() {
-        let config = default_genesis_config();
-        build_test_externalities(config).execute_with(|| {
-            create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                descriptions[index].clone(),
-                results[index],
-            );
-        });
-    }
 }
 
 /*
@@ -300,13 +170,7 @@ fn update_category_origin() {
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
-            create_category_mock(
-                origin,
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            create_category_mock(origin, None, generate_hash(), Ok(()));
             update_category_mock(origins[index].clone(), 1, Some(true), None, results[index]);
         });
     }
@@ -318,13 +182,7 @@ fn update_category_without_updates() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         update_category_mock(origin, 1, None, None, Err(ERROR_CATEGORY_NOT_BEING_UPDATED));
     });
 }
@@ -335,13 +193,7 @@ fn update_category_without_updates_two() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         update_category_mock(
             origin,
             1,
@@ -359,13 +211,7 @@ fn update_category_without_updates_three() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         update_category_mock(origin.clone(), 1, Some(false), Some(true), Ok(()));
         update_category_mock(
             origin.clone(),
@@ -384,13 +230,7 @@ fn update_category_deleted_then_unarchived() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         update_category_mock(origin.clone(), 1, Some(true), Some(true), Ok(()));
         update_category_mock(
             origin.clone(),
@@ -414,102 +254,15 @@ fn create_thread_origin() {
         let config = default_genesis_config();
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
-
+        let hash_category = generate_hash();
+        let hash_thread = generate_hash();
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(
-                origin,
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            let category_id = create_category_mock(origin, None, hash_category, Ok(()));
             create_thread_mock(
                 origins[index].clone(),
                 forum_lead,
                 category_id,
-                good_thread_title(),
-                good_thread_text(),
-                None,
-                results[index],
-            );
-        });
-    }
-}
-
-#[test]
-// test thread title length
-fn create_thread_title() {
-    let constraint = default_genesis_config().thread_title_constraint;
-    let titles = [
-        generate_text(constraint.min as usize),
-        generate_text((constraint.min as usize) - 1),
-        generate_text((constraint.max() as usize) + 1),
-    ];
-    let results = vec![
-        Ok(()),
-        Err(ERROR_THREAD_TITLE_TOO_SHORT),
-        Err(ERROR_THREAD_TITLE_TOO_LONG),
-    ];
-    for index in 0..titles.len() {
-        let config = default_genesis_config();
-        let forum_lead = FORUM_LEAD_ORIGIN_ID;
-        let origin = OriginType::Signed(forum_lead);
-
-        build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
-            create_thread_mock(
-                origin.clone(),
-                forum_lead,
-                category_id,
-                titles[index].clone(),
-                good_thread_text(),
-                None,
-                results[index],
-            );
-        });
-    }
-}
-
-#[test]
-// test thread text length
-fn create_thread_text() {
-    let constraint = default_genesis_config().post_text_constraint;
-    let texts = [
-        generate_text(constraint.min as usize),
-        generate_text((constraint.min as usize) - 1),
-        generate_text((constraint.max() as usize) + 1),
-    ];
-
-    let results = vec![
-        Ok(()),
-        Err(ERROR_POST_TEXT_TOO_SHORT),
-        Err(ERROR_POST_TEXT_TOO_LONG),
-    ];
-    for index in 0..texts.len() {
-        let config = default_genesis_config();
-        let forum_lead = FORUM_LEAD_ORIGIN_ID;
-        let origin = OriginType::Signed(forum_lead);
-
-        build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
-            create_thread_mock(
-                origin.clone(),
-                forum_lead,
-                category_id,
-                good_thread_title(),
-                texts[index].clone(),
+                hash_thread,
                 None,
                 results[index],
             );
@@ -531,20 +284,13 @@ fn create_thread_poll_timestamp() {
         let origin = OriginType::Signed(forum_lead);
 
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
 
             create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                good_thread_title(),
-                good_thread_text(),
+                generate_hash(),
                 Some(generate_poll_timestamp_cases(index)),
                 results[index],
             );
@@ -565,19 +311,12 @@ fn vote_on_poll_origin() {
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                good_thread_title(),
-                good_thread_text(),
+                generate_hash(),
                 Some(generate_poll()),
                 Ok(()),
             );
@@ -600,19 +339,12 @@ fn vote_on_poll_exists() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            good_thread_title(),
-            good_thread_text(),
+            generate_hash(),
             None,
             Ok(()),
         );
@@ -633,19 +365,12 @@ fn vote_on_poll_expired() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            good_thread_title(),
-            good_thread_text(),
+            generate_hash(),
             Some(generate_poll()),
             Ok(()),
         );
@@ -667,20 +392,13 @@ fn moderate_thread_origin_ok() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            good_thread_title(),
-            good_thread_text(),
+            generate_hash(),
             None,
             Ok(()),
         );
@@ -708,20 +426,13 @@ fn moderate_thread_rationale() {
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
             let moderator_id = forum_lead;
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
             set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                good_thread_title(),
-                good_thread_text(),
+                generate_hash(),
                 None,
                 Ok(()),
             );
@@ -750,20 +461,13 @@ fn add_post_origin() {
         let forum_lead = FORUM_LEAD_ORIGIN_ID;
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
 
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                good_thread_title(),
-                good_thread_text(),
+                generate_hash(),
                 None,
                 Ok(()),
             );
@@ -771,109 +475,7 @@ fn add_post_origin() {
                 origins[index].clone(),
                 forum_lead,
                 thread_id,
-                good_post_text(),
-                results[index],
-            );
-        });
-    }
-}
-
-#[test]
-// test post text's length
-fn add_post_text() {
-    let constraint = default_genesis_config().post_text_constraint;
-    let texts = vec![
-        generate_text(constraint.min as usize),
-        generate_text((constraint.min - 1) as usize),
-        generate_text((constraint.max() + 1) as usize),
-    ];
-    let results = vec![
-        Ok(()),
-        Err(ERROR_POST_TEXT_TOO_SHORT),
-        Err(ERROR_POST_TEXT_TOO_LONG),
-    ];
-    for index in 0..texts.len() {
-        let config = default_genesis_config();
-        let forum_lead = FORUM_LEAD_ORIGIN_ID;
-        let origin = OriginType::Signed(forum_lead);
-        build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
-
-            let thread_id = create_thread_mock(
-                origin.clone(),
-                forum_lead,
-                category_id,
-                good_thread_title(),
-                good_thread_text(),
-                None,
-                Ok(()),
-            );
-            create_post_mock(
-                origin.clone(),
-                forum_lead,
-                thread_id,
-                texts[index].clone(),
-                results[index],
-            );
-        });
-    }
-}
-
-#[test]
-// test post text's length
-fn edit_post_text() {
-    let constraint = default_genesis_config().post_text_constraint;
-    let texts = vec![
-        generate_text(constraint.min as usize),
-        generate_text((constraint.min - 1) as usize),
-        generate_text((constraint.max() + 1) as usize),
-    ];
-    let results = vec![
-        Ok(()),
-        Err(ERROR_POST_TEXT_TOO_SHORT),
-        Err(ERROR_POST_TEXT_TOO_LONG),
-    ];
-    for index in 0..texts.len() {
-        let config = default_genesis_config();
-        let forum_lead = FORUM_LEAD_ORIGIN_ID;
-        let origin = OriginType::Signed(forum_lead);
-        build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
-
-            let thread_id = create_thread_mock(
-                origin.clone(),
-                forum_lead,
-                category_id,
-                good_thread_title(),
-                good_thread_text(),
-                None,
-                Ok(()),
-            );
-            let post_id = create_post_mock(
-                origin.clone(),
-                forum_lead,
-                thread_id,
-                good_post_text(),
-                Ok(()),
-            );
-
-            edit_post_text_mock(
-                origin.clone(),
-                forum_lead,
-                post_id,
-                texts[index].clone(),
+                generate_hash(),
                 results[index],
             );
         });
@@ -898,20 +500,13 @@ fn react_post() {
         let origin = FORUM_LEAD_ORIGIN;
 
         build_test_externalities(config).execute_with(|| {
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
 
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                good_thread_title(),
-                good_thread_text(),
+                generate_hash(),
                 None,
                 Ok(()),
             );
@@ -919,7 +514,7 @@ fn react_post() {
                 origin.clone(),
                 forum_lead,
                 thread_id,
-                good_post_text(),
+                generate_hash(),
                 Ok(()),
             );
             assert_eq!(
@@ -955,21 +550,14 @@ fn moderate_post_origin() {
         build_test_externalities(config).execute_with(|| {
             let moderator_id = forum_lead;
 
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
             set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
 
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                good_thread_title(),
-                good_thread_text(),
+                generate_hash(),
                 None,
                 Ok(()),
             );
@@ -977,7 +565,7 @@ fn moderate_post_origin() {
                 origin.clone(),
                 forum_lead,
                 thread_id,
-                good_post_text(),
+                generate_hash(),
                 Ok(()),
             );
             moderate_post_mock(
@@ -1012,21 +600,14 @@ fn moderate_post_rationale() {
         build_test_externalities(config).execute_with(|| {
             let moderator_id = forum_lead;
 
-            let category_id = create_category_mock(
-                origin.clone(),
-                None,
-                good_category_title(),
-                good_category_description(),
-                Ok(()),
-            );
+            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
 
             set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
             let thread_id = create_thread_mock(
                 origin.clone(),
                 forum_lead,
                 category_id,
-                good_thread_title(),
-                good_thread_text(),
+                generate_hash(),
                 None,
                 Ok(()),
             );
@@ -1034,7 +615,7 @@ fn moderate_post_rationale() {
                 origin.clone(),
                 forum_lead,
                 thread_id,
-                good_post_text(),
+                generate_hash(),
                 Ok(()),
             );
             moderate_post_mock(
@@ -1055,20 +636,13 @@ fn set_stickied_threads_ok() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            good_thread_title(),
-            good_thread_text(),
+            generate_hash(),
             None,
             Ok(()),
         );
@@ -1083,20 +657,13 @@ fn set_stickied_threads_wrong_moderator() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
 
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            good_thread_title(),
-            good_thread_text(),
+            generate_hash(),
             None,
             Ok(()),
         );
@@ -1117,20 +684,13 @@ fn set_stickied_threads_thread_not_exists() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            good_thread_title(),
-            good_thread_text(),
+            generate_hash(),
             None,
             Ok(()),
         );
@@ -1152,36 +712,22 @@ fn set_stickied_threads_wrong_category() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let moderator_id = forum_lead;
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
         let _ = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id,
-            good_thread_title(),
-            good_thread_text(),
+            generate_hash(),
             None,
             Ok(()),
         );
-        let category_id_2 = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
+        let category_id_2 = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
         let thread_id = create_thread_mock(
             origin.clone(),
             forum_lead,
             category_id_2,
-            good_thread_title(),
-            good_thread_text(),
+            generate_hash(),
             None,
             Ok(()),
         );
@@ -1208,12 +754,7 @@ fn test_migration_not_done() {
         let post_id = 1;
 
         assert_eq!(
-            TestForumModule::create_category(
-                mock_origin(origin.clone()),
-                None,
-                good_category_title(),
-                good_category_description(),
-            ),
+            TestForumModule::create_category(mock_origin(origin.clone()), None, generate_hash(),),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );
 
@@ -1222,8 +763,7 @@ fn test_migration_not_done() {
                 mock_origin(origin.clone()),
                 forum_user_id,
                 category_id,
-                good_thread_title(),
-                good_thread_text(),
+                generate_hash(),
                 None,
             ),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
@@ -1234,7 +774,7 @@ fn test_migration_not_done() {
                 mock_origin(origin.clone()),
                 forum_user_id,
                 thread_id,
-                good_post_text(),
+                generate_hash(),
             ),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -402,49 +402,8 @@ fn moderate_thread_origin_ok() {
             None,
             Ok(()),
         );
-        moderate_thread_mock(origin, moderator_id, thread_id, good_rationale(), Ok(()));
+        moderate_thread_mock(origin, moderator_id, thread_id, Ok(()));
     });
-}
-
-#[test]
-// test thread moderate rationale's length
-fn moderate_thread_rationale() {
-    let constraint = default_genesis_config().thread_moderation_rationale_constraint;
-    let rationales = vec![
-        generate_text(constraint.min as usize),
-        generate_text((constraint.min - 1) as usize),
-        generate_text((constraint.max() + 1) as usize),
-    ];
-    let results = vec![
-        Ok(()),
-        Err(ERROR_THREAD_MODERATION_RATIONALE_TOO_SHORT),
-        Err(ERROR_THREAD_MODERATION_RATIONALE_TOO_LONG),
-    ];
-    for index in 0..rationales.len() {
-        let config = default_genesis_config();
-        let forum_lead = FORUM_LEAD_ORIGIN_ID;
-        let origin = OriginType::Signed(forum_lead);
-        build_test_externalities(config).execute_with(|| {
-            let moderator_id = forum_lead;
-            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
-            set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
-            let thread_id = create_thread_mock(
-                origin.clone(),
-                forum_lead,
-                category_id,
-                generate_hash(),
-                None,
-                Ok(()),
-            );
-            moderate_thread_mock(
-                origin.clone(),
-                moderator_id,
-                thread_id,
-                rationales[index].clone(),
-                results[index],
-            );
-        });
-    }
 }
 
 /*
@@ -572,57 +531,6 @@ fn moderate_post_origin() {
                 origins[index].clone(),
                 moderator_id,
                 post_id,
-                good_rationale(),
-                results[index],
-            );
-        });
-    }
-}
-
-#[test]
-// test post rationale text's length
-fn moderate_post_rationale() {
-    let constraint = default_genesis_config().post_moderation_rationale_constraint;
-    let rationales = vec![
-        generate_text(constraint.min as usize),
-        generate_text((constraint.min - 1) as usize),
-        generate_text((constraint.max() + 1) as usize),
-    ];
-    let results = vec![
-        Ok(()),
-        Err(ERROR_POST_MODERATION_RATIONALE_TOO_SHORT),
-        Err(ERROR_POST_MODERATION_RATIONALE_TOO_LONG),
-    ];
-    for index in 0..rationales.len() {
-        let config = default_genesis_config();
-        let forum_lead = FORUM_LEAD_ORIGIN_ID;
-        let origin = OriginType::Signed(forum_lead);
-        build_test_externalities(config).execute_with(|| {
-            let moderator_id = forum_lead;
-
-            let category_id = create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
-
-            set_moderator_category_mock(origin.clone(), moderator_id, category_id, true, Ok(()));
-            let thread_id = create_thread_mock(
-                origin.clone(),
-                forum_lead,
-                category_id,
-                generate_hash(),
-                None,
-                Ok(()),
-            );
-            let post_id = create_post_mock(
-                origin.clone(),
-                forum_lead,
-                thread_id,
-                generate_hash(),
-                Ok(()),
-            );
-            moderate_post_mock(
-                origin.clone(),
-                moderator_id,
-                post_id,
-                rationales[index].clone(),
                 results[index],
             );
         });
@@ -784,7 +692,6 @@ fn test_migration_not_done() {
                 mock_origin(origin.clone()),
                 moderator_id,
                 thread_id,
-                good_rationale(),
             ),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );
@@ -794,7 +701,6 @@ fn test_migration_not_done() {
                 mock_origin(origin.clone()),
                 moderator_id,
                 post_id,
-                good_rationale(),
             ),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -688,20 +688,12 @@ fn test_migration_not_done() {
         );
 
         assert_eq!(
-            TestForumModule::moderate_thread(
-                mock_origin(origin.clone()),
-                moderator_id,
-                thread_id,
-            ),
+            TestForumModule::moderate_thread(mock_origin(origin.clone()), moderator_id, thread_id,),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );
 
         assert_eq!(
-            TestForumModule::moderate_post(
-                mock_origin(origin.clone()),
-                moderator_id,
-                post_id,
-            ),
+            TestForumModule::moderate_post(mock_origin(origin.clone()), moderator_id, post_id,),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );
     });

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -826,6 +826,10 @@ impl forum::Trait for Runtime {
     fn is_moderator(_account_id: &Self::AccountId, _moderator_id: &Self::ModeratorId) -> bool {
         true
     }
+
+    fn calculate_hash(text: &[u8]) -> Self::Hash {
+        Self::Hash::from_slice(text)
+    }
 }
 
 impl migration::Trait for Runtime {


### PR DESCRIPTION
Solves subtasks of #766:
- Remove all label label semantics in the runtime
- We no longer store category names, post/thread titles or texts, or any other text, just the hash.
- We no longer enforce length constraints on any such texts either, hence all such parameters and checks can be removed.
- We no longer store poll alternative texts: `PollAlternative.alternative_text`, just hash.

To minimize merge conflict potential, this PR assumes #837 will be merged first.