### PR TITLE
Forum archival status

### DIFF
--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -1269,7 +1269,7 @@ impl<T: Trait> Module<T> {
             Ok(())
         };
 
-        // Decide if actor can delete category
+        // Decide if actor can update thread
         match actor {
             PrivilegedActor::Lead => (),
             PrivilegedActor::Moderator(moderator_id) => ensure_moderator_can_update(moderator_id)?,


### PR DESCRIPTION
Solves subtask of #766:
- Allow both the author and forum moderators to update archival status.

It allows categories and threads to be archived, making them (and their content) immutable. 

To minimize merge conflict potential, this PR assumes #901, #909, and #911 will be merged first.