### PR TITLE
Indexer error handling

### DIFF
--- a/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/ModelRenderer.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { ObjectType, WarthogModel, FieldResolver } from '../model';
 import Debug from 'debug';
 import { GeneratorContext } from './SourcesGenerator';
-import { buildFieldContext, TYPE_FIELDS } from './field-context';
+import { buildFieldContext } from './field-context';
 import * as utils from './utils';
 import { GraphQLEnumType } from 'graphql';
 import { AbstractRenderer } from './AbstractRenderer';
@@ -83,9 +83,10 @@ export class ModelRenderer extends AbstractRenderer {
 
   withHasProps(): GeneratorContext {
     const has: GeneratorContext = {};
-    for (const key in TYPE_FIELDS) {
-      const _key: string = key === 'numeric' ? 'numeric' || 'decimal' : key;
-      has[key] = this.objType.fields.some(f => f.columnType() === _key);
+    for (const field of this.objType.fields) {
+      let ct = field.columnType();
+      if (ct === 'numeric' || ct === 'decimal') ct = 'numeric';
+      has[ct] = true;
     }
     has['array'] = this.objType.fields.some(f => f.isArray());
     has['enum'] = this.objType.fields.some(f => f.isEnum());

--- a/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/RelationshipGenerator.ts
@@ -78,6 +78,9 @@ export class RelationshipGenerator {
   }
 
   listTypeWithDerivedDirective(field: Field, currentObject: ObjectType): void {
+    // Shoud never happen!
+    if (!field.derivedFrom) throw new Error(`No derivedFrom found on ${currentObject.name}->${field.name}`);
+
     const relatedObject = this.model.lookupType(field.type);
     const relatedField = this.model.lookupField(field.type, field.derivedFrom.argument);
 
@@ -93,6 +96,9 @@ export class RelationshipGenerator {
   }
 
   typeWithDerivedDirective(field: Field, currentObject: ObjectType): void {
+    // Shoud never happen!
+    if (!field.derivedFrom) throw new Error(`No derivedFrom found on ${currentObject.name}->${field.name}`);
+
     const relatedObject = this.model.lookupType(field.type);
     const relatedField = this.model.lookupField(field.type, field.derivedFrom.argument);
 

--- a/query-node/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/resolver.ts.mst
@@ -18,7 +18,7 @@ import { {{className}}Service } from './{{kebabName}}.service';
   {{{.}}}
 {{/fieldResolverImports}}
 
-@Resolver()
+@Resolver({{className}})
 export class {{className}}Resolver {
   constructor(@Inject('{{className}}Service') public readonly service: {{className}}Service) {}
 

--- a/query-node/substrate-query-framework/index-builder/src/QueryEvent.ts
+++ b/query-node/substrate-query-framework/index-builder/src/QueryEvent.ts
@@ -40,8 +40,10 @@ export default class QueryEvent implements SubstrateEvent {
 
   get event_params(): EventParameters {
     const { event } = this.event_record;
-
     let params: EventParameters = {};
+
+    // Event data can be Null(polkadot type)
+    if (!event.data.length) return params;
 
     event.data.forEach((data, index) => {
       params[event.typeDef[index].type] = data;
@@ -57,6 +59,9 @@ export default class QueryEvent implements SubstrateEvent {
   log(indent: number, logger: (str: string) => void): void {
     // Extract the phase, event
     const { event, phase } = this.event_record;
+
+    // Event data can be Null(polkadot type)
+    if (!event.data.length) return;
 
     logger(`\t\t\tParameters:`);
     event.data.forEach((data, index) => {


### PR DESCRIPTION
The PR:
- If block indexer fails to fetch events from the current block it will continue with the next block. This is a temporary fix until the reason is found.
- Some runtime events may not have data (`EventData`)

To minimize merge conflict potential, this PR assumes #926 will be merged first.