### PR TITLE
Forum archival state removal 4

### DIFF
--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -459,13 +459,6 @@ pub struct Post<ForumUserId, ModeratorId, ThreadId, Hash> {
 
     /// Author of post.
     pub author_id: ForumUserId,
-
-    /// The post number of this post in its thread, i.e. total number of posts added (including this)
-    /// to a thread when it was added.
-    /// Is needed to give light clients assurance about getting all posts in a given range,
-    // `created_at` is not sufficient.
-    /// Starts at 1 for first post in thread.
-    pub nr_in_thread: u32,
 }
 
 /// Represents a thread
@@ -486,13 +479,6 @@ pub struct Thread<ForumUserId, ModeratorId, CategoryId, Moment, Hash> {
 
     /// poll description.
     pub poll: Option<Poll<Moment, Hash>>,
-
-    /// The thread number of this thread in its category, i.e. total number of thread added (including this)
-    /// to a category when it was added.
-    /// Is needed to give light clients assurance about getting all threads in a given range,
-    /// `created_at` is not sufficient.
-    /// Starts at 1 for first thread in category.
-    pub nr_in_category: u32,
 
     /// Number of unmoderated and moderated posts in this thread.
     /// The sum of these two only increases, and former is incremented
@@ -1162,9 +1148,6 @@ impl<T: Trait> Module<T> {
             Self::ensure_poll_is_valid(&data)?;
         }
 
-        // Get the category
-        let category = <CategoryById<T>>::get(category_id);
-
         // Create and add new thread
         let new_thread_id = <NextThreadId<T>>::get();
 
@@ -1178,7 +1161,6 @@ impl<T: Trait> Module<T> {
             moderation: None,
             author_id,
             poll: poll.clone(),
-            nr_in_category: category.num_threads_created() + 1,
             num_unmoderated_posts: 0,
             num_moderated_posts: 0,
         };
@@ -1227,7 +1209,6 @@ impl<T: Trait> Module<T> {
             hash,
             moderation: None,
             author_id,
-            nr_in_thread: thread.num_posts_ever_created(),
         };
 
         // Store post

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -321,26 +321,16 @@ pub fn update_category_mock(
     origin: OriginType,
     category_id: <Runtime as Trait>::CategoryId,
     new_archival_status: Option<bool>,
-    new_deletion_status: Option<bool>,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::CategoryId {
     assert_eq!(
-        TestForumModule::update_category(
-            mock_origin(origin),
-            category_id,
-            new_archival_status,
-            new_deletion_status
-        ),
+        TestForumModule::update_category(mock_origin(origin), category_id, new_archival_status,),
         result
     );
     if result.is_ok() {
         assert_eq!(
             System::events().last().unwrap().event,
-            TestEvent::forum_mod(RawEvent::CategoryUpdated(
-                category_id,
-                new_archival_status,
-                new_deletion_status
-            ))
+            TestEvent::forum_mod(RawEvent::CategoryUpdated(category_id, new_archival_status,))
         );
     };
     category_id

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -366,16 +366,21 @@ pub fn vote_on_poll_mock(
 pub fn update_category_archival_status_mock(
     origin: OriginType,
     category_id: <Runtime as Trait>::CategoryId,
+    new_archival_status: bool,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::CategoryId {
     assert_eq!(
-        TestForumModule::update_category_archival_status(mock_origin(origin), category_id),
+        TestForumModule::update_category_archival_status(
+            mock_origin(origin),
+            category_id,
+            new_archival_status
+        ),
         result
     );
     if result.is_ok() {
         assert_eq!(
             System::events().last().unwrap().event,
-            TestEvent::forum_mod(RawEvent::CategoryArchived(category_id))
+            TestEvent::forum_mod(RawEvent::CategoryUpdated(category_id, new_archival_status))
         );
     };
     category_id

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -363,20 +363,19 @@ pub fn vote_on_poll_mock(
     thread_id
 }
 
-pub fn update_category_mock(
+pub fn update_category_archival_status_mock(
     origin: OriginType,
     category_id: <Runtime as Trait>::CategoryId,
-    new_archival_status: Option<bool>,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::CategoryId {
     assert_eq!(
-        TestForumModule::update_category(mock_origin(origin), category_id, new_archival_status,),
+        TestForumModule::update_category_archival_status(mock_origin(origin), category_id),
         result
     );
     if result.is_ok() {
         assert_eq!(
             System::events().last().unwrap().event,
-            TestEvent::forum_mod(RawEvent::CategoryUpdated(category_id, new_archival_status,))
+            TestEvent::forum_mod(RawEvent::CategoryArchived(category_id))
         );
     };
     category_id

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -159,7 +159,7 @@ fn create_category_parent() {
                 good_category_description(),
                 Ok(()),
             );
-            update_category_mock(origin.clone(), 2, Some(true), Ok(()));
+            update_category_archival_status_mock(origin.clone(), 2, Ok(()));
 
             create_category_mock(
                 origin.clone(),
@@ -222,7 +222,7 @@ fn create_category_depth() {
  */
 #[test]
 // test if category updator is forum lead
-fn update_category_origin() {
+fn update_category_archival_status_origin() {
     let origins = [FORUM_LEAD_ORIGIN, NOT_FORUM_LEAD_ORIGIN];
     let results = vec![Ok(()), Err(ERROR_ORIGIN_NOT_FORUM_LEAD)];
 
@@ -238,13 +238,13 @@ fn update_category_origin() {
                 good_category_description(),
                 Ok(()),
             );
-            update_category_mock(origins[index].clone(), 1, Some(true), results[index]);
+            update_category_archival_status_mock(origins[index].clone(), 1, results[index]);
         });
     }
 }
 #[test]
 // test case for new setting actually not update category status
-fn update_category_without_updates() {
+fn update_category_archival_status_category_exists() {
     let config = default_genesis_config();
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
@@ -256,29 +256,8 @@ fn update_category_without_updates() {
             good_category_description(),
             Ok(()),
         );
-        update_category_mock(origin, 1, None, Err(ERROR_CATEGORY_NOT_BEING_UPDATED));
-    });
-}
-#[test]
-// test case for new setting actually not update category status
-fn update_category_without_updates_two() {
-    let config = default_genesis_config();
-    let forum_lead = FORUM_LEAD_ORIGIN_ID;
-    let origin = OriginType::Signed(forum_lead);
-    build_test_externalities(config).execute_with(|| {
-        create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
-        update_category_mock(
-            origin,
-            1,
-            Some(false),
-            Err(ERROR_CATEGORY_NOT_BEING_UPDATED),
-        );
+        update_category_archival_status_mock(origin.clone(), 1, Ok(()));
+        update_category_archival_status_mock(origin.clone(), 2, Err(ERROR_CATEGORY_DOES_NOT_EXIST));
     });
 }
 

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -106,12 +106,11 @@ fn create_category_origin() {
 }
 
 #[test]
-// test case for check if parent category is archived, deleted , not existed.
+// test case for check if parent category is archived or not existing.
 fn create_category_parent() {
-    let parents = vec![Some(1), Some(2), Some(3), Some(4)];
+    let parents = vec![Some(1), Some(2), Some(3)];
     let results = vec![
         Ok(()),
-        Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE),
         Err(ERROR_ANCESTOR_CATEGORY_IMMUTABLE),
         Err(ERROR_CATEGORY_DOES_NOT_EXIST),
     ];
@@ -123,9 +122,7 @@ fn create_category_parent() {
         build_test_externalities(config).execute_with(|| {
             create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
             create_category_mock(origin.clone(), Some(1), generate_hash(), Ok(()));
-            create_category_mock(origin.clone(), Some(2), generate_hash(), Ok(()));
-            update_category_mock(origin.clone(), 3, Some(true), None, Ok(()));
-            update_category_mock(origin.clone(), 2, None, Some(true), Ok(()));
+            update_category_mock(origin.clone(), 2, Some(true), Ok(()));
             create_category_mock(
                 origin.clone(),
                 parents[index],
@@ -171,7 +168,7 @@ fn update_category_origin() {
         let origin = OriginType::Signed(forum_lead);
         build_test_externalities(config).execute_with(|| {
             create_category_mock(origin, None, generate_hash(), Ok(()));
-            update_category_mock(origins[index].clone(), 1, Some(true), None, results[index]);
+            update_category_mock(origins[index].clone(), 1, Some(true), results[index]);
         });
     }
 }
@@ -183,7 +180,7 @@ fn update_category_without_updates() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
-        update_category_mock(origin, 1, None, None, Err(ERROR_CATEGORY_NOT_BEING_UPDATED));
+        update_category_mock(origin, 1, None, Err(ERROR_CATEGORY_NOT_BEING_UPDATED));
     });
 }
 #[test]
@@ -198,46 +195,7 @@ fn update_category_without_updates_two() {
             origin,
             1,
             Some(false),
-            Some(false),
             Err(ERROR_CATEGORY_NOT_BEING_UPDATED),
-        );
-    });
-}
-
-#[test]
-// test case for new setting actually not update category status
-fn update_category_without_updates_three() {
-    let config = default_genesis_config();
-    let forum_lead = FORUM_LEAD_ORIGIN_ID;
-    let origin = OriginType::Signed(forum_lead);
-    build_test_externalities(config).execute_with(|| {
-        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
-        update_category_mock(origin.clone(), 1, Some(false), Some(true), Ok(()));
-        update_category_mock(
-            origin.clone(),
-            1,
-            Some(false),
-            Some(true),
-            Err(ERROR_CATEGORY_CANNOT_BE_UNARCHIVED_WHEN_DELETED),
-        );
-    });
-}
-
-#[test]
-// test unarchived not doable after category deleted
-fn update_category_deleted_then_unarchived() {
-    let config = default_genesis_config();
-    let forum_lead = FORUM_LEAD_ORIGIN_ID;
-    let origin = OriginType::Signed(forum_lead);
-    build_test_externalities(config).execute_with(|| {
-        create_category_mock(origin.clone(), None, generate_hash(), Ok(()));
-        update_category_mock(origin.clone(), 1, Some(true), Some(true), Ok(()));
-        update_category_mock(
-            origin.clone(),
-            1,
-            Some(false),
-            None,
-            Err(ERROR_CATEGORY_CANNOT_BE_UNARCHIVED_WHEN_DELETED),
         );
     });
 }

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -159,7 +159,7 @@ fn create_category_parent() {
                 good_category_description(),
                 Ok(()),
             );
-            update_category_archival_status_mock(origin.clone(), 2, Ok(()));
+            update_category_archival_status_mock(origin.clone(), 2, true, Ok(()));
 
             create_category_mock(
                 origin.clone(),
@@ -238,12 +238,36 @@ fn update_category_archival_status_origin() {
                 good_category_description(),
                 Ok(()),
             );
-            update_category_archival_status_mock(origins[index].clone(), 1, results[index]);
+            update_category_archival_status_mock(origins[index].clone(), 1, true, results[index]);
         });
     }
 }
+
 #[test]
 // test case for new setting actually not update category status
+fn update_category_archival_status_no_change() {
+    let config = default_genesis_config();
+    let forum_lead = FORUM_LEAD_ORIGIN_ID;
+    let origin = OriginType::Signed(forum_lead);
+    build_test_externalities(config).execute_with(|| {
+        create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
+        update_category_archival_status_mock(
+            origin,
+            1,
+            false,
+            Err(ERROR_CATEGORY_NOT_BEING_UPDATED),
+        );
+    });
+}
+
+#[test]
+// test case for editing nonexistent category
 fn update_category_archival_status_category_exists() {
     let config = default_genesis_config();
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
@@ -256,8 +280,13 @@ fn update_category_archival_status_category_exists() {
             good_category_description(),
             Ok(()),
         );
-        update_category_archival_status_mock(origin.clone(), 1, Ok(()));
-        update_category_archival_status_mock(origin.clone(), 2, Err(ERROR_CATEGORY_DOES_NOT_EXIST));
+        update_category_archival_status_mock(origin.clone(), 1, true, Ok(()));
+        update_category_archival_status_mock(
+            origin.clone(),
+            2,
+            true,
+            Err(ERROR_CATEGORY_DOES_NOT_EXIST),
+        );
     });
 }
 


### PR DESCRIPTION
Solves subtasks of #766:
- We no longer store Post.nr_in_thread and Thread.nr_in_category.
- We no longer store num_unmoderated_posts and num_moderated_posts in Thread.
- Drop all deletion indicators (post, threads, categories), see next section for genuine deletion.
- We no longer store title, description, creation date, deletions status in categories. They should however just have a single counter for the number of threads and the number of subcategories in as these are not archival, since they must be read when evaluating whether category deletion is safe. But there is no need to distinguish between number of moderated vs. unmoderated threads.

To minimize merge conflict potential, this PR assumes #845 will be merged first.