### PR TITLE
Pioneer javascript playground inject joy types

### DIFF
--- a/pioneer/packages/app-js/src/Playground.tsx
+++ b/pioneer/packages/app-js/src/Playground.tsx
@@ -41,8 +41,8 @@ interface Injected {
   util: typeof util;
   window: null;
   joy: {
-    types: typeof joy_types
-  }
+    types: typeof joy_types;
+  };
 }
 
 interface Props extends AppProps, I18nProps, RouteComponentProps<{}> {

--- a/pioneer/packages/app-js/src/Playground.tsx
+++ b/pioneer/packages/app-js/src/Playground.tsx
@@ -18,6 +18,7 @@ import uiKeyring from '@polkadot/ui-keyring';
 import * as types from '@polkadot/types';
 import * as util from '@polkadot/util';
 import * as hashing from '@polkadot/util-crypto';
+import * as joy_types from '@joystream/types';
 
 import makeWrapper from './snippets/wrapping';
 import allSnippets from './snippets';
@@ -39,6 +40,10 @@ interface Injected {
   types: typeof types;
   util: typeof util;
   window: null;
+  joy: {
+    types: typeof joy_types,
+  },
+  decodeAddress: typeof uiKeyring.keyring.decodeAddress
 }
 
 interface Props extends AppProps, I18nProps, RouteComponentProps<{}> {
@@ -195,7 +200,11 @@ function Playground ({ className, history, match: { params: { base64 } }, t }: P
         : null,
       types,
       util,
-      window: null
+      window: null,
+      joy: {
+        types: joy_types
+      },
+      decodeAddress: uiKeyring.keyring.decodeAddress
     };
 
     await injectedRef.current.api.isReady;

--- a/pioneer/packages/app-js/src/Playground.tsx
+++ b/pioneer/packages/app-js/src/Playground.tsx
@@ -41,9 +41,8 @@ interface Injected {
   util: typeof util;
   window: null;
   joy: {
-    types: typeof joy_types,
-  },
-  decodeAddress: typeof uiKeyring.keyring.decodeAddress
+    types: typeof joy_types
+  }
 }
 
 interface Props extends AppProps, I18nProps, RouteComponentProps<{}> {
@@ -203,8 +202,7 @@ function Playground ({ className, history, match: { params: { base64 } }, t }: P
       window: null,
       joy: {
         types: joy_types
-      },
-      decodeAddress: uiKeyring.keyring.decodeAddress
+      }
     };
 
     await injectedRef.current.api.isReady;

--- a/pioneer/packages/joy-election/src/Applicant.tsx
+++ b/pioneer/packages/joy-election/src/Applicant.tsx
@@ -11,12 +11,12 @@ import CandidatePreview from './CandidatePreview';
 
 import translate from './translate';
 import { calcTotalStake } from '@polkadot/joy-utils/index';
-import { Stake } from '@joystream/types/council';
+import { ElectionStake } from '@joystream/types/council';
 
 type Props = ApiProps & I18nProps & {
   index: number;
   accountId: AccountId;
-  stake?: Stake;
+  stake?: ElectionStake;
 };
 
 class Applicant extends React.PureComponent<Props> {

--- a/pioneer/packages/joy-election/src/ApplyForm.tsx
+++ b/pioneer/packages/joy-election/src/ApplyForm.tsx
@@ -10,13 +10,13 @@ import { Balance } from '@polkadot/types/interfaces';
 import translate from './translate';
 import TxButton from '@polkadot/joy-utils/TxButton';
 import InputStake from '@polkadot/joy-utils/InputStake';
-import { Stake } from '@joystream/types/council';
+import { ElectionStake } from '@joystream/types/council';
 import { calcTotalStake, ZERO } from '@polkadot/joy-utils/index';
 import { MyAddressProps, withOnlyMembers } from '@polkadot/joy-utils/MyAccount';
 
 type Props = ApiProps & I18nProps & MyAddressProps & {
   minStake?: Balance;
-  alreadyStaked?: Stake;
+  alreadyStaked?: ElectionStake;
   myBalance?: Balance;
 };
 

--- a/pioneer/packages/joy-utils/src/index.ts
+++ b/pioneer/packages/joy-utils/src/index.ts
@@ -7,7 +7,7 @@ import keyring from '@polkadot/ui-keyring';
 // Joystream Stake utils
 // --------------------------------------
 
-import { Stake, Backer } from '@joystream/types/council';
+import { ElectionStake, Backer } from '@joystream/types/council';
 
 // Substrate/Polkadot API utils
 // --------------------------------------
@@ -117,11 +117,11 @@ export function newOptionalText (str?: string): OptionalText {
   return new Option(Text, text);
 }
 
-export function calcTotalStake (stakes: Stake | Stake[] | undefined): BN {
+export function calcTotalStake (stakes: ElectionStake | ElectionStake[] | undefined): BN {
   if (typeof stakes === 'undefined') {
     return ZERO;
   }
-  const total = (stake: Stake) => stake.new.add(stake.transferred);
+  const total = (stake: ElectionStake) => stake.new.add(stake.transferred);
   try {
     if (Array.isArray(stakes)) {
       return stakes.reduce((accum, stake) => {

--- a/types/src/council/index.ts
+++ b/types/src/council/index.ts
@@ -9,7 +9,7 @@ export type TransferableStake = {
     backing: Balance;
 };
 
-export type Stake = {
+export type ElectionStake = {
     new: Balance;
     transferred: Balance;
 };
@@ -65,7 +65,7 @@ export class Seats extends Vec.with(Seat) {}
 export type SealedVote = {
     voter: AccountId;
     commitment: Hash;
-    stake: Stake;
+    stake: ElectionStake;
     vote: Option<AccountId>;
 };
 

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -18,6 +18,23 @@ import { registerDiscoveryTypes } from "./discovery";
 import { registerMediaTypes } from "./media";
 import { registerProposalTypes } from "./proposals";
 
+export * from "./common";
+export * from "./members";
+export * from "./council";
+export * from "./roles";
+export * from "./forum";
+export * from "./stake";
+export * from "./mint";
+export * from "./recurring-rewards";
+// export * from "./hiring"; // name clashes with working-group
+export * from "./versioned-store";
+export * from "./versioned-store/permissions";
+// export * from "./content-working-group"; // clashes with content-working-group
+export * from "./working-group";
+export * from "./discovery";
+export * from "./media";
+export * from "./proposals";
+
 export function registerJoystreamTypes() {
   const typeRegistry = getTypeRegistry();
 

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -1,39 +1,41 @@
 
 import { getTypeRegistry } from "@polkadot/types";
 
-import { registerCommonTypes } from "./common";
-import { registerMembershipTypes } from "./members";
-import { registerCouncilAndElectionTypes } from "./council";
-import { registerRolesTypes } from "./roles";
-import { registerForumTypes } from "./forum";
-import { registerStakeTypes } from "./stake";
-import { registerMintTypes } from "./mint";
-import { registerRecurringRewardsTypes } from "./recurring-rewards";
-import { registerHiringTypes } from "./hiring";
-import { registerVersionedStoreTypes } from "./versioned-store";
-import { registerVersionedStorePermissionsTypes } from "./versioned-store/permissions";
-import { registerContentWorkingGroupTypes } from "./content-working-group";
-import { registerWorkingGroupTypes } from "./working-group";
-import { registerDiscoveryTypes } from "./discovery";
-import { registerMediaTypes } from "./media";
-import { registerProposalTypes } from "./proposals";
+import * as common from "./common";
+import * as members from "./members";
+import * as council from "./council";
+import * as roles from "./roles";
+import * as forum from "./forum";
+import * as stake from "./stake";
+import * as mint from "./mint";
+import * as recurringRewards from "./recurring-rewards";
+import * as hiring from "./hiring";
+import * as versionedStore from "./versioned-store";
+import * as versionedStorePermissions from "./versioned-store/permissions";
+import * as contentWorkingGroup from "./content-working-group";
+import * as workingGroup from "./working-group";
+import * as discovery from "./discovery";
+import * as media from "./media";
+import * as proposals from "./proposals";
 
-export * from "./common";
-export * from "./members";
-export * from "./council";
-export * from "./roles";
-export * from "./forum";
-export * from "./stake";
-export * from "./mint";
-export * from "./recurring-rewards";
-// export * from "./hiring"; // name clashes with working-group
-export * from "./versioned-store";
-export * from "./versioned-store/permissions";
-// export * from "./content-working-group"; // clashes with content-working-group
-export * from "./working-group";
-export * from "./discovery";
-export * from "./media";
-export * from "./proposals";
+export {
+  common,
+  members,
+  council,
+  roles,
+  forum,
+  stake,
+  mint,
+  recurringRewards,
+  hiring,
+  versionedStore,
+  versionedStorePermissions,
+  contentWorkingGroup,
+  workingGroup,
+  discovery,
+  media,
+  proposals
+};
 
 export function registerJoystreamTypes() {
   const typeRegistry = getTypeRegistry();
@@ -42,20 +44,20 @@ export function registerJoystreamTypes() {
     MemoText: "Text", // for the memo module
   });
 
-  registerCommonTypes();
-  registerMembershipTypes();
-  registerCouncilAndElectionTypes();
-  registerRolesTypes();
-  registerForumTypes();
-  registerStakeTypes();
-  registerMintTypes();
-  registerRecurringRewardsTypes();
-  registerHiringTypes();
-  registerVersionedStoreTypes();
-  registerVersionedStorePermissionsTypes();
-  registerContentWorkingGroupTypes();
-  registerWorkingGroupTypes();
-  registerDiscoveryTypes();
-  registerMediaTypes();
-  registerProposalTypes();
+  common.registerCommonTypes();
+  members.registerMembershipTypes();
+  council.registerCouncilAndElectionTypes();
+  roles.registerRolesTypes();
+  forum.registerForumTypes();
+  stake.registerStakeTypes();
+  mint.registerMintTypes();
+  recurringRewards.registerRecurringRewardsTypes();
+  hiring.registerHiringTypes();
+  versionedStore.registerVersionedStoreTypes();
+  versionedStorePermissions.registerVersionedStorePermissionsTypes();
+  contentWorkingGroup.registerContentWorkingGroupTypes();
+  workingGroup.registerWorkingGroupTypes();
+  discovery.registerDiscoveryTypes();
+  media.registerMediaTypes();
+  proposals.registerProposalTypes();
 }


### PR DESCRIPTION
I'm finding the javascript toolbox quite useful for prototyping qurey and even tx submission code.

For examples: https://github.com/Joystream/joystream/pull/877#issuecomment-653601853

The sandbox allows us to create custom types through `types.createType(...)` but we only get instances and cannot access the core types to take advantage any helper static methods.

With this PR I added can access them on `joy.types`

so you can generate a content id for example like so:

```js
const new_id = joy.types.ContentId.generate()
```

Ttried to expose all the types but due to some name clashes  types from hiring and content-working-group are not exposed.
Renamed exported Stake type to ElectionStake from council types.
