### PR TITLE
Content dir 2.0 tests: add_schema_support_to_entity extrinsic full coverage 

### DIFF
--- a/runtime-modules/content-directory/src/errors.rs
+++ b/runtime-modules/content-directory/src/errors.rs
@@ -48,7 +48,7 @@ pub const ERROR_CLASS_SCHEMA_REFERS_UNKNOWN_CLASS: &str =
 pub const ERROR_NO_PROPS_IN_CLASS_SCHEMA: &str =
     "Cannot add a class schema with an empty list of properties";
 pub const ERROR_ENTITY_NOT_FOUND: &str = "Entity was not found by id";
-pub const ERROR_SCHEMA_ALREADY_ADDED_TO_ENTITY: &str =
+pub const ERROR_SCHEMA_ALREADY_ADDED_TO_THE_ENTITY: &str =
     "Cannot add a schema that is already added to this entity";
 pub const ERROR_PROP_VALUE_DONT_MATCH_TYPE: &str =
     "Some of the provided property values don't match the expected property type";

--- a/runtime-modules/content-directory/src/helpers.rs
+++ b/runtime-modules/content-directory/src/helpers.rs
@@ -15,6 +15,11 @@ impl<'a, T: Trait> ValueForExistingProperty<'a, T> {
         self.0
     }
 
+    /// Retrieve `Value` reference
+    pub fn get_value(&self) -> &PropertyValue<T> {
+        self.1
+    }
+
     /// Retrieve `Property` and `PropertyValue` references
     pub fn unzip(&self) -> (&Property<T>, &PropertyValue<T>) {
         (self.0, self.1)

--- a/runtime-modules/content-directory/src/lib.rs
+++ b/runtime-modules/content-directory/src/lib.rs
@@ -450,7 +450,7 @@ impl<T: Trait> Entity<T> {
     /// Ensure `Schema` under given id is not added to given `Entity` yet
     pub fn ensure_schema_id_is_not_added(&self, schema_id: SchemaId) -> dispatch::Result {
         let schema_not_added = !self.supported_schemas.contains(&schema_id);
-        ensure!(schema_not_added, ERROR_SCHEMA_ALREADY_ADDED_TO_ENTITY);
+        ensure!(schema_not_added, ERROR_SCHEMA_ALREADY_ADDED_TO_THE_ENTITY);
         Ok(())
     }
 
@@ -462,7 +462,7 @@ impl<T: Trait> Entity<T> {
         ensure!(
             property_values
                 .keys()
-                .all(|key| property_values.contains_key(key)),
+                .all(|key| !self.values.contains_key(key)),
             ERROR_ENTITY_ALREADY_CONTAINS_GIVEN_PROPERTY_ID
         );
         Ok(())
@@ -2194,12 +2194,17 @@ impl<T: Trait> Module<T> {
     pub fn ensure_property_values_unique_option_satisfied(
         updated_values_for_existing_properties: ValuesForExistingProperties<T>,
     ) -> dispatch::Result {
-        for updated_value_for_existing_property in updated_values_for_existing_properties.values() {
+        for (&property_id, updated_value_for_existing_property) in
+            updated_values_for_existing_properties.iter()
+        {
             let (property, value) = updated_value_for_existing_property.unzip();
 
             // Ensure all PropertyValue's with unique option set are unique, except of null non required ones
-            property
-                .ensure_unique_option_satisfied(value, &updated_values_for_existing_properties)?;
+            property.ensure_unique_option_satisfied(
+                property_id,
+                value,
+                &updated_values_for_existing_properties,
+            )?;
         }
         Ok(())
     }

--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -863,13 +863,20 @@ impl<T: Trait> Property<T> {
         }
     }
 
-    pub fn with_name_and_type(name_len: usize, property_type: PropertyType<T>) -> Self {
+    pub fn with_name_and_type(
+        name_len: usize,
+        property_type: PropertyType<T>,
+        required: bool,
+        unique: bool,
+    ) -> Self {
         let name = generate_text(name_len);
         let description = generate_text(PropertyDescriptionLengthConstraint::get().min() as usize);
         Self {
             name,
             description,
             property_type,
+            required,
+            unique,
             ..Property::<T>::default()
         }
     }
@@ -933,6 +940,12 @@ impl<T: Trait> PropertyValue<T> {
         let vec_value = VecValue::<Runtime>::Reference(entity_ids);
         let vec_property_value = VecPropertyValue::<Runtime>::new(vec_value, 0);
         PropertyValue::<Runtime>::Vector(vec_property_value)
+    }
+
+    pub fn single_text(text_len: TextMaxLength) -> PropertyValue<Runtime> {
+        let text_value = Value::<Runtime>::Text(generate_text(text_len as usize));
+        let text_property_value = SinglePropertyValue::<Runtime>::new(text_value);
+        PropertyValue::<Runtime>::Single(text_property_value)
     }
 }
 

--- a/runtime-modules/content-directory/src/tests/add_class_schema.rs
+++ b/runtime-modules/content-directory/src/tests/add_class_schema.rs
@@ -468,7 +468,7 @@ fn add_class_schema_property_refers_unknown_class() {
             true,
             VecMaxLengthConstraint::get(),
         );
-        let property = Property::<Runtime>::with_name_and_type(1, reference_vec_type);
+        let property = Property::<Runtime>::with_name_and_type(1, reference_vec_type, true, true);
 
         // Make an attempt to add class schema, providing property with Type::Reference, which refers to unknown ClassId
         let add_class_schema_result =

--- a/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
+++ b/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
@@ -13,3 +13,5 @@ fn add_schema_support_to_entity_success() {
         assert_eq!(second_entity, entity_by_id(SECOND_ENTITY_ID));
     })
 }
+
+

--- a/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
+++ b/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
@@ -14,4 +14,1153 @@ fn add_schema_support_to_entity_success() {
     })
 }
 
+#[test]
+fn add_schema_support_to_non_existent_entity() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityNotFound,
+        );
 
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to add schema support to non existent Entity
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_lead_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::LeadAuthFailed,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to add schema support under non lead origin
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_member_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::MemberAuthFailed,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to add schema support to entity using unknown origin and member actor
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_MEMBER_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_curator_group_is_not_active() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorGroupIsNotActive,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity using curator group, which is not active as actor
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            FIRST_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CURATOR_GROUP_IS_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_curator_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity under unknown origin and curator actor,
+        // which corresponding group is current entity controller
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CURATOR_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_curator_not_found_in_curator_group() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity, using actor in group,
+        // which curator id was not added to corresponding group set
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CURATOR_IS_NOT_A_MEMBER_OF_A_GIVEN_CURATOR_GROUP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_access_denied() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityAccessDenied,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity, using origin,
+        // which corresponding actor is neither entity maintainer, nor controller.
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            SECOND_MEMBER_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_ENTITY_ACCESS_DENIED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_to_entity_schema_does_not_exist() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity, providing shema_id,
+        // which corresponding Schema does not exist on Class level
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_UNKNOWN_CLASS_SCHEMA_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_to_entity_class_property_not_found() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(SECOND_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, providing property value under property_id,
+        // which does not not yet added to corresponding Class properties
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CLASS_PROP_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_already_added_to_the_entity() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to add schema support to entity, providing schema_id,
+        // which was already added to the Entity
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_SCHEMA_ALREADY_ADDED_TO_THE_ENTITY,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_already_contains_given_property_id() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create first property
+        let first_property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add first Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![first_property]
+        ));
+
+        // Create second property
+        let second_property_type =
+            PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let second_property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+            second_property_type,
+            true,
+            false,
+        );
+
+        // Add second Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::from_iter(vec![FIRST_PROPERTY_ID].into_iter()),
+            vec![second_property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        schema_property_values.insert(
+            SECOND_PROPERTY_ID,
+            PropertyValue::<Runtime>::single_text(TextMaxLengthConstraint::get()),
+        );
+
+        // Make an attempt to add schema support to entity, providing Schema property_values,
+        // some of which were already added to this Entity
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            SECOND_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_ENTITY_ALREADY_CONTAINS_GIVEN_PROPERTY_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_is_not_active() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Make Class Schema inactive
+        assert_ok!(update_class_schema_status(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            FIRST_SCHEMA_ID,
+            false
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, providing schema id,
+        // which correspondin class Schema is not active
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CLASS_SCHEMA_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_does_not_contain_provided_property_id() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create first property
+        let first_property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![first_property]
+        ));
+
+        // Create second property
+        let second_property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![second_property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(SECOND_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, providing property values, which are not a members of
+        // provided Schema
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_SCHEMA_DOES_NOT_CONTAIN_PROVIDED_PROPERTY_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_missing_required_property() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create first property
+        let first_property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Create second property
+        let second_property_type =
+            PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let second_property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+            second_property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![first_property, second_property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, do not providing some of required property values
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_MISSING_REQUIRED_PROP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_dont_match_type() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, providing property values, some of which do not match
+        // Class level Property Type
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_PROP_VALUE_DONT_MATCH_TYPE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_referenced_entity_does_not_match_class() {
+    with_test_externalities(|| {
+        // Create first class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create second class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create first entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        // Create second entity
+        assert_ok!(create_entity(
+            LEAD_ORIGIN,
+            SECOND_CLASS_ID,
+            actor.to_owned()
+        ));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the first Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![SECOND_ENTITY_ID, SECOND_ENTITY_ID]);
+
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the Entity, when provided schema property value(s) refer(s) Entity, which Class
+        // does not match the class in corresponding Class Schema
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_REFERENCED_ENTITY_DOES_NOT_MATCH_ITS_CLASS,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_referenced_entity_does_not_exist() {
+    with_test_externalities(|| {
+        // Create first class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create second class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(SECOND_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the first Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![UNKNOWN_ENTITY_ID, UNKNOWN_ENTITY_ID]);
+
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the first entity, if provided property value(s) refer(s) to another Entity,
+        // which does not exist in runtime
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_text_property_is_too_long() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        // Create text property
+        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+
+        let property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the first Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::single_text(TextMaxLengthConstraint::get() + 1);
+
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the entity, providing text property value(s), which
+        // length exceeds TextMaxLengthConstraint.
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_TEXT_PROP_IS_TOO_LONG,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_vec_property_is_too_long() {
+    with_test_externalities(|| {
+        // Create first class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create second class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create first entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        // Create second entity
+        assert_ok!(create_entity(
+            LEAD_ORIGIN,
+            SECOND_CLASS_ID,
+            actor.to_owned()
+        ));
+
+        // Create vec property
+        let property_type = PropertyType::<Runtime>::vec_reference(
+            SECOND_CLASS_ID,
+            true,
+            VecMaxLengthConstraint::get(),
+        );
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the first Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![
+                SECOND_ENTITY_ID;
+                VecMaxLengthConstraint::get() as usize + 1
+            ]);
+
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the Entity, providing vector property value(s), which
+        // length exceeds VecMaxLengthConstraint.
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_VEC_PROP_IS_TOO_LONG,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_property_should_be_unique() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+
+        // Create first text property
+
+        let first_property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize,
+            property_type.clone(),
+            true,
+            true,
+        );
+
+        // Create second text property
+
+        let second_property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+            property_type,
+            true,
+            true,
+        );
+
+        // Add first Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![first_property]
+        ));
+
+        // Add second Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![second_property]
+        ));
+
+        let mut first_schema_property_values = BTreeMap::new();
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::single_text(TextMaxLengthConstraint::get());
+
+        first_schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value.clone());
+
+        // Add Entity Schema support
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            first_schema_property_values,
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut second_schema_property_values = BTreeMap::new();
+
+        second_schema_property_values.insert(SECOND_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the entity, providing property value(s), which are identical to thouse, are already added to The Entity,
+        // though should be unique on Class Schema level
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            SECOND_SCHEMA_ID,
+            second_schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_PROPERTY_VALUE_SHOULD_BE_UNIQUE,
+            number_of_events_before_call,
+        );
+    })
+}

--- a/runtime-modules/content-directory/src/tests/remove_entity.rs
+++ b/runtime-modules/content-directory/src/tests/remove_entity.rs
@@ -45,13 +45,9 @@ fn remove_entity_success() {
 #[test]
 fn remove_non_existent_entity() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        let actor = Actor::Lead;
-
-        // Create entity
-        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityNotFound,
+        );
 
         // Runtime state before tested call
 
@@ -73,13 +69,9 @@ fn remove_non_existent_entity() {
 #[test]
 fn remove_entity_lead_auth_failed() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        let actor = Actor::Lead;
-
-        // Create entity
-        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::LeadAuthFailed,
+        );
 
         // Runtime state before tested call
 
@@ -87,7 +79,7 @@ fn remove_entity_lead_auth_failed() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity under non lead origin
-        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -101,23 +93,9 @@ fn remove_entity_lead_auth_failed() {
 #[test]
 fn remove_entity_member_auth_failed() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Update class permissions to force any member be available to create entities
-        assert_ok!(update_class_permissions(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            Some(true),
-            None,
-            None,
-            None
-        ));
-
-        let actor = Actor::Member(FIRST_MEMBER_ID);
-
-        // Create entity
-        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::MemberAuthFailed,
+        );
 
         // Runtime state before tested call
 
@@ -125,7 +103,7 @@ fn remove_entity_member_auth_failed() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity using unknown origin and member actor, which is current Entity controller
-        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -139,48 +117,9 @@ fn remove_entity_member_auth_failed() {
 #[test]
 fn create_entity_curator_group_is_not_active() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Add curator group
-        assert_ok!(add_curator_group(LEAD_ORIGIN));
-
-        // Add curator to group
-        assert_ok!(add_curator_to_group(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            FIRST_CURATOR_ID,
-        ));
-
-        // Add curator group as class maintainer
-        assert_ok!(add_maintainer_to_class(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            FIRST_CURATOR_GROUP_ID
-        ));
-
-        // Make curator group active
-        assert_ok!(set_curator_group_status(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            true
-        ));
-
-        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
-
-        // Create Entity
-        assert_ok!(create_entity(
-            FIRST_CURATOR_ORIGIN,
-            FIRST_CLASS_ID,
-            actor.clone()
-        ));
-
-        // Make curator group inactive to block entity removal
-        assert_ok!(set_curator_group_status(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            false
-        ));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorGroupIsNotActive,
+        );
 
         // Runtime state before tested call
 
@@ -188,8 +127,7 @@ fn create_entity_curator_group_is_not_active() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity using curator group, which is not active as actor
-        let remove_entity_result =
-            remove_entity(FIRST_CURATOR_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+        let remove_entity_result = remove_entity(FIRST_CURATOR_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -203,41 +141,9 @@ fn create_entity_curator_group_is_not_active() {
 #[test]
 fn remove_entity_curator_auth_failed() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Add curator group
-        assert_ok!(add_curator_group(LEAD_ORIGIN));
-
-        // Add curator to group
-        assert_ok!(add_curator_to_group(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            FIRST_CURATOR_ID,
-        ));
-
-        // Add curator group as class maintainer
-        assert_ok!(add_maintainer_to_class(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            FIRST_CURATOR_GROUP_ID
-        ));
-
-        // Make curator group active
-        assert_ok!(set_curator_group_status(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            true
-        ));
-
-        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
-
-        // Create Entity
-        assert_ok!(create_entity(
-            FIRST_CURATOR_ORIGIN,
-            FIRST_CLASS_ID,
-            actor.clone()
-        ));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
 
         // Runtime state before tested call
 
@@ -245,7 +151,7 @@ fn remove_entity_curator_auth_failed() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity under unknown origin and curator actor, which corresponding group is current entity controller
-        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -259,50 +165,18 @@ fn remove_entity_curator_auth_failed() {
 #[test]
 fn remove_entity_curator_not_found_in_curator_group() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Add curator group
-        assert_ok!(add_curator_group(LEAD_ORIGIN));
-
-        // Add curator to group
-        assert_ok!(add_curator_to_group(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            FIRST_CURATOR_ID,
-        ));
-
-        // Make curator group active
-        assert_ok!(set_curator_group_status(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            true
-        ));
-
-        // Add curator group as class maintainer
-        assert_ok!(add_maintainer_to_class(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            FIRST_CURATOR_GROUP_ID
-        ));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
+        );
 
         // Runtime state before tested call
-
-        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
-
-        // Create entity
-        assert_ok!(create_entity(FIRST_CURATOR_ORIGIN, FIRST_CLASS_ID, actor));
 
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity, using actor in group,
         // which curator id was not added to corresponding group set
-        let remove_entity_result = remove_entity(
-            SECOND_CURATOR_ORIGIN,
-            Actor::Curator(FIRST_CURATOR_GROUP_ID, SECOND_CURATOR_ID),
-            FIRST_ENTITY_ID,
-        );
+        let remove_entity_result = remove_entity(SECOND_CURATOR_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -316,23 +190,9 @@ fn remove_entity_curator_not_found_in_curator_group() {
 #[test]
 fn remove_entity_access_denied() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Update class permissions to force any member be available to create entities
-        assert_ok!(update_class_permissions(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            Some(true),
-            None,
-            None,
-            None
-        ));
-
-        // Create entity
-        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, Actor::Lead));
-
-        let actor = Actor::Member(SECOND_MEMBER_ID);
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityAccessDenied,
+        );
 
         // Runtime state before tested call
 
@@ -417,7 +277,7 @@ fn remove_entity_rc_does_not_equal_to_zero() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity, which rc does not equal to zero
-        let remove_entity_result = remove_entity(LEAD_ORIGIN, actor.clone(), SECOND_ENTITY_ID);
+        let remove_entity_result = remove_entity(LEAD_ORIGIN, actor, SECOND_ENTITY_ID);
 
         // Failure checked
         assert_failure(

--- a/runtime-modules/content-directory/src/tests/transaction.rs
+++ b/runtime-modules/content-directory/src/tests/transaction.rs
@@ -12,6 +12,8 @@ fn transaction_success() {
         let property = Property::<Runtime>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             PropertyType::Single(property_type_reference),
+            true,
+            false,
         );
 
         // Add Schema to the Class


### PR DESCRIPTION
The scope of this PR includes: 
1. Fix to `ensure_unique_option_satisfied` ensure check https://github.com/Joystream/joystream/pull/898/files#diff-a97a30de99ce8e1af97bbabe070f035fR615
1. `add_schema_support_to_entity` extrinsic full coverage

Closes: https://github.com/Joystream/joystream/issues/794