### PR TITLE
Forum archival state removal 5

### DIFF
--- a/node/src/forum_config/from_serialized.rs
+++ b/node/src/forum_config/from_serialized.rs
@@ -3,7 +3,7 @@
 use super::new_validation;
 use node_runtime::{
     forum::{Category, Post, Thread},
-    CategoryId, ForumConfig, ForumUserId, Hash, ModeratorId, Moment, PostId, ThreadId,
+    CategoryId, ForumConfig, ForumUserId, Hash, Moment, PostId, ThreadId,
 };
 use serde::Deserialize;
 use serde_json::Result;
@@ -11,11 +11,8 @@ use serde_json::Result;
 #[derive(Deserialize)]
 struct ForumData {
     categories: Vec<(CategoryId, Category<CategoryId, ThreadId, Hash>)>,
-    posts: Vec<(PostId, Post<ForumUserId, ModeratorId, ThreadId, Hash>)>,
-    threads: Vec<(
-        ThreadId,
-        Thread<ForumUserId, ModeratorId, CategoryId, Moment, Hash>,
-    )>,
+    posts: Vec<(PostId, Post<ForumUserId, ThreadId, Hash>)>,
+    threads: Vec<(ThreadId, Thread<ForumUserId, CategoryId, Moment, Hash>)>,
 }
 
 fn parse_forum_json() -> Result<ForumData> {

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -332,14 +332,11 @@ const ERROR_MODERATOR_ID_NOT_MATCH_ACCOUNT: &str = "Moderator id not match its a
 
 // Errors about thread.
 const ERROR_THREAD_DOES_NOT_EXIST: &str = "Thread does not exist";
-const ERROR_THREAD_ALREADY_MODERATED: &str = "Thread already moderated.";
-const ERROR_THREAD_MODERATED: &str = "Thread is moderated.";
 const ERROR_THREAD_WITH_WRONG_CATEGORY_ID: &str = "thread and its category not match.";
 
 // Errors about post.
 const ERROR_POST_DOES_NOT_EXIST: &str = "Post does not exist.";
 const ERROR_ACCOUNT_DOES_NOT_MATCH_POST_AUTHOR: &str = "Account does not match post author.";
-const ERROR_POST_MODERATED: &str = "Post is moderated.";
 
 // Errors about category.
 const ERROR_CATEGORY_NOT_BEING_UPDATED: &str = "Category not being updated.";
@@ -369,14 +366,6 @@ const ERROR_DATA_MIGRATION_NOT_DONE: &str = "data migration not done yet.";
 //use sr_primitives::{StorageOverlay, ChildrenStorageOverlay};
 
 use system::ensure_signed;
-
-/// Represents a moderation outcome applied to a post or a thread.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Default, Clone, PartialEq, Eq)]
-pub struct ModerationAction<ModeratorId> {
-    /// Account forum lead which acted.
-    pub moderator_id: ModeratorId,
-}
 
 /// Represents a reaction to a post
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -434,15 +423,12 @@ pub struct Poll<Timestamp, Hash> {
 /// Represents a thread post
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq)]
-pub struct Post<ForumUserId, ModeratorId, ThreadId, Hash> {
+pub struct Post<ForumUserId, ThreadId, Hash> {
     /// Id of thread to which this post corresponds.
     pub thread_id: ThreadId,
 
     /// Hash of current text
     pub text_hash: Hash,
-
-    /// Possible moderation of this post
-    pub moderation: Option<ModerationAction<ModeratorId>>,
 
     /// Author of post.
     pub author_id: ForumUserId,
@@ -451,15 +437,12 @@ pub struct Post<ForumUserId, ModeratorId, ThreadId, Hash> {
 /// Represents a thread
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq)]
-pub struct Thread<ForumUserId, ModeratorId, CategoryId, Moment, Hash> {
+pub struct Thread<ForumUserId, CategoryId, Moment, Hash> {
     /// Title hash
     pub title_hash: Hash,
 
     /// Category in which this thread lives
     pub category_id: CategoryId,
-
-    /// Possible moderation of this thread
-    pub moderation: Option<ModerationAction<ModeratorId>>,
 
     /// Author of post.
     pub author_id: ForumUserId,
@@ -514,13 +497,13 @@ decl_storage! {
         pub NextCategoryId get(next_category_id) config(): T::CategoryId;
 
         /// Map thread identifier to corresponding thread.
-        pub ThreadById get(thread_by_id) config(): map T::ThreadId => Thread<T::ForumUserId, T::ModeratorId, T::CategoryId, T::Moment, T::Hash>;
+        pub ThreadById get(thread_by_id) config(): map T::ThreadId => Thread<T::ForumUserId, T::CategoryId, T::Moment, T::Hash>;
 
         /// Thread identifier value to be used for next Thread in threadById.
         pub NextThreadId get(next_thread_id) config(): T::ThreadId;
 
         /// Map post identifier to corresponding post.
-        pub PostById get(post_by_id) config(): map T::PostId => Post<T::ForumUserId, T::ModeratorId, T::ThreadId, T::Hash>;
+        pub PostById get(post_by_id) config(): map T::PostId => Post<T::ForumUserId, T::ThreadId, T::Hash>;
 
         /// Post identifier value to be used for for next post created.
         pub NextPostId get(next_post_id) config(): T::PostId;
@@ -824,10 +807,7 @@ decl_module! {
             let who = Self::ensure_is_moderator(origin, &moderator_id)?;
 
             // Get thread
-            let mut thread = Self::ensure_thread_exists(&thread_id)?;
-
-            // Thread is not already moderated
-            ensure!(thread.moderation.is_none(), ERROR_THREAD_ALREADY_MODERATED);
+            let thread = Self::ensure_thread_exists(&thread_id)?;
 
             // ensure origin can moderate category
             Self::ensure_moderate_category(&who, &moderator_id, thread.category_id)?;
@@ -840,14 +820,6 @@ decl_module! {
 
             // Path can be updated
             Self::ensure_can_mutate_in_path_leaf(&path)?;
-
-            // Add moderation to thread
-            thread.moderation = Some(ModerationAction {
-                moderator_id,
-            });
-
-            // Insert new value into map
-            <ThreadById<T>>::mutate(thread_id, |value| *value = thread.clone());
 
             // Generate event
             Self::deposit_event(RawEvent::ThreadModerated(thread_id));
@@ -946,14 +918,6 @@ decl_module! {
             // ensure the moderator can moderate the category
             Self::ensure_moderate_category(&who, &moderator_id, thread.category_id)?;
 
-            // Update moderation action on post
-            let moderation_action = ModerationAction{
-                moderator_id,
-            };
-
-            // Update post with moderation
-            <PostById<T>>::mutate(post_id, |p| p.moderation = Some(moderation_action));
-
             // Generate event
             Self::deposit_event(RawEvent::PostModerated(post_id));
 
@@ -1001,10 +965,7 @@ impl<T: Trait> Module<T> {
         title: &[u8],
         text: &[u8],
         poll: &Option<Poll<T::Moment, T::Hash>>,
-    ) -> Result<
-        Thread<T::ForumUserId, T::ModeratorId, T::CategoryId, T::Moment, T::Hash>,
-        &'static str,
-    > {
+    ) -> Result<Thread<T::ForumUserId, T::CategoryId, T::Moment, T::Hash>, &'static str> {
         // Ensure data migration is done
         Self::ensure_data_migration_done()?;
 
@@ -1034,7 +995,6 @@ impl<T: Trait> Module<T> {
         let new_thread = Thread {
             category_id,
             title_hash: T::calculate_hash(title),
-            moderation: None,
             author_id,
             poll: poll.clone(),
         };
@@ -1060,7 +1020,7 @@ impl<T: Trait> Module<T> {
         thread_id: T::ThreadId,
         text: &[u8],
         author_id: T::ForumUserId,
-    ) -> Result<Post<T::ForumUserId, T::ModeratorId, T::ThreadId, T::Hash>, &'static str> {
+    ) -> Result<Post<T::ForumUserId, T::ThreadId, T::Hash>, &'static str> {
         // Ensure data migration is done
         Self::ensure_data_migration_done()?;
 
@@ -1081,7 +1041,6 @@ impl<T: Trait> Module<T> {
         let new_post = Post {
             thread_id,
             text_hash: T::calculate_hash(text),
-            moderation: None,
             author_id,
         };
 
@@ -1130,12 +1089,9 @@ impl<T: Trait> Module<T> {
 
     fn ensure_post_is_mutable(
         post_id: &T::PostId,
-    ) -> Result<Post<T::ForumUserId, T::ModeratorId, T::ThreadId, T::Hash>, &'static str> {
+    ) -> Result<Post<T::ForumUserId, T::ThreadId, T::Hash>, &'static str> {
         // Make sure post exists
         let post = Self::ensure_post_exists(post_id)?;
-
-        // and is unmoderated
-        ensure!(post.moderation.is_none(), ERROR_POST_MODERATED);
 
         // and make sure thread is mutable
         Self::ensure_thread_is_mutable(&post.thread_id)?;
@@ -1145,7 +1101,7 @@ impl<T: Trait> Module<T> {
 
     fn ensure_post_exists(
         post_id: &T::PostId,
-    ) -> Result<Post<T::ForumUserId, T::ModeratorId, T::ThreadId, T::Hash>, &'static str> {
+    ) -> Result<Post<T::ForumUserId, T::ThreadId, T::Hash>, &'static str> {
         if <PostById<T>>::exists(post_id) {
             Ok(<PostById<T>>::get(post_id))
         } else {
@@ -1155,15 +1111,9 @@ impl<T: Trait> Module<T> {
 
     fn ensure_thread_is_mutable(
         thread_id: &T::ThreadId,
-    ) -> Result<
-        Thread<T::ForumUserId, T::ModeratorId, T::CategoryId, T::Moment, T::Hash>,
-        &'static str,
-    > {
+    ) -> Result<Thread<T::ForumUserId, T::CategoryId, T::Moment, T::Hash>, &'static str> {
         // Make sure thread exists
         let thread = Self::ensure_thread_exists(&thread_id)?;
-
-        // and is unmoderated
-        ensure!(thread.moderation.is_none(), ERROR_THREAD_MODERATED);
 
         // and corresponding category is mutable
         Self::ensure_catgory_is_mutable(thread.category_id)?;
@@ -1173,10 +1123,7 @@ impl<T: Trait> Module<T> {
 
     fn ensure_thread_exists(
         thread_id: &T::ThreadId,
-    ) -> Result<
-        Thread<T::ForumUserId, T::ModeratorId, T::CategoryId, T::Moment, T::Hash>,
-        &'static str,
-    > {
+    ) -> Result<Thread<T::ForumUserId, T::CategoryId, T::Moment, T::Hash>, &'static str> {
         if <ThreadById<T>>::exists(thread_id) {
             Ok(<ThreadById<T>>::get(thread_id))
         } else {
@@ -1346,7 +1293,7 @@ impl<T: Trait> Module<T> {
 
     /// Check the vote is valid
     fn ensure_vote_is_valid(
-        thread: &Thread<T::ForumUserId, T::ModeratorId, T::CategoryId, T::Moment, T::Hash>,
+        thread: &Thread<T::ForumUserId, T::CategoryId, T::Moment, T::Hash>,
         index: u32,
     ) -> Result<(), &'static str> {
         // Poll not existed

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -410,9 +410,6 @@ pub struct Poll<Timestamp, Hash> {
     /// hash of description
     pub description_hash: Hash,
 
-    /// timestamp of poll start
-    pub start_time: Timestamp,
-
     /// timestamp of poll end
     pub end_time: Timestamp,
 
@@ -1057,10 +1054,6 @@ impl<T: Trait> Module<T> {
     fn ensure_poll_is_valid(poll: &Poll<T::Moment, T::Hash>) -> dispatch::Result {
         // Poll end time must larger than now
         if poll.end_time < <timestamp::Module<T>>::now() {
-            return Err(ERROR_POLL_TIME_SETTING);
-        }
-        // Check the timestamp setting
-        if poll.start_time > poll.end_time {
             return Err(ERROR_POLL_TIME_SETTING);
         }
 

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -807,7 +807,7 @@ decl_module! {
             let thread = Self::ensure_thread_exists(&thread_id)?;
 
             // ensure origin can moderate category
-            Self::ensure_moderate_category(&who, &moderator_id, thread.category_id)?;
+            Self::ensure_can_moderate_category(&who, &moderator_id, thread.category_id)?;
 
             // Can mutate in corresponding category
             let path = Self::build_category_tree_path(thread.category_id);
@@ -913,7 +913,7 @@ decl_module! {
             let thread = Self::ensure_thread_exists(&post.thread_id)?;
 
             // ensure the moderator can moderate the category
-            Self::ensure_moderate_category(&who, &moderator_id, thread.category_id)?;
+            Self::ensure_can_moderate_category(&who, &moderator_id, thread.category_id)?;
 
             // Generate event
             Self::deposit_event(RawEvent::PostModerated(post_id));
@@ -930,7 +930,7 @@ decl_module! {
             let who = Self::ensure_is_moderator(origin, &moderator_id)?;
 
             // ensure the moderator can moderate the category
-            Self::ensure_moderate_category(&who, &moderator_id, category_id)?;
+            Self::ensure_can_moderate_category(&who, &moderator_id, category_id)?;
 
             // Ensure all thread id valid and is under the category
             for item in &stickied_ids {
@@ -1264,7 +1264,7 @@ impl<T: Trait> Module<T> {
     }
 
     /// check if an account can moderate a category.
-    fn ensure_moderate_category(
+    fn ensure_can_moderate_category(
         account_id: &T::AccountId,
         moderator_id: &T::ModeratorId,
         category_id: T::CategoryId,

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -398,12 +398,6 @@ pub fn moderate_thread_mock(
     );
     if result.is_ok() {
         assert_eq!(
-            TestForumModule::thread_by_id(thread_id)
-                .moderation
-                .is_some(),
-            true
-        );
-        assert_eq!(
             System::events().last().unwrap().event,
             TestEvent::forum_mod(RawEvent::ThreadModerated(thread_id,))
         );
@@ -422,10 +416,6 @@ pub fn moderate_post_mock(
         result
     );
     if result.is_ok() {
-        assert_eq!(
-            TestForumModule::post_by_id(post_id).moderation.is_some(),
-            true
-        );
         assert_eq!(
             System::events().last().unwrap().event,
             TestEvent::forum_mod(RawEvent::PostModerated(post_id,))

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -145,11 +145,11 @@ pub fn good_poll_alternative_text() -> Vec<u8> {
 }
 
 pub fn generate_poll(
+    expiration_diff: u64,
 ) -> Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash> {
     Poll {
         description_hash: Runtime::calculate_hash(good_poll_description().as_slice()),
-        start_time: Timestamp::now(),
-        end_time: Timestamp::now() + 10,
+        end_time: Timestamp::now() + expiration_diff,
         poll_alternatives: {
             let mut alternatives = vec![];
             for _ in 0..5 {
@@ -167,43 +167,9 @@ pub fn generate_poll(
 
 pub fn generate_poll_timestamp_cases(
     index: usize,
+    expiration_diff: u64,
 ) -> Poll<<Runtime as timestamp::Trait>::Moment, <Runtime as system::Trait>::Hash> {
-    let test_cases = vec![
-        Poll {
-            description_hash: Runtime::calculate_hash(good_poll_description().as_slice()),
-            start_time: Timestamp::now(),
-            end_time: Timestamp::now() + 10,
-            poll_alternatives: {
-                let mut alternatives = vec![];
-                for _ in 0..5 {
-                    alternatives.push(PollAlternative {
-                        alternative_text_hash: Runtime::calculate_hash(
-                            good_poll_alternative_text().as_slice(),
-                        ),
-                        vote_count: 0,
-                    });
-                }
-                alternatives
-            },
-        },
-        Poll {
-            description_hash: Runtime::calculate_hash(good_poll_description().as_slice()),
-            start_time: Timestamp::now() + 10,
-            end_time: Timestamp::now(),
-            poll_alternatives: {
-                let mut alternatives = vec![];
-                for _ in 0..5 {
-                    alternatives.push(PollAlternative {
-                        alternative_text_hash: Runtime::calculate_hash(
-                            good_poll_alternative_text().as_slice(),
-                        ),
-                        vote_count: 0,
-                    });
-                }
-                alternatives
-            },
-        },
-    ];
+    let test_cases = vec![generate_poll(expiration_diff), generate_poll(1)];
     test_cases[index].clone()
 }
 
@@ -287,6 +253,10 @@ pub fn create_post_mock(
         );
     };
     post_id
+}
+
+pub fn change_current_time(diff: u64) -> () {
+    Timestamp::set_timestamp(Timestamp::now() + diff);
 }
 
 pub fn set_max_category_depth_mock(


### PR DESCRIPTION
Solves the rest of #766's *Removing archival state* subtask.
- removes poll `start_time`
- fixes some tests around poll time constraints
- removes `moderationAction`

To minimize merge conflict potential, this PR assumes #846 will be merged first.
