### PR TITLE
developer setting for proposals on devchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,10 +390,11 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chain-spec-builder"
-version = "2.0.0-alpha.3"
+version = "2.1.0"
 dependencies = [
  "ansi_term 0.12.1",
  "joystream-node",
+ "joystream-node-runtime",
  "rand 0.7.3",
  "structopt",
  "substrate-keystore",
@@ -1569,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "ctrlc",
  "derive_more 0.14.1",
@@ -1614,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "6.20.0"
+version = "6.21.0"
 dependencies = [
  "parity-scale-codec",
  "safe-mix",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '2.6.0'
+version = '2.7.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -108,6 +108,7 @@ impl Alternative {
                             get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                             get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
                         ],
+                        node_runtime::ProposalsConfigParameters::development(),
                     )
                 },
                 vec![],
@@ -140,6 +141,7 @@ impl Alternative {
                             get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
                             get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                         ],
+                        node_runtime::ProposalsConfigParameters::default(),
                     )
                 },
                 vec![],
@@ -181,14 +183,13 @@ pub fn testnet_genesis(
     initial_authorities: Vec<(AccountId, AccountId, GrandpaId, BabeId, ImOnlineId)>,
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,
+    cpcp: node_runtime::ProposalsConfigParameters,
 ) -> GenesisConfig {
     const CENTS: Balance = 1;
     const DOLLARS: Balance = 100 * CENTS;
     const STASH: Balance = 20 * DOLLARS;
     const ENDOWMENT: Balance = 100_000 * DOLLARS;
 
-    // default codex proposals config parameters
-    let cpcp = node_runtime::ProposalsConfigParameters::default();
     let default_text_constraint = node_runtime::working_group::default_text_constraint();
 
     GenesisConfig {

--- a/runtime-modules/proposals/codex/src/proposal_types/mod.rs
+++ b/runtime-modules/proposals/codex/src/proposal_types/mod.rs
@@ -348,3 +348,42 @@ impl Default for ProposalsConfigParameters {
         }
     }
 }
+
+impl ProposalsConfigParameters {
+    /// Development chain config. No grace period,
+    /// proposals executed immediatly. Short voting period.
+    pub fn development() -> Self {
+        ProposalsConfigParameters {
+            set_validator_count_proposal_voting_period: 200u32,
+            set_validator_count_proposal_grace_period: 0u32,
+            runtime_upgrade_proposal_voting_period: 200u32,
+            runtime_upgrade_proposal_grace_period: 0u32,
+            text_proposal_voting_period: 200u32,
+            text_proposal_grace_period: 0u32,
+            set_election_parameters_proposal_voting_period: 200u32,
+            set_election_parameters_proposal_grace_period: 0u32,
+            set_content_working_group_mint_capacity_proposal_voting_period: 200u32,
+            set_content_working_group_mint_capacity_proposal_grace_period: 0u32,
+            set_lead_proposal_voting_period: 200u32,
+            set_lead_proposal_grace_period: 0u32,
+            spending_proposal_voting_period: 200u32,
+            spending_proposal_grace_period: 0u32,
+            add_working_group_opening_proposal_voting_period: 200u32,
+            add_working_group_opening_proposal_grace_period: 0u32,
+            begin_review_working_group_leader_applications_proposal_voting_period: 200u32,
+            begin_review_working_group_leader_applications_proposal_grace_period: 0u32,
+            fill_working_group_leader_opening_proposal_voting_period: 200u32,
+            fill_working_group_leader_opening_proposal_grace_period: 0u32,
+            set_working_group_mint_capacity_proposal_voting_period: 200u32,
+            set_working_group_mint_capacity_proposal_grace_period: 0u32,
+            decrease_working_group_leader_stake_proposal_voting_period: 200u32,
+            decrease_working_group_leader_stake_proposal_grace_period: 0u32,
+            slash_working_group_leader_stake_proposal_voting_period: 200u32,
+            slash_working_group_leader_stake_proposal_grace_period: 0u32,
+            set_working_group_leader_reward_proposal_voting_period: 200u32,
+            set_working_group_leader_reward_proposal_grace_period: 0u32,
+            terminate_working_group_leader_role_proposal_voting_period: 200u32,
+            terminate_working_group_leader_role_proposal_grace_period: 0u32,
+        }
+    }
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '6.20.0'
+version = '6.21.0'
 
 [features]
 default = ['std']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -161,7 +161,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 6,
-    spec_version: 20,
+    spec_version: 21,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
 };

--- a/utils/chain-spec-builder/Cargo.toml
+++ b/utils/chain-spec-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-spec-builder"
-version = "2.0.0-alpha.3"
+version = "2.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 build = "build.rs"
@@ -12,7 +12,8 @@ repository = "https://github.com/paritytech/substrate/"
 ansi_term = "0.12.1"
 rand = "0.7.2"
 structopt = "0.3.5"
-joystream-node = { version = "2.1.2", path = "../../node" }
+joystream-node = { path = "../../node" }
+joystream-runtime = { path = "../../runtime", package = "joystream-node-runtime" }
 
 [dependencies.sr-keystore]
 git = 'https://github.com/paritytech/substrate.git'

--- a/utils/chain-spec-builder/src/main.rs
+++ b/utils/chain-spec-builder/src/main.rs
@@ -102,13 +102,11 @@ fn genesis_constructor(
         .map(chain_spec::get_authority_keys_from_seed)
         .collect::<Vec<_>>();
 
-    // let enable_println = true;
-
     chain_spec::testnet_genesis(
         authorities,
         sudo_account.clone(),
         endowed_accounts.to_vec(),
-        // enable_println,
+        joystream_runtime::ProposalsConfigParameters::default(),
     )
 }
 


### PR DESCRIPTION
This is a cleaner way of settings voting and grace periods for testing environment, when running a dev chain.
So we don't need an [external script](https://github.com/Joystream/joystream/blob/nicaea/scripts/run-test-chain.sh)

This is low priority and doesn't need to go into nicaea per say, to avoiding our policy of doing last minute runtime code changes.