### PR TITLE
CLI: Import path fix

### DIFF
--- a/cli/src/commands/working-groups/fillOpening.ts
+++ b/cli/src/commands/working-groups/fillOpening.ts
@@ -4,8 +4,7 @@ import { OpeningStatus } from '../../Types';
 import ExitCodes from '../../ExitCodes';
 import { apiModuleByGroup } from '../../Api';
 import { OpeningId } from '@joystream/types/hiring';
-import { ApplicationIdSet } from '@joystream/types/working-group';
-import { RewardPolicy } from '@joystream/types/content-working-group';
+import { ApplicationIdSet, RewardPolicy } from '@joystream/types/working-group';
 import chalk from 'chalk';
 
 export default class WorkingGroupsFillOpening extends WorkingGroupsCommandBase {


### PR DESCRIPTION
Minor fix for `nicaea` branch after merging https://github.com/Joystream/joystream/pull/869 and then outdated https://github.com/Joystream/joystream/pull/707 has caused a build to fail due to outdated import path (https://github.com/Joystream/joystream/runs/844501297)