### PR TITLE
Query node indexer start options

### DIFF
--- a/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
@@ -75,7 +75,7 @@ function banner():Command {
         .description("Joystream Indexer")
         .option('-b, --bootstrap', 'Load initial data using the boot* mappings')
         .option('-l, --logging <file>', 'Path to log4js config', null)
-        .option('-h, --height <height>', 'Block height to start from', 0)
+        .option('-h, --height <height>', 'Block height to start from')
         .option('-e, --env <file>', '.env file location', '../../.env')
         .option('-n, --no-start', "Do not run the indexer");
 
@@ -86,16 +86,18 @@ function banner():Command {
 }
 
 function setUp(opts: any) {
-      
-    const height:string = opts.height || '0';
-    process.env.BLOCK_HEIGHT = height;
-
     if (opts.bootstrap) {
         process.env.QUERY_NODE_BOOTSTRAP_DB = 'true'
     }
 
     // dotenv config
     dotenv.config({ path: opts.env });
+
+    if (opts.height) {
+      process.env.BLOCK_HEIGHT = opts.height;
+    } else if (!process.env.BLOCK_HEIGHT) {
+      process.env.BLOCK_HEIGHT = '0';
+    }
 
     //log4js config
     if (opts.logging) {

--- a/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import * as dotenv from "dotenv";
 import * as chalk from 'chalk';
 import * as figlet from 'figlet';
+import * as BN from 'bn.js';
 import { Command } from 'commander';
 import { configure, getLogger } from 'log4js';
 
@@ -107,12 +108,13 @@ function setUp(opts: any) {
 }
 
 async function doBootstrap(node: QueryNodeManager) {
-    await node.bootstrap(
-        process.env.WS_PROVIDER_ENDPOINT_URI as string,
-        getBootstrapPack(),
-        {{#typeRegistrator}} {{typeRegistrator}} {{/typeRegistrator}}
-    );
-    logger.info("Bootstrap done");
+  await node.bootstrap({
+    wsProviderURI: process.env.WS_PROVIDER_ENDPOINT_URI as string,
+    processingPack: getBootstrapPack(),
+    {{#typeRegistrator}}typeRegistrator: {{typeRegistrator}} {{/typeRegistrator}}
+  });
+
+  logger.info("Bootstrap done");
 }
 
 async function main() {
@@ -120,6 +122,7 @@ async function main() {
   setUp(command);
   
   const providerUri = process.env.WS_PROVIDER_ENDPOINT_URI;
+  const atBlock = process.env.BLOCK_HEIGHT;
 
   if (!providerUri) {
     throw new Error(
@@ -144,7 +147,12 @@ async function main() {
       process.exit(0);
   }
 
-  node.start(providerUri, getProcessingPack(), {{#typeRegistrator}} {{typeRegistrator}} {{/typeRegistrator}});
+  node.start({
+    wsProviderURI: providerUri,
+    processingPack: getProcessingPack(),
+    atBlock: atBlock && atBlock !== '0' ? new BN(atBlock) : undefined,
+    {{#typeRegistrator}}typeRegistrator: {{typeRegistrator}} {{/typeRegistrator}}
+  });
 }
 
 main().catch((e) => {

--- a/query-node/substrate-query-framework/index-builder/src/IndexBuilder.ts
+++ b/query-node/substrate-query-framework/index-builder/src/IndexBuilder.ts
@@ -45,9 +45,14 @@ export default class IndexBuilder {
 
     const lastProcessedEvent = await getRepository(SavedEntityEvent).findOne({ where: { id: 1 } });
 
-    // Priority is belongs to `startAt` parameter, if parameter is provided then ignore the saved event start
-    // block producer from `startAt` block number.
-    if (!atBlock && lastProcessedEvent) {
+    if (atBlock && lastProcessedEvent) {
+      throw new Error(
+        `Existing processed history detected on the database!
+        Last processed block is ${lastProcessedEvent.blockNumber.toString()}`
+      );
+    }
+
+    if (lastProcessedEvent) {
       this.lastProcessedEvent = lastProcessedEvent;
       await this._producer.start(this.lastProcessedEvent.blockNumber, this.lastProcessedEvent.index);
     } else {

--- a/query-node/substrate-query-framework/index-builder/src/IndexBuilder.ts
+++ b/query-node/substrate-query-framework/index-builder/src/IndexBuilder.ts
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { getRepository, getConnection } from 'typeorm';
+import * as BN from 'bn.js';
 
 import {
   QueryBlockProducer,
@@ -32,7 +33,7 @@ export default class IndexBuilder {
     return new IndexBuilder(producer, processing_pack);
   }
 
-  async start() {
+  async start(atBlock?: BN) {
     // check state
 
     // STORE THIS SOMEWHERE
@@ -44,12 +45,14 @@ export default class IndexBuilder {
 
     const lastProcessedEvent = await getRepository(SavedEntityEvent).findOne({ where: { id: 1 } });
 
-    if (lastProcessedEvent !== undefined) {
+    // Priority is belongs to `startAt` parameter, if parameter is provided then ignore the saved event start
+    // block producer from `startAt` block number.
+    if (!atBlock && lastProcessedEvent) {
       this.lastProcessedEvent = lastProcessedEvent;
       await this._producer.start(this.lastProcessedEvent.blockNumber, this.lastProcessedEvent.index);
     } else {
       // Setup worker
-      await this._producer.start();
+      await this._producer.start(atBlock);
     }
 
     debug('Started worker.');

--- a/query-node/substrate-query-framework/index-builder/src/QueryNode.ts
+++ b/query-node/substrate-query-framework/index-builder/src/QueryNode.ts
@@ -1,8 +1,9 @@
 // @ts-check
 
 import { ApiPromise, WsProvider /*RuntimeVersion*/ } from '@polkadot/api';
+import * as BN from 'bn.js';
 
-import { makeQueryService, IndexBuilder, QueryEventProcessingPack } from '.';
+import { makeQueryService, IndexBuilder, QueryEventProcessingPack, QueryNodeStartUpOptions } from '.';
 
 export enum QueryNodeState {
   NOT_STARTED,
@@ -28,37 +29,38 @@ export default class QueryNode {
   // Query index building node.
   private _indexBuilder: IndexBuilder;
 
-  private constructor(websocketProvider: WsProvider, api: ApiPromise, indexBuilder: IndexBuilder) {
+  private _atBlock?: BN;
+
+  private constructor(websocketProvider: WsProvider, api: ApiPromise, indexBuilder: IndexBuilder, atBlock?: BN) {
     this._state = QueryNodeState.NOT_STARTED;
     this._websocketProvider = websocketProvider;
     this._api = api;
     this._indexBuilder = indexBuilder;
+    this._atBlock = atBlock;
   }
 
-  static async create(
-    ws_provider_endpoint_uri: string,
-    processing_pack: QueryEventProcessingPack,
-    type_registrator?: () => void
-  ) {
+  static async create(options: QueryNodeStartUpOptions) {
     // TODO: Do we really need to do it like this?
     // Its pretty ugly, but the registrtion appears to be
     // accessing some sort of global state, and has to be done after
     // the provider is created.
 
+    const { wsProviderURI, typeRegistrator, processingPack, atBlock } = options;
+
     // Initialise the provider to connect to the local node
-    const provider = new WsProvider(ws_provider_endpoint_uri);
+    const provider = new WsProvider(wsProviderURI);
 
     // Register types before creating the api
-    type_registrator ? type_registrator() : null;
+    typeRegistrator ? typeRegistrator() : null;
 
     // Create the API and wait until ready
     const api = await ApiPromise.create({ provider });
 
     const service = makeQueryService(api);
 
-    const index_buider = IndexBuilder.create(service, processing_pack);
+    const index_buider = IndexBuilder.create(service, processingPack as QueryEventProcessingPack);
 
-    return new QueryNode(provider, api, index_buider);
+    return new QueryNode(provider, api, index_buider, atBlock);
   }
 
   async start() {
@@ -67,7 +69,7 @@ export default class QueryNode {
     this._state = QueryNodeState.STARTING;
 
     // Start the
-    await this._indexBuilder.start();
+    await this._indexBuilder.start(this._atBlock);
 
     this._state = QueryNodeState.STARTED;
   }

--- a/query-node/substrate-query-framework/index-builder/src/QueryNodeManager.ts
+++ b/query-node/substrate-query-framework/index-builder/src/QueryNodeManager.ts
@@ -1,7 +1,8 @@
 import QueryNode, { QueryNodeState } from './QueryNode';
 import { QueryEventProcessingPack } from '.';
 import { EventEmitter } from 'events';
-import { Bootstrapper, BootstrapPack } from './bootstrap';
+import { Bootstrapper } from './bootstrap';
+import { QueryNodeStartUpOptions } from '.';
 
 // Respondible for creating, starting up and shutting down the query node.
 // Currently this class is a bit thin, but it will almost certainly grow
@@ -16,19 +17,15 @@ export default class QueryNodeManager {
     process.on('exit', this._onProcessExit);
   }
 
-  async start(
-    ws_provider_endpoint_uri: string,
-    processing_pack: QueryEventProcessingPack,
-    type_registrator?: () => void
-  ) {
+  async start(options: QueryNodeStartUpOptions) {
     if (this._query_node) throw Error('Cannot start the same manager multiple times.');
 
-    this._query_node = await QueryNode.create(ws_provider_endpoint_uri, processing_pack, type_registrator);
+    this._query_node = await QueryNode.create(options);
     await this._query_node.start();
   }
 
-  async bootstrap(ws_provider_endpoint_uri: string, bootstrap_pack: BootstrapPack, type_registrator?: () => void) {
-    let bootstrapper = await Bootstrapper.create(ws_provider_endpoint_uri, bootstrap_pack, type_registrator);
+  async bootstrap(options: QueryNodeStartUpOptions) {
+    let bootstrapper = await Bootstrapper.create(options);
     await bootstrapper.bootstrap();
   }
 

--- a/query-node/substrate-query-framework/index-builder/src/QueryNodeStartOptions.ts
+++ b/query-node/substrate-query-framework/index-builder/src/QueryNodeStartOptions.ts
@@ -1,0 +1,17 @@
+import * as BN from 'bn.js';
+import { QueryEventProcessingPack } from '.';
+import { BootstrapPack } from './bootstrap';
+
+export interface QueryNodeStartUpOptions {
+  // Web socket endpoint url
+  wsProviderURI: string;
+
+  // Event processors they are defined in mappings/bootstrap
+  processingPack: QueryEventProcessingPack | BootstrapPack;
+
+  // Custum type register function
+  typeRegistrator?: () => void;
+
+  // Block number that indexer will start from, default is 0
+  atBlock?: BN;
+}

--- a/query-node/substrate-query-framework/index-builder/src/bootstrap/Bootstrapper.ts
+++ b/query-node/substrate-query-framework/index-builder/src/bootstrap/Bootstrapper.ts
@@ -1,102 +1,104 @@
-import * as BN from 'bn.js'
-import { BootstrapPack, BootstrapFunc, SubstrateEvent, DatabaseManager, SavedEntityEvent } from '..';
+import * as BN from 'bn.js';
+import {
+  BootstrapPack,
+  BootstrapFunc,
+  SubstrateEvent,
+  DatabaseManager,
+  SavedEntityEvent,
+  QueryNodeStartUpOptions,
+} from '..';
 import { WsProvider, ApiPromise } from '@polkadot/api';
-import {  getConnection, EntityManager } from 'typeorm';
+import { getConnection, EntityManager } from 'typeorm';
 import { makeDatabaseManager } from '..';
 
 const debug = require('debug')('index-builder:bootstrapper');
 
 export default class Bootstrapper {
+  private _api: ApiPromise;
+  private _bootstrapPack: BootstrapPack;
 
-    private _api: ApiPromise;
-    private _bootstrapPack: BootstrapPack;
+  private constructor(api: ApiPromise, bootstrapPack: BootstrapPack) {
+    this._api = api;
+    this._bootstrapPack = bootstrapPack;
+  }
 
-    private constructor(api: ApiPromise, 
-        bootstrapPack: BootstrapPack) {
-        this._api = api;
-        this._bootstrapPack = bootstrapPack;
-    }
+  static async create(options: QueryNodeStartUpOptions): Promise<Bootstrapper> {
+    const { wsProviderURI, typeRegistrator, processingPack } = options;
 
-    static async create(
-        ws_provider_endpoint_uri: string,
-        bootstrapPack: BootstrapPack,
-    type_registrator?: () => void
-  ): Promise<Bootstrapper> {
-        // Initialise the provider to connect to the local node
-        const provider = new WsProvider(ws_provider_endpoint_uri);
+    // Initialise the provider to connect to the local node
+    const provider = new WsProvider(wsProviderURI);
 
-        // Register types before creating the api
-    type_registrator ? type_registrator() : null;
+    // Register types before creating the api
+    typeRegistrator ? typeRegistrator() : null;
 
-        // Create the API and wait until ready
-        const api = await ApiPromise.create({ provider });
-        return new Bootstrapper(api, bootstrapPack);
-    }
+    // Create the API and wait until ready
+    const api = await ApiPromise.create({ provider });
+    return new Bootstrapper(api, processingPack as BootstrapPack);
+  }
 
-    async bootstrap() {
-        debug("Bootstraping the database");
-        const queryRunner = getConnection().createQueryRunner();
-        const api = this._api;
-        await queryRunner.connect();
-        
-        try {
-            await queryRunner.startTransaction();
-            // establish real database connection
-            // perform all the bootstrap logic in one large
-            // atomic transaction 
-            for (const boot of this._bootstrapPack.pack) {
-                let shouldBootstrap = await this.shouldBootstrap(queryRunner.manager, boot);
-                if (!shouldBootstrap) {
-                    debug(`${boot.name} already bootstrapped, skipping`);
-                    continue;
-                }
+  async bootstrap() {
+    debug('Bootstraping the database');
+    const queryRunner = getConnection().createQueryRunner();
+    const api = this._api;
+    await queryRunner.connect();
 
-                let bootEvent = this.createBootEvent(boot);
-                await boot(api, makeDatabaseManager(queryRunner.manager));
-
-                // Save the bootstrap events so 
-                await SavedEntityEvent.update(bootEvent, queryRunner.manager);
-            }
-
-            debug("Database bootstrap successfull");
-            await queryRunner.commitTransaction();
-
-        } catch (error) {
-            console.error(error);
-            await queryRunner.rollbackTransaction();
-            throw new Error(`Bootstrapping failed: ${error}`);
-        } finally {
-            await queryRunner.release();
+    try {
+      await queryRunner.startTransaction();
+      // establish real database connection
+      // perform all the bootstrap logic in one large
+      // atomic transaction
+      for (const boot of this._bootstrapPack.pack) {
+        let shouldBootstrap = await this.shouldBootstrap(queryRunner.manager, boot);
+        if (!shouldBootstrap) {
+          debug(`${boot.name} already bootstrapped, skipping`);
+          continue;
         }
-    }
-    
-    /**
-     * This creates a generic bootstrap event for compatibility with DB
-     * and bookeeping of successfull bootstrap events
-     */
-    private createBootEvent(boot: BootstrapFunc): SubstrateEvent {
-        return {
-            event_name: 'Bootstrap',
-            event_method: `Bootstrap.${boot.name}`,
-            event_params: {},
-            index: new BN(Date.now() / 1000 | 0), // simply put the timestamp here
-            block_number: process.env.BLOCK_HEIGHT ? new BN(process.env.BLOCK_HEIGHT) : new BN(0), 
-        };
-    }
 
-    /**
-     * Looksup the saved boot events to find out if the given handler has already
-     * bootstrapped the data
-     * 
-     * @param em  `EntityManager` by `typeorm`
-     * @param boot boothandler
-     */
-    private async shouldBootstrap(em: EntityManager, boot: BootstrapFunc):Promise<boolean> {
-        const event = await em.findOne(SavedEntityEvent, { 
-            where: { 
-                eventName: `Bootstrap.${boot.name}`,
-            }
-        })
-        return event ? false : true;
+        let bootEvent = this.createBootEvent(boot);
+        await boot(api, makeDatabaseManager(queryRunner.manager));
+
+        // Save the bootstrap events so
+        await SavedEntityEvent.update(bootEvent, queryRunner.manager);
+      }
+
+      debug('Database bootstrap successfull');
+      await queryRunner.commitTransaction();
+    } catch (error) {
+      console.error(error);
+      await queryRunner.rollbackTransaction();
+      throw new Error(`Bootstrapping failed: ${error}`);
+    } finally {
+      await queryRunner.release();
     }
+  }
+
+  /**
+   * This creates a generic bootstrap event for compatibility with DB
+   * and bookeeping of successfull bootstrap events
+   */
+  private createBootEvent(boot: BootstrapFunc): SubstrateEvent {
+    return {
+      event_name: 'Bootstrap',
+      event_method: `Bootstrap.${boot.name}`,
+      event_params: {},
+      index: new BN((Date.now() / 1000) | 0), // simply put the timestamp here
+      block_number: process.env.BLOCK_HEIGHT ? new BN(process.env.BLOCK_HEIGHT) : new BN(0),
+    };
+  }
+
+  /**
+   * Looksup the saved boot events to find out if the given handler has already
+   * bootstrapped the data
+   *
+   * @param em  `EntityManager` by `typeorm`
+   * @param boot boothandler
+   */
+  private async shouldBootstrap(em: EntityManager, boot: BootstrapFunc): Promise<boolean> {
+    const event = await em.findOne(SavedEntityEvent, {
+      where: {
+        eventName: `Bootstrap.${boot.name}`,
+      },
+    });
+    return event ? false : true;
+  }
 }

--- a/query-node/substrate-query-framework/index-builder/src/index.ts
+++ b/query-node/substrate-query-framework/index-builder/src/index.ts
@@ -8,6 +8,7 @@ import QueryNode, { QueryNodeState } from './QueryNode';
 import QueryNodeManager from './QueryNodeManager';
 import { DatabaseManager, SavedEntityEvent, makeDatabaseManager, createDBConnection } from './db';
 import BootstrapPack, { BootstrapFunc } from './bootstrap/BootstrapPack';
+import { QueryNodeStartUpOptions } from './QueryNodeStartOptions';
 
 export {
   ISubstrateQueryService,
@@ -27,4 +28,5 @@ export {
   BootstrapPack,
   BootstrapFunc,
   createDBConnection,
+  QueryNodeStartUpOptions,
 };


### PR DESCRIPTION
This PR adds the option to start indexer from a block number. Block number is passed as an argument:

```
yarn start --height 123
```

If block number is not provided either block number is `0` or retrieved from the database.


_Note_: `Bootstrapper.ts` file update is mostly white space removal so can be ignored.