### PR TITLE
Propagate descriptions to GraphQL API & Unique constraint

### DIFF
--- a/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
@@ -26,28 +26,28 @@ export class ModelRenderer extends AbstractRenderer {
 
   withInterfaceProp(): GeneratorContext {
     return {
-      isInterface: this.objType.isInterface
-    }
+      isInterface: this.objType.isInterface,
+    };
   }
 
   withInterfaces(): GeneratorContext {
-    if (utils.hasInterfaces(this.objType) && this.objType.interfaces !== undefined)  {
+    if (utils.hasInterfaces(this.objType) && this.objType.interfaces !== undefined) {
       return {
-        interfaces: [utils.withNames(this.objType.interfaces[0].name)]
-      }
-    } 
-    return {}
+        interfaces: [utils.withNames(this.objType.interfaces[0].name)],
+      };
+    }
+    return {};
   }
 
   withSubclasses(): GeneratorContext {
     if (this.objType.isInterface !== true) {
-      return {}
+      return {};
     }
     const subclasses: GeneratorContext[] = [];
     this.model.getSubclasses(this.objType.name).map(o => subclasses.push(utils.withNames(o.name)));
     return {
-      subclasses
-    }
+      subclasses,
+    };
   }
 
   withEnums(): GeneratorContext {
@@ -67,10 +67,16 @@ export class ModelRenderer extends AbstractRenderer {
 
   withFields(): GeneratorContext {
     const fields: GeneratorContext[] = [];
-  
+
     utils.ownFields(this.objType).map(f => fields.push(buildFieldContext(f, this.objType)));
     return {
       fields,
+    };
+  }
+
+  withDescription(): GeneratorContext {
+    return {
+      description: this.objType.description,
     };
   }
 
@@ -98,6 +104,7 @@ export class ModelRenderer extends AbstractRenderer {
       ...this.withInterfaceProp(),
       ...this.withHasProps(),
       ...this.withSubclasses(),
+      ...this.withDescription(),
       ...utils.withNames(this.objType.name),
     };
   }

--- a/query-node/substrate-query-framework/cli/src/generate/field-context.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/field-context.ts
@@ -69,6 +69,7 @@ export function buildFieldContext(f: Field, entity: ObjectType): GeneratorContex
   return {
     ...withFieldTypeGuardProps(f),
     ...withRequired(f),
+    ...withUnique(f),
     ...withArrayCustomFieldConfig(f),
     ...withTsTypeAndDecorator(f),
     ...withDerivedNames(f, entity),
@@ -99,6 +100,12 @@ export function withRequired(f: Field): GeneratorContext {
 export function withDescription(f: Field): GeneratorContext {
   return {
     description: f.description,
+  };
+}
+
+export function withUnique(f: Field): GeneratorContext {
+  return {
+    unique: f.unique,
   };
 }
 

--- a/query-node/substrate-query-framework/cli/src/generate/field-context.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/field-context.ts
@@ -73,6 +73,7 @@ export function buildFieldContext(f: Field, entity: ObjectType): GeneratorContex
     ...withTsTypeAndDecorator(f),
     ...withDerivedNames(f, entity),
     ...withRelativePathForModel(f, entity),
+    ...withDescription(f),
   };
 }
 
@@ -92,6 +93,12 @@ export function withFieldTypeGuardProps(f: Field): GeneratorContext {
 export function withRequired(f: Field): GeneratorContext {
   return {
     required: !f.nullable,
+  };
+}
+
+export function withDescription(f: Field): GeneratorContext {
+  return {
+    description: f.description,
   };
 }
 

--- a/query-node/substrate-query-framework/cli/src/model/Field.ts
+++ b/query-node/substrate-query-framework/cli/src/model/Field.ts
@@ -15,14 +15,10 @@ export class Field {
   nullable: boolean;
   // Is field a list. eg: post: [Post]
   isList: boolean;
+  // Description of the field will be shown in GrapqQL API
+  description?: string;
 
-  constructor(
-    name: string,
-    type: string,
-    nullable = true,
-    isBuildinType = true,
-    isList = false
-  ) {
+  constructor(name: string, type: string, nullable = true, isBuildinType = true, isList = false) {
     this.name = name;
     this.type = type;
     this.nullable = nullable;
@@ -43,7 +39,7 @@ export class Field {
   }
 
   isRelationType(): boolean {
-    return ['otm', 'mto', 'oto'].some((s) => s === this.type);
+    return ['otm', 'mto', 'oto'].some(s => s === this.type);
   }
 
   isEnum(): boolean {

--- a/query-node/substrate-query-framework/cli/src/model/Field.ts
+++ b/query-node/substrate-query-framework/cli/src/model/Field.ts
@@ -17,6 +17,8 @@ export class Field {
   isList: boolean;
   // Description of the field will be shown in GrapqQL API
   description?: string;
+  // Make field as a unique column on database
+  unique?: boolean;
 
   constructor(name: string, type: string, nullable = true, isBuildinType = true, isList = false) {
     this.name = name;

--- a/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
+++ b/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
@@ -111,7 +111,7 @@ export class WarthogModel {
 
   /**
    * Get subclasses of a given interface
-   * 
+   *
    * @param interfaceName Name of the interface
    */
   getSubclasses(interfaceName: string): ObjectType[] {
@@ -158,6 +158,8 @@ export interface ObjectType {
   name: string;
   fields: Field[];
   isEntity: boolean;
+  // Description of the field will be shown in GrapqQL API
+  description?: string;
   isInterface?: boolean;
   interfaces?: ObjectType[]; //interface names
 }

--- a/query-node/substrate-query-framework/cli/src/parse/WarthogModelBuilder.ts
+++ b/query-node/substrate-query-framework/cli/src/parse/WarthogModelBuilder.ts
@@ -9,7 +9,7 @@ import {
 import { GraphQLSchemaParser, Visitors, SchemaNode } from './SchemaParser';
 import { WarthogModel, Field, ObjectType } from '../model';
 import Debug from 'debug';
-import { ENTITY_DIRECTIVE } from './constant';
+import { ENTITY_DIRECTIVE, UNIQUE_DIRECTIVE } from './constant';
 import { FTSDirective, FULL_TEXT_SEARCHABLE_DIRECTIVE } from './FTSDirective';
 
 const debug = Debug('qnode-cli:model-generator');
@@ -78,6 +78,11 @@ export class WarthogModelBuilder {
     return entityDirective ? true : false;
   }
 
+  private isUnique(field: FieldDefinitionNode): boolean {
+    const entityDirective = field.directives?.find(d => d.name.value === UNIQUE_DIRECTIVE);
+    return entityDirective ? true : false;
+  }
+
   /**
    * Generate a new ObjectType from ObjectTypeDefinitionNode
    * @param o ObjectTypeDefinitionNode
@@ -134,6 +139,7 @@ export class WarthogModelBuilder {
         throw new Error(`Unrecognized type. ${JSON.stringify(typeNode, null, 2)}`);
       }
       field.description = fieldNode.description?.value;
+      field.unique = this.isUnique(fieldNode);
       return field;
     });
     debug(`Read and parsed fields: ${JSON.stringify(fields, null, 2)}`);

--- a/query-node/substrate-query-framework/cli/src/parse/WarthogModelBuilder.ts
+++ b/query-node/substrate-query-framework/cli/src/parse/WarthogModelBuilder.ts
@@ -87,6 +87,7 @@ export class WarthogModelBuilder {
       name: o.name.value,
       fields: this.getFields(o),
       isEntity: this.isEntity(o),
+      description: o.description?.value,
       isInterface: o.kind === 'InterfaceTypeDefinition',
       interfaces: o.kind === 'ObjectTypeDefinition' ? this.getInterfaces(o) : [],
     } as ObjectType;
@@ -116,21 +117,24 @@ export class WarthogModelBuilder {
       const typeNode = fieldNode.type;
       const fieldName = fieldNode.name.value;
 
+      let field: Field;
+
       if (typeNode.kind === 'NamedType') {
-        return this._namedType(fieldName, typeNode);
+        field = this._namedType(fieldName, typeNode);
       } else if (typeNode.kind === 'NonNullType') {
-        const field =
+        field =
           typeNode.type.kind === 'NamedType'
             ? this._namedType(fieldName, typeNode.type)
             : this._listType(typeNode.type, fieldName);
 
         field.nullable = false;
-        return field;
       } else if (typeNode.kind === 'ListType') {
-        return this._listType(typeNode, fieldName);
+        field = this._listType(typeNode, fieldName);
       } else {
         throw new Error(`Unrecognized type. ${JSON.stringify(typeNode, null, 2)}`);
       }
+      field.description = fieldNode.description?.value;
+      return field;
     });
     debug(`Read and parsed fields: ${JSON.stringify(fields, null, 2)}`);
     return fields;
@@ -193,23 +197,23 @@ export class WarthogModelBuilder {
   private genereateQueries() {
     const fts = new FTSDirective();
     const visitors: Visitors = {
-      directives: {}
+      directives: {},
     };
     visitors.directives[FULL_TEXT_SEARCHABLE_DIRECTIVE] = {
       visit: (path: SchemaNode[]) => fts.generate(path, this._model),
-    } 
+    };
     this._schemaParser.dfsTraversal(visitors);
   }
 
   buildWarthogModel(): WarthogModel {
     this._model = new WarthogModel();
-    
+
     this.generateEnums();
     this.generateInterfaces();
     this.generateObjectTypes();
     this.generateSQLRelationships();
     this.genereateQueries();
-  
+
     return this._model;
   }
 }

--- a/query-node/substrate-query-framework/cli/src/parse/constant.ts
+++ b/query-node/substrate-query-framework/cli/src/parse/constant.ts
@@ -4,12 +4,14 @@
  */
 export const SCHEMA_DEFINITIONS_PREAMBLE = `
 directive @entity on OBJECT | INTERFACE  # Mark both object types and interfaces
+directive @unique on FIELD_DEFINITION
 scalar BigInt                # Arbitrarily large integers
 scalar BigDecimal            # is used to represent arbitrary precision decimals
 scalar Bytes                 # Byte array, represented as a hexadecimal string
 type Query {
     _dummy: String           # empty queries are not allowed
 }
-`
+`;
 
-export const ENTITY_DIRECTIVE = 'entity'
+export const ENTITY_DIRECTIVE = 'entity';
+export const UNIQUE_DIRECTIVE = 'unique';

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -67,15 +67,21 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
   {{/is.oto}}
 
   {{#is.array}}
-    @CustomField({ db: { type: '{{dbType}}', array: true{{^required}}, nullable: true{{/required}} }, 
-        api: { type: '{{apiType}}',{{^required}}nullable: true,{{/required}}
-        {{#description}}description: `{{{description}}}`{{/description}} }})
+    @CustomField({
+      db: { type: '{{dbType}}', array: true,{{^required}}nullable: true,{{/required}} {{#unique}}unique: true,{{/unique}}}, 
+      api: { type: '{{apiType}}', {{^required}}nullable: true,{{/required}}
+        {{#description}}description: `{{{description}}}`{{/description}} }
+    })
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{tsType}}[];
   {{/is.array}}
 
   {{! TODO: add enums here }}
   {{#is.scalar}}
-    @{{decorator}}({ {{^required}}nullable: true,{{/required}} {{#description}}description: `{{{description}}}`{{/description}} })
+    @{{decorator}}({
+      {{^required}}nullable: true,{{/required}}
+      {{#description}}description: `{{{description}}}`,{{/description}}
+      {{#unique}}unique: true,{{/unique}}
+    })
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{tsType}};
   {{/is.scalar}}
 

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -38,10 +38,10 @@ import { InterfaceType } from 'type-graphql';
 {{/interfaces}}
 
 {{^isInterface}}
-@Model({{#interfaces}} { api: { implements: {{className}} }} {{/interfaces}}) {{! only a single interface can be here }}
+@Model({ api: { {{#interfaces}}implements: {{className}},{{/interfaces}} {{#description}} description: `{{{description}}}`{{/description}} }}) {{! only a single interface can be here }}
 {{/isInterface}}
 {{#isInterface}}
-@InterfaceType()
+@InterfaceType({{#description}} { description: `{{{description}}}` } {{/description}})
 {{/isInterface}}
 export {{#isInterface}}abstract{{/isInterface}} class {{className}} 
   extends {{^interfaces}}BaseModel{{/interfaces}} {{#interfaces}} {{className}} {{/interfaces}} {
@@ -68,18 +68,21 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
 
   {{#is.array}}
     @CustomField({ db: { type: '{{dbType}}', array: true{{^required}}, nullable: true{{/required}} }, 
-        api: { type: '{{apiType}}'{{^required}}, nullable: true{{/required}} }})
+        api: { type: '{{apiType}}',{{^required}}nullable: true,{{/required}}
+        {{#description}}description: `{{{description}}}`{{/description}} }})
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{tsType}}[];
   {{/is.array}}
 
   {{! TODO: add enums here }}
   {{#is.scalar}}
-    @{{decorator}}({{^required}}{ nullable: true }{{/required}})
+    @{{decorator}}({ {{^required}}nullable: true,{{/required}} {{#description}}description: `{{{description}}}`{{/description}} })
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{tsType}};
   {{/is.scalar}}
 
   {{#is.enum}}
-    @EnumField('{{tsType}}', {{tsType}} {{^required}},{ nullable: true }{{/required}})
+    @EnumField('{{tsType}}', {{tsType}}, { 
+      {{^required}}nullable: true,{{/required}} 
+      {{#description}}description: `{{{description}}}`{{/description}} })
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}:{{tsType}} 
   {{/is.enum}}
 {{/fields}}


### PR DESCRIPTION
This PR adds support for GraphQL API documentation https://github.com/Joystream/joystream/issues/429 and introduce `@unique` directive.

### Descriptions
Descriptions are supported for:
- Entity types
- Scalar types
- Enum types
- Interface types

**Example**

```graphql
"""
Multiple line description...
Joystream membership
"""
type Member @entity {
  "One line description"
  memberId: BigInt!

  """
  The unique handle chosen by a member
  """
  handle: String @fulltext(query: "handles")
}


"Enum description"
enum Status {
  ...
}
```
### Unique Constraint
`@unique` directive allows you to make a field unique that means the database column for this field will have unique constraint:

```graphql
type Member @entity {
  "The unique handle chosen by a member"
  handle: String @fulltext(query: "handles") @unique
}
```

