### PR TITLE
Query node make custom type registration optional

### DIFF
--- a/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { ObjectType, WarthogModel, FieldResolver } from '../model';
 import Debug from 'debug';
 import { GeneratorContext } from './SourcesGenerator';
-import { buildFieldContext, TYPE_FIELDS } from './field-context';
+import { buildFieldContext } from './field-context';
 import * as utils from './utils';
 import { GraphQLEnumType } from 'graphql';
 import { AbstractRenderer } from './AbstractRenderer';
@@ -83,9 +83,10 @@ export class ModelRenderer extends AbstractRenderer {
 
   withHasProps(): GeneratorContext {
     const has: GeneratorContext = {};
-    for (const key in TYPE_FIELDS) {
-      const _key: string = key === 'numeric' ? 'numeric' || 'decimal' : key;
-      has[key] = this.objType.fields.some(f => f.columnType() === _key);
+    for (const field of this.objType.fields) {
+      let ct = field.columnType();
+      if (ct === 'numeric' || ct === 'decimal') ct = 'numeric';
+      has[ct] = true;
     }
     has['array'] = this.objType.fields.some(f => f.isArray());
     has['enum'] = this.objType.fields.some(f => f.isEnum());

--- a/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
@@ -78,6 +78,9 @@ export class RelationshipGenerator {
   }
 
   listTypeWithDerivedDirective(field: Field, currentObject: ObjectType): void {
+    // Shoud never happen!
+    if (!field.derivedFrom) throw new Error(`No derivedFrom found on ${currentObject.name}->${field.name}`);
+
     const relatedObject = this.model.lookupType(field.type);
     const relatedField = this.model.lookupField(field.type, field.derivedFrom.argument);
 
@@ -93,6 +96,9 @@ export class RelationshipGenerator {
   }
 
   typeWithDerivedDirective(field: Field, currentObject: ObjectType): void {
+    // Shoud never happen!
+    if (!field.derivedFrom) throw new Error(`No derivedFrom found on ${currentObject.name}->${field.name}`);
+
     const relatedObject = this.model.lookupType(field.type);
     const relatedField = this.model.lookupField(field.type, field.derivedFrom.argument);
 

--- a/query-node/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
@@ -18,7 +18,7 @@ import { {{className}}Service } from './{{kebabName}}.service';
   {{{.}}}
 {{/fieldResolverImports}}
 
-@Resolver()
+@Resolver({{className}})
 export class {{className}}Resolver {
   constructor(@Inject('{{className}}Service') public readonly service: {{className}}Service) {}
 

--- a/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
@@ -6,7 +6,10 @@ import { Command } from 'commander';
 import { configure, getLogger } from 'log4js';
 
 import { createConnection } from "typeorm";
+{{#typeRegistrator}}
 import { {{typeRegistrator}} } from '{{{packageName}}}';
+{{/typeRegistrator}}
+
 import {
   QueryNodeManager,
   BootstrapPack,
@@ -107,7 +110,7 @@ async function doBootstrap(node: QueryNodeManager) {
     await node.bootstrap(
         process.env.WS_PROVIDER_ENDPOINT_URI as string,
         getBootstrapPack(),
-        {{typeRegistrator}}
+        {{#typeRegistrator}} {{typeRegistrator}} {{/typeRegistrator}}
     );
     logger.info("Bootstrap done");
 }
@@ -141,7 +144,7 @@ async function main() {
       process.exit(0);
   }
 
-  node.start(providerUri, getProcessingPack(), {{typeRegistrator}});
+  node.start(providerUri, getProcessingPack(), {{#typeRegistrator}} {{typeRegistrator}} {{/typeRegistrator}});
 }
 
 main().catch((e) => {

--- a/query-node/substrate-query-framework/cli/src/templates/indexer.package.json
+++ b/query-node/substrate-query-framework/cli/src/templates/indexer.package.json
@@ -11,7 +11,6 @@
         "postinstall": "rm -rf node_modules/index-builder/node_modules"
     },
     "dependencies": {
-      "@joystream/types": "^0.8.0",
       "@types/bn.js": "^4.11.6",
       "@types/shortid": "^0.0.29",
       "bn.js": "^5.1.1",

--- a/query-node/substrate-query-framework/index-builder/src/QueryNode.ts
+++ b/query-node/substrate-query-framework/index-builder/src/QueryNode.ts
@@ -27,10 +27,8 @@ export default class QueryNode {
 
   // Query index building node.
   private _indexBuilder: IndexBuilder;
-  
 
-  private constructor(websocketProvider: WsProvider, api: ApiPromise, 
-    indexBuilder: IndexBuilder) {
+  private constructor(websocketProvider: WsProvider, api: ApiPromise, indexBuilder: IndexBuilder) {
     this._state = QueryNodeState.NOT_STARTED;
     this._websocketProvider = websocketProvider;
     this._api = api;
@@ -40,7 +38,7 @@ export default class QueryNode {
   static async create(
     ws_provider_endpoint_uri: string,
     processing_pack: QueryEventProcessingPack,
-    type_registrator: () => void,
+    type_registrator?: () => void
   ) {
     // TODO: Do we really need to do it like this?
     // Its pretty ugly, but the registrtion appears to be
@@ -51,7 +49,7 @@ export default class QueryNode {
     const provider = new WsProvider(ws_provider_endpoint_uri);
 
     // Register types before creating the api
-    type_registrator();
+    type_registrator ? type_registrator() : null;
 
     // Create the API and wait until ready
     const api = await ApiPromise.create({ provider });

--- a/query-node/substrate-query-framework/index-builder/src/QueryNodeManager.ts
+++ b/query-node/substrate-query-framework/index-builder/src/QueryNodeManager.ts
@@ -19,21 +19,15 @@ export default class QueryNodeManager {
   async start(
     ws_provider_endpoint_uri: string,
     processing_pack: QueryEventProcessingPack,
-    type_registrator: () => void
+    type_registrator?: () => void
   ) {
-    
     if (this._query_node) throw Error('Cannot start the same manager multiple times.');
-    
+
     this._query_node = await QueryNode.create(ws_provider_endpoint_uri, processing_pack, type_registrator);
     await this._query_node.start();
-    
   }
 
-  async bootstrap(
-    ws_provider_endpoint_uri: string,
-    bootstrap_pack: BootstrapPack,
-    type_registrator: () => void,
-  ) {
+  async bootstrap(ws_provider_endpoint_uri: string, bootstrap_pack: BootstrapPack, type_registrator?: () => void) {
     let bootstrapper = await Bootstrapper.create(ws_provider_endpoint_uri, bootstrap_pack, type_registrator);
     await bootstrapper.bootstrap();
   }

--- a/query-node/substrate-query-framework/index-builder/src/bootstrap/Bootstrapper.ts
+++ b/query-node/substrate-query-framework/index-builder/src/bootstrap/Bootstrapper.ts
@@ -20,12 +20,13 @@ export default class Bootstrapper {
     static async create(
         ws_provider_endpoint_uri: string,
         bootstrapPack: BootstrapPack,
-        type_registrator: () => void): Promise<Bootstrapper> {
+    type_registrator?: () => void
+  ): Promise<Bootstrapper> {
         // Initialise the provider to connect to the local node
         const provider = new WsProvider(ws_provider_endpoint_uri);
 
         // Register types before creating the api
-        type_registrator();
+    type_registrator ? type_registrator() : null;
 
         // Create the API and wait until ready
         const api = await ApiPromise.create({ provider });


### PR DESCRIPTION
This PR makes custom type registration optional since there is no package to register for Polkadot chains.

> Additional types used by runtime modules can be added when a new instance of the API is created. This is necessary if the runtime modules use types that are not available in the base Substrate runtime.

To minimize merge conflict potential, this PR assumes https://github.com/Joystream/joystream/pull/926 will be merged first. 