### PR TITLE
Content dir 2.0 tests: update_entity_property_values extrinsic full coverage

### DIFF
--- a/runtime-modules/content-directory/src/errors.rs
+++ b/runtime-modules/content-directory/src/errors.rs
@@ -112,7 +112,7 @@ pub const ERROR_CLASS_ACCESS_DENIED: &str = "Class access denied";
 pub const ERROR_ENTITY_ACCESS_DENIED: &str = "Entity access denied";
 pub const ERROR_ENTITY_CAN_NOT_BE_REFERENCED: &str = "Given entity can`t be referenced";
 pub const ERROR_CLASS_PROPERTY_TYPE_IS_LOCKED_FOR_GIVEN_ACTOR: &str =
-    "Given class property type is locked for updating";
+    "Given class property type is locked for given actor";
 pub const ERROR_NUMBER_OF_MAINTAINERS_PER_CLASS_LIMIT_REACHED: &str =
     "Class maintainers limit reached";
 pub const ERROR_NUMBER_OF_CURATORS_PER_GROUP_LIMIT_REACHED: &str =

--- a/runtime-modules/content-directory/src/errors.rs
+++ b/runtime-modules/content-directory/src/errors.rs
@@ -48,7 +48,7 @@ pub const ERROR_CLASS_SCHEMA_REFERS_UNKNOWN_CLASS: &str =
 pub const ERROR_NO_PROPS_IN_CLASS_SCHEMA: &str =
     "Cannot add a class schema with an empty list of properties";
 pub const ERROR_ENTITY_NOT_FOUND: &str = "Entity was not found by id";
-pub const ERROR_SCHEMA_ALREADY_ADDED_TO_ENTITY: &str =
+pub const ERROR_SCHEMA_ALREADY_ADDED_TO_THE_ENTITY: &str =
     "Cannot add a schema that is already added to this entity";
 pub const ERROR_PROP_VALUE_DONT_MATCH_TYPE: &str =
     "Some of the provided property values don't match the expected property type";

--- a/runtime-modules/content-directory/src/helpers.rs
+++ b/runtime-modules/content-directory/src/helpers.rs
@@ -15,6 +15,11 @@ impl<'a, T: Trait> ValueForExistingProperty<'a, T> {
         self.0
     }
 
+    /// Retrieve `Value` reference
+    pub fn get_value(&self) -> &PropertyValue<T> {
+        self.1
+    }
+
     /// Retrieve `Property` and `PropertyValue` references
     pub fn unzip(&self) -> (&Property<T>, &PropertyValue<T>) {
         (self.0, self.1)

--- a/runtime-modules/content-directory/src/lib.rs
+++ b/runtime-modules/content-directory/src/lib.rs
@@ -1476,16 +1476,16 @@ decl_module! {
             // Retrieve Class, Entity and EntityAccessLevel for the actor, attemting to perform operation
             let (class, entity, access_level) = Self::ensure_class_entity_and_access_level(origin, entity_id, &actor)?;
 
-            // Ensure PropertyValue under given in_class_schema_property_id is Vector
-            let property_value_vector =
-                entity.ensure_property_value_is_vec(in_class_schema_property_id)?;
-
             // Ensure Property under given PropertyId is unlocked from actor with given EntityAccessLevel
             // Retrieve corresponding Property by value
             let property = class.ensure_class_property_type_unlocked_from(
                 in_class_schema_property_id,
                 access_level,
             )?;
+
+            // Ensure PropertyValue under given in_class_schema_property_id is Vector
+            let property_value_vector =
+                entity.ensure_property_value_is_vec(in_class_schema_property_id)?;
 
             //
             // == MUTATION SAFE ==
@@ -1535,16 +1535,16 @@ decl_module! {
             // Retrieve Class, Entity and EntityAccessLevel for the actor, attemting to perform operation
             let (class, entity, access_level) = Self::ensure_class_entity_and_access_level(origin, entity_id, &actor)?;
 
-            // Ensure PropertyValue under given in_class_schema_property_id is Vector
-            let property_value_vector =
-                entity.ensure_property_value_is_vec(in_class_schema_property_id)?;
-
             // Ensure Property under given PropertyId is unlocked from actor with given EntityAccessLevel
             // Retrieve corresponding Property by value
             let property = class.ensure_class_property_type_unlocked_from(
                 in_class_schema_property_id,
                 access_level,
             )?;
+
+            // Ensure PropertyValue under given in_class_schema_property_id is Vector
+            let property_value_vector =
+                entity.ensure_property_value_is_vec(in_class_schema_property_id)?;
 
             // Ensure `VecPropertyValue` nonce is equal to the provided one.
             // Used to to avoid possible data races, when performing vector specific operations
@@ -1617,6 +1617,13 @@ decl_module! {
             // Retrieve Class, Entity and EntityAccessLevel for the actor, attemting to perform operation
             let (class, entity, access_level) = Self::ensure_class_entity_and_access_level(origin, entity_id, &actor)?;
 
+            // Ensure Property under given PropertyId is unlocked from actor with given EntityAccessLevel
+            // Retrieve corresponding Property by value
+            let class_property = class.ensure_class_property_type_unlocked_from(
+                in_class_schema_property_id,
+                access_level,
+            )?;
+
             // Ensure PropertyValue under given in_class_schema_property_id is Vector
             let property_value_vector =
                 entity.ensure_property_value_is_vec(in_class_schema_property_id)?;
@@ -1626,13 +1633,6 @@ decl_module! {
             property_value_vector.ensure_nonce_equality(nonce)?;
 
             let entity_controller = entity.get_permissions_ref().get_controller();
-
-            // Ensure Property under given PropertyId is unlocked from actor with given EntityAccessLevel
-            // Retrieve corresponding Property by value
-            let class_property = class.ensure_class_property_type_unlocked_from(
-                in_class_schema_property_id,
-                access_level,
-            )?;
 
             // Ensure property_value type is equal to the property_value_vector type and check all constraints
             class_property.ensure_property_value_can_be_inserted_at_property_vector(

--- a/runtime-modules/content-directory/src/lib.rs
+++ b/runtime-modules/content-directory/src/lib.rs
@@ -450,7 +450,7 @@ impl<T: Trait> Entity<T> {
     /// Ensure `Schema` under given id is not added to given `Entity` yet
     pub fn ensure_schema_id_is_not_added(&self, schema_id: SchemaId) -> dispatch::Result {
         let schema_not_added = !self.supported_schemas.contains(&schema_id);
-        ensure!(schema_not_added, ERROR_SCHEMA_ALREADY_ADDED_TO_ENTITY);
+        ensure!(schema_not_added, ERROR_SCHEMA_ALREADY_ADDED_TO_THE_ENTITY);
         Ok(())
     }
 
@@ -462,7 +462,7 @@ impl<T: Trait> Entity<T> {
         ensure!(
             property_values
                 .keys()
-                .all(|key| property_values.contains_key(key)),
+                .all(|key| !self.values.contains_key(key)),
             ERROR_ENTITY_ALREADY_CONTAINS_GIVEN_PROPERTY_ID
         );
         Ok(())
@@ -2194,12 +2194,17 @@ impl<T: Trait> Module<T> {
     pub fn ensure_property_values_unique_option_satisfied(
         updated_values_for_existing_properties: ValuesForExistingProperties<T>,
     ) -> dispatch::Result {
-        for updated_value_for_existing_property in updated_values_for_existing_properties.values() {
+        for (&property_id, updated_value_for_existing_property) in
+            updated_values_for_existing_properties.iter()
+        {
             let (property, value) = updated_value_for_existing_property.unzip();
 
             // Ensure all PropertyValue's with unique option set are unique, except of null non required ones
-            property
-                .ensure_unique_option_satisfied(value, &updated_values_for_existing_properties)?;
+            property.ensure_unique_option_satisfied(
+                property_id,
+                value,
+                &updated_values_for_existing_properties,
+            )?;
         }
         Ok(())
     }

--- a/runtime-modules/content-directory/src/lib.rs
+++ b/runtime-modules/content-directory/src/lib.rs
@@ -1291,7 +1291,7 @@ decl_module! {
             Ok(())
         }
 
-        /// Add schema support to entity under given `shema_id` and provided `property_values`
+        /// Add schema support to entity under given `schema_id` and provided `property_values`
         pub fn add_schema_support_to_entity(
             origin,
             actor: Actor<T>,
@@ -1428,7 +1428,7 @@ decl_module! {
 
                     // Create wrapper structure from new_property_values and their corresponding Class properties
                     let updated_values_for_existing_properties = ValuesForExistingProperties::from(
-                        &class_properties, &new_property_values
+                        &class_properties, &entity_property_values_updated
                     )?;
 
                     // Traverse all values_for_updated_properties to ensure unique option satisfied (if required)
@@ -2262,10 +2262,11 @@ impl<T: Trait> Module<T> {
         new_property_values
             .into_iter()
             .filter(|(id, new_property_value)| {
-                matches!(
-                    entity_property_values.get(id),
-                    Some(entity_property_value) if *entity_property_value != *new_property_value
-                )
+                if let Some(entity_property_value) = entity_property_values.get(id) {
+                    *entity_property_value != *new_property_value
+                } else {
+                    true
+                }
             })
             .collect()
     }

--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -863,13 +863,20 @@ impl<T: Trait> Property<T> {
         }
     }
 
-    pub fn with_name_and_type(name_len: usize, property_type: PropertyType<T>) -> Self {
+    pub fn with_name_and_type(
+        name_len: usize,
+        property_type: PropertyType<T>,
+        required: bool,
+        unique: bool,
+    ) -> Self {
         let name = generate_text(name_len);
         let description = generate_text(PropertyDescriptionLengthConstraint::get().min() as usize);
         Self {
             name,
             description,
             property_type,
+            required,
+            unique,
             ..Property::<T>::default()
         }
     }
@@ -933,6 +940,12 @@ impl<T: Trait> PropertyValue<T> {
         let vec_value = VecValue::<Runtime>::Reference(entity_ids);
         let vec_property_value = VecPropertyValue::<Runtime>::new(vec_value, 0);
         PropertyValue::<Runtime>::Vector(vec_property_value)
+    }
+
+    pub fn single_text(text_len: TextMaxLength) -> PropertyValue<Runtime> {
+        let text_value = Value::<Runtime>::Text(generate_text(text_len as usize));
+        let text_property_value = SinglePropertyValue::<Runtime>::new(text_value);
+        PropertyValue::<Runtime>::Single(text_property_value)
     }
 }
 

--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -929,6 +929,15 @@ impl<T: Trait> PropertyType<T> {
         PropertyType::<Runtime>::Vector(vec_reference)
     }
 
+    pub fn vec_text(
+        text_max_len: TextMaxLength,
+        vec_max_length: VecMaxLength,
+    ) -> PropertyType<Runtime> {
+        let vec_type = Type::<Runtime>::Text(text_max_len);
+        let vec_text = VecPropertyType::<Runtime>::new(vec_type, vec_max_length);
+        PropertyType::<Runtime>::Vector(vec_text)
+    }
+
     pub fn single_text(text_max_len: TextMaxLength) -> PropertyType<Runtime> {
         let text_type = SingleValuePropertyType(Type::<Runtime>::Text(text_max_len));
         PropertyType::<Runtime>::Single(text_type)
@@ -938,6 +947,12 @@ impl<T: Trait> PropertyType<T> {
 impl<T: Trait> PropertyValue<T> {
     pub fn vec_reference(entity_ids: Vec<EntityId>) -> PropertyValue<Runtime> {
         let vec_value = VecValue::<Runtime>::Reference(entity_ids);
+        let vec_property_value = VecPropertyValue::<Runtime>::new(vec_value, 0);
+        PropertyValue::<Runtime>::Vector(vec_property_value)
+    }
+
+    pub fn vec_text(texts: Vec<Vec<u8>>) -> PropertyValue<Runtime> {
+        let vec_value = VecValue::<Runtime>::Text(texts);
         let vec_property_value = VecPropertyValue::<Runtime>::new(vec_value, 0);
         PropertyValue::<Runtime>::Vector(vec_property_value)
     }

--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -964,6 +964,15 @@ impl EntityReferenceCounterSideEffect {
     }
 }
 
+impl PropertyLockingPolicy {
+    pub fn new(is_locked_from_maintainer: bool, is_locked_from_controller: bool) -> Self {
+        Self {
+            is_locked_from_maintainer,
+            is_locked_from_controller,
+        }
+    }
+}
+
 // Assign back to type variables so we can make dispatched calls of these modules later.
 pub type System = system::Module<Runtime>;
 pub type TestModule = Module<Runtime>;

--- a/runtime-modules/content-directory/src/schema.rs
+++ b/runtime-modules/content-directory/src/schema.rs
@@ -23,8 +23,8 @@ pub type SameController = bool;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Default, Decode, Clone, Copy, PartialEq, Eq, Debug)]
 pub struct PropertyLockingPolicy {
-    is_locked_from_maintainer: bool,
-    is_locked_from_controller: bool,
+    pub is_locked_from_maintainer: bool,
+    pub is_locked_from_controller: bool,
 }
 
 /// Enum, used for `PropertyType` representation

--- a/runtime-modules/content-directory/src/schema.rs
+++ b/runtime-modules/content-directory/src/schema.rs
@@ -412,7 +412,7 @@ impl<T: Trait> VecPropertyValue<T> {
         index_in_property_vec: VecMaxLength,
     ) -> dispatch::Result {
         ensure!(
-            (index_in_property_vec as usize) < self.len(),
+            (index_in_property_vec as usize) <= self.len(),
             ERROR_ENTITY_PROP_VALUE_VECTOR_INDEX_IS_OUT_OF_RANGE
         );
 

--- a/runtime-modules/content-directory/src/tests.rs
+++ b/runtime-modules/content-directory/src/tests.rs
@@ -298,3 +298,38 @@ pub fn emulate_entity_access_state_for_failure_case(
         }
     }
 }
+
+pub fn add_class_reference_schema_and_entity_schema_support(actor: &Actor<Runtime>, origin: u64) {
+    // Create property
+    let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+    let property = Property::<Runtime>::with_name_and_type(
+        (PropertyNameLengthConstraint::get().max() - 1) as usize,
+        property_type,
+        true,
+        false,
+    );
+
+    // Add Schema to the Class
+    assert_ok!(add_class_schema(
+        LEAD_ORIGIN,
+        FIRST_CLASS_ID,
+        BTreeSet::new(),
+        vec![property]
+    ));
+
+    let schema_property_value =
+        PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+    let mut schema_property_values = BTreeMap::new();
+    schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+    // Add schema support to the entity
+    assert_ok!(add_schema_support_to_entity(
+        origin,
+        actor.to_owned(),
+        FIRST_ENTITY_ID,
+        FIRST_SCHEMA_ID,
+        schema_property_values.clone()
+    ));
+}

--- a/runtime-modules/content-directory/src/tests.rs
+++ b/runtime-modules/content-directory/src/tests.rs
@@ -299,7 +299,7 @@ pub fn emulate_entity_access_state_for_failure_case(
     }
 }
 
-pub fn add_class_reference_schema_and_entity_schema_support(actor: &Actor<Runtime>, origin: u64) {
+pub fn add_class_reference_schema() {
     // Create property
     let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
 
@@ -317,6 +317,10 @@ pub fn add_class_reference_schema_and_entity_schema_support(actor: &Actor<Runtim
         BTreeSet::new(),
         vec![property]
     ));
+}
+
+pub fn add_class_reference_schema_and_entity_schema_support(actor: &Actor<Runtime>, origin: u64) {
+    add_class_reference_schema();
 
     let schema_property_value =
         PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);

--- a/runtime-modules/content-directory/src/tests.rs
+++ b/runtime-modules/content-directory/src/tests.rs
@@ -301,7 +301,8 @@ pub fn emulate_entity_access_state_for_failure_case(
 
 pub fn add_class_reference_schema() {
     // Create property
-    let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+    let property_type =
+        PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, VecMaxLengthConstraint::get());
 
     let property = Property::<Runtime>::with_name_and_type(
         (PropertyNameLengthConstraint::get().max() - 1) as usize,
@@ -334,6 +335,6 @@ pub fn add_class_reference_schema_and_entity_schema_support(actor: &Actor<Runtim
         actor.to_owned(),
         FIRST_ENTITY_ID,
         FIRST_SCHEMA_ID,
-        schema_property_values.clone()
+        schema_property_values
     ));
 }

--- a/runtime-modules/content-directory/src/tests.rs
+++ b/runtime-modules/content-directory/src/tests.rs
@@ -152,10 +152,10 @@ pub enum EntityAccessStateFailureType {
     EntityNotFound,
     LeadAuthFailed,
     MemberAuthFailed,
-    CuratorGroupIsNotActive,
     CuratorAuthFailed,
     CuratorNotFoundInCuratorGroup,
     EntityAccessDenied,
+    PropertyValuesLocked,
 }
 
 pub fn emulate_entity_access_state_for_failure_case(
@@ -191,48 +191,6 @@ pub fn emulate_entity_access_state_for_failure_case(
                 FIRST_MEMBER_ORIGIN,
                 FIRST_CLASS_ID,
                 actor.clone()
-            ));
-            actor
-        }
-        EntityAccessStateFailureType::CuratorGroupIsNotActive => {
-            // Add curator group
-            assert_ok!(add_curator_group(LEAD_ORIGIN));
-
-            // Add curator to group
-            assert_ok!(add_curator_to_group(
-                LEAD_ORIGIN,
-                FIRST_CURATOR_GROUP_ID,
-                FIRST_CURATOR_ID,
-            ));
-
-            // Add curator group as class maintainer
-            assert_ok!(add_maintainer_to_class(
-                LEAD_ORIGIN,
-                FIRST_CLASS_ID,
-                FIRST_CURATOR_GROUP_ID
-            ));
-
-            // Make curator group active
-            assert_ok!(set_curator_group_status(
-                LEAD_ORIGIN,
-                FIRST_CURATOR_GROUP_ID,
-                true
-            ));
-
-            let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
-
-            // Create Entity
-            assert_ok!(create_entity(
-                FIRST_CURATOR_ORIGIN,
-                FIRST_CLASS_ID,
-                actor.clone()
-            ));
-
-            // Make curator group inactive to block it from any entity operations
-            assert_ok!(set_curator_group_status(
-                LEAD_ORIGIN,
-                FIRST_CURATOR_GROUP_ID,
-                false
             ));
             actor
         }
@@ -321,6 +279,22 @@ pub fn emulate_entity_access_state_for_failure_case(
             assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, Actor::Lead));
 
             Actor::Member(SECOND_MEMBER_ID)
+        }
+        EntityAccessStateFailureType::PropertyValuesLocked => {
+            // Update class permissions to force lock all entity property values from update being performed
+            assert_ok!(update_class_permissions(
+                LEAD_ORIGIN,
+                FIRST_CLASS_ID,
+                None,
+                None,
+                Some(true),
+                None
+            ));
+
+            // Create entity
+            assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, Actor::Lead));
+
+            Actor::Lead
         }
     }
 }

--- a/runtime-modules/content-directory/src/tests/add_class_schema.rs
+++ b/runtime-modules/content-directory/src/tests/add_class_schema.rs
@@ -468,7 +468,7 @@ fn add_class_schema_property_refers_unknown_class() {
             true,
             VecMaxLengthConstraint::get(),
         );
-        let property = Property::<Runtime>::with_name_and_type(1, reference_vec_type);
+        let property = Property::<Runtime>::with_name_and_type(1, reference_vec_type, true, true);
 
         // Make an attempt to add class schema, providing property with Type::Reference, which refers to unknown ClassId
         let add_class_schema_result =

--- a/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
+++ b/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
@@ -365,7 +365,7 @@ fn add_schema_support_to_entity_schema_does_not_exist() {
         let mut schema_property_values = BTreeMap::new();
         schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
 
-        // Make an attempt to add schema support to entity, providing shema_id,
+        // Make an attempt to add schema support to entity, providing schema_id,
         // which corresponding Schema does not exist on Class level
         let add_schema_support_to_entity_result = add_schema_support_to_entity(
             LEAD_ORIGIN,

--- a/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
+++ b/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
@@ -13,3 +13,5 @@ fn add_schema_support_to_entity_success() {
         assert_eq!(second_entity, entity_by_id(SECOND_ENTITY_ID));
     })
 }
+
+

--- a/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
+++ b/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
@@ -156,8 +156,15 @@ fn add_schema_support_member_auth_failed() {
 fn add_schema_support_curator_group_is_not_active() {
     with_test_externalities(|| {
         let actor = emulate_entity_access_state_for_failure_case(
-            EntityAccessStateFailureType::CuratorGroupIsNotActive,
+            EntityAccessStateFailureType::CuratorAuthFailed,
         );
+
+        // Make curator group inactive to block it from any entity operations
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            false
+        ));
 
         // Create property
         let property = Property::<Runtime>::default_with_name(

--- a/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
+++ b/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
@@ -14,4 +14,1153 @@ fn add_schema_support_to_entity_success() {
     })
 }
 
+#[test]
+fn add_schema_support_to_non_existent_entity() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityNotFound,
+        );
 
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to add schema support to non existent Entity
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_lead_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::LeadAuthFailed,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to add schema support under non lead origin
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_member_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::MemberAuthFailed,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to add schema support to entity using unknown origin and member actor
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_MEMBER_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_curator_group_is_not_active() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorGroupIsNotActive,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity using curator group, which is not active as actor
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            FIRST_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CURATOR_GROUP_IS_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_curator_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity under unknown origin and curator actor,
+        // which corresponding group is current entity controller
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CURATOR_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_curator_not_found_in_curator_group() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity, using actor in group,
+        // which curator id was not added to corresponding group set
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CURATOR_IS_NOT_A_MEMBER_OF_A_GIVEN_CURATOR_GROUP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_access_denied() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityAccessDenied,
+        );
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity, using origin,
+        // which corresponding actor is neither entity maintainer, nor controller.
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            SECOND_MEMBER_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_ENTITY_ACCESS_DENIED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_to_entity_schema_does_not_exist() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to entity, providing shema_id,
+        // which corresponding Schema does not exist on Class level
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_UNKNOWN_CLASS_SCHEMA_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_to_entity_class_property_not_found() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(SECOND_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, providing property value under property_id,
+        // which does not not yet added to corresponding Class properties
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CLASS_PROP_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_already_added_to_the_entity() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to add schema support to entity, providing schema_id,
+        // which was already added to the Entity
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_SCHEMA_ALREADY_ADDED_TO_THE_ENTITY,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_already_contains_given_property_id() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create first property
+        let first_property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add first Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![first_property]
+        ));
+
+        // Create second property
+        let second_property_type =
+            PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let second_property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+            second_property_type,
+            true,
+            false,
+        );
+
+        // Add second Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::from_iter(vec![FIRST_PROPERTY_ID].into_iter()),
+            vec![second_property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        schema_property_values.insert(
+            SECOND_PROPERTY_ID,
+            PropertyValue::<Runtime>::single_text(TextMaxLengthConstraint::get()),
+        );
+
+        // Make an attempt to add schema support to entity, providing Schema property_values,
+        // some of which were already added to this Entity
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            SECOND_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_ENTITY_ALREADY_CONTAINS_GIVEN_PROPERTY_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_is_not_active() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Make Class Schema inactive
+        assert_ok!(update_class_schema_status(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            FIRST_SCHEMA_ID,
+            false
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, providing schema id,
+        // which correspondin class Schema is not active
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_CLASS_SCHEMA_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_does_not_contain_provided_property_id() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create first property
+        let first_property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![first_property]
+        ));
+
+        // Create second property
+        let second_property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![second_property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(SECOND_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, providing property values, which are not a members of
+        // provided Schema
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_SCHEMA_DOES_NOT_CONTAIN_PROVIDED_PROPERTY_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_missing_required_property() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create first property
+        let first_property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Create second property
+        let second_property_type =
+            PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let second_property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+            second_property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![first_property, second_property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, do not providing some of required property values
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_MISSING_REQUIRED_PROP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_dont_match_type() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Make an attempt to add schema support to Entity, providing property values, some of which do not match
+        // Class level Property Type
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_PROP_VALUE_DONT_MATCH_TYPE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_referenced_entity_does_not_match_class() {
+    with_test_externalities(|| {
+        // Create first class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create second class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create first entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        // Create second entity
+        assert_ok!(create_entity(
+            LEAD_ORIGIN,
+            SECOND_CLASS_ID,
+            actor.to_owned()
+        ));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the first Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![SECOND_ENTITY_ID, SECOND_ENTITY_ID]);
+
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the Entity, when provided schema property value(s) refer(s) Entity, which Class
+        // does not match the class in corresponding Class Schema
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_REFERENCED_ENTITY_DOES_NOT_MATCH_ITS_CLASS,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_referenced_entity_does_not_exist() {
+    with_test_externalities(|| {
+        // Create first class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create second class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(SECOND_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the first Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![UNKNOWN_ENTITY_ID, UNKNOWN_ENTITY_ID]);
+
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the first entity, if provided property value(s) refer(s) to another Entity,
+        // which does not exist in runtime
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_text_property_is_too_long() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        // Create text property
+        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+
+        let property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the first Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::single_text(TextMaxLengthConstraint::get() + 1);
+
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the entity, providing text property value(s), which
+        // length exceeds TextMaxLengthConstraint.
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_TEXT_PROP_IS_TOO_LONG,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_vec_property_is_too_long() {
+    with_test_externalities(|| {
+        // Create first class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create second class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create first entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        // Create second entity
+        assert_ok!(create_entity(
+            LEAD_ORIGIN,
+            SECOND_CLASS_ID,
+            actor.to_owned()
+        ));
+
+        // Create vec property
+        let property_type = PropertyType::<Runtime>::vec_reference(
+            SECOND_CLASS_ID,
+            true,
+            VecMaxLengthConstraint::get(),
+        );
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the first Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_property_values = BTreeMap::new();
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![
+                SECOND_ENTITY_ID;
+                VecMaxLengthConstraint::get() as usize + 1
+            ]);
+
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the Entity, providing vector property value(s), which
+        // length exceeds VecMaxLengthConstraint.
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone(),
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_VEC_PROP_IS_TOO_LONG,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn add_schema_support_property_should_be_unique() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+
+        // Create first text property
+
+        let first_property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize,
+            property_type.clone(),
+            true,
+            true,
+        );
+
+        // Create second text property
+
+        let second_property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize - 1,
+            property_type,
+            true,
+            true,
+        );
+
+        // Add first Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![first_property]
+        ));
+
+        // Add second Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![second_property]
+        ));
+
+        let mut first_schema_property_values = BTreeMap::new();
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::single_text(TextMaxLengthConstraint::get());
+
+        first_schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value.clone());
+
+        // Add Entity Schema support
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            first_schema_property_values,
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut second_schema_property_values = BTreeMap::new();
+
+        second_schema_property_values.insert(SECOND_PROPERTY_ID, schema_property_value);
+
+        // Make an attempt to add schema support to the entity, providing property value(s), which are identical to thouse, are already added to The Entity,
+        // though should be unique on Class Schema level
+        let add_schema_support_to_entity_result = add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            SECOND_SCHEMA_ID,
+            second_schema_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            add_schema_support_to_entity_result,
+            ERROR_PROPERTY_VALUE_SHOULD_BE_UNIQUE,
+            number_of_events_before_call,
+        );
+    })
+}

--- a/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
@@ -67,23 +67,8 @@ fn clear_entity_property_vector_entity_not_found() {
             EntityAccessStateFailureType::EntityNotFound,
         );
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
+        // Create class reference schema
+        add_class_reference_schema();
 
         // Runtime state before tested call
 
@@ -442,23 +427,8 @@ fn clear_entity_property_vector_unknown_entity_property_id() {
         // Create class with default permissions
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
+        // Create class reference schema
+        add_class_reference_schema();
 
         let actor = Actor::Lead;
 

--- a/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
@@ -115,38 +115,8 @@ fn clear_entity_property_vector_lead_auth_failed() {
             EntityAccessStateFailureType::LeadAuthFailed,
         );
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
-
-        let schema_property_value =
-            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
-
-        let mut schema_property_values = BTreeMap::new();
-        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
-
-        // Add schema support to the entity
-        assert_ok!(add_schema_support_to_entity(
-            LEAD_ORIGIN,
-            actor.to_owned(),
-            FIRST_ENTITY_ID,
-            FIRST_SCHEMA_ID,
-            schema_property_values.clone()
-        ));
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
 
         // Runtime state before tested call
 
@@ -178,38 +148,8 @@ fn clear_entity_property_vector_member_auth_failed() {
             EntityAccessStateFailureType::MemberAuthFailed,
         );
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
-
-        let schema_property_value =
-            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
-
-        let mut schema_property_values = BTreeMap::new();
-        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
-
-        // Add schema support to the entity
-        assert_ok!(add_schema_support_to_entity(
-            FIRST_MEMBER_ORIGIN,
-            actor.to_owned(),
-            FIRST_ENTITY_ID,
-            FIRST_SCHEMA_ID,
-            schema_property_values.clone()
-        ));
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_MEMBER_ORIGIN);
 
         // Runtime state before tested call
 
@@ -241,38 +181,8 @@ fn clear_entity_property_vector_curator_group_is_not_active() {
             EntityAccessStateFailureType::CuratorAuthFailed,
         );
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
-
-        let schema_property_value =
-            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
-
-        let mut schema_property_values = BTreeMap::new();
-        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
-
-        // Add schema support to the entity
-        assert_ok!(add_schema_support_to_entity(
-            FIRST_CURATOR_ORIGIN,
-            actor.clone(),
-            FIRST_ENTITY_ID,
-            FIRST_SCHEMA_ID,
-            schema_property_values
-        ));
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
 
         // Make curator group inactive to block it from any entity operations
         assert_ok!(set_curator_group_status(
@@ -311,38 +221,8 @@ fn clear_entity_property_vector_curator_auth_failed() {
             EntityAccessStateFailureType::CuratorAuthFailed,
         );
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
-
-        let schema_property_value =
-            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
-
-        let mut schema_property_values = BTreeMap::new();
-        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
-
-        // Add schema support to the entity
-        assert_ok!(add_schema_support_to_entity(
-            FIRST_CURATOR_ORIGIN,
-            actor.clone(),
-            FIRST_ENTITY_ID,
-            FIRST_SCHEMA_ID,
-            schema_property_values
-        ));
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
 
         // Runtime state before tested call
 
@@ -370,38 +250,11 @@ fn clear_entity_property_vector_curator_not_found_in_curator_group() {
             EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
         );
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
-
-        let schema_property_value =
-            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
-
-        let mut schema_property_values = BTreeMap::new();
-        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
-
-        // Add schema support to the entity
-        assert_ok!(add_schema_support_to_entity(
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(
+            &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
             FIRST_CURATOR_ORIGIN,
-            Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
-            FIRST_ENTITY_ID,
-            FIRST_SCHEMA_ID,
-            schema_property_values
-        ));
+        );
 
         // Runtime state before tested call
 
@@ -433,38 +286,8 @@ fn clear_entity_property_vector_entity_access_denied() {
             EntityAccessStateFailureType::EntityAccessDenied,
         );
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
-
-        let schema_property_value =
-            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
-
-        let mut schema_property_values = BTreeMap::new();
-        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
-
-        // Add schema support to the entity
-        assert_ok!(add_schema_support_to_entity(
-            LEAD_ORIGIN,
-            Actor::Lead,
-            FIRST_ENTITY_ID,
-            FIRST_SCHEMA_ID,
-            schema_property_values
-        ));
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call
 
@@ -496,38 +319,8 @@ fn clear_entity_property_vector_values_locked_on_class_level() {
             EntityAccessStateFailureType::PropertyValuesLocked,
         );
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
-
-        let schema_property_value =
-            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
-
-        let mut schema_property_values = BTreeMap::new();
-        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
-
-        // Add schema support to the entity
-        assert_ok!(add_schema_support_to_entity(
-            LEAD_ORIGIN,
-            Actor::Lead,
-            FIRST_ENTITY_ID,
-            FIRST_SCHEMA_ID,
-            schema_property_values
-        ));
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call
 

--- a/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
@@ -175,6 +175,35 @@ fn clear_entity_property_vector_member_auth_failed() {
 }
 
 #[test]
+fn clear_entity_property_vector_curator_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // using unknown origin and curator actor
+        let clear_entity_property_vector_result =
+            clear_entity_property_vector(UNKNOWN_ORIGIN, actor, FIRST_ENTITY_ID, FIRST_PROPERTY_ID);
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_CURATOR_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
 fn clear_entity_property_vector_curator_group_is_not_active() {
     with_test_externalities(|| {
         let actor = emulate_entity_access_state_for_failure_case(
@@ -209,35 +238,6 @@ fn clear_entity_property_vector_curator_group_is_not_active() {
         assert_failure(
             clear_entity_property_vector_result,
             ERROR_CURATOR_GROUP_IS_NOT_ACTIVE,
-            number_of_events_before_call,
-        );
-    })
-}
-
-#[test]
-fn clear_entity_property_vector_curator_auth_failed() {
-    with_test_externalities(|| {
-        let actor = emulate_entity_access_state_for_failure_case(
-            EntityAccessStateFailureType::CuratorAuthFailed,
-        );
-
-        // Create class reference shema and add corresponding schema support to the Entity
-        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
-
-        // Runtime state before tested call
-
-        // Events number before tested call
-        let number_of_events_before_call = System::events().len();
-
-        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
-        // using unknown origin and curator actor
-        let clear_entity_property_vector_result =
-            clear_entity_property_vector(UNKNOWN_ORIGIN, actor, FIRST_ENTITY_ID, FIRST_PROPERTY_ID);
-
-        // Failure checked
-        assert_failure(
-            clear_entity_property_vector_result,
-            ERROR_CURATOR_AUTH_FAILED,
             number_of_events_before_call,
         );
     })

--- a/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
@@ -59,3 +59,689 @@ fn clear_entity_property_vector_success() {
         );
     })
 }
+
+#[test]
+fn clear_entity_property_vector_entity_not_found() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityNotFound,
+        );
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // in case when corresponding Entity does not exist
+        let clear_entity_property_vector_result = clear_entity_property_vector(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+        );
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_lead_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::LeadAuthFailed,
+        );
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone()
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // using unknown origin and lead actor
+        let clear_entity_property_vector_result = clear_entity_property_vector(
+            UNKNOWN_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+        );
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_member_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::MemberAuthFailed,
+        );
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            FIRST_MEMBER_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone()
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // using unknown origin an member actor
+        let clear_entity_property_vector_result = clear_entity_property_vector(
+            UNKNOWN_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+        );
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_MEMBER_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_curator_group_is_not_active() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            FIRST_CURATOR_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Make curator group inactive to block it from any entity operations
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            false
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // using curator group, which is not active as actor
+        let clear_entity_property_vector_result = clear_entity_property_vector(
+            FIRST_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+        );
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_CURATOR_GROUP_IS_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_curator_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            FIRST_CURATOR_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // using unknown origin and curator actor
+        let clear_entity_property_vector_result =
+            clear_entity_property_vector(UNKNOWN_ORIGIN, actor, FIRST_ENTITY_ID, FIRST_PROPERTY_ID);
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_CURATOR_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_curator_not_found_in_curator_group() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
+        );
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            FIRST_CURATOR_ORIGIN,
+            Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // using actor in group, which curator id was not added to corresponding group set
+        let clear_entity_property_vector_result = clear_entity_property_vector(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+        );
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_CURATOR_IS_NOT_A_MEMBER_OF_A_GIVEN_CURATOR_GROUP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_entity_access_denied() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityAccessDenied,
+        );
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            Actor::Lead,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // using origin, which corresponding actor is neither entity maintainer, nor controller.
+        let clear_entity_property_vector_result = clear_entity_property_vector(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+        );
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_ENTITY_ACCESS_DENIED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_values_locked_on_class_level() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::PropertyValuesLocked,
+        );
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            Actor::Lead,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // in the case, when all property values were locked on Class level
+        let clear_entity_property_vector_result =
+            clear_entity_property_vector(LEAD_ORIGIN, actor, FIRST_ENTITY_ID, FIRST_PROPERTY_ID);
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_ALL_PROP_WERE_LOCKED_ON_CLASS_LEVEL,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_class_property_not_found() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // in the case, when Property under corresponding PropertyId was not found on Class level
+        let clear_entity_property_vector_result =
+            clear_entity_property_vector(LEAD_ORIGIN, actor, FIRST_ENTITY_ID, FIRST_PROPERTY_ID);
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_CLASS_PROP_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_is_locked_for_given_actor() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let mut property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        property.locking_policy = PropertyLockingPolicy::new(false, true);
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            Actor::Lead,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id` under lead origin,
+        // which is current Entity controller, in the case, when corresponding class Property was locked from controller on Class level
+        let clear_entity_property_vector_result =
+            clear_entity_property_vector(LEAD_ORIGIN, actor, FIRST_ENTITY_ID, FIRST_PROPERTY_ID);
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_CLASS_PROPERTY_TYPE_IS_LOCKED_FOR_GIVEN_ACTOR,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_unknown_entity_property_id() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // in the case, when property value was not added to current Entity values yet.
+        let clear_entity_property_vector_result =
+            clear_entity_property_vector(LEAD_ORIGIN, actor, FIRST_ENTITY_ID, FIRST_PROPERTY_ID);
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_UNKNOWN_ENTITY_PROP_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_value_under_given_index_is_not_a_vector() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to clear property_vector under given `entity_id` & `in_class_schema_property_id`
+        // in the case, when entity property value corresponding to a given in_class_schema_property_id is not a vector.
+        let clear_entity_property_vector_result =
+            clear_entity_property_vector(LEAD_ORIGIN, actor, FIRST_ENTITY_ID, FIRST_PROPERTY_ID);
+
+        // Failure checked
+        assert_failure(
+            clear_entity_property_vector_result,
+            ERROR_PROP_VALUE_UNDER_GIVEN_INDEX_IS_NOT_A_VECTOR,
+            number_of_events_before_call,
+        );
+    })
+}

--- a/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
@@ -100,7 +100,7 @@ fn clear_entity_property_vector_lead_auth_failed() {
             EntityAccessStateFailureType::LeadAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -133,7 +133,7 @@ fn clear_entity_property_vector_member_auth_failed() {
             EntityAccessStateFailureType::MemberAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, FIRST_MEMBER_ORIGIN);
 
         // Runtime state before tested call
@@ -166,7 +166,7 @@ fn clear_entity_property_vector_curator_auth_failed() {
             EntityAccessStateFailureType::CuratorAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
 
         // Runtime state before tested call
@@ -195,7 +195,7 @@ fn clear_entity_property_vector_curator_group_is_not_active() {
             EntityAccessStateFailureType::CuratorAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
 
         // Make curator group inactive to block it from any entity operations
@@ -235,7 +235,7 @@ fn clear_entity_property_vector_curator_not_found_in_curator_group() {
             EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(
             &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
             FIRST_CURATOR_ORIGIN,
@@ -271,7 +271,7 @@ fn clear_entity_property_vector_entity_access_denied() {
             EntityAccessStateFailureType::EntityAccessDenied,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -304,7 +304,7 @@ fn clear_entity_property_vector_values_locked_on_class_level() {
             EntityAccessStateFailureType::PropertyValuesLocked,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call

--- a/runtime-modules/content-directory/src/tests/insert_at_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/insert_at_entity_property_vector.rs
@@ -116,7 +116,7 @@ fn insert_at_entity_property_vector_lead_auth_failed() {
             EntityAccessStateFailureType::LeadAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -156,7 +156,7 @@ fn insert_at_entity_property_vector_member_auth_failed() {
             EntityAccessStateFailureType::MemberAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -196,7 +196,7 @@ fn insert_at_entity_property_vector_curator_group_is_not_active() {
             EntityAccessStateFailureType::CuratorAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
 
         // Make curator group inactive to block it from any entity operations
@@ -243,8 +243,11 @@ fn insert_at_entity_property_vector_curator_auth_failed() {
             EntityAccessStateFailureType::CuratorAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
-        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(
+            &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
+            FIRST_CURATOR_ORIGIN,
+        );
 
         // Runtime state before tested call
 
@@ -283,7 +286,7 @@ fn insert_at_entity_property_vector_curator_not_found_in_curator_group() {
             EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(
             &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
             FIRST_CURATOR_ORIGIN,
@@ -327,7 +330,7 @@ fn insert_at_entity_property_vector_access_denied() {
             EntityAccessStateFailureType::EntityAccessDenied,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -368,7 +371,7 @@ fn insert_at_entity_property_vector_values_locked_on_class_level() {
             EntityAccessStateFailureType::PropertyValuesLocked,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -645,7 +648,7 @@ fn insert_at_entity_property_vector_nonces_does_not_match() {
         // Create entity
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -966,7 +969,7 @@ fn insert_at_entity_property_vector_referenced_entity_not_found() {
         // Create entity
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -1008,16 +1011,16 @@ fn insert_at_entity_property_vector_entity_can_not_be_referenced() {
 
         let actor = Actor::Lead;
 
-        // Create first Entity
+        // Create first Entity of first Class
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
 
-        // Create class reference shema and add corresponding schema support to the first  Entity
+        // Create class reference schema and add corresponding schema support to the first Entity
         add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
 
-        // Create second Entity
+        // Create second Entity of first Class
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
 
-        // Update entity permissions for chosen entity to forbid it from being referencable
+        // Update second entity permissions to forbid it from being referencable
         assert_ok!(update_entity_permissions(
             LEAD_ORIGIN,
             SECOND_ENTITY_ID,
@@ -1077,7 +1080,7 @@ fn insert_at_entity_property_vector_same_controller_constraint_violation() {
         // Create first Entity
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
 
-        // Create class reference shema and add corresponding schema support to the first  Entity
+        // Create class reference schema and add corresponding schema support to the first  Entity
         add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
 
         // Create second Entity

--- a/runtime-modules/content-directory/src/tests/insert_at_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/insert_at_entity_property_vector.rs
@@ -68,3 +68,1052 @@ fn insert_at_entity_property_vector_success() {
         );
     })
 }
+
+#[test]
+fn insert_at_entity_property_vector_entity_not_found() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityNotFound,
+        );
+
+        // Create class reference schema
+        add_class_reference_schema();
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 1;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` in case when corresponding Entity does not exist
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_lead_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::LeadAuthFailed,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 1;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` using unknown origin and lead actor
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_member_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::MemberAuthFailed,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` using unknown origin and member actor
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_MEMBER_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_curator_group_is_not_active() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
+
+        // Make curator group inactive to block it from any entity operations
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            false
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` using curator group, which is not active as actor
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            FIRST_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_CURATOR_GROUP_IS_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_curator_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` using unknown origin and curator actor
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_CURATOR_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_curator_not_found_in_curator_group() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(
+            &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
+            FIRST_CURATOR_ORIGIN,
+        );
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id`,
+        // using actor in group, which curator id was not added to corresponding group set
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_CURATOR_IS_NOT_A_MEMBER_OF_A_GIVEN_CURATOR_GROUP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_access_denied() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityAccessDenied,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id`,
+        // using origin, which corresponding actor is neither entity maintainer, nor controller.
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_ENTITY_ACCESS_DENIED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_values_locked_on_class_level() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::PropertyValuesLocked,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id`,
+        // in the case, when all property values were locked on Class level.
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_ALL_PROP_WERE_LOCKED_ON_CLASS_LEVEL,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_class_property_not_found() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id`,
+        // in the case, when Property under corresponding PropertyId was not found on Class level.
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_CLASS_PROP_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_is_locked_for_given_actor() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let mut property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        property.locking_policy = PropertyLockingPolicy::new(false, true);
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            Actor::Lead,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id`,
+        // under lead origin, which is current Entity controller, in the case,
+        // when corresponding class Property was locked from controller on Class level
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_CLASS_PROPERTY_TYPE_IS_LOCKED_FOR_GIVEN_ACTOR,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_unknown_entity_property_id() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create class reference schema
+        add_class_reference_schema();
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // intto `PropertyValueVec` under `in_class_schema_property_id`,
+        // in the case, when property value was not added to current Entity values yet.
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_UNKNOWN_ENTITY_PROP_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_value_under_given_index_is_not_a_vector() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id`,
+        // in the case, when entity property value corresponding to a given in_class_schema_property_id is not a vector.
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_PROP_VALUE_UNDER_GIVEN_INDEX_IS_NOT_A_VECTOR,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_nonces_does_not_match() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 1;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id`,
+        // providing nonce that does not corresponding property value vector one.
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_PROP_VALUE_VEC_NONCES_DOES_NOT_MATCH,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_index_is_out_of_range() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema
+        add_class_reference_schema();
+
+        let entity_ids = vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID];
+        let schema_property_value = PropertyValue::<Runtime>::vec_reference(entity_ids.clone());
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone()
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` in case,
+        // when provided index_in_property_vector is out of range of the related vector
+        let nonce = 0;
+        let index_in_property_vector = entity_ids.len() as u16 + 1;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_ENTITY_PROP_VALUE_VECTOR_INDEX_IS_OUT_OF_RANGE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_is_too_long() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema
+        add_class_reference_schema();
+
+        let entity_ids = vec![FIRST_ENTITY_ID; VecMaxLengthConstraint::get() as usize];
+        let schema_property_value = PropertyValue::<Runtime>::vec_reference(entity_ids.clone());
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone()
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` in case,
+        // when corresponding property_vector can not contain more values
+        let nonce = 0;
+        let index_in_property_vector = 1;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(FIRST_ENTITY_ID));
+
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_ENTITY_PROP_VALUE_VECTOR_IS_TOO_LONG,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_text_prop_is_too_long() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_text(
+            TextMaxLengthConstraint::get(),
+            VecMaxLengthConstraint::get(),
+        );
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value = PropertyValue::<Runtime>::vec_text(vec![]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` in case,
+        // when corresponding property text value is too long
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Text(generate_text(
+            TextMaxLengthConstraint::get() as usize + 1,
+        )));
+
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_TEXT_PROP_IS_TOO_LONG,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_prop_type_does_not_match_internal_vec_property() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_text(
+            TextMaxLengthConstraint::get(),
+            VecMaxLengthConstraint::get(),
+        );
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value = PropertyValue::<Runtime>::vec_text(vec![]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` in case,
+        // when corresponding property type does not match internal vector property type
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::default();
+
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_PROP_VALUE_TYPE_DOESNT_MATCH_INTERNAL_ENTITY_VECTOR_TYPE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_referenced_entity_not_found() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` in case,
+        // when corresponding single_property_value referes to unknown Entity
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(SECOND_ENTITY_ID));
+
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_entity_can_not_be_referenced() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create first Entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference shema and add corresponding schema support to the first  Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Create second Entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Update entity permissions for chosen entity to forbid it from being referencable
+        assert_ok!(update_entity_permissions(
+            LEAD_ORIGIN,
+            SECOND_ENTITY_ID,
+            None,
+            Some(false)
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` in case,
+        // when corresponding Entity can not be referenced
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(SECOND_ENTITY_ID));
+
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_ENTITY_CAN_NOT_BE_REFERENCED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn insert_at_entity_property_vector_same_controller_constraint_violation() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Update class permissions to force any member be available to create Entities
+        assert_ok!(update_class_permissions(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            Some(true),
+            None,
+            None,
+            None
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create first Entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference shema and add corresponding schema support to the first  Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Create second Entity
+        assert_ok!(create_entity(
+            FIRST_MEMBER_ORIGIN,
+            FIRST_CLASS_ID,
+            Actor::Member(FIRST_MEMBER_ID)
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to insert value at given `index_in_property_vector`
+        // into `PropertyValueVec` under `in_class_schema_property_id` in case,
+        // when corresponding Entity can only be referenced from Entity with the same controller.
+        let nonce = 0;
+        let index_in_property_vector = 0;
+        let single_property_value = SinglePropertyValue::new(Value::Reference(SECOND_ENTITY_ID));
+
+        let insert_at_entity_property_vector_result = insert_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            single_property_value,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            insert_at_entity_property_vector_result,
+            ERROR_SAME_CONTROLLER_CONSTRAINT_VIOLATION,
+            number_of_events_before_call,
+        );
+    })
+}

--- a/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
@@ -65,3 +65,675 @@ fn remove_at_entity_property_vector_success() {
         );
     })
 }
+
+#[test]
+fn remove_at_entity_property_vector_entity_not_found() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityNotFound,
+        );
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id` in case when corresponding Entity does not exist
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_lead_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::LeadAuthFailed,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id` using unknown origin and lead actor
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_member_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::MemberAuthFailed,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id` using unknown origin and member actor
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_MEMBER_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_curator_group_is_not_active() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
+
+        // Make curator group inactive to block it from any entity operations
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            false
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id` using curator group, which is not active as actor
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            FIRST_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_CURATOR_GROUP_IS_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_curator_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id` using unknown origin and curator actor
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_CURATOR_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_curator_not_found_in_curator_group() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(
+            &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
+            FIRST_CURATOR_ORIGIN,
+        );
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id`,
+        // using actor in group, which curator id was not added to corresponding group set
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_CURATOR_IS_NOT_A_MEMBER_OF_A_GIVEN_CURATOR_GROUP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_access_denied() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityAccessDenied,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id`,
+        // using origin, which corresponding actor is neither entity maintainer, nor controller.
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_ENTITY_ACCESS_DENIED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_values_locked_on_class_level() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::PropertyValuesLocked,
+        );
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id`,
+        // in the case, when all property values were locked on Class level.
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_ALL_PROP_WERE_LOCKED_ON_CLASS_LEVEL,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_class_property_not_found() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id`,
+        // in the case, when Property under corresponding PropertyId was not found on Class level.
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_CLASS_PROP_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_is_locked_for_given_actor() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let mut property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        property.locking_policy = PropertyLockingPolicy::new(false, true);
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            Actor::Lead,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id`,
+        // under lead origin, which is current Entity controller, in the case,
+        // when corresponding class Property was locked from controller on Class level
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_CLASS_PROPERTY_TYPE_IS_LOCKED_FOR_GIVEN_ACTOR,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_unknown_entity_property_id() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id`,
+        // in the case, when property value was not added to current Entity values yet.
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_UNKNOWN_ENTITY_PROP_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn clear_entity_property_vector_value_under_given_index_is_not_a_vector() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property = Property::<Runtime>::default_with_name(
+            PropertyNameLengthConstraint::get().max() as usize,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, PropertyValue::default());
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.clone(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values,
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 0;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id`,
+        // in the case, when entity property value corresponding to a given in_class_schema_property_id is not a vector.
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_PROP_VALUE_UNDER_GIVEN_INDEX_IS_NOT_A_VECTOR,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_nonces_does_not_match() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference shema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let nonce = 1;
+        let index_in_property_vector = 0;
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id`,
+        // providing nonce that does not corresponding property value vector one.
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_PROP_VALUE_VEC_NONCES_DOES_NOT_MATCH,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn remove_at_entity_property_vector_index_is_out_of_range() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference shema
+        add_class_reference_schema();
+
+        let entity_ids = vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID];
+        let schema_property_value = PropertyValue::<Runtime>::vec_reference(entity_ids.clone());
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values.clone()
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        // Make an attempt to remove value at given `index_in_property_vector`
+        // from `PropertyValueVec` under `in_class_schema_property_id` in case,
+        // when provided index_in_property_vector is out of range of the related vector
+        let nonce = 0;
+        let index_in_property_vector = entity_ids.len() as u16 + 1;
+
+        let remove_at_entity_property_vector_result = remove_at_entity_property_vector(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            FIRST_PROPERTY_ID,
+            index_in_property_vector,
+            nonce,
+        );
+
+        // Failure checked
+        assert_failure(
+            remove_at_entity_property_vector_result,
+            ERROR_ENTITY_PROP_VALUE_VECTOR_INDEX_IS_OUT_OF_RANGE,
+            number_of_events_before_call,
+        );
+    })
+}

--- a/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
@@ -500,7 +500,7 @@ fn remove_at_entity_property_vector_is_locked_for_given_actor() {
 }
 
 #[test]
-fn clear_entity_property_vector_unknown_entity_property_id() {
+fn remove_at_entity_property_vector_unknown_entity_property_id() {
     with_test_externalities(|| {
         // Create class with default permissions
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
@@ -543,7 +543,7 @@ fn clear_entity_property_vector_unknown_entity_property_id() {
 }
 
 #[test]
-fn clear_entity_property_vector_value_under_given_index_is_not_a_vector() {
+fn remove_at_entity_property_vector_value_under_given_index_is_not_a_vector() {
     with_test_externalities(|| {
         // Create class with default permissions
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));

--- a/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
@@ -111,7 +111,7 @@ fn remove_at_entity_property_vector_lead_auth_failed() {
             EntityAccessStateFailureType::LeadAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -149,7 +149,7 @@ fn remove_at_entity_property_vector_member_auth_failed() {
             EntityAccessStateFailureType::MemberAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -187,7 +187,7 @@ fn remove_at_entity_property_vector_curator_group_is_not_active() {
             EntityAccessStateFailureType::CuratorAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
 
         // Make curator group inactive to block it from any entity operations
@@ -232,7 +232,7 @@ fn remove_at_entity_property_vector_curator_auth_failed() {
             EntityAccessStateFailureType::CuratorAuthFailed,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&actor, FIRST_CURATOR_ORIGIN);
 
         // Runtime state before tested call
@@ -270,7 +270,7 @@ fn remove_at_entity_property_vector_curator_not_found_in_curator_group() {
             EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(
             &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
             FIRST_CURATOR_ORIGIN,
@@ -312,7 +312,7 @@ fn remove_at_entity_property_vector_access_denied() {
             EntityAccessStateFailureType::EntityAccessDenied,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -351,7 +351,7 @@ fn remove_at_entity_property_vector_values_locked_on_class_level() {
             EntityAccessStateFailureType::PropertyValuesLocked,
         );
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call
@@ -618,7 +618,7 @@ fn remove_at_entity_property_vector_nonces_does_not_match() {
         // Create entity
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
 
-        // Create class reference shema and add corresponding schema support to the Entity
+        // Create class reference schema and add corresponding schema support to the Entity
         add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
 
         // Runtime state before tested call

--- a/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
@@ -73,23 +73,8 @@ fn remove_at_entity_property_vector_entity_not_found() {
             EntityAccessStateFailureType::EntityNotFound,
         );
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
+        // Create class reference schema
+        add_class_reference_schema();
 
         // Runtime state before tested call
 
@@ -520,23 +505,8 @@ fn clear_entity_property_vector_unknown_entity_property_id() {
         // Create class with default permissions
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
-        // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
-
-        let property = Property::<Runtime>::with_name_and_type(
-            (PropertyNameLengthConstraint::get().max() - 1) as usize,
-            property_type,
-            true,
-            false,
-        );
-
-        // Add Schema to the Class
-        assert_ok!(add_class_schema(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            BTreeSet::new(),
-            vec![property]
-        ));
+        // Create class reference schema
+        add_class_reference_schema();
 
         let actor = Actor::Lead;
 
@@ -691,7 +661,7 @@ fn remove_at_entity_property_vector_index_is_out_of_range() {
         // Create entity
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
 
-        // Create class reference shema
+        // Create class reference schema
         add_class_reference_schema();
 
         let entity_ids = vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID];

--- a/runtime-modules/content-directory/src/tests/remove_entity.rs
+++ b/runtime-modules/content-directory/src/tests/remove_entity.rs
@@ -118,8 +118,15 @@ fn remove_entity_member_auth_failed() {
 fn create_entity_curator_group_is_not_active() {
     with_test_externalities(|| {
         let actor = emulate_entity_access_state_for_failure_case(
-            EntityAccessStateFailureType::CuratorGroupIsNotActive,
+            EntityAccessStateFailureType::CuratorAuthFailed,
         );
+
+        // Make curator group inactive to block it from any entity operations
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            false
+        ));
 
         // Runtime state before tested call
 

--- a/runtime-modules/content-directory/src/tests/remove_entity.rs
+++ b/runtime-modules/content-directory/src/tests/remove_entity.rs
@@ -45,13 +45,9 @@ fn remove_entity_success() {
 #[test]
 fn remove_non_existent_entity() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        let actor = Actor::Lead;
-
-        // Create entity
-        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityNotFound,
+        );
 
         // Runtime state before tested call
 
@@ -73,13 +69,9 @@ fn remove_non_existent_entity() {
 #[test]
 fn remove_entity_lead_auth_failed() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        let actor = Actor::Lead;
-
-        // Create entity
-        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::LeadAuthFailed,
+        );
 
         // Runtime state before tested call
 
@@ -87,7 +79,7 @@ fn remove_entity_lead_auth_failed() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity under non lead origin
-        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -101,23 +93,9 @@ fn remove_entity_lead_auth_failed() {
 #[test]
 fn remove_entity_member_auth_failed() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Update class permissions to force any member be available to create entities
-        assert_ok!(update_class_permissions(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            Some(true),
-            None,
-            None,
-            None
-        ));
-
-        let actor = Actor::Member(FIRST_MEMBER_ID);
-
-        // Create entity
-        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::MemberAuthFailed,
+        );
 
         // Runtime state before tested call
 
@@ -125,7 +103,7 @@ fn remove_entity_member_auth_failed() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity using unknown origin and member actor, which is current Entity controller
-        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -139,48 +117,9 @@ fn remove_entity_member_auth_failed() {
 #[test]
 fn create_entity_curator_group_is_not_active() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Add curator group
-        assert_ok!(add_curator_group(LEAD_ORIGIN));
-
-        // Add curator to group
-        assert_ok!(add_curator_to_group(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            FIRST_CURATOR_ID,
-        ));
-
-        // Add curator group as class maintainer
-        assert_ok!(add_maintainer_to_class(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            FIRST_CURATOR_GROUP_ID
-        ));
-
-        // Make curator group active
-        assert_ok!(set_curator_group_status(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            true
-        ));
-
-        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
-
-        // Create Entity
-        assert_ok!(create_entity(
-            FIRST_CURATOR_ORIGIN,
-            FIRST_CLASS_ID,
-            actor.clone()
-        ));
-
-        // Make curator group inactive to block entity removal
-        assert_ok!(set_curator_group_status(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            false
-        ));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorGroupIsNotActive,
+        );
 
         // Runtime state before tested call
 
@@ -188,8 +127,7 @@ fn create_entity_curator_group_is_not_active() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity using curator group, which is not active as actor
-        let remove_entity_result =
-            remove_entity(FIRST_CURATOR_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+        let remove_entity_result = remove_entity(FIRST_CURATOR_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -203,41 +141,9 @@ fn create_entity_curator_group_is_not_active() {
 #[test]
 fn remove_entity_curator_auth_failed() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Add curator group
-        assert_ok!(add_curator_group(LEAD_ORIGIN));
-
-        // Add curator to group
-        assert_ok!(add_curator_to_group(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            FIRST_CURATOR_ID,
-        ));
-
-        // Add curator group as class maintainer
-        assert_ok!(add_maintainer_to_class(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            FIRST_CURATOR_GROUP_ID
-        ));
-
-        // Make curator group active
-        assert_ok!(set_curator_group_status(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            true
-        ));
-
-        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
-
-        // Create Entity
-        assert_ok!(create_entity(
-            FIRST_CURATOR_ORIGIN,
-            FIRST_CLASS_ID,
-            actor.clone()
-        ));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
 
         // Runtime state before tested call
 
@@ -245,7 +151,7 @@ fn remove_entity_curator_auth_failed() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity under unknown origin and curator actor, which corresponding group is current entity controller
-        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor.clone(), FIRST_ENTITY_ID);
+        let remove_entity_result = remove_entity(UNKNOWN_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -259,50 +165,18 @@ fn remove_entity_curator_auth_failed() {
 #[test]
 fn remove_entity_curator_not_found_in_curator_group() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Add curator group
-        assert_ok!(add_curator_group(LEAD_ORIGIN));
-
-        // Add curator to group
-        assert_ok!(add_curator_to_group(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            FIRST_CURATOR_ID,
-        ));
-
-        // Make curator group active
-        assert_ok!(set_curator_group_status(
-            LEAD_ORIGIN,
-            FIRST_CURATOR_GROUP_ID,
-            true
-        ));
-
-        // Add curator group as class maintainer
-        assert_ok!(add_maintainer_to_class(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            FIRST_CURATOR_GROUP_ID
-        ));
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
+        );
 
         // Runtime state before tested call
-
-        let actor = Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID);
-
-        // Create entity
-        assert_ok!(create_entity(FIRST_CURATOR_ORIGIN, FIRST_CLASS_ID, actor));
 
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity, using actor in group,
         // which curator id was not added to corresponding group set
-        let remove_entity_result = remove_entity(
-            SECOND_CURATOR_ORIGIN,
-            Actor::Curator(FIRST_CURATOR_GROUP_ID, SECOND_CURATOR_ID),
-            FIRST_ENTITY_ID,
-        );
+        let remove_entity_result = remove_entity(SECOND_CURATOR_ORIGIN, actor, FIRST_ENTITY_ID);
 
         // Failure checked
         assert_failure(
@@ -316,23 +190,9 @@ fn remove_entity_curator_not_found_in_curator_group() {
 #[test]
 fn remove_entity_access_denied() {
     with_test_externalities(|| {
-        // Create simple class with default permissions
-        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
-
-        // Update class permissions to force any member be available to create entities
-        assert_ok!(update_class_permissions(
-            LEAD_ORIGIN,
-            FIRST_CLASS_ID,
-            Some(true),
-            None,
-            None,
-            None
-        ));
-
-        // Create entity
-        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, Actor::Lead));
-
-        let actor = Actor::Member(SECOND_MEMBER_ID);
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityAccessDenied,
+        );
 
         // Runtime state before tested call
 
@@ -417,7 +277,7 @@ fn remove_entity_rc_does_not_equal_to_zero() {
         let number_of_events_before_call = System::events().len();
 
         // Make an attempt to remove entity, which rc does not equal to zero
-        let remove_entity_result = remove_entity(LEAD_ORIGIN, actor.clone(), SECOND_ENTITY_ID);
+        let remove_entity_result = remove_entity(LEAD_ORIGIN, actor, SECOND_ENTITY_ID);
 
         // Failure checked
         assert_failure(

--- a/runtime-modules/content-directory/src/tests/transaction.rs
+++ b/runtime-modules/content-directory/src/tests/transaction.rs
@@ -12,6 +12,8 @@ fn transaction_success() {
         let property = Property::<Runtime>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             PropertyType::Single(property_type_reference),
+            true,
+            false,
         );
 
         // Add Schema to the Class

--- a/runtime-modules/content-directory/src/tests/update_entity_property_values.rs
+++ b/runtime-modules/content-directory/src/tests/update_entity_property_values.rs
@@ -20,12 +20,12 @@ fn update_entity_property_values_success() {
         second_schema_new_property_values
             .insert(SECOND_PROPERTY_ID, second_schema_new_property_value.clone());
 
-        // Update first entity property values
+        // Update entity property values
         assert_ok!(update_entity_property_values(
             LEAD_ORIGIN,
             actor.clone(),
             FIRST_ENTITY_ID,
-            second_schema_new_property_values.clone()
+            second_schema_new_property_values
         ));
 
         // Runtime tested state after call
@@ -58,6 +58,908 @@ fn update_entity_property_values_success() {
         assert_event_success(
             entity_property_values_updated_event,
             number_of_events_before_calls + 1,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_entity_not_found() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityNotFound,
+        );
+
+        // Create class reference schema
+        add_class_reference_schema();
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values in case when corresponding Entity does not exist
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_lead_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::LeadAuthFailed,
+        );
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values using unknown origin and lead actor
+        let update_entity_property_values_result = update_entity_property_values(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_LEAD_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_member_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::MemberAuthFailed,
+        );
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values using unknown origin and member actor
+        let update_entity_property_values_result = update_entity_property_values(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_MEMBER_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_curator_group_is_not_active() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(
+            &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
+            FIRST_CURATOR_ORIGIN,
+        );
+
+        // Make curator group inactive to block it from any entity operations
+        assert_ok!(set_curator_group_status(
+            LEAD_ORIGIN,
+            FIRST_CURATOR_GROUP_ID,
+            false
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values using curator group, which is not active as actor
+        let update_entity_property_values_result = update_entity_property_values(
+            FIRST_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_CURATOR_GROUP_IS_NOT_ACTIVE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_curator_auth_failed() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorAuthFailed,
+        );
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(
+            &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
+            FIRST_CURATOR_ORIGIN,
+        );
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values using unknown origin and curator actor
+        let update_entity_property_values_result = update_entity_property_values(
+            UNKNOWN_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_CURATOR_AUTH_FAILED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_curator_not_found_in_curator_group() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::CuratorNotFoundInCuratorGroup,
+        );
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(
+            &Actor::Curator(FIRST_CURATOR_GROUP_ID, FIRST_CURATOR_ID),
+            FIRST_CURATOR_ORIGIN,
+        );
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values using actor in group, which curator id was not added to corresponding group set
+        let update_entity_property_values_result = update_entity_property_values(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_CURATOR_IS_NOT_A_MEMBER_OF_A_GIVEN_CURATOR_GROUP,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_entity_access_denied() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::EntityAccessDenied,
+        );
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values using actor in group,
+        // using origin, which corresponding actor is neither entity maintainer, nor controller.
+        let update_entity_property_values_result = update_entity_property_values(
+            SECOND_CURATOR_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_ENTITY_ACCESS_DENIED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_locked_on_class_level() {
+    with_test_externalities(|| {
+        let actor = emulate_entity_access_state_for_failure_case(
+            EntityAccessStateFailureType::PropertyValuesLocked,
+        );
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&Actor::Lead, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values using actor in group,
+        // in the case, when all property values were locked on Class level.
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_ALL_PROP_WERE_LOCKED_ON_CLASS_LEVEL,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_is_locked_for_given_actor() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create property
+        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+
+        let mut property = Property::<Runtime>::with_name_and_type(
+            (PropertyNameLengthConstraint::get().max() - 1) as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        property.locking_policy = PropertyLockingPolicy::new(false, true);
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create second entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        let schema_property_value = PropertyValue::<Runtime>::vec_reference(vec![
+            FIRST_ENTITY_ID,
+            FIRST_ENTITY_ID,
+            FIRST_ENTITY_ID,
+        ]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            Actor::Lead,
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values
+        // under lead origin, which is current Entity controller, in the case,
+        // when corresponding class Property was locked from controller on Class level
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_CLASS_PROPERTY_TYPE_IS_LOCKED_FOR_GIVEN_ACTOR,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_unknown_entity_property_id() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(SECOND_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values in the case, when Property
+        // under corresponding property id was not added to the current Entity yet
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_UNKNOWN_ENTITY_PROP_ID,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_prop_value_do_not_match_type() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value = PropertyValue::<Runtime>::default();
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values in the case, providing property values,
+        // some of which do not match Class level Property Type
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_PROP_VALUE_DONT_MATCH_TYPE,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_vec_prop_is_too_long() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value = PropertyValue::<Runtime>::vec_reference(vec![
+                FIRST_ENTITY_ID;
+                VecMaxLengthConstraint::get() as usize + 1
+            ]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values providing vector property value(s), which
+        // length exceeds VecMaxLengthConstraint.
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_VEC_PROP_IS_TOO_LONG,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_text_prop_is_too_long() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
+
+        // Create text property
+        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+
+        let property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize,
+            property_type,
+            true,
+            false,
+        );
+
+        // Add Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let mut schema_property_values = BTreeMap::new();
+
+        let schema_property_value =
+            PropertyValue::<Runtime>::single_text(TextMaxLengthConstraint::get());
+
+        schema_property_values.insert(FIRST_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            FIRST_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::single_text(TextMaxLengthConstraint::get() + 1);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values providing text property value(s), which
+        // length exceeds TextMaxLengthConstraint.
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_TEXT_PROP_IS_TOO_LONG,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_referenced_entity_not_found() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value = PropertyValue::<Runtime>::vec_reference(vec![
+                SECOND_ENTITY_ID;
+                VecMaxLengthConstraint::get() as usize
+            ]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values, providing new property value(s),
+        // some of which refer(s) to another Entity, which does not exist in runtime
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_ENTITY_NOT_FOUND,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_referenced_entity_does_not_match_its_class() {
+    with_test_externalities(|| {
+        // Create first class
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Create second class
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create first entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema and add corresponding schema support to the first Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Create second entity
+        assert_ok!(create_entity(LEAD_ORIGIN, SECOND_CLASS_ID, actor.clone()));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value = PropertyValue::<Runtime>::vec_reference(vec![
+                SECOND_ENTITY_ID;
+                VecMaxLengthConstraint::get() as usize
+            ]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values, when provided schema new property value(s)
+        // refer(s) Entity, which Class does not match the class in corresponding Class Schema
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_REFERENCED_ENTITY_DOES_NOT_MATCH_ITS_CLASS,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_entity_can_not_be_referenced() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create first Entity of first Class
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema and add corresponding schema support to the first Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Create second Entity of first Class
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Update second entity permissions to forbid it from being referencable
+        assert_ok!(update_entity_permissions(
+            LEAD_ORIGIN,
+            SECOND_ENTITY_ID,
+            None,
+            Some(false)
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value = PropertyValue::<Runtime>::vec_reference(vec![
+                SECOND_ENTITY_ID;
+                VecMaxLengthConstraint::get() as usize
+            ]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values, when provided schema new property value(s)
+        // refer(s) to Entity which can not be referenced
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_ENTITY_CAN_NOT_BE_REFERENCED,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_same_controller_constraint_violation() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        // Update class permissions to force any member be available to create Entities
+        assert_ok!(update_class_permissions(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            Some(true),
+            None,
+            None,
+            None
+        ));
+
+        let actor = Actor::Lead;
+
+        // Create first Entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema and add corresponding schema support to the first  Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Create second Entity
+        assert_ok!(create_entity(
+            FIRST_MEMBER_ORIGIN,
+            FIRST_CLASS_ID,
+            Actor::Member(FIRST_MEMBER_ID)
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value = PropertyValue::<Runtime>::vec_reference(vec![
+                SECOND_ENTITY_ID;
+                VecMaxLengthConstraint::get() as usize
+            ]);
+
+        schema_new_property_values.insert(FIRST_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values, providing new reference property value(s) in case,
+        // when corresponding Entity can only be referenced from Entity with the same controller.
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_SAME_CONTROLLER_CONSTRAINT_VIOLATION,
+            number_of_events_before_call,
+        );
+    })
+}
+
+#[test]
+fn update_entity_property_values_property_should_be_unique() {
+    with_test_externalities(|| {
+        // Create class with default permissions
+        assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
+
+        let actor = Actor::Lead;
+
+        // Create first Entity
+        assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
+
+        // Create class reference schema and add corresponding schema support to the Entity
+        add_class_reference_schema_and_entity_schema_support(&actor, LEAD_ORIGIN);
+
+        // Create second property with unique constraint
+        let property_type = PropertyType::<Runtime>::vec_reference(
+            FIRST_CLASS_ID,
+            true,
+            VecMaxLengthConstraint::get(),
+        );
+
+        let property = Property::<Runtime>::with_name_and_type(
+            PropertyNameLengthConstraint::get().max() as usize,
+            property_type,
+            true,
+            true,
+        );
+
+        // Add second Schema to the Class
+        assert_ok!(add_class_schema(
+            LEAD_ORIGIN,
+            FIRST_CLASS_ID,
+            BTreeSet::new(),
+            vec![property]
+        ));
+
+        let schema_property_value = PropertyValue::<Runtime>::vec_reference(vec![
+            FIRST_ENTITY_ID,
+            FIRST_ENTITY_ID,
+            FIRST_ENTITY_ID,
+        ]);
+
+        let mut schema_property_values = BTreeMap::new();
+        schema_property_values.insert(SECOND_PROPERTY_ID, schema_property_value);
+
+        // Add schema support to the entity
+        assert_ok!(add_schema_support_to_entity(
+            LEAD_ORIGIN,
+            actor.to_owned(),
+            FIRST_ENTITY_ID,
+            SECOND_SCHEMA_ID,
+            schema_property_values
+        ));
+
+        // Runtime state before tested call
+
+        // Events number before tested call
+        let number_of_events_before_call = System::events().len();
+
+        let mut schema_new_property_values = BTreeMap::new();
+        let schema_new_property_value =
+            PropertyValue::<Runtime>::vec_reference(vec![FIRST_ENTITY_ID, FIRST_ENTITY_ID]);
+
+        schema_new_property_values.insert(SECOND_PROPERTY_ID, schema_new_property_value);
+
+        // Make an attempt to update entity property values, providing new reference property value(s) in case,
+        // when corresponding Entity can only be referenced from Entity with the same controller.
+        let update_entity_property_values_result = update_entity_property_values(
+            LEAD_ORIGIN,
+            actor,
+            FIRST_ENTITY_ID,
+            schema_new_property_values,
+        );
+
+        // Failure checked
+        assert_failure(
+            update_entity_property_values_result,
+            ERROR_PROPERTY_VALUE_SHOULD_BE_UNIQUE,
+            number_of_events_before_call,
         );
     })
 }

--- a/runtime-modules/content-directory/src/tests/update_entity_property_values.rs
+++ b/runtime-modules/content-directory/src/tests/update_entity_property_values.rs
@@ -946,8 +946,8 @@ fn update_entity_property_values_property_should_be_unique() {
 
         schema_new_property_values.insert(SECOND_PROPERTY_ID, schema_new_property_value);
 
-        // Make an attempt to update entity property values, providing new reference property value(s) in case,
-        // when corresponding Entity can only be referenced from Entity with the same controller.
+        // Make an attempt to update entity property values, providing property value(s), which are identical to thouse, 
+        // are already added to The Entity, though should be unique on Class Schema level
         let update_entity_property_values_result = update_entity_property_values(
             LEAD_ORIGIN,
             actor,


### PR DESCRIPTION
The scope of this PR includes:
1. `update_entity_property_values` extrinsic full failure cases coverage
1. `update_entity_property_values` related logic minor fixes https://github.com/Joystream/joystream/pull/928/files#diff-0a165b042aa89a04d896ad36b8a33af5R1430, https://github.com/Joystream/joystream/pull/928/files#diff-0a165b042aa89a04d896ad36b8a33af5R2262

Closes #795