### PR TITLE
Qnode field resolver

### DIFF
--- a/query-node/docs/entity-relationship.md
+++ b/query-node/docs/entity-relationship.md
@@ -1,0 +1,140 @@
+# GraphQL Entity Relationships
+
+### One-To-One (1:1) Relationships
+
+In One-To-One relation, one entity instance is related to only one instance of another entity. One side of the relationship should always derive.
+
+```graphql
+type User @entity {
+	name: String!
+	profile: Profile! @derivedFrom(field: "user")
+}
+
+type Profile @entity {
+	avatar: String!
+	user: User!
+}
+```
+
+Database tables:
+
+```
+          user
+| Column  | Type
+----------|-------
+| id      | character varying
+| name    | character varying
+```
+
+```
+          profile
+| Column  | Type
+----------|-------
+| id      | character varying
+| avatar  | character varying
+| userId  | character varying FOREIGN KEY UNIQUE CONSTRAINT
+```
+
+### One-To-Many (1:n) Relationships
+
+In One-To-Many relation, one entity instance is related to multiple instance of the other entity.
+
+```graphql
+type User @entity {
+	name: String
+}
+
+type Post @entity {
+	title: String
+	author: User!
+}
+```
+
+Database table for the `Post` entity:
+
+```
+          post
+| Column  | Type
+----------|-------
+| id      | character varying
+| avatar  | character varying
+| authorId  | character varying FOREIGN KEY
+```
+
+The only difference between `1:1` and `1:n` is the unique constraint that `1:1` has.
+
+### Many-To-Many (n:n) Relationships
+
+Many-To-Many is a relationship where one entity instance is related to many instance of other entity and vice-versa. In this relationship one side of the relation must derive.
+
+```graphql
+type User @entity {
+	name: String
+	books: [Book!] @derivedFrom(field: "authors")
+}
+
+type Book @entity {
+	title: String
+	authors: [User!]
+}
+```
+
+A junction table is created for n:n relationship.
+
+Database tables:
+
+```
+          book
+| Column  | Type
+----------|-------
+| id      | character varying
+| title   | character varying
+```
+
+```
+          book_user
+| Column  | Type
+----------|-------
+| book_id | character varying
+| user_id | character varying
+```
+
+### Reverse Lookups
+
+Defining reverse lookups on an entity allows you to query other side of the relation. Use `@derivedFrom` directive to add reverse lookup to an entity.
+
+**Example**
+If we want to access a user's `posts` from the user entity we should add a derived field to `User` entity:
+
+```graphql
+type User @entity {
+	name: String
+	posts: [Post!] @derivedField(field: "author")
+}
+
+type Post @entity {
+	title: String
+	author: User!
+}
+```
+
+## Relationships In Mappings
+
+Each GraphQL entity has a corresponding typeorm entity and we use these entities to perform CRUD operations.
+
+**Example**
+
+We will create a new post for an existing user:
+
+```ts
+export async function handleNewPost(db: DB, event: SubstrateEvent) {
+	const { userId, title } = event.params;
+	const user = await db.get(User, { where: { id: userId } });
+
+	const newPost = new Post();
+	newPost.title = title;
+	newPost.author = user;
+
+	db.save<Post>(newPost);
+}
+```

--- a/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { ObjectType, WarthogModel } from '../model';
 import Debug from 'debug';
 import { GeneratorContext } from './SourcesGenerator';
@@ -95,6 +96,21 @@ export class ModelRenderer extends AbstractRenderer {
     };
   }
 
+  withImportProps(): GeneratorContext {
+    const relatedEntityImports: string[] = [];
+    this.objType.relatedEntityImports.forEach(entityName => {
+      const import_ = path.join(
+        `import { ${entityName} } from  '..`,
+        utils.kebabCase(entityName),
+        `${utils.kebabCase(entityName)}.model'`
+      );
+      relatedEntityImports.push(import_);
+    });
+    return {
+      relatedEntityImports,
+    };
+  }
+
   transform(): GeneratorContext {
     return {
       ...this.context, //this.getGeneratedFolderRelativePath(objType.name),
@@ -105,6 +121,7 @@ export class ModelRenderer extends AbstractRenderer {
       ...this.withHasProps(),
       ...this.withSubclasses(),
       ...this.withDescription(),
+      ...this.withImportProps(),
       ...utils.withNames(this.objType.name),
     };
   }

--- a/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
@@ -99,12 +99,13 @@ export class ModelRenderer extends AbstractRenderer {
   withImportProps(): GeneratorContext {
     const relatedEntityImports: string[] = [];
     this.objType.relatedEntityImports.forEach(entityName => {
-      const import_ = path.join(
-        `import { ${entityName} } from  '..`,
-        utils.kebabCase(entityName),
-        `${utils.kebabCase(entityName)}.model'`
+      relatedEntityImports.push(
+        path.join(
+          `import { ${entityName} } from  '..`,
+          utils.kebabCase(entityName),
+          `${utils.kebabCase(entityName)}.model'`
+        )
       );
-      relatedEntityImports.push(import_);
     });
     return {
       relatedEntityImports,

--- a/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
@@ -1,0 +1,115 @@
+import { WarthogModel, Field, ObjectType } from '../model';
+
+export class RelationshipGenerator {
+  visited: Field[];
+  model: WarthogModel;
+
+  constructor(model: WarthogModel) {
+    this.model = model;
+    this.visited = [];
+  }
+
+  addMany2Many(field: Field, relatedField: Field, objType: ObjectType, relatedObject: ObjectType): void {
+    field.relation = { type: 'mtm', columnType: field.type, joinTable: true, relatedTsProp: relatedField.name };
+    relatedField.relation = { type: 'mtm', columnType: relatedField.type, relatedTsProp: field.name };
+
+    objType.relatedEntityImports.add(relatedObject.name);
+    relatedObject.relatedEntityImports.add(objType.name);
+    this.visited.push(field, relatedField);
+  }
+
+  addOne2Many(field: Field, relatedField: Field, objType: ObjectType, relatedObject: ObjectType): void {
+    field.relation = { type: 'otm', columnType: field.type, relatedTsProp: relatedField.name };
+    relatedField.relation = { type: 'mto', columnType: relatedField.type, relatedTsProp: field.name };
+
+    objType.relatedEntityImports.add(field.type);
+    relatedObject.relatedEntityImports.add(objType.name);
+    this.visited.push(field, relatedField);
+  }
+
+  addMany2One(field: Field, currentObject: ObjectType, relatedObject: ObjectType): void {
+    field.relation = { type: 'mto', columnType: field.type };
+    currentObject.relatedEntityImports.add(relatedObject.name);
+    this.visited.push(field);
+  }
+
+  addOne2One(field: Field, relatedField: Field, objType: ObjectType, relatedObject: ObjectType): void {
+    field.relation = { type: 'oto', columnType: field.type, joinColumn: true };
+    relatedField.relation = { type: 'oto', columnType: relatedField.type };
+
+    objType.relatedEntityImports.add(relatedObject.name);
+    relatedObject.relatedEntityImports.add(objType.name);
+    this.visited.push(field, relatedField);
+  }
+
+  generate(): void {
+    this.model.types.forEach(currentObject => {
+      for (const field of currentObject.fields) {
+        if (this.visited.includes(field)) return;
+
+        // ============= Case 0 =============
+        if (field.derivedFrom && !field.isList) return;
+
+        // ============= Case 1 =============
+        if (!field.isBuildinType && field.derivedFrom && field.isList) {
+          const relatedObject = this.model.lookupType(field.type);
+          // if related field not found lookupField will throw error anyway
+          const relatedField = this.model.lookupField(field.type, field.derivedFrom.argument);
+
+          if (relatedField.derivedFrom) {
+            throw new Error(
+              `${relatedObject.name}->${relatedField.name} derived field can not reference to another derived field!`
+            );
+          }
+          if (relatedField.isList) {
+            return this.addMany2Many(field, relatedField, currentObject, relatedObject);
+          }
+          return this.addOne2Many(field, relatedField, currentObject, relatedObject);
+        }
+
+        if (!field.isBuildinType && !field.isList && !field.derivedFrom) {
+          const relatedObject = this.model.lookupType(field.type);
+          const relatedFields = relatedObject.fields.filter(f => f.type === currentObject.name);
+
+          if (relatedFields.length === 0) {
+            return this.addMany2One(field, currentObject, relatedObject);
+          } else if (relatedFields.length > 1) {
+            // Found multiple fields?
+            const derivedField = relatedFields.find(f => f.derivedFrom?.argument === field.name);
+
+            if (derivedField) {
+              return this.addOne2Many(field, derivedField, currentObject, relatedObject);
+            } else {
+              const relatedField = relatedFields.find(f => !f.isList);
+              if (relatedField) {
+                return this.addOne2One(field, relatedField, currentObject, relatedObject);
+              } else {
+                throw new Error(
+                  `Incorrect relationship detected! Between ${currentObject.name}<->${relatedObject.name}`
+                );
+              }
+            }
+          } else {
+            return this.addOne2One(field, relatedFields[0], currentObject, relatedObject);
+          }
+        }
+
+        // ============= Case 3 =============
+        if (!field.isBuildinType && field.isList) {
+          const relatedObject = this.model.lookupType(field.type);
+          const relatedFields = relatedObject.fields.filter(f => f.type === currentObject.name && f.isList);
+
+          if (relatedFields.length !== 1) {
+            throw new Error(`Incorrect ManyToMany relationship detected! ${currentObject.name} -> ${field.name}
+            found ${relatedFields.length} fields on ${relatedObject.name} of list type`);
+          }
+          if (!relatedFields[0].derivedFrom) {
+            throw new Error(`Incorrect ManyToMany relationship detected! @derived directive
+            for ${relatedObject.name}->${relatedFields[0].name} could not found`);
+          }
+          return this.addMany2Many(field, relatedFields[0], currentObject, relatedObject);
+        }
+      }
+    });
+  }
+}

--- a/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
@@ -34,8 +34,8 @@ export class RelationshipGenerator {
   }
 
   addOne2One(field: Field, relatedField: Field, objType: ObjectType, relatedObject: ObjectType): void {
-    field.relation = { type: 'oto', columnType: field.type, joinColumn: true };
-    relatedField.relation = { type: 'oto', columnType: relatedField.type };
+    field.relation = { type: 'oto', columnType: field.type, joinColumn: true, relatedTsProp: relatedField.name };
+    relatedField.relation = { type: 'oto', columnType: relatedField.type, relatedTsProp: field.name };
 
     objType.relatedEntityImports.add(relatedObject.name);
     relatedObject.relatedEntityImports.add(objType.name);

--- a/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
@@ -102,8 +102,10 @@ export class RelationshipGenerator {
 
           if (field.isList && relatedField.isList) {
             return this.addMany2Many(field, relatedField, currentObject, relatedObject);
+          } else if (field.isList && !relatedField.isList) {
+            return this.addOne2Many(field, relatedField, currentObject, relatedObject);
           }
-          return this.addOne2Many(field, relatedField, currentObject, relatedObject);
+          return this.addOne2One(field, relatedField, currentObject, relatedObject);
         }
 
         if (!field.isBuildinType && !field.isList && !field.derivedFrom) {

--- a/query-node/substrate-query-framework/cli/src/generate/field-context.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/field-context.ts
@@ -2,6 +2,7 @@ import { GeneratorContext } from './SourcesGenerator';
 import { Field, ObjectType } from '../model';
 import * as util from './utils';
 import { withRelativePathForEnum } from './enum-context';
+import { fieldTypes } from '../helpers/tsTypes';
 
 export const TYPE_FIELDS: { [key: string]: { [key: string]: string } } = {
   bool: {
@@ -26,6 +27,14 @@ export const TYPE_FIELDS: { [key: string]: { [key: string]: string } } = {
   },
   otm: {
     decorator: 'OneToMany',
+    tsType: '---',
+  },
+  mto: {
+    decorator: 'ManyToOne',
+    tsType: '---',
+  },
+  mtm: {
+    decorator: 'ManyToMany',
     tsType: '---',
   },
   string: {
@@ -66,7 +75,6 @@ const graphQLFieldTypes: { [key: string]: string } = {
 
 export function buildFieldContext(f: Field, entity: ObjectType): GeneratorContext {
   return {
-    relatedEntityImports: entity.imports,
     ...withFieldTypeGuardProps(f),
     ...withRequired(f),
     ...withUnique(f),
@@ -83,9 +91,8 @@ export function withFieldTypeGuardProps(f: Field): GeneratorContext {
   is['scalar'] = f.isScalar();
   is['refType'] = f.isRelationType();
   is['enum'] = f.isEnum();
-  is['relation'] = f.relation;
 
-  ['mto', 'oto', 'otm'].map(s => (is[s] = f.relation?.type === s));
+  ['mto', 'oto', 'otm', 'mtm'].map(s => (is[s] = f.relation?.type === s));
   return {
     is: is,
   };
@@ -143,9 +150,8 @@ export function withArrayCustomFieldConfig(f: Field): GeneratorContext {
 }
 
 export function withDerivedNames(f: Field, entity: ObjectType): GeneratorContext {
-  const single = f.type === 'otm' ? f.name.slice(0, -1) : f.name; // strip s at the end if otm
   return {
-    ...util.names(single),
+    ...util.names(f.name),
     relFieldName: util.camelCase(entity.name),
     relFieldNamePlural: util.camelPlural(entity.name),
   };

--- a/query-node/substrate-query-framework/cli/src/generate/field-context.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/field-context.ts
@@ -166,3 +166,15 @@ export function withImport(f: Field): GeneratorContext {
     ...withRelativePathForEnum(),
   };
 }
+
+export function withEntityRelationImports(entity: ObjectType): GeneratorContext {
+  return {
+    relatedEntityImports: entity.relatedEntityImports,
+  };
+}
+
+export function withRelation(f: Field): GeneratorContext {
+  return {
+    relation: f.relation,
+  };
+}

--- a/query-node/substrate-query-framework/cli/src/generate/field-context.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/field-context.ts
@@ -2,7 +2,6 @@ import { GeneratorContext } from './SourcesGenerator';
 import { Field, ObjectType } from '../model';
 import * as util from './utils';
 import { withRelativePathForEnum } from './enum-context';
-import { fieldTypes } from '../helpers/tsTypes';
 
 export const TYPE_FIELDS: { [key: string]: { [key: string]: string } } = {
   bool: {
@@ -78,6 +77,7 @@ export function buildFieldContext(f: Field, entity: ObjectType): GeneratorContex
     ...withFieldTypeGuardProps(f),
     ...withRequired(f),
     ...withUnique(f),
+    ...withRelation(f),
     ...withArrayCustomFieldConfig(f),
     ...withTsTypeAndDecorator(f),
     ...withDerivedNames(f, entity),

--- a/query-node/substrate-query-framework/cli/src/generate/utils.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/utils.ts
@@ -1,4 +1,4 @@
-import { upperFirst, kebabCase, camelCase } from 'lodash';
+import { upperFirst, kebabCase, camelCase, snakeCase } from 'lodash';
 import { GeneratorContext } from './SourcesGenerator';
 import { ObjectType, Field } from '../model';
 import _ from 'lodash';
@@ -57,4 +57,11 @@ export function ownFields(o: ObjectType): Field[] {
 
   const intrFields = o.interfaces[0].fields || [];
   return _.differenceBy(o.fields, intrFields, 'name');
+}
+export function generateJoinColumnName(name: string): string {
+  return snakeCase(name.concat('_id'));
+}
+
+export function generateJoinTableName(table1: string, table2: string): string {
+  return snakeCase(table1.concat('_', table2));
 }

--- a/query-node/substrate-query-framework/cli/src/generate/utils.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/utils.ts
@@ -65,3 +65,12 @@ export function generateJoinColumnName(name: string): string {
 export function generateJoinTableName(table1: string, table2: string): string {
   return snakeCase(table1.concat('_', table2));
 }
+
+export function generateEntityImport(entityName: string): string {
+  const kebabName = kebabCase(entityName);
+  return `import {${entityName}} from '../${kebabName}/${kebabName}.model'`;
+}
+
+export function generateResolverReturnType(type: string, isList: boolean): string {
+  return `Promise<${type}${isList ? '[]' : ''}>`;
+}

--- a/query-node/substrate-query-framework/cli/src/model/FTSQuery.ts
+++ b/query-node/substrate-query-framework/cli/src/model/FTSQuery.ts
@@ -1,5 +1,4 @@
-import { ObjectType } from './WarthogModel';
-import { Field } from './Field';
+import { ObjectType, Field } from '.';
 
 /**
  * FTSQueryClause represents a single entity/field which

--- a/query-node/substrate-query-framework/cli/src/model/Field.ts
+++ b/query-node/substrate-query-framework/cli/src/model/Field.ts
@@ -1,3 +1,4 @@
+import { Relation } from '.';
 import { availableTypes } from './ScalarTypes';
 
 /**
@@ -20,6 +21,9 @@ export class Field {
   // Make field as a unique column on database
   unique?: boolean;
 
+  // Relation
+  relation?: Relation;
+
   constructor(name: string, type: string, nullable = true, isBuildinType = true, isList = false) {
     this.name = name;
     this.type = type;
@@ -29,6 +33,7 @@ export class Field {
   }
 
   columnType(): string {
+    if (this.relation) return this.relation?.type;
     return this.isBuildinType ? availableTypes[this.type] : this.type;
   }
 
@@ -41,10 +46,10 @@ export class Field {
   }
 
   isRelationType(): boolean {
-    return ['otm', 'mto', 'oto'].some(s => s === this.type);
+    return this.relation ? true : false;
   }
 
   isEnum(): boolean {
-    return !this.isBuildinType && !this.isRelationType();
+    return !this.isBuildinType && !this.relation;
   }
 }

--- a/query-node/substrate-query-framework/cli/src/model/Field.ts
+++ b/query-node/substrate-query-framework/cli/src/model/Field.ts
@@ -1,6 +1,10 @@
 import { Relation } from '.';
 import { availableTypes } from './ScalarTypes';
 
+interface DerivedFrom {
+  argument: string;
+}
+
 /**
  * Reperenst GraphQL object type field
  * @constructor(name: string, type: string, nullable: boolean = true, isBuildinType: boolean = true, isList = false)
@@ -23,6 +27,8 @@ export class Field {
 
   // Relation
   relation?: Relation;
+
+  derivedFrom?: DerivedFrom;
 
   constructor(name: string, type: string, nullable = true, isBuildinType = true, isList = false) {
     this.name = name;

--- a/query-node/substrate-query-framework/cli/src/model/ObjectType.ts
+++ b/query-node/substrate-query-framework/cli/src/model/ObjectType.ts
@@ -1,0 +1,16 @@
+import { Field } from '.';
+
+/**
+ * Reperesent GraphQL object type
+ */
+export interface ObjectType {
+  name: string;
+  fields: Field[];
+  isEntity: boolean;
+  // imports for relations
+  imports: Set<string>;
+  // Description of the field will be shown in GrapqQL API
+  description?: string;
+  isInterface?: boolean;
+  interfaces?: ObjectType[]; //interface names
+}

--- a/query-node/substrate-query-framework/cli/src/model/ObjectType.ts
+++ b/query-node/substrate-query-framework/cli/src/model/ObjectType.ts
@@ -7,8 +7,7 @@ export interface ObjectType {
   name: string;
   fields: Field[];
   isEntity: boolean;
-  // imports for relations
-  imports: Set<string>;
+  relatedEntityImports: Set<string>;
   // Description of the field will be shown in GrapqQL API
   description?: string;
   isInterface?: boolean;

--- a/query-node/substrate-query-framework/cli/src/model/Relation.ts
+++ b/query-node/substrate-query-framework/cli/src/model/Relation.ts
@@ -1,0 +1,13 @@
+
+export interface Relation {
+  // Relation type oto, otm, mtm
+  type: string;
+  
+  // Column type
+  columnType: string;
+
+  // Table that will hold relation id (foreign key)
+  joinColumn?: boolean;
+
+  joinTable?: boolean;
+}

--- a/query-node/substrate-query-framework/cli/src/model/Relation.ts
+++ b/query-node/substrate-query-framework/cli/src/model/Relation.ts
@@ -1,15 +1,20 @@
+interface JoinTable {
+  tableName: string;
+  joinColumn: string;
+  inverseJoinColumn: string;
+}
 
 export interface Relation {
   // Relation type oto, otm, mtm
   type: string;
-  
+
   // Column type
   columnType: string;
 
   // Table that will hold relation id (foreign key)
   joinColumn?: boolean;
 
-  joinTable?: boolean;
+  joinTable?: JoinTable;
 
   relatedTsProp?: string;
 }

--- a/query-node/substrate-query-framework/cli/src/model/Relation.ts
+++ b/query-node/substrate-query-framework/cli/src/model/Relation.ts
@@ -10,4 +10,6 @@ export interface Relation {
   joinColumn?: boolean;
 
   joinTable?: boolean;
+
+  relatedTsProp?: string;
 }

--- a/query-node/substrate-query-framework/cli/src/model/Relation.ts
+++ b/query-node/substrate-query-framework/cli/src/model/Relation.ts
@@ -18,3 +18,11 @@ export interface Relation {
 
   relatedTsProp?: string;
 }
+
+export function makeRelation(type: string, columnType: string, relatedTsProp: string): Relation {
+  return {
+    type,
+    columnType,
+    relatedTsProp,
+  };
+}

--- a/query-node/substrate-query-framework/cli/src/model/Relation.ts
+++ b/query-node/substrate-query-framework/cli/src/model/Relation.ts
@@ -19,6 +19,17 @@ export interface Relation {
   relatedTsProp?: string;
 }
 
+/**
+ * Field resolver for related fields
+ */
+export interface FieldResolver {
+  returnTypeFunc: string;
+  fieldName: string;
+  rootArgName: string;
+  rootArgType: string;
+  returnType: string;
+}
+
 export function makeRelation(type: string, columnType: string, relatedTsProp: string): Relation {
   return {
     type,

--- a/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
+++ b/query-node/substrate-query-framework/cli/src/model/WarthogModel.ts
@@ -1,6 +1,6 @@
-import { FTSQuery } from './FTSQuery';
-import { Field } from './Field';
 import { GraphQLEnumType } from 'graphql';
+
+import { ObjectType, Field, FTSQuery } from '.';
 
 export class WarthogModel {
   private _types: ObjectType[];
@@ -149,17 +149,4 @@ export class WarthogModel {
     }
     return this._name2type[name];
   }
-}
-
-/**
- * Reperesent GraphQL object type
- */
-export interface ObjectType {
-  name: string;
-  fields: Field[];
-  isEntity: boolean;
-  // Description of the field will be shown in GrapqQL API
-  description?: string;
-  isInterface?: boolean;
-  interfaces?: ObjectType[]; //interface names
 }

--- a/query-node/substrate-query-framework/cli/src/model/index.ts
+++ b/query-node/substrate-query-framework/cli/src/model/index.ts
@@ -1,5 +1,7 @@
 import { Field } from './Field';
+import { Relation } from './Relation'
 import { FTSQuery } from './FTSQuery';
-import { WarthogModel, ObjectType } from './WarthogModel';
+import { WarthogModel } from './WarthogModel';
+import { ObjectType } from './ObjectType'
 
-export { FTSQuery, WarthogModel, ObjectType, Field };
+export { FTSQuery, WarthogModel, ObjectType, Field, Relation };

--- a/query-node/substrate-query-framework/cli/src/model/index.ts
+++ b/query-node/substrate-query-framework/cli/src/model/index.ts
@@ -1,7 +1,7 @@
 import { Field } from './Field';
-import { Relation, makeRelation } from './Relation';
+import { Relation, makeRelation, FieldResolver } from './Relation';
 import { FTSQuery } from './FTSQuery';
 import { WarthogModel } from './WarthogModel';
 import { ObjectType } from './ObjectType';
 
-export { FTSQuery, WarthogModel, ObjectType, Field, Relation, makeRelation };
+export { FTSQuery, WarthogModel, ObjectType, Field, Relation, makeRelation, FieldResolver };

--- a/query-node/substrate-query-framework/cli/src/model/index.ts
+++ b/query-node/substrate-query-framework/cli/src/model/index.ts
@@ -1,7 +1,7 @@
 import { Field } from './Field';
-import { Relation } from './Relation'
+import { Relation, makeRelation } from './Relation';
 import { FTSQuery } from './FTSQuery';
 import { WarthogModel } from './WarthogModel';
-import { ObjectType } from './ObjectType'
+import { ObjectType } from './ObjectType';
 
-export { FTSQuery, WarthogModel, ObjectType, Field, Relation };
+export { FTSQuery, WarthogModel, ObjectType, Field, Relation, makeRelation };

--- a/query-node/substrate-query-framework/cli/src/parse/DerivedFromDirective.ts
+++ b/query-node/substrate-query-framework/cli/src/parse/DerivedFromDirective.ts
@@ -1,0 +1,36 @@
+import { FieldDefinitionNode, StringValueNode } from 'graphql';
+import { Field, WarthogModel } from '../model';
+import { DERIVED_FROM_DIRECTIVE } from './constant';
+
+export function addDerivedFromIfy(fieldDef: FieldDefinitionNode, field: Field): void {
+  const d = fieldDef.directives?.find(d => d.name.value === DERIVED_FROM_DIRECTIVE);
+  if (!d) return;
+
+  if (!d.arguments) {
+    throw new Error(`@${DERIVED_FROM_DIRECTIVE} should have a field argument`);
+  }
+
+  const directiveArgs = d.arguments.find(arg => arg.name.value === 'field' && arg.value.kind === 'StringValue');
+
+  // TODO: graphql-js already throw error??
+  if (!directiveArgs) {
+    throw new Error(`@${DERIVED_FROM_DIRECTIVE} should have a single field argument with a sting value`);
+  }
+
+  field.derivedFrom = { argument: (directiveArgs.value as StringValueNode).value };
+}
+
+export function validateDerivedFields(model: WarthogModel): void {
+  model.types.forEach(objType => {
+    objType.fields.forEach(f => {
+      if (!f.derivedFrom) return;
+
+      if (f.isScalar()) {
+        throw new Error('Derived field type is not an entity type');
+      }
+      if (!model.lookupField(f.type, f.derivedFrom?.argument)) {
+        throw new Error('Derived field does not exists on the related type');
+      }
+    });
+  });
+}

--- a/query-node/substrate-query-framework/cli/src/parse/constant.ts
+++ b/query-node/substrate-query-framework/cli/src/parse/constant.ts
@@ -2,9 +2,15 @@
  * This preamble is added to the schema in order to pass the SDL validation
  * Add additional scalar types and directives to the schema
  */
+
+export const ENTITY_DIRECTIVE = 'entity';
+export const UNIQUE_DIRECTIVE = 'unique';
+export const DERIVED_FROM_DIRECTIVE = `derivedFrom`;
+
 export const SCHEMA_DEFINITIONS_PREAMBLE = `
-directive @entity on OBJECT | INTERFACE  # Mark both object types and interfaces
-directive @unique on FIELD_DEFINITION
+directive @${ENTITY_DIRECTIVE} on OBJECT | INTERFACE  # Mark both object types and interfaces
+directive @${DERIVED_FROM_DIRECTIVE}(field: String!) on FIELD_DEFINITION
+directive @${UNIQUE_DIRECTIVE} on FIELD_DEFINITION
 scalar BigInt                # Arbitrarily large integers
 scalar BigDecimal            # is used to represent arbitrary precision decimals
 scalar Bytes                 # Byte array, represented as a hexadecimal string
@@ -12,6 +18,3 @@ type Query {
     _dummy: String           # empty queries are not allowed
 }
 `;
-
-export const ENTITY_DIRECTIVE = 'entity';
-export const UNIQUE_DIRECTIVE = 'unique';

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -23,8 +23,9 @@ import { InterfaceType } from 'type-graphql';
 
 {{#has.mtm}}import { JoinTable } from 'typeorm';{{/has.mtm}}
 
+
 {{#relatedEntityImports}}
-  {{{ entityName }}}
+  {{{ . }}}
 {{/relatedEntityImports}}
 
 {{#enums}}

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -49,27 +49,38 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
 
 {{#fields}}
   {{#is.otm}}
-    @OneToMany(() => {{relation.columnType}}, ({{camelName}}: {{relation.columnType}}) => {{camelName}}.{{relation.relatedTsProp}})
+    @OneToMany(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
     {{camelName}}?: {{relation.columnType}}[];  
   {{/is.otm}}
 
   {{#is.mto}}
-    @ManyToOne(() => {{relation.columnType}}, {{#relation.relatedTsProp}}({{camelName}}: {{relation.columnType}}) => {{camelName}}.{{relation.relatedTsProp}},{{/relation.relatedTsProp}} { 
-      skipGraphQLField: true{{^required}},
-      nullable: true{{/required}} 
+    @ManyToOne(() => {{relation.columnType}},
+      {{#relation.relatedTsProp}}
+        (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}},
+      {{/relation.relatedTsProp}}
+      { 
+        skipGraphQLField: true{{^required}},
+        nullable: true{{/required}} 
     })
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relation.columnType}};
   {{/is.mto}}
 
   {{#is.oto}}
-    {{^relation.joinColumn}}@OneToOne{{/relation.joinColumn}}{{#relation.joinColumn}}@OneToOneJoin{{/relation.joinColumn}}(() => {{relation.columnType}}
-      ,({{camelName}}: {{relation.columnType}}) => {{camelName}}.{{relation.relatedTsProp}})
+    {{^relation.joinColumn}}@OneToOne{{/relation.joinColumn}}
+    {{#relation.joinColumn}}@OneToOneJoin{{/relation.joinColumn}}
+    (() => {{relation.columnType}},(param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relation.columnType}};
   {{/is.oto}}
 
   {{#is.mtm}}
-    @ManyToMany(() => {{relation.columnType}}, ({{camelName}}: {{relation.columnType}}) => {{camelName}}.{{relation.relatedTsProp}})
-    {{#relation.joinTable}}@JoinTable(){{/relation.joinTable}}
+    @ManyToMany(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
+    {{#relation.joinTable}}
+      @JoinTable({
+        name: '{{relation.joinTable.tableName}}',
+        joinColumn: {name: '{{relation.joinTable.joinColumn}}' },
+        inverseJoinColumn: {name: '{{relation.joinTable.inverseJoinColumn}}' }
+      })
+    {{/relation.joinTable}}
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relation.columnType}}[];
   {{/is.mtm}}
   

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -62,7 +62,7 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
   {{/is.mto}}
 
   {{#is.oto}}
-    @OneToOne(() => {{relation.columnType}})
+    @OneToOne(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
     {{#relation.joinColumn}}@JoinColumn(){{/relation.joinColumn}}
     {{camelName}}?: {{relation.columnType}};
   {{/is.oto}}

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -11,7 +11,7 @@ import {
   {{#has.mto}}ManyToOne,{{/has.mto}}
   {{#has.mtm}}ManyToMany,{{/has.mtm}}
   {{#has.otm}}OneToMany,{{/has.otm}}
-  {{#has.oto}}OneToOne, JoinColumn,{{/has.oto}}
+  {{#has.oto}}OneToOne, OneToOneJoin,{{/has.oto}}
   {{#has.array}}CustomField,{{/has.array}}
   {{#has.enum}}EnumField,{{/has.enum}}
   StringField
@@ -63,9 +63,9 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
   {{/is.mto}}
 
   {{#is.oto}}
-    @OneToOne(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
-    {{#relation.joinColumn}}@JoinColumn(){{/relation.joinColumn}}
-    {{camelName}}?: {{relation.columnType}};
+    {{^relation.joinColumn}}@OneToOne{{/relation.joinColumn}}{{#relation.joinColumn}}@OneToOneJoin{{/relation.joinColumn}}(() => {{relation.columnType}}
+      ,({{camelName}}: {{relation.columnType}}) => {{camelName}}.{{relation.relatedTsProp}})
+    {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relation.columnType}};
   {{/is.oto}}
 
   {{#is.mtm}}

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -23,7 +23,6 @@ import { InterfaceType } from 'type-graphql';
 
 {{#has.mtm}}import { JoinTable } from 'typeorm';{{/has.mtm}}
 
-
 {{#relatedEntityImports}}
   {{{ . }}}
 {{/relatedEntityImports}}
@@ -50,12 +49,12 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
 
 {{#fields}}
   {{#is.otm}}
-    @OneToMany(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
+    @OneToMany(() => {{relation.columnType}}, ({{camelName}}: {{relation.columnType}}) => {{camelName}}.{{relation.relatedTsProp}})
     {{camelName}}?: {{relation.columnType}}[];  
   {{/is.otm}}
 
   {{#is.mto}}
-    @ManyToOne(() => {{relation.columnType}}, {{#relation.relatedTsProp}}(param: {{relation.columnType}}) => param.{{relation.relatedTsProp}},{{/relation.relatedTsProp}} { 
+    @ManyToOne(() => {{relation.columnType}}, {{#relation.relatedTsProp}}({{camelName}}: {{relation.columnType}}) => {{camelName}}.{{relation.relatedTsProp}},{{/relation.relatedTsProp}} { 
       skipGraphQLField: true{{^required}},
       nullable: true{{/required}} 
     })
@@ -69,7 +68,7 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
   {{/is.oto}}
 
   {{#is.mtm}}
-    @ManyToMany(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
+    @ManyToMany(() => {{relation.columnType}}, ({{camelName}}: {{relation.columnType}}) => {{camelName}}.{{relation.relatedTsProp}})
     {{#relation.joinTable}}@JoinTable(){{/relation.joinTable}}
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relation.columnType}}[];
   {{/is.mtm}}

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -9,6 +9,7 @@ import {
   {{#has.bytes}}BytesField,{{/has.bytes}}
   Model,
   {{#has.mto}}ManyToOne,{{/has.mto}}
+  {{#has.mtm}}ManyToMany,{{/has.mtm}}
   {{#has.otm}}OneToMany,{{/has.otm}}
   {{#has.oto}}OneToOne, JoinColumn,{{/has.oto}}
   {{#has.array}}CustomField,{{/has.array}}
@@ -20,8 +21,10 @@ import {
 import { InterfaceType } from 'type-graphql';
 {{/isInterface}}
 
-{{#relatedEntityImports}} {{! import related entities }}
-  {{{ relatedEntityImports }}}
+{{#has.mtm}}import { JoinTable } from 'typeorm';{{/has.mtm}}
+
+{{#relatedEntityImports}}
+  {{{ entityName }}}
 {{/relatedEntityImports}}
 
 {{#enums}}
@@ -46,24 +49,30 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
 
 {{#fields}}
   {{#is.otm}}
-    @OneToMany(() => {{relClassName}}, ({{relCamelName}}: {{relClassName}}) => {{relCamelName}}.{{relFieldName}})
-    {{camelNamePlural}}?: {{relClassName}}[];  
+    @OneToMany(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
+    {{camelName}}?: {{relation.columnType}}[];  
   {{/is.otm}}
 
   {{#is.mto}}
-    @ManyToOne(() => {{relClassName}}, ({{relCamelName}}: {{relClassName}}) => {{relCamelName}}.{{relFieldNamePlural}}, { 
+    @ManyToOne(() => {{relation.columnType}}, {{#relation.relatedTsProp}}(param: {{relation.columnType}}) => param.{{relation.relatedTsProp}},{{/relation.relatedTsProp}} { 
       skipGraphQLField: true{{^required}},
       nullable: true{{/required}} 
     })
-    {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relClassName}};
+    {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relation.columnType}};
   {{/is.mto}}
 
   {{#is.oto}}
-    @OneToOne(() => {{relClassName}})
-    {{#is.relation.joinColumn}}@JoinColumn(){{/is.relation.joinColumn}}
-    {{camelName}}?: {{relClassName}};
+    @OneToOne(() => {{relation.columnType}})
+    {{#relation.joinColumn}}@JoinColumn(){{/relation.joinColumn}}
+    {{camelName}}?: {{relation.columnType}};
   {{/is.oto}}
 
+  {{#is.mtm}}
+    @ManyToMany(() => {{relation.columnType}}, (param: {{relation.columnType}}) => param.{{relation.relatedTsProp}})
+    {{#relation.joinTable}}@JoinTable(){{/relation.joinTable}}
+    {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{relation.columnType}}[];
+  {{/is.mtm}}
+  
   {{#is.array}}
     @CustomField({
       db: { type: '{{dbType}}', array: true,{{^required}}nullable: true,{{/required}} {{#unique}}unique: true,{{/unique}}}, 

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -20,11 +20,9 @@ import {
 import { InterfaceType } from 'type-graphql';
 {{/isInterface}}
 
-{{#fields}}
-  {{#is.refType}}
-  import { {{relClassName}} } from '{{{relPathForModel}}}'
-  {{/is.refType}}
-{{/fields}}
+{{#relatedEntityImports}} {{! import related entities }}
+  {{{ relatedEntityImports }}}
+{{/relatedEntityImports}}
 
 {{#enums}}
   import { {{name}} } from '../enums/enums';
@@ -62,7 +60,7 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
 
   {{#is.oto}}
     @OneToOne(() => {{relClassName}})
-    @JoinColumn()
+    {{#is.relation.joinColumn}}@JoinColumn(){{/is.relation.joinColumn}}
     {{camelName}}?: {{relClassName}};
   {{/is.oto}}
 

--- a/query-node/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
@@ -1,4 +1,4 @@
-import { Arg, Args, Mutation, Query, Resolver } from 'type-graphql';
+import { Arg, Args, Mutation, Query, Resolver, Root, FieldResolver} from 'type-graphql';
 import { Inject } from 'typedi';
 import { Fields, StandardDeleteResponse, UserId } from 'warthog';
 
@@ -14,6 +14,10 @@ import {
 import { {{className}} } from './{{kebabName}}.model';
 import { {{className}}Service } from './{{kebabName}}.service';
 
+{{#fieldResolverImports}}
+  {{{.}}}
+{{/fieldResolverImports}}
+
 @Resolver()
 export class {{className}}Resolver {
   constructor(@Inject('{{className}}Service') public readonly service: {{className}}Service) {}
@@ -26,4 +30,14 @@ export class {{className}}Resolver {
     return this.service.find<{{className}}WhereInput>(where, orderBy, limit, offset, fields);
   }
 
+  {{#fieldResolvers}}
+    @FieldResolver(() => {{returnTypeFunc}})
+    async {{fieldName}}(@Root() {{rootArgName}}: {{rootArgType}}): {{{returnType}}} {
+      const result = await getConnection().getRepository({{rootArgType}}).findOne({{rootArgName}}.id, { relations: ['{{fieldName}}'] })
+      if (!result || !result.{{fieldName}}) {
+        throw new Error('Unable to find result for {{rootArgType}}.{{fieldName}}');
+      }
+      return result.{{fieldName}};
+    }
+  {{/fieldResolvers}}
 }

--- a/query-node/substrate-query-framework/cli/src/templates/graphql-server.index.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/graphql-server.index.mst
@@ -15,9 +15,6 @@ class CustomNamingStrategy extends SnakeNamingStrategy {
   tableName(className: string, customName?: string): string {
     return customName ? customName : `${snakeCase(className)}`;
   }
-  columnName(propertyName: string, customName?: string, embeddedPrefixes?: string[]): string {
-    return propertyName;
-  }
 }
 
 async function bootstrap() {

--- a/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
@@ -12,7 +12,8 @@ import {
   BootstrapPack,
   BootstrapFunc,
   DatabaseManager,
-  SubstrateEvent
+  SubstrateEvent,
+  createDBConnection,
 } from "index-builder/lib";
 
 // Mappings use!
@@ -125,7 +126,8 @@ async function main() {
   
   // Required for warthog models.
   dotenv.config({ path: '../graphql-server/.env' });
-  await createConnection();
+
+  await createDBConnection();
 
   const node = new QueryNodeManager(process);
 

--- a/query-node/substrate-query-framework/index-builder/src/db/SnakeNamingStrategy.ts
+++ b/query-node/substrate-query-framework/index-builder/src/db/SnakeNamingStrategy.ts
@@ -1,0 +1,42 @@
+/**
+ * This file is from warthog, in order to not have naming conflict with warthog
+ * it is used by typeorm as naming strategy
+ * warthog/src/torm/SnakeNamingStrategy.ts
+ */
+
+import { DefaultNamingStrategy, NamingStrategyInterface } from 'typeorm';
+import { snakeCase } from 'typeorm/util/StringUtils';
+
+export class SnakeNamingStrategy extends DefaultNamingStrategy implements NamingStrategyInterface {
+  constructor() {
+    super();
+  }
+
+  tableName(className: string, customName?: string): string {
+    return customName ? customName : `${snakeCase(className)}`; // `${snakeCase(className)}s`;
+  }
+
+  columnName(propertyName: string, customName?: string, embeddedPrefixes: string[] = []): string {
+    return snakeCase(embeddedPrefixes.join('_')) + (customName ? customName : snakeCase(propertyName));
+  }
+
+  relationName(propertyName: string): string {
+    return snakeCase(propertyName);
+  }
+
+  joinColumnName(relationName: string, referencedColumnName: string): string {
+    return snakeCase(`${relationName}_${referencedColumnName}`);
+  }
+
+  joinTableName(firstTableName: string, secondTableName: string): string {
+    return snakeCase(`${firstTableName}_${secondTableName}`);
+  }
+
+  joinTableColumnName(tableName: string, propertyName: string, columnName?: string): string {
+    return snakeCase(`${tableName}_${columnName ? columnName : propertyName}`);
+  }
+
+  classTableInheritanceParentColumnName(parentTableName: any, parentTableIdPropertyName: any): string {
+    return snakeCase(`${parentTableName}_${parentTableIdPropertyName}`);
+  }
+}

--- a/query-node/substrate-query-framework/index-builder/src/db/helper.ts
+++ b/query-node/substrate-query-framework/index-builder/src/db/helper.ts
@@ -1,5 +1,7 @@
 import * as shortid from 'shortid';
-import { DeepPartial } from 'typeorm';
+import { DeepPartial, createConnection, Connection, getConnectionOptions } from 'typeorm';
+
+import { SnakeNamingStrategy } from './SnakeNamingStrategy';
 /**
  * Fixes compatibility between typeorm and warthog models.
  *
@@ -19,4 +21,9 @@ export function fillRequiredWarthogFields<T>(entity: DeepPartial<T>): DeepPartia
     version: 1,
   };
   return Object.assign(entity, requiredFields);
+}
+
+export async function createDBConnection(): Promise<Connection> {
+  const connectionOptions = await getConnectionOptions();
+  return createConnection(Object.assign(connectionOptions, { namingStrategy: new SnakeNamingStrategy() }));
 }

--- a/query-node/substrate-query-framework/index-builder/src/db/index.ts
+++ b/query-node/substrate-query-framework/index-builder/src/db/index.ts
@@ -1,4 +1,5 @@
 import { SavedEntityEvent } from './entities';
 import DatabaseManager, { makeDatabaseManager } from './DatabaseManager';
+import { createDBConnection } from './helper';
 
-export { DatabaseManager, makeDatabaseManager, SavedEntityEvent };
+export { DatabaseManager, makeDatabaseManager, SavedEntityEvent, createDBConnection };

--- a/query-node/substrate-query-framework/index-builder/src/index.ts
+++ b/query-node/substrate-query-framework/index-builder/src/index.ts
@@ -6,7 +6,7 @@ import QueryEventBlock from './QueryEventBlock';
 import IndexBuilder from './IndexBuilder';
 import QueryNode, { QueryNodeState } from './QueryNode';
 import QueryNodeManager from './QueryNodeManager';
-import { DatabaseManager, SavedEntityEvent, makeDatabaseManager } from './db';
+import { DatabaseManager, SavedEntityEvent, makeDatabaseManager, createDBConnection } from './db';
 import BootstrapPack, { BootstrapFunc } from './bootstrap/BootstrapPack';
 
 export {
@@ -26,4 +26,5 @@ export {
   SavedEntityEvent,
   BootstrapPack,
   BootstrapFunc,
+  createDBConnection,
 };


### PR DESCRIPTION
This PR introduces support for field resolvers. Field resolvers make it possible to query relational data from the database.
It is built upon https://github.com/Joystream/joystream/pull/876

- Field resolvers do not accept arguments

Example: 

```graphql
type User @entity {
  name: String
  posts: [Post] @derivedFrom(field: "author")
}

type Post @entity {
  title: String
  author: User
}
```

Query all users along with their posts:

```graphql
query {
  users {
    posts {
      id
      title
    }  
  }
}
```

Query one post and get author info:
```graphql
query {
  post(where: {id: "123"}) {
    title
    author {
      name
    } 
  }
}
```
