### PR TITLE
Forum post thread moderation

### DIFF
--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -554,6 +554,7 @@ decl_event!(
         <T as Trait>::ThreadId,
         <T as Trait>::PostId,
         <T as Trait>::ForumUserId,
+        <T as system::Trait>::Hash,
     {
         /// A category was introduced
         CategoryCreated(CategoryId),
@@ -581,7 +582,7 @@ decl_event!(
         PostAdded(PostId),
 
         /// Post with givne id was moderated.
-        PostModerated(PostId),
+        PostModerated(PostId, Hash),
 
         /// Post with given id had its text updated.
         /// The second argument reflects the number of total edits when the text update occurs.
@@ -951,24 +952,21 @@ decl_module! {
         }
 
         /// Moderate post
-        fn moderate_post(origin, moderator_id: T::ModeratorId, category_id: T::CategoryId, thread_id: T::ThreadId, post_id: T::PostId) -> dispatch::Result {
+        fn moderate_post(origin, moderator_id: T::ModeratorId, category_id: T::CategoryId, thread_id: T::ThreadId, post_id: T::PostId, rationale: Vec<u8>) -> dispatch::Result {
             // Ensure data migration is done
             Self::ensure_data_migration_done()?;
 
-            // Get moderator id.
-            let who = Self::ensure_is_moderator(origin, &moderator_id)?;
+            // Ensure moderator is allowed to moderate post
+            Self::ensure_can_moderate_post(origin, &moderator_id, &category_id, &thread_id, &post_id)?;
 
-            // Make sure post exists and is mutable
-            let post = Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?;
+            // Calculate rationale's hash
+            let rationale_hash = T::calculate_hash(rationale.as_slice());
 
-            // make sure origin can moderate the category
-            Self::ensure_thread_exists(&category_id, &post.thread_id)?;
-
-            // ensure the moderator can moderate the category
-            Self::ensure_can_moderate_category(&who, &moderator_id, &category_id)?;
+            // Delete post
+            <PostById<T>>::remove(thread_id, post_id);
 
             // Generate event
-            Self::deposit_event(RawEvent::PostModerated(post_id));
+            Self::deposit_event(RawEvent::PostModerated(post_id, rationale_hash));
 
             Ok(())
         }
@@ -1158,6 +1156,25 @@ impl<T: Trait> Module<T> {
         }
 
         Ok(<PostById<T>>::get(thread_id, post_id))
+    }
+
+    fn ensure_can_moderate_post(
+        origin: T::Origin,
+        moderator_id: &T::ModeratorId,
+        category_id: &T::CategoryId,
+        thread_id: &T::ThreadId,
+        post_id: &T::PostId,
+    ) -> dispatch::Result {
+        // Get moderator id.
+        let who = ensure_signed(origin)?;
+
+        // Make sure post exists and is mutable
+        Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?;
+
+        // ensure the moderator can moderate the category
+        Self::ensure_can_moderate_category(&who, &moderator_id, &category_id)?;
+
+        Ok(())
     }
 
     fn ensure_thread_is_mutable(

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -567,7 +567,7 @@ decl_event!(
         ThreadCreated(ThreadId),
 
         /// A thread with given id was moderated.
-        ThreadModerated(ThreadId),
+        ThreadModerated(ThreadId, Hash),
 
         /// A thread with given id was moderated.
         ThreadTitleUpdated(ThreadId),
@@ -847,30 +847,21 @@ decl_module! {
         }
 
         /// Moderate thread
-        fn moderate_thread(origin, moderator_id: T::ModeratorId, category_id: T::CategoryId, thread_id: T::ThreadId) -> dispatch::Result {
+        fn moderate_thread(origin, moderator_id: T::ModeratorId, category_id: T::CategoryId, thread_id: T::ThreadId, rationale: Vec<u8>) -> dispatch::Result {
             // Ensure data migration is done
             Self::ensure_data_migration_done()?;
 
-            // Ensure origin is medorator
-            let who = Self::ensure_is_moderator(origin, &moderator_id)?;
+            // Ensure moderator is allowed to moderate post
+            Self::ensure_can_moderate_thread(origin, &moderator_id, &category_id, &thread_id)?;
 
-            // Get thread
-            let thread = Self::ensure_thread_exists(&category_id, &thread_id)?;
+            // Calculate rationale's hash
+            let rationale_hash = T::calculate_hash(rationale.as_slice());
 
-            // ensure origin can moderate category
-            Self::ensure_can_moderate_category(&who, &moderator_id, &thread.category_id)?;
-
-            // Can mutate in corresponding category
-            let path = Self::build_category_tree_path(&thread.category_id);
-
-            // Path must be non-empty, as category id is from thread in state
-            assert!(!path.is_empty());
-
-            // Path can be updated
-            Self::ensure_can_mutate_in_path_leaf(&path)?;
+            // Delete thread
+            <ThreadById<T>>::remove(category_id, thread_id);
 
             // Generate event
-            Self::deposit_event(RawEvent::ThreadModerated(thread_id));
+            Self::deposit_event(RawEvent::ThreadModerated(thread_id, rationale_hash));
 
             Ok(())
         }

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -554,7 +554,6 @@ decl_event!(
         <T as Trait>::ThreadId,
         <T as Trait>::PostId,
         <T as Trait>::ForumUserId,
-        <T as system::Trait>::Hash,
     {
         /// A category was introduced
         CategoryCreated(CategoryId),
@@ -567,7 +566,7 @@ decl_event!(
         ThreadCreated(ThreadId),
 
         /// A thread with given id was moderated.
-        ThreadModerated(ThreadId, Hash),
+        ThreadModerated(ThreadId, Vec<u8>),
 
         /// A thread with given id was moderated.
         ThreadTitleUpdated(ThreadId),
@@ -582,7 +581,7 @@ decl_event!(
         PostAdded(PostId),
 
         /// Post with givne id was moderated.
-        PostModerated(PostId, Hash),
+        PostModerated(PostId, Vec<u8>),
 
         /// Post with given id had its text updated.
         /// The second argument reflects the number of total edits when the text update occurs.
@@ -854,14 +853,11 @@ decl_module! {
             // Ensure moderator is allowed to moderate post
             Self::ensure_can_moderate_thread(origin, &moderator_id, &category_id, &thread_id)?;
 
-            // Calculate rationale's hash
-            let rationale_hash = T::calculate_hash(rationale.as_slice());
-
             // Delete thread
             <ThreadById<T>>::remove(category_id, thread_id);
 
             // Generate event
-            Self::deposit_event(RawEvent::ThreadModerated(thread_id, rationale_hash));
+            Self::deposit_event(RawEvent::ThreadModerated(thread_id, rationale));
 
             Ok(())
         }
@@ -950,14 +946,11 @@ decl_module! {
             // Ensure moderator is allowed to moderate post
             Self::ensure_can_moderate_post(origin, &moderator_id, &category_id, &thread_id, &post_id)?;
 
-            // Calculate rationale's hash
-            let rationale_hash = T::calculate_hash(rationale.as_slice());
-
             // Delete post
             <PostById<T>>::remove(thread_id, post_id);
 
             // Generate event
-            Self::deposit_event(RawEvent::PostModerated(post_id, rationale_hash));
+            Self::deposit_event(RawEvent::PostModerated(post_id, rationale));
 
             Ok(())
         }

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -171,6 +171,10 @@ pub fn good_post_new_text() -> Vec<u8> {
     b"Changed post's text".to_vec()
 }
 
+pub fn good_moderation_rationale() -> Vec<u8> {
+    b"Moderation rationale".to_vec()
+}
+
 pub fn good_poll_description() -> Vec<u8> {
     b"poll description".to_vec()
 }
@@ -527,6 +531,7 @@ pub fn moderate_post_mock(
     category_id: <Runtime as Trait>::CategoryId,
     thread_id: <Runtime as Trait>::ThreadId,
     post_id: <Runtime as Trait>::PostId,
+    rationale: Vec<u8>,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::PostId {
     assert_eq!(
@@ -535,14 +540,16 @@ pub fn moderate_post_mock(
             moderator_id,
             category_id,
             thread_id,
-            post_id
+            post_id,
+            rationale.clone(),
         ),
         result
     );
     if result.is_ok() {
+        let rationale_hash = Runtime::calculate_hash(rationale.clone().as_slice());
         assert_eq!(
             System::events().last().unwrap().event,
-            TestEvent::forum_mod(RawEvent::PostModerated(post_id,))
+            TestEvent::forum_mod(RawEvent::PostModerated(post_id, rationale_hash))
         );
     }
 

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -310,6 +310,10 @@ pub fn delete_thread_mock(
     thread_id: <Runtime as Trait>::PostId,
     result: Result<(), &'static str>,
 ) {
+    let num_direct_threads = match <CategoryById<Runtime>>::exists(category_id) {
+        true => <CategoryById<Runtime>>::get(category_id).num_direct_threads,
+        false => 0,
+    };
     assert_eq!(
         TestForumModule::delete_thread(
             mock_origin(origin.clone()),
@@ -321,6 +325,10 @@ pub fn delete_thread_mock(
     );
     if result.is_ok() {
         assert!(!<ThreadById<Runtime>>::exists(category_id, thread_id));
+        assert_eq!(
+            <CategoryById<Runtime>>::get(category_id).num_direct_threads,
+            num_direct_threads - 1,
+        );
         assert_eq!(
             System::events().last().unwrap().event,
             TestEvent::forum_mod(RawEvent::ThreadDeleted(thread_id))

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -525,11 +525,9 @@ pub fn moderate_thread_mock(
     );
     if result.is_ok() {
         assert!(!<ThreadById<Runtime>>::exists(category_id, thread_id));
-
-        let rationale_hash = Runtime::calculate_hash(rationale.clone().as_slice());
         assert_eq!(
             System::events().last().unwrap().event,
-            TestEvent::forum_mod(RawEvent::ThreadModerated(thread_id, rationale_hash))
+            TestEvent::forum_mod(RawEvent::ThreadModerated(thread_id, rationale))
         );
     }
     thread_id
@@ -557,11 +555,9 @@ pub fn moderate_post_mock(
     );
     if result.is_ok() {
         assert!(!<PostById<Runtime>>::exists(thread_id, post_id));
-
-        let rationale_hash = Runtime::calculate_hash(rationale.clone().as_slice());
         assert_eq!(
             System::events().last().unwrap().event,
-            TestEvent::forum_mod(RawEvent::PostModerated(post_id, rationale_hash))
+            TestEvent::forum_mod(RawEvent::PostModerated(post_id, rationale))
         );
     }
 

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -524,6 +524,8 @@ pub fn moderate_thread_mock(
         result
     );
     if result.is_ok() {
+        assert!(!<ThreadById<Runtime>>::exists(category_id, thread_id));
+
         let rationale_hash = Runtime::calculate_hash(rationale.clone().as_slice());
         assert_eq!(
             System::events().last().unwrap().event,
@@ -554,6 +556,8 @@ pub fn moderate_post_mock(
         result
     );
     if result.is_ok() {
+        assert!(!<PostById<Runtime>>::exists(thread_id, post_id));
+
         let rationale_hash = Runtime::calculate_hash(rationale.clone().as_slice());
         assert_eq!(
             System::events().last().unwrap().event,

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -510,16 +510,24 @@ pub fn moderate_thread_mock(
     moderator_id: <Runtime as Trait>::ModeratorId,
     category_id: <Runtime as Trait>::CategoryId,
     thread_id: <Runtime as Trait>::ThreadId,
+    rationale: Vec<u8>,
     result: Result<(), &'static str>,
 ) -> <Runtime as Trait>::ThreadId {
     assert_eq!(
-        TestForumModule::moderate_thread(mock_origin(origin), moderator_id, category_id, thread_id),
+        TestForumModule::moderate_thread(
+            mock_origin(origin),
+            moderator_id,
+            category_id,
+            thread_id,
+            rationale.clone(),
+        ),
         result
     );
     if result.is_ok() {
+        let rationale_hash = Runtime::calculate_hash(rationale.clone().as_slice());
         assert_eq!(
             System::events().last().unwrap().event,
-            TestEvent::forum_mod(RawEvent::ThreadModerated(thread_id,))
+            TestEvent::forum_mod(RawEvent::ThreadModerated(thread_id, rationale_hash))
         );
     }
     thread_id

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -1004,6 +1004,7 @@ fn moderate_post_origin() {
                 category_id,
                 thread_id,
                 post_id,
+                good_moderation_rationale(),
                 results[index],
             );
         });
@@ -1181,6 +1182,7 @@ fn test_migration_not_done() {
                 category_id,
                 thread_id,
                 post_id,
+                good_moderation_rationale(),
             ),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -778,7 +778,14 @@ fn moderate_thread_origin_ok() {
             None,
             Ok(()),
         );
-        moderate_thread_mock(origin, moderator_id, category_id, thread_id, Ok(()));
+        moderate_thread_mock(
+            origin,
+            moderator_id,
+            category_id,
+            thread_id,
+            good_moderation_rationale(),
+            Ok(()),
+        );
     });
 }
 
@@ -1171,6 +1178,7 @@ fn test_migration_not_done() {
                 moderator_id,
                 category_id,
                 thread_id,
+                good_moderation_rationale(),
             ),
             Err(ERROR_DATA_MIGRATION_NOT_DONE),
         );


### PR DESCRIPTION
Solves subtasks of #766:
- Moderation semantics for posts changed to mean that it is deleted by the moderator, and that some accompanying rationale is submitted, but is not itself stored.
- Moderation semantics for threads changed in the same way as posts. This can only be done after efficient thread deletion has been implemented.

To minimize merge conflict potential, this PR assumes #886 will be merged first.