### PR TITLE
Forum category depth

### DIFF
--- a/node/src/forum_config/from_serialized.rs
+++ b/node/src/forum_config/from_serialized.rs
@@ -41,7 +41,6 @@ pub fn create() -> ForumConfig {
         next_post_id,
 
         // TODO: get rid of mocks and setup valid values
-        max_category_depth: 10,
         category_by_moderator: Vec::new(),
         reaction_by_post: Vec::new(),
         poll_desc_constraint: new_validation(10, 90),

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -216,7 +216,9 @@ use codec::{Codec, Decode, Encode};
 use rstd::prelude::*;
 pub use runtime_io::clear_prefix;
 use runtime_primitives::traits::{MaybeSerialize, Member, One, SimpleArithmetic};
-use srml_support::{decl_event, decl_module, decl_storage, dispatch, ensure, Parameter};
+use srml_support::{
+    decl_event, decl_module, decl_storage, dispatch, ensure, traits::Get, Parameter,
+};
 
 mod mock;
 mod tests;
@@ -274,16 +276,7 @@ pub trait Trait: system::Trait + timestamp::Trait + Sized {
         + From<u64>
         + Into<u64>;
 
-    type MaxCategoryDepth: Parameter
-        + Member
-        + SimpleArithmetic
-        + Codec
-        + Default
-        + Copy
-        + MaybeSerialize
-        + PartialEq
-        + From<u64>
-        + Into<u64>;
+    type MaxCategoryDepth: Get<u64>;
 
     fn is_lead(account_id: &<Self as system::Trait>::AccountId) -> bool;
     fn is_forum_member(
@@ -293,7 +286,6 @@ pub trait Trait: system::Trait + timestamp::Trait + Sized {
     fn is_moderator(account_id: &Self::AccountId, moderator_id: &Self::ModeratorId) -> bool;
 
     fn calculate_hash(text: &[u8]) -> Self::Hash;
-    fn get_max_category_depth() -> Self::MaxCategoryDepth;
 }
 
 /*
@@ -1233,7 +1225,7 @@ impl<T: Trait> Module<T> {
         let category_tree_path =
             Self::ensure_valid_category_and_build_category_tree_path(parent_category_id)?;
 
-        let max_category_depth: u64 = T::get_max_category_depth().into();
+        let max_category_depth: u64 = T::MaxCategoryDepth::get();
 
         // Check if max depth reached
         if category_tree_path.len() as u64 >= max_category_depth {

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -70,6 +70,7 @@ impl Trait for Runtime {
     type CategoryId = u64;
     type ThreadId = u64;
     type PostId = u64;
+    type MaxCategoryDepth = u64;
 
     fn is_lead(account_id: &<Self as system::Trait>::AccountId) -> bool {
         *account_id == FORUM_LEAD_ORIGIN_ID
@@ -94,6 +95,10 @@ impl Trait for Runtime {
 
     fn calculate_hash(text: &[u8]) -> Self::Hash {
         Self::Hashing::hash(text)
+    }
+
+    fn get_max_category_depth() -> Self::MaxCategoryDepth {
+        5
     }
 }
 
@@ -336,26 +341,6 @@ pub fn change_current_time(diff: u64) -> () {
     Timestamp::set_timestamp(Timestamp::now() + diff);
 }
 
-pub fn set_max_category_depth_mock(
-    origin: OriginType,
-    max_category_depth: u8,
-    result: Result<(), &'static str>,
-) -> u8 {
-    assert_eq!(
-        TestForumModule::set_max_category_depth(mock_origin(origin), max_category_depth),
-        result
-    );
-    if result.is_ok() {
-        assert_eq!(TestForumModule::max_category_depth(), max_category_depth);
-        assert_eq!(
-            System::events().last().unwrap().event,
-            TestEvent::forum_mod(RawEvent::MaxCategoryDepthUpdated(max_category_depth,))
-        );
-    };
-
-    max_category_depth
-}
-
 pub fn update_category_membership_of_moderator_mock(
     origin: OriginType,
     moderator_id: <Runtime as Trait>::ModeratorId,
@@ -522,7 +507,6 @@ pub fn create_genesis_config(data_migration_done: bool) -> GenesisConfig<Runtime
         next_post_id: 1,
 
         category_by_moderator: vec![],
-        max_category_depth: 5,
         reaction_by_post: vec![],
 
         poll_desc_constraint: InputValidationLengthConstraint {

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -11,7 +11,7 @@ use runtime_primitives::{
     traits::{BlakeTwo256, Hash, IdentityLookup},
     Perbill,
 };
-use srml_support::{impl_outer_event, impl_outer_origin, parameter_types};
+use srml_support::{impl_outer_event, impl_outer_origin, parameter_types, traits::Get};
 
 impl_outer_origin! {
     pub enum Origin for Runtime {}
@@ -63,6 +63,10 @@ impl timestamp::Trait for Runtime {
     type MinimumPeriod = MinimumPeriod;
 }
 
+parameter_types! {
+    pub const MaxCategoryDepth: u64 = 20;
+}
+
 impl Trait for Runtime {
     type Event = TestEvent;
     type ForumUserId = u64;
@@ -70,7 +74,7 @@ impl Trait for Runtime {
     type CategoryId = u64;
     type ThreadId = u64;
     type PostId = u64;
-    type MaxCategoryDepth = u64;
+    type MaxCategoryDepth = MaxCategoryDepth;
 
     fn is_lead(account_id: &<Self as system::Trait>::AccountId) -> bool {
         *account_id == FORUM_LEAD_ORIGIN_ID
@@ -95,10 +99,6 @@ impl Trait for Runtime {
 
     fn calculate_hash(text: &[u8]) -> Self::Hash {
         Self::Hashing::hash(text)
-    }
-
-    fn get_max_category_depth() -> Self::MaxCategoryDepth {
-        5
     }
 }
 

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -11,7 +11,7 @@ use runtime_primitives::{
     traits::{BlakeTwo256, Hash, IdentityLookup},
     Perbill,
 };
-use srml_support::{impl_outer_event, impl_outer_origin, parameter_types, traits::Get};
+use srml_support::{impl_outer_event, impl_outer_origin, parameter_types};
 
 impl_outer_origin! {
     pub enum Origin for Runtime {}

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -183,7 +183,7 @@ fn create_category_depth() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        let max_depth = <Runtime as Trait>::get_max_category_depth();
+        let max_depth = <Runtime as Trait>::MaxCategoryDepth::get();
         for i in 0..(max_depth + 1) {
             let parent_category_id = match i {
                 0 => None,

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -184,7 +184,6 @@ fn create_category_depth() {
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
         let max_depth = <Runtime as Trait>::get_max_category_depth();
-        println!("{:?}", max_depth);
         for i in 0..(max_depth + 1) {
             let parent_category_id = match i {
                 0 => None,
@@ -195,11 +194,7 @@ fn create_category_depth() {
                 _ => Ok(()),
             };
 
-            if let Some(tmp_parent_category_id) = parent_category_id {
-                let tree_path = TestForumModule::build_category_tree_path(&tmp_parent_category_id);
-            }
-
-            let tmp = create_category_mock(
+            create_category_mock(
                 origin.clone(),
                 parent_category_id,
                 good_category_title(),

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -7,20 +7,6 @@ use crate::mock::*;
 /// second layer is each parameter of the specific method.
 
 /*
- * set_max_category_depth
- */
-#[test]
-// test set max category depth works
-fn set_max_category_depth() {
-    let config = default_genesis_config();
-    let origin = FORUM_LEAD_ORIGIN;
-    build_test_externalities(config).execute_with(|| {
-        set_max_category_depth_mock(NOT_FORUM_LEAD_ORIGIN, 1, Err(ERROR_ORIGIN_NOT_FORUM_LEAD));
-        set_max_category_depth_mock(origin, 1, Ok(()));
-    });
-}
-
-/*
  * update_category_membership_of_moderator_origin
  */
 #[test]
@@ -197,41 +183,30 @@ fn create_category_depth() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     build_test_externalities(config).execute_with(|| {
-        create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
-        create_category_mock(
-            origin.clone(),
-            Some(1),
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
-        create_category_mock(
-            origin.clone(),
-            Some(2),
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
-        create_category_mock(
-            origin.clone(),
-            Some(3),
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
-        create_category_mock(
-            origin.clone(),
-            Some(4),
-            good_category_title(),
-            good_category_description(),
-            Err(ERROR_MAX_VALID_CATEGORY_DEPTH_EXCEEDED),
-        );
+        let max_depth = <Runtime as Trait>::get_max_category_depth();
+        println!("{:?}", max_depth);
+        for i in 0..(max_depth + 1) {
+            let parent_category_id = match i {
+                0 => None,
+                _ => Some(i),
+            };
+            let expected_result = match i {
+                _ if i >= max_depth => Err(ERROR_MAX_VALID_CATEGORY_DEPTH_EXCEEDED),
+                _ => Ok(()),
+            };
+
+            if let Some(tmp_parent_category_id) = parent_category_id {
+                let tree_path = TestForumModule::build_category_tree_path(&tmp_parent_category_id);
+            }
+
+            let tmp = create_category_mock(
+                origin.clone(),
+                parent_category_id,
+                good_category_title(),
+                good_category_description(),
+                expected_result,
+            );
+        }
     });
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -53,7 +53,8 @@ pub use sr_primitives::BuildStorage;
 pub use sr_primitives::{Perbill, Permill};
 
 pub use srml_support::{
-    construct_runtime, parameter_types, traits::Currency, traits::Imbalance, traits::Randomness,
+    construct_runtime, parameter_types,
+    traits::{Currency, Get, Imbalance, Randomness},
     StorageLinkedMap, StorageMap, StorageValue,
 };
 pub use staking::StakerStatus;
@@ -208,7 +209,7 @@ impl system::Trait for Runtime {
     type AccountId = AccountId;
     /// The aggregated dispatch type that is available for extrinsics.
     type Call = Call;
-    /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
+    /// The lookup mechanism to é account ID from whatever is passed in dispatchers.
     type Lookup = Indices;
     /// The index type for storing how many extrinsics an account has signed.
     type Index = Index;
@@ -803,6 +804,11 @@ impl forum::ForumUserRegistry<AccountId> for ShimMembershipRegistry {
     }
 }
 */
+
+parameter_types! {
+    pub const MaxCategoryDepth: u64 = 5;
+}
+
 impl forum::Trait for Runtime {
     type Event = Event;
     //type MembershipRegistry = ShimMembershipRegistry;
@@ -811,7 +817,7 @@ impl forum::Trait for Runtime {
     type ForumUserId = ForumUserId;
     type ModeratorId = ModeratorId;
     type CategoryId = u64;
-    type MaxCategoryDepth = u64;
+    type MaxCategoryDepth = MaxCategoryDepth;
 
     fn is_lead(_account_id: &AccountId) -> bool {
         true
@@ -830,10 +836,6 @@ impl forum::Trait for Runtime {
 
     fn calculate_hash(text: &[u8]) -> Self::Hash {
         Self::Hash::from_slice(text)
-    }
-
-    fn get_max_category_depth() -> Self::MaxCategoryDepth {
-        5
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -811,6 +811,7 @@ impl forum::Trait for Runtime {
     type ForumUserId = ForumUserId;
     type ModeratorId = ModeratorId;
     type CategoryId = u64;
+    type MaxCategoryDepth = u64;
 
     fn is_lead(_account_id: &AccountId) -> bool {
         true
@@ -829,6 +830,10 @@ impl forum::Trait for Runtime {
 
     fn calculate_hash(text: &[u8]) -> Self::Hash {
         Self::Hash::from_slice(text)
+    }
+
+    fn get_max_category_depth() -> Self::MaxCategoryDepth {
+        5
     }
 }
 


### PR DESCRIPTION
Solves subtasks of #766:
- Make maximum category depth parameter getable through runtime trait parameters, remove from storage: MaxCategoryDepth
- Drop set_max_category_depth and the value in storage, its not safe. Instead make it a parameter in the runtime trait.
