### PR TITLE
Forum thread editable by author

### DIFF
--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -774,13 +774,9 @@ decl_module! {
             // Store the event
             Self::deposit_event(RawEvent::ThreadTitleUpdated(thread_id));
 
-            // Update post text
-            <ThreadById<T>>::mutate(thread_id, |thread| {
-                let title_hash = T::calculate_hash(&new_title);
-
-                // Set current text to new text
-                thread.title_hash = title_hash;
-            });
+            // Update thread title
+            let title_hash = T::calculate_hash(&new_title);
+            <ThreadById<T>>::mutate(thread_id, |thread| thread.title_hash = title_hash);
 
             Ok(())
         }
@@ -927,12 +923,8 @@ decl_module! {
             ensure!(post.author_id == forum_user_id, ERROR_ACCOUNT_DOES_NOT_MATCH_POST_AUTHOR);
 
             // Update post text
-            <PostById<T>>::mutate(post_id, |p| {
-                let text_hash = T::calculate_hash(&new_text);
-
-                // Set current text to new text
-                p.text_hash = text_hash;
-            });
+            let text_hash = T::calculate_hash(&new_text);
+            <PostById<T>>::mutate(post_id, |p| p.text_hash = text_hash);
 
             // Generate event
             Self::deposit_event(RawEvent::PostTextUpdated(post_id));

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -325,19 +325,8 @@ pub fn edit_post_text_mock(
             Runtime::calculate_hash(new_text.as_slice()),
         );
         assert_eq!(
-            TestForumModule::post_by_id(post_id)
-                .text_change_history
-                .len(),
-            post.text_change_history.len() + 1
-        );
-        assert_eq!(
             System::events().last().unwrap().event,
-            TestEvent::forum_mod(RawEvent::PostTextUpdated(
-                post_id,
-                TestForumModule::post_by_id(post_id)
-                    .text_change_history
-                    .len() as u64,
-            ))
+            TestEvent::forum_mod(RawEvent::PostTextUpdated(post_id))
         );
     }
     post_id

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -547,6 +547,57 @@ fn add_post_origin() {
     }
 }
 
+#[test]
+// test if post text can be edited by author can edit it's post thread
+fn edit_post_text() {
+    let config = default_genesis_config();
+    let author = NOT_FORUM_LEAD_ORIGIN_ID;
+    let not_author = FORUM_LEAD_ORIGIN_ID;
+    let forum_lead = FORUM_LEAD_ORIGIN_ID;
+    let origin = OriginType::Signed(forum_lead);
+
+    build_test_externalities(config).execute_with(|| {
+        // prepare category and thread
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
+        let thread_id = create_thread_mock(
+            origin.clone(),
+            forum_lead,
+            category_id,
+            good_thread_title(),
+            good_thread_text(),
+            None,
+            Ok(()),
+        );
+
+        // create post by author
+        let post_id = create_post_mock(origin.clone(), author, thread_id, good_post_text(), Ok(()));
+
+        // check author can edit text
+        edit_post_text_mock(
+            origin.clone(),
+            author,
+            post_id,
+            good_post_new_text(),
+            Ok(()),
+        );
+
+        // check non-author is forbidden from editing text
+        edit_post_text_mock(
+            origin.clone(),
+            not_author,
+            post_id,
+            good_post_new_text(),
+            Err(ERROR_ACCOUNT_DOES_NOT_MATCH_POST_AUTHOR),
+        );
+    });
+}
+
 /*
  ** react_post
  */


### PR DESCRIPTION
Solves subtask of #766:
- Make thread title editable by author.

To minimize merge conflict potential, this PR assumes #867 will be merged first.