### PR TITLE
remove_entity full test coverage

### DIFF
--- a/runtime-modules/content-directory/src/lib.rs
+++ b/runtime-modules/content-directory/src/lib.rs
@@ -2038,7 +2038,7 @@ impl<T: Trait> Module<T> {
         // Ensure Entity under given id exists, retrieve corresponding one
         let entity = Self::ensure_known_entity_id(entity_id)?;
 
-        // Ensure Class under given id exists, retrieve corresponding one
+        // Retrieve corresponding Class
         let class = Self::class_by_id(entity.class_id);
 
         // Derive EntityAccessLevel for the actor, attempting to act.

--- a/runtime-modules/content-directory/src/lib.rs
+++ b/runtime-modules/content-directory/src/lib.rs
@@ -1303,7 +1303,7 @@ decl_module! {
             // Retrieve Class, Entity and ensure given have access to the Entity under given entity_id
             let (class, entity, _) = Self::ensure_class_entity_and_access_level(origin, entity_id, &actor)?;
 
-            // Ensure Class Schema under given index exist, return corresponding Schema
+            // Ensure Class Schema under given index exists, return corresponding Schema
             let schema = class.ensure_schema_exists(schema_id)?.to_owned();
 
             let class_properties = class.properties;

--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -32,6 +32,7 @@ pub const SECOND_CURATOR_ORIGIN: u64 = 3;
 
 pub const FIRST_MEMBER_ORIGIN: u64 = 4;
 pub const SECOND_MEMBER_ORIGIN: u64 = 5;
+pub const UNKNOWN_ORIGIN: u64 = 7777;
 
 /// Runtime Id's
 
@@ -57,6 +58,7 @@ pub const UNKNOWN_SCHEMA_ID: SchemaId = 444;
 
 pub const UNKNOWN_CURATOR_GROUP_ID: CuratorGroupId = 555;
 pub const UNKNOWN_CURATOR_ID: CuratorGroupId = 555;
+pub const UNKNOWN_MEMBER_ID: CuratorGroupId = 777;
 
 pub const FIRST_SCHEMA_ID: SchemaId = 0;
 pub const SECOND_SCHEMA_ID: SchemaId = 1;
@@ -282,11 +284,8 @@ impl ActorAuthenticator for Runtime {
             || (second_curator_account_id == *account_id && SECOND_CURATOR_ID == *curator_id)
     }
 
-    fn is_member(member_id: &Self::MemberId, account_id: &Self::AccountId) -> bool {
-        let first_member_account_id = ensure_signed(Origin::signed(FIRST_MEMBER_ORIGIN)).unwrap();
-        let second_member_account_id = ensure_signed(Origin::signed(SECOND_MEMBER_ORIGIN)).unwrap();
-        (first_member_account_id == *account_id && FIRST_MEMBER_ID == *member_id)
-            || (second_member_account_id == *account_id && SECOND_MEMBER_ID == *member_id)
+    fn is_member(member_id: &Self::MemberId, _account_id: &Self::AccountId) -> bool {
+        *member_id < MaxNumberOfEntitiesPerClass::get()
     }
 }
 
@@ -705,11 +704,11 @@ pub fn next_entity_id() -> EntityId {
 }
 
 pub fn create_entity(
-    lead_origin: u64,
+    origin: u64,
     class_id: ClassId,
     actor: Actor<Runtime>,
 ) -> Result<(), &'static str> {
-    TestModule::create_entity(Origin::signed(lead_origin), class_id, actor)
+    TestModule::create_entity(Origin::signed(origin), class_id, actor)
 }
 
 pub fn remove_entity(

--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -284,8 +284,9 @@ impl ActorAuthenticator for Runtime {
             || (second_curator_account_id == *account_id && SECOND_CURATOR_ID == *curator_id)
     }
 
-    fn is_member(member_id: &Self::MemberId, _account_id: &Self::AccountId) -> bool {
-        *member_id < MaxNumberOfEntitiesPerClass::get()
+    fn is_member(member_id: &Self::MemberId, account_id: &Self::AccountId) -> bool {
+        let unknown_member_account_id = ensure_signed(Origin::signed(UNKNOWN_ORIGIN)).unwrap();
+        *member_id < MaxNumberOfEntitiesPerClass::get() && unknown_member_account_id != *account_id
     }
 }
 

--- a/runtime-modules/content-directory/src/permissions.rs
+++ b/runtime-modules/content-directory/src/permissions.rs
@@ -107,8 +107,8 @@ pub fn perform_curator_in_group_auth<T: Trait>(
     // Ensure curator authorization performed succesfully
     ensure_curator_auth_success::<T>(curator_id, account_id)?;
 
-    // Ensure CuratorGroup under given curator_group_id exists, retrieve corresponding one
-    let curator_group = Module::<T>::ensure_curator_group_exists(curator_group_id)?;
+    // Retrieve corresponding curator group
+    let curator_group = Module::<T>::curator_group_by_id(curator_group_id);
 
     // Ensure curator group is active
     ensure!(curator_group.is_active(), ERROR_CURATOR_GROUP_IS_NOT_ACTIVE);

--- a/runtime-modules/content-directory/src/tests.rs
+++ b/runtime-modules/content-directory/src/tests.rs
@@ -1,8 +1,8 @@
 mod add_class_schema;
 mod add_curator_group;
 mod add_curator_to_group;
-mod add_entity_schema_support;
 mod add_maintainer_to_class;
+mod add_schema_support_to_entity;
 mod clear_entity_property_vector;
 mod create_class;
 mod create_entity;

--- a/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
+++ b/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[test]
-fn add_entity_schema_support_success() {
+fn add_schema_support_to_entity_success() {
     with_test_externalities(|| {
         // Add entity schemas support
         let (first_entity, second_entity) = add_entity_schemas_support();

--- a/runtime-modules/content-directory/src/tests/create_entity.rs
+++ b/runtime-modules/content-directory/src/tests/create_entity.rs
@@ -6,7 +6,7 @@ fn create_entity_success() {
         // Create simple class with default permissions
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
-        // Update class permissions to force any maintainer be available to create entities
+        // Update class permissions to force any member be available to create entities
         assert_ok!(update_class_permissions(
             LEAD_ORIGIN,
             FIRST_CLASS_ID,
@@ -72,5 +72,380 @@ fn create_entity_success() {
 
         // Last event checked
         assert_event_success(entity_created_event, number_of_events_before_call + 1);
+    })
+}
+
+#[test]
+fn create_entity_of_non_existent_class() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let actor = Actor::Lead;
+
+        // Make an attempt to create Entity of non existent Class
+        let create_entity_result = create_entity(LEAD_ORIGIN, UNKNOWN_CLASS_ID, actor.clone());
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_CLASS_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn create_entity_creation_limit_reached() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Update class permissions to force any member be available to create entities
+        assert_ok!(update_class_permissions(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            Some(true),
+            None,
+            None,
+            None
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut number_of_entities_created = 0;
+
+        // Create entities of the same Class entities limit per class reached
+        let create_entity_result = loop {
+            let create_entity_result = create_entity(
+                number_of_entities_created,
+                FIRST_CLASS_ID,
+                Actor::Member(number_of_entities_created),
+            );
+            if create_entity_result.is_err() {
+                break create_entity_result;
+            } else {
+                number_of_entities_created += 1;
+            }
+        };
+
+        // Runtime tested state after call
+
+        // Ensure number of entities created is equal to MaxNumberOfEntitiesPerClass runtime constraint.
+        assert_eq!(
+            number_of_entities_created,
+            MaxNumberOfEntitiesPerClass::get()
+        );
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_MAX_NUMBER_OF_ENTITIES_PER_CLASS_LIMIT_REACHED,
+            number_of_events_before_call + number_of_entities_created as usize,
+        );
+    })
+}
+
+#[test]
+fn create_entity_creation_blocked_on_class_level() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Update class permissions to block entity creation on class level
+        assert_ok!(update_class_permissions(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            None,
+            Some(true),
+            None,
+            None
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let actor = Actor::Lead;
+
+        // Make an attempt to create Entity, when entiti creation was previously blocked on class level
+        let create_entity_result = create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone());
+
+        // Runtime tested state after call
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_ENTITY_CREATION_BLOCKED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn create_entity_lead_auth_failed() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let actor = Actor::Lead;
+
+        // Make an attempt to authorize as Lead under non lead origin
+        let create_entity_result =
+            create_entity(FIRST_MEMBER_ORIGIN, FIRST_CLASS_ID, actor.clone());
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn create_entity_member_auth_failed() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Update class permissions to force any member be available to create entities
+        assert_ok!(update_class_permissions(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            Some(true),
+            None,
+            None,
+            None
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let actor = Actor::Member(UNKNOWN_MEMBER_ID);
+
+        // Make an attempt to authorize under non existent member id
+        let create_entity_result = create_entity(UNKNOWN_ORIGIN, FIRST_CLASS_ID, actor.clone());
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_MEMBER_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn create_entity_actor_can_not_create_entities() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let actor = Actor::Member(UNKNOWN_MEMBER_ID);
+
+        // Make an attempt to create entity, authorizing as member in case, when members are not permitted to create entities on class level
+        let create_entity_result = create_entity(UNKNOWN_ORIGIN, FIRST_CLASS_ID, actor.clone());
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_ACTOR_CAN_NOT_CREATE_ENTITIES,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn create_entity_unknown_curator_id() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Add curator group
+        assert_ok!(add_curator_group(LEAD_ORIGIN));
+
+        // Make curator group active
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            true
+        ));
+
+        // Add curator group as class maintainer
+        assert_ok!(add_maintainer_to_class(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            FIRST_CURATOR_GROUP_ID
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, UNKNOWN_CURATOR_ID);
+
+        // Make an attempt to create entity, authorizing as curator in group,
+        // in case, when provided curator id wasn`t added to respective curator group set
+        let create_entity_result =
+            create_entity(FIRST_CURATOR_ORIGIN, FIRST_CLASS_ID, actor.clone());
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_CURATOR_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn create_entity_curator_group_is_not_active() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Add curator group
+        assert_ok!(add_curator_group(LEAD_ORIGIN));
+
+        // Add curator to group
+        assert_ok!(add_curator_to_group(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            FIRST_CURATOR_ID,
+        ));
+
+        // Add curator group as class maintainer
+        assert_ok!(add_maintainer_to_class(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            FIRST_CURATOR_GROUP_ID
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
+
+        // Make an attempt to create entity, authorizing as curator in group, in case, when
+        // corresponding curator group is not active. (default status of curator group right after creation)
+        let create_entity_result =
+            create_entity(FIRST_CURATOR_ORIGIN, FIRST_CLASS_ID, actor.clone());
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_CURATOR_GROUP_IS_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn create_entity_curator_not_found_in_curator_group() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Add curator group
+        assert_ok!(add_curator_group(LEAD_ORIGIN));
+
+        // Make curator group active
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            true
+        ));
+
+        // Add curator group as class maintainer
+        assert_ok!(add_maintainer_to_class(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            FIRST_CURATOR_GROUP_ID
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
+
+        // Make an attempt to create entity, authorizing as curator in group, in case, when
+        // curator was not added to corresponding curator group.
+        let create_entity_result =
+            create_entity(FIRST_CURATOR_ORIGIN, FIRST_CLASS_ID, actor.clone());
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_CURATOR_IS_NOT_A_MEMBER_OF_A_GIVEN_CURATOR_GROUP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn create_entity_voucher_limit_reached() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let actor = Actor::Lead;
+
+        let mut number_of_entities_created = 0;
+
+        // Create entities until individual creation limit reached
+        let create_entity_result = loop {
+            let create_entity_result =
+                create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone());
+            if create_entity_result.is_err() {
+                break create_entity_result;
+            } else {
+                number_of_entities_created += 1;
+            }
+        };
+
+        // Ensure number of entities created is equal to IndividualEntitiesCreationLimit runtime constraint.
+        assert_eq!(
+            number_of_entities_created,
+            IndividualEntitiesCreationLimit::get()
+        );
+
+        // Failure checked
+        assert_failure(
+            create_entity_result,
+            ERROR_VOUCHER_LIMIT_REACHED,
+            number_of_events_before_call + number_of_entities_created as usize,
+        );
     })
 }

--- a/runtime-modules/content-directory/src/tests/create_entity.rs
+++ b/runtime-modules/content-directory/src/tests/create_entity.rs
@@ -426,8 +426,7 @@ fn create_entity_voucher_limit_reached() {
 
         // Create entities until individual creation limit reached
         let create_entity_result = loop {
-            let create_entity_result =
-                create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone());
+            let create_entity_result = create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone());
             if create_entity_result.is_err() {
                 break create_entity_result;
             } else {

--- a/runtime-modules/content-directory/src/tests/remove_entity.rs
+++ b/runtime-modules/content-directory/src/tests/remove_entity.rs
@@ -124,7 +124,7 @@ fn remove_entity_member_auth_failed() {
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
 
-        // Make an attempt to remove entity under non lead origin
+        // Make an attempt to remove entity using unknown origin and member actor, which is current Entity controller
         let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
 
         // Failure checked
@@ -187,7 +187,7 @@ fn create_entity_curator_group_is_not_active() {
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
 
-        // Make an attempt to remove entity under non lead origin
+        // Make an attempt to remove entity using curator group, which is not active as actor
         let remove_entity_result =
             remove_entity(FIRST_CURATOR_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
 
@@ -244,7 +244,7 @@ fn remove_entity_curator_auth_failed() {
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
 
-        // Make an attempt to remove entity under unknown origin and curator actor
+        // Make an attempt to remove entity under unknown origin and curator actor, which corresponding group is current entity controller
         let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
 
         // Failure checked
@@ -296,7 +296,8 @@ fn remove_entity_curator_not_found_in_curator_group() {
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
 
-        // Make an attempt to remove entity, using actor, which corresponding origin
+        // Make an attempt to remove entity, using actor in group,
+        // which curator id was not added to corresponding group set
         let remove_entity_result = remove_entity(
             SECOND_CURATOR_ORIGIN,
             Actor::Curator(FIRST_CURATOR_GROUP_ID, SECOND_CURATOR_ID),
@@ -338,7 +339,7 @@ fn remove_entity_access_denied() {
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
 
-        // Make an attempt to remove entity, using actor, which is neither entity maintainer, nor controller.
+        // Make an attempt to remove entity, using origin, which corresponding actor is neither entity maintainer, nor controller.
         let remove_entity_result = remove_entity(SECOND_MEMBER_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
@@ -390,7 +391,7 @@ fn remove_entity_removal_access_denied() {
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
 
-        // Make an attempt to remove entity, using actor, which corresponding origin
+        // Make an attempt to remove entity, using origin, which corresponding actor is not an entity controller
         let remove_entity_result = remove_entity(FIRST_CURATOR_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked

--- a/runtime-modules/content-directory/src/tests/remove_entity.rs
+++ b/runtime-modules/content-directory/src/tests/remove_entity.rs
@@ -41,3 +41,388 @@ fn remove_entity_success() {
         assert_event_success(entity_removed_event, number_of_events_before_call + 1);
     })
 }
+
+#[test]
+fn remove_non_existent_entity() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove Entity, which does not exist in runtime
+        let remove_entity_result = remove_entity(LEAD_ORIGIN, actor, UNKNOWN_ENTITY_ID);
+
+        // Failure checked
+        assert_failure(
+            remove_entity_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_entity_lead_auth_failed() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove entity under non lead origin
+        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+
+        // Failure checked
+        assert_failure(
+            remove_entity_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_entity_member_auth_failed() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Update class permissions to force any member be available to create entities
+        assert_ok!(update_class_permissions(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            Some(true),
+            None,
+            None,
+            None
+        ));
+
+        let actor = Actor::Member(FIRST_MEMBER_ID);
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove entity under non lead origin
+        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+
+        // Failure checked
+        assert_failure(
+            remove_entity_result,
+            ERROR_MEMBER_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn create_entity_curator_group_is_not_active() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Add curator group
+        assert_ok!(add_curator_group(LEAD_ORIGIN));
+
+        // Add curator to group
+        assert_ok!(add_curator_to_group(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            FIRST_CURATOR_ID,
+        ));
+
+        // Add curator group as class maintainer
+        assert_ok!(add_maintainer_to_class(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            FIRST_CURATOR_GROUP_ID
+        ));
+
+        // Make curator group active
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            true
+        ));
+
+        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
+
+        // Create Entity
+        assert_ok!(create_entity(
+            FIRST_CURATOR_ORIGIN,
+            FIRST_CLASS_ID,
+            actor.clone()
+        ));
+
+        // Make curator group inactive to block entity removal
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            false
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove entity under non lead origin
+        let remove_entity_result =
+            remove_entity(FIRST_CURATOR_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+
+        // Failure checked
+        assert_failure(
+            remove_entity_result,
+            ERROR_CURATOR_GROUP_IS_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_entity_curator_auth_failed() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Add curator group
+        assert_ok!(add_curator_group(LEAD_ORIGIN));
+
+        // Add curator to group
+        assert_ok!(add_curator_to_group(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            FIRST_CURATOR_ID,
+        ));
+
+        // Add curator group as class maintainer
+        assert_ok!(add_maintainer_to_class(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            FIRST_CURATOR_GROUP_ID
+        ));
+
+        // Make curator group active
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            true
+        ));
+
+        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
+
+        // Create Entity
+        assert_ok!(create_entity(
+            FIRST_CURATOR_ORIGIN,
+            FIRST_CLASS_ID,
+            actor.clone()
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove entity under unknown origin and curator actor
+        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+
+        // Failure checked
+        assert_failure(
+            remove_entity_result,
+            ERROR_CURATOR_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_entity_curator_not_found_in_curator_group() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Add curator group
+        assert_ok!(add_curator_group(LEAD_ORIGIN));
+
+        // Add curator to group
+        assert_ok!(add_curator_to_group(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            FIRST_CURATOR_ID,
+        ));
+
+        // Make curator group active
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            true
+        ));
+
+        // Add curator group as class maintainer
+        assert_ok!(add_maintainer_to_class(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            FIRST_CURATOR_GROUP_ID
+        ));
+
+        // Runtime state before tested call
+
+        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
+
+        // Create entity
+        assert_ok!(create_entity(FIRST_CURATOR_ORIGIN, FIRST_CLASS_ID, actor));
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove entity, using actor, which corresponding origin
+        let remove_entity_result = remove_entity(
+            SECOND_CURATOR_ORIGIN,
+            Actor::Curator(FIRST_CURATOR_GROUP_ID, SECOND_CURATOR_ID),
+            FIRST_ENTITY_ID,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_entity_result,
+            ERROR_CURATOR_IS_NOT_A_MEMBER_OF_A_GIVEN_CURATOR_GROUP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_entity_access_denied() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Update class permissions to force any member be available to create entities
+        assert_ok!(update_class_permissions(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            Some(true),
+            None,
+            None,
+            None
+        ));
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, Actor::Lead));
+
+        let actor = Actor::Member(SECOND_MEMBER_ID);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove entity, using actor, which is neither entity maintainer, nor controller.
+        let remove_entity_result = remove_entity(SECOND_MEMBER_ORIGIN, actor, FIRST_ENTITY_ID);
+
+        // Failure checked
+        assert_failure(
+            remove_entity_result,
+            ERROR_ENTITY_ACCESS_DENIED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_entity_removal_access_denied() {
+    with_test_externalities(|| {
+        // Create simple class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Add curator group
+        assert_ok!(add_curator_group(LEAD_ORIGIN));
+
+        // Add curator to group
+        assert_ok!(add_curator_to_group(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            FIRST_CURATOR_ID,
+        ));
+
+        // Make curator group active
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            true
+        ));
+
+        // Add curator group as class maintainer
+        assert_ok!(add_maintainer_to_class(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            FIRST_CURATOR_GROUP_ID
+        ));
+
+        // Runtime state before tested call
+
+        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, Actor::Lead));
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove entity, using actor, which corresponding origin
+        let remove_entity_result = remove_entity(FIRST_CURATOR_ORIGIN, actor, FIRST_ENTITY_ID);
+
+        // Failure checked
+        assert_failure(
+            remove_entity_result,
+            ERROR_ENTITY_REMOVAL_ACCESS_DENIED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_entity_rc_does_not_equal_to_zero() {
+    with_test_externalities(|| {
+        let actor = Actor::Lead;
+
+        // Create class, two corresponding entities and force first entity have schema support with property value referencing second entity
+        add_entity_schemas_support();
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove entity, which rc does not equal to zero
+        let remove_entity_result = remove_entity(LEAD_ORIGIN, actor.clone(), SECOND_ENTITY_ID);
+
+        // Failure checked
+        assert_failure(
+            remove_entity_result,
+            ERROR_ENTITY_RC_DOES_NOT_EQUAL_TO_ZERO,
+            number_of_events_before_call,
+        );
+    })
+}

--- a/runtime-modules/content-directory/src/tests/update_entity_creation_voucher.rs
+++ b/runtime-modules/content-directory/src/tests/update_entity_creation_voucher.rs
@@ -55,7 +55,7 @@ fn update_entity_creation_voucher_success() {
 
         let actor = Actor::Member(FIRST_MEMBER_ID);
 
-        // Update class permissions to force any maintainer be available to create entities
+        // Update class permissions to force any member be available to create entities
         assert_ok!(update_class_permissions(
             LEAD_ORIGIN,
             FIRST_CLASS_ID,


### PR DESCRIPTION
Full test coverage for `remove_entity` extrinsic
Closes https://github.com/Joystream/joystream/issues/792
Depends on: #842, #848, #841, #822, #817

