### PR TITLE
Query node cli pack

### DIFF
--- a/query-node/substrate-query-framework/cli/package.json
+++ b/query-node/substrate-query-framework/cli/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1-alpha",
   "author": "metmirr @metmirr dzlzv @dzhelezov",
   "bin": {
-    "cli": "./bin/run"
+    "hydra-cli": "./bin/run"
   },
   "bugs": "https://github.com/joystream/joystream/joystream-query-node/cli/issues",
   "dependencies": {
@@ -65,7 +65,7 @@
   "main": "lib/index.js",
   "oclif": {
     "commands": "./lib/src/commands",
-    "bin": "cli",
+    "bin": "hydra-cli",
     "plugins": [
       "@oclif/plugin-help"
     ],

--- a/query-node/substrate-query-framework/cli/package.json
+++ b/query-node/substrate-query-framework/cli/package.json
@@ -57,7 +57,7 @@
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json"
   ],
-  "homepage": "https://github.com/joystream/joystream/joystream-query-node/cli",
+  "homepage": "https://github.com/joystream/joystream/query-node/substrate-query-framework/cli",
   "keywords": [
     "oclif"
   ],
@@ -68,9 +68,12 @@
     "bin": "cli",
     "plugins": [
       "@oclif/plugin-help"
-    ]
+    ],
+    "macos" : {
+      "identifier": "org.joystream.hydra.cli"
+    }
   },
-  "repository": "joystream/joystream/joystream-query-node/cli",
+  "repository": "git@github.com:Joystream/joystream.git",
   "scripts": {
     "build": "rm -rf lib && tsc --build tsconfig.json",
     "postpack": "rm -f oclif.manifest.json",

--- a/query-node/substrate-query-framework/cli/package.json
+++ b/query-node/substrate-query-framework/cli/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "cli",
-  "description": "Query node cli",
-  "version": "0.0.0",
-  "author": "metmirr @metmirr",
+  "name": "hydra-cli",
+  "description": "CLI tool for building a Hydra query node",
+  "version": "0.0.1-alpha",
+  "author": "metmirr @metmirr dzlzv @dzhelezov",
   "bin": {
     "cli": "./bin/run"
   },


### PR DESCRIPTION
This PR renames the query node cli to `hydra-cli`. One can now run `oclif-dev pack` to generate tarball distros for win, macos, deb, linux. Another (perhaps preferrable) option is to publish to npm and run (without any prior installation) `npx @joystream/hydra-cli --version` 