### PR TITLE
Query node cli fixes

### DIFF
--- a/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { ObjectType, WarthogModel, FieldResolver } from '../model';
 import Debug from 'debug';
 import { GeneratorContext } from './SourcesGenerator';
-import { buildFieldContext, TYPE_FIELDS } from './field-context';
+import { buildFieldContext } from './field-context';
 import * as utils from './utils';
 import { GraphQLEnumType } from 'graphql';
 import { AbstractRenderer } from './AbstractRenderer';
@@ -83,9 +83,10 @@ export class ModelRenderer extends AbstractRenderer {
 
   withHasProps(): GeneratorContext {
     const has: GeneratorContext = {};
-    for (const key in TYPE_FIELDS) {
-      const _key: string = key === 'numeric' ? 'numeric' || 'decimal' : key;
-      has[key] = this.objType.fields.some(f => f.columnType() === _key);
+    for (const field of this.objType.fields) {
+      let ct = field.columnType();
+      if (ct === 'numeric' || ct === 'decimal') ct = 'numeric';
+      has[ct] = true;
     }
     has['array'] = this.objType.fields.some(f => f.isArray());
     has['enum'] = this.objType.fields.some(f => f.isEnum());

--- a/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
@@ -78,6 +78,9 @@ export class RelationshipGenerator {
   }
 
   listTypeWithDerivedDirective(field: Field, currentObject: ObjectType): void {
+    // Shoud never happen!
+    if (!field.derivedFrom) throw new Error(`No derivedFrom found on ${currentObject.name}->${field.name}`);
+
     const relatedObject = this.model.lookupType(field.type);
     const relatedField = this.model.lookupField(field.type, field.derivedFrom.argument);
 
@@ -93,6 +96,9 @@ export class RelationshipGenerator {
   }
 
   typeWithDerivedDirective(field: Field, currentObject: ObjectType): void {
+    // Shoud never happen!
+    if (!field.derivedFrom) throw new Error(`No derivedFrom found on ${currentObject.name}->${field.name}`);
+
     const relatedObject = this.model.lookupType(field.type);
     const relatedField = this.model.lookupField(field.type, field.derivedFrom.argument);
 

--- a/query-node/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
@@ -18,7 +18,7 @@ import { {{className}}Service } from './{{kebabName}}.service';
   {{{.}}}
 {{/fieldResolverImports}}
 
-@Resolver()
+@Resolver({{className}})
 export class {{className}}Resolver {
   constructor(@Inject('{{className}}Service') public readonly service: {{className}}Service) {}
 


### PR DESCRIPTION
This PR fixes:
- Missing object type for `@Resolver` decorator
- Overwriting `has['numeric']` property multiple times set the property to false eventually
- tsc compilation error