### PR TITLE
Working groups admin glitches

### DIFF
--- a/pioneer/packages/joy-roles/src/index.tsx
+++ b/pioneer/packages/joy-roles/src/index.tsx
@@ -60,7 +60,7 @@ export const App: React.FC<Props> = (props: Props) => {
   const oppsCtrl = new OpportunitiesController(transport, props.myMemberId);
   const [applyCtrl] = useState(new ApplyController(transport));
   const myRolesCtrl = new MyRolesController(transport, props.myAddress);
-  const [adminCtrl] = useState(new AdminController(transport, api));
+  const [adminCtrl] = useState(new AdminController(transport, api, queueExtrinsic));
 
   useEffect(() => {
     return () => {

--- a/pioneer/packages/joy-roles/src/tabs/Admin.controller.tsx
+++ b/pioneer/packages/joy-roles/src/tabs/Admin.controller.tsx
@@ -379,7 +379,7 @@ export class AdminController extends Controller<State, ITransport> {
     this.updateState();
   }
 
-  onTxSuccess = () => { this.updateState() }
+  onTxSuccess = () => { this.updateState(); }
 
   newOpening (accountId: string, desc: openingDescriptor) {
     const tx = this.api.tx.contentWorkingGroup.addCuratorOpening(
@@ -543,7 +543,7 @@ type AdminContainerProps = {
   state: State;
   controller: AdminController;
 }
-const AdminContainer = ({state, controller}: AdminContainerProps) => {
+const AdminContainer = ({ state, controller }: AdminContainerProps) => {
   const address = useMyAccount().state.address;
   const containerRef = useRef<HTMLDivElement>(null);
   return (
@@ -570,7 +570,7 @@ const AdminContainer = ({state, controller}: AdminContainerProps) => {
               open={state.modalOpen}
               onClose={() => controller.closeModal()}
               mountNode={containerRef.current} // Prevent conflicts with tx-modal (after form values reset issue is fixed, see FIXME: above)
-              >
+            >
               <Modal.Content image>
                 <Modal.Description>
                   <NewOpening desc={state.currentDescriptor} fn={(desc) => address && controller.newOpening(address, desc)} />
@@ -585,13 +585,13 @@ const AdminContainer = ({state, controller}: AdminContainerProps) => {
         <br />
       </Container>
     </div>
-  )
-}
+  );
+};
 
 export const AdminView = View<AdminController, State>(
   (state, controller) => {
     return (
-        <AdminContainer state={state} controller={controller} />
+      <AdminContainer state={state} controller={controller} />
     );
   }
 );


### PR DESCRIPTION
An attempt to finalize https://github.com/Joystream/joystream/issues/741 by fixing an issue with React hooks and incorrect method of sending extrinsics in `Admin.controller.tsx`.

Note that most of the issues from https://github.com/Joystream/joystream/issues/741 have already been fixed at this point (either intentionally or as a side-effect of fixing other issues, like the `ts-nocheck` comment).

What should be improved after this PR is:
- No more `Do not call Hooks inside useEffect(...), useMemo(...), or other built-in Hooks...` error
- When extrinsic fails in the working groups Admin panel - it should display the correct error message, just like it does when using `TxButton` (due to the fact that Admin controller now uses `queueExtrinsic`)

I tried to also fix an additioanl issue I found, which is that form values are beeing reset on submit when adding a new opening via admin tool modal, but this turned out to be a bit more complex of an issue, due to bad design of the data flow etc., so I decided to just call `closeModal` on submit to prevent possible mistakes.