### PR TITLE
Runtime DataObject migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
  "ctrlc",
  "derive_more 0.14.1",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "6.18.0"
+version = "6.19.0"
 dependencies = [
  "parity-scale-codec",
  "safe-mix",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '2.4.1'
+version = '2.5.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/runtime-modules/storage/src/data_directory.rs
+++ b/runtime-modules/storage/src/data_directory.rs
@@ -300,7 +300,7 @@ decl_module! {
         /// The number of objects that can be added per call is limited to prevent the dispatch
         /// from causing the block production to fail if it takes too much time to process.
         /// Existing data objects will be overwritten.
-        fn inject_data_objects(origin, objects: DataObjectsMap<T>) {
+        pub(crate) fn inject_data_objects(origin, objects: DataObjectsMap<T>) {
             ensure_root(origin)?;
 
             // limit size - do some benchmarking to test how much we can allow per call.

--- a/runtime-modules/storage/src/data_directory.rs
+++ b/runtime-modules/storage/src/data_directory.rs
@@ -278,15 +278,6 @@ decl_module! {
                 .collect();
             <KnownContentIds<T>>::put(upd_content_ids);
         }
-
-        /// Sets the content id from the list of known content ids. Requires root privileges.
-        fn set_known_content_id(origin, content_ids: Vec<T::ContentId>) {
-            ensure_root(origin)?;
-
-            // == MUTATION SAFE ==
-
-            <KnownContentIds<T>>::put(content_ids);
-        }
     }
 }
 

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -89,6 +89,7 @@ parameter_types! {
     pub const MaximumBlockLength: u32 = 2 * 1024;
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
+    pub const MaxObjectsPerInjection: u32 = 5;
 }
 
 impl system::Trait for Test {
@@ -166,6 +167,7 @@ impl data_directory::Trait for Test {
     type StorageProviderHelper = ();
     type IsActiveDataObjectType = AnyDataObjectTypeIsActive;
     type MemberOriginValidator = ();
+    type MaxObjectsPerInjection = MaxObjectsPerInjection;
 }
 
 impl crate::data_directory::StorageProviderHelper<Test> for () {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -63,7 +63,7 @@ impl ContentIdExists<Test> for MockContent {
         which: &<Test as data_directory::Trait>::ContentId,
     ) -> Result<data_directory::DataObject<Test>, &'static str> {
         match *which {
-            TEST_MOCK_EXISTING_CID => Ok(data_directory::DataObject {
+            TEST_MOCK_EXISTING_CID => Ok(data_directory::DataObjectInternal {
                 type_id: 1,
                 size: 1234,
                 added_at: data_directory::BlockAndTime {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '6.18.0'
+version = '6.19.0'
 
 [features]
 default = ['std']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -161,7 +161,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 6,
-    spec_version: 18,
+    spec_version: 19,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
 };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -560,6 +560,10 @@ impl memo::Trait for Runtime {
     type Event = Event;
 }
 
+parameter_types! {
+    pub const MaxObjectsPerInjection: u32 = 100;
+}
+
 impl storage::data_object_type_registry::Trait for Runtime {
     type Event = Event;
     type DataObjectTypeId = u64;
@@ -571,6 +575,7 @@ impl storage::data_directory::Trait for Runtime {
     type StorageProviderHelper = integration::storage::StorageProviderHelper;
     type IsActiveDataObjectType = DataObjectTypeRegistry;
     type MemberOriginValidator = MembershipOriginValidator<Self>;
+    type MaxObjectsPerInjection = MaxObjectsPerInjection;
 }
 
 impl storage::data_object_storage_registry::Trait for Runtime {

--- a/runtime/src/migration.rs
+++ b/runtime/src/migration.rs
@@ -3,7 +3,10 @@
 
 use crate::VERSION;
 use rstd::prelude::*;
-use sr_primitives::{print, traits::Zero};
+use sr_primitives::{
+    print,
+    traits::{One, Zero},
+};
 use srml_support::{debug, decl_event, decl_module, decl_storage};
 
 impl<T: Trait> Module<T> {
@@ -21,8 +24,7 @@ impl<T: Trait> Module<T> {
 
         Self::initialize_storage_working_group_mint();
         Self::initialize_storage_working_group_text_constraints();
-        // temporary comment storage migration
-        //        Self::clear_storage_data();
+        Self::clear_storage_data();
     }
 }
 
@@ -98,28 +100,28 @@ impl<T: Trait> Module<T> {
         );
     }
 
-    // fn clear_storage_data() {
-    //     // Clear storage data object registry data.
-    //     for id in <storage::data_directory::Module<T>>::known_content_ids() {
-    //         <storage::data_object_storage_registry::RelationshipsByContentId<T>>::remove(id);
-    //     }
-    //
-    //     let mut potential_id = <T as storage::data_object_storage_registry::Trait>::DataObjectStorageRelationshipId::zero();
-    //     while potential_id
-    //         < storage::data_object_storage_registry::Module::<T>::next_relationship_id()
-    //     {
-    //         <storage::data_object_storage_registry::Relationships<T>>::remove(&potential_id);
-    //
-    //         potential_id += <T as storage::data_object_storage_registry::Trait>::DataObjectStorageRelationshipId::one();
-    //     }
-    //
-    //     storage::data_object_storage_registry::NextRelationshipId::<T>::kill();
-    //
-    //     // Clear storage data directory data.
-    //     for id in <storage::data_directory::Module<T>>::known_content_ids() {
-    //         <storage::data_directory::DataObjectByContentId<T>>::remove(id);
-    //     }
-    //
-    //     <storage::data_directory::KnownContentIds<T>>::kill();
-    // }
+    fn clear_storage_data() {
+        // Clear storage data object registry data.
+        for id in <storage::data_directory::Module<T>>::known_content_ids() {
+            <storage::data_object_storage_registry::RelationshipsByContentId<T>>::remove(id);
+        }
+
+        let mut potential_id = <T as storage::data_object_storage_registry::Trait>::DataObjectStorageRelationshipId::zero();
+        while potential_id
+            < storage::data_object_storage_registry::Module::<T>::next_relationship_id()
+        {
+            <storage::data_object_storage_registry::Relationships<T>>::remove(&potential_id);
+
+            potential_id += <T as storage::data_object_storage_registry::Trait>::DataObjectStorageRelationshipId::one();
+        }
+
+        storage::data_object_storage_registry::NextRelationshipId::<T>::kill();
+
+        // Clear storage data directory data.
+        for id in <storage::data_directory::Module<T>>::known_content_ids() {
+            <storage::data_directory::DataObjectByContentId<T>>::remove(id);
+        }
+
+        <storage::data_directory::KnownContentIds<T>>::kill();
+    }
 }

--- a/types/src/media.ts
+++ b/types/src/media.ts
@@ -1,4 +1,4 @@
-import { Enum, Struct, Option, Vec as Vector, H256 } from '@polkadot/types';
+import { Enum, Struct, Option, Vec as Vector, H256, BTreeMap } from '@polkadot/types';
 import { getTypeRegistry, u64, bool, Text } from '@polkadot/types';
 import { BlockAndTime } from './common';
 import { MemberId } from './members';
@@ -127,11 +127,11 @@ export class DataObjectType extends Struct {
   }
 }
 
+export class DataObjectsMap extends BTreeMap.with(ContentId, DataObject) {}
+
 export function registerMediaTypes () {
   try {
     getTypeRegistry().register({
-      '::ContentId': ContentId,
-      '::DataObjectTypeId': DataObjectTypeId,
       ContentId,
       LiaisonJudgement,
       DataObject,
@@ -139,6 +139,7 @@ export function registerMediaTypes () {
       DataObjectStorageRelationship,
       DataObjectTypeId,
       DataObjectType,
+      DataObjectsMap
     });
   } catch (err) {
     console.error('Failed to register custom types of media module', err);


### PR DESCRIPTION
- Re-enabled the clearing of data_directory at runtime upgrade
- Added a new `inject_data_objects(origin, BTreeMap<T::ContentId, DataObject<T>>)` root dispatchable method the directory
- Unit tests for 
- Had to refactor `struct DataObject` because after introducing `BTreeMap<T::ContentId, DataObject<T>>` type into the runtime public API, compiler complained that type `T::Trait` didn't implement the `Debug` trait.
- Updates @joystream/types with necessary new type `DataObjectsMap`, (removed some old stale registrations)

You can do a simple test of injection on a fresh develoment storage setup using the pioneer js toolbox http://localhost:3000/#/js

Paste this code snippet and run it:

```javascript
  const id = types.createType('ContentId', 'TEST')
  console.log(id)

  const object = types.createType('DataObject', {
    'owner': 200,
    'added_at': {'block': 100, 'time': 5000},
    'type_id': 1,
    'size': 40,
    'liaison': 0,
    'liaison_judgement': 'Accepted',
    // https://testnet.joystream.org/#/media/videos/925
    'ipfs_content_id': 'QmNw2pRA32PGTxVeq7ktaM9ttUHkj5P3is3QLqamLCJ7Bk'
  })

  const objects = types.createType('DataObjectsMap')

  objects.set(id, object)

  const injectTx = api.tx.dataDirectory.injectDataObjects(objects)
  // injectDataObjects requires root origin, so send as proposal on sudo module
  // fetch the required sudo account.
  const sudo = await api.query.sudo.key()

  // if the key is not in the keyring it will not work
  api.tx.sudo.sudo(injectTx).signAndSend(sudo)
```

You can then inspect the chain state to verify the object id `0x5445535400000000000000000000000000000000000000000000000000000000` 

exists.
If you check the log of the storage node, you should see it on the next sync run pinning the item:

```
  ipfs-http-client:request POST localhost:5001/api/v0/files/stat?with-local=true&arg=%2Fipfs%2FQmNw2pRA32PGTxVeq7ktaM9ttUHkj5P3is3QLqamLCJ7Bk&stream-channels=true 200 OK +3s
  joystream:storage:storage Pinning QmNw2pRA32PGTxVeq7ktaM9ttUHkj5P3is3QLqamLCJ7Bk +3s
  joystream:sync sync run complete +3s
```

The file is large so it may take some time to download :)

I will prepare the export (from constantinople testnet) / import scripts in a separate PR