### PR TITLE
Query node fts fixes

### DIFF
--- a/query-node/substrate-query-framework/cli/src/generate/SourcesGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/SourcesGenerator.ts
@@ -77,19 +77,13 @@ export class SourcesGenerator {
     const migrationsDir = this.config.getMigrationsFolder();
     fs.ensureDirSync(path.resolve(process.cwd(), migrationsDir));
 
-    //createDir(path.resolve(process.cwd(), migrationsDir), false, true);
-
     // create dir if the textsearch module
     const ftsDir = this.config.getDestFolder(QUERIES_FOLDER);
     fs.ensureDirSync(path.resolve(process.cwd(), ftsDir));
-    //createDir(path.resolve(process.cwd(), ftsDir), false, true);
 
     const queryRenderer = new FTSQueryRenderer();
 
     this.model.ftsQueries.map(query => {
-      //const render = (template: string) => queryRenderer.generate(template, query);
-      //const filePrefix = kebabCase(query.name);
-
       const tempateFile = (name: string) => this.readTemplate(`textsearch/${name}.ts.mst`);
       const destPath = {
         migration: path.join(migrationsDir, `${query.name}.migration.ts`),
@@ -99,6 +93,7 @@ export class SourcesGenerator {
 
       ['migration', 'resolver', 'service'].map(name => {
         const rendered = queryRenderer.generate(tempateFile(name), query);
+        debug(`Writing ${query.name} ${name} to ${destPath[name]}`);
         this.writeFile(destPath[name], rendered);
       });
     });

--- a/query-node/substrate-query-framework/cli/src/generate/SourcesGenerator.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/SourcesGenerator.ts
@@ -75,11 +75,14 @@ export class SourcesGenerator {
 
     // create migrations dir if not exists
     const migrationsDir = this.config.getMigrationsFolder();
-    createDir(path.resolve(process.cwd(), migrationsDir), false, true);
+    fs.ensureDirSync(path.resolve(process.cwd(), migrationsDir));
+
+    //createDir(path.resolve(process.cwd(), migrationsDir), false, true);
 
     // create dir if the textsearch module
     const ftsDir = this.config.getDestFolder(QUERIES_FOLDER);
-    createDir(path.resolve(process.cwd(), ftsDir), false, true);
+    fs.ensureDirSync(path.resolve(process.cwd(), ftsDir));
+    //createDir(path.resolve(process.cwd(), ftsDir), false, true);
 
     const queryRenderer = new FTSQueryRenderer();
 
@@ -88,11 +91,15 @@ export class SourcesGenerator {
       //const filePrefix = kebabCase(query.name);
 
       const tempateFile = (name: string) => this.readTemplate(`textsearch/${name}.ts.mst`);
-      const destPath = (name: string) => path.join(ftsDir, `${kebabCase(query.name)}.${name}.ts`);
+      const destPath = {
+        migration: path.join(migrationsDir, `${query.name}.migration.ts`),
+        resolver: path.join(ftsDir, `${query.name}.resolver.ts`),
+        service: path.join(ftsDir, `${query.name}.service.ts`),
+      } as { [key: string]: string };
 
       ['migration', 'resolver', 'service'].map(name => {
         const rendered = queryRenderer.generate(tempateFile(name), query);
-        this.writeFile(destPath(name), rendered);
+        this.writeFile(destPath[name], rendered);
       });
     });
   }

--- a/query-node/substrate-query-framework/cli/src/templates/textsearch/service.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/textsearch/service.ts.mst
@@ -6,7 +6,7 @@ import { {{type}} } from '../{{model}}/{{model}}.model';
 import { InjectRepository } from 'typeorm-typedi-extensions';
 import { Repository, getConnection } from 'typeorm';
 
-import { {{query.typePrefix}}FTSOutput } from './{{query.typePrefix}}.resolver';
+import { {{query.typePrefix}}FTSOutput } from './{{query.name}}.resolver';
 
 interface RawSQLResult {
     origin_table: string,


### PR DESCRIPTION
This PR fixes Fulltext search bugs:
- Migration file was generated in the wrong place, and thus was not performed at the migration phase
- File import caused TS errors