### PR TITLE
fix broken call to create identities api after linter autofix?

### DIFF
--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -29,15 +29,19 @@ const FLAG_DEFINITIONS = {
   },
   keyFile: {
     type: 'string',
-    isRequired: (flags) => {
-      return !flags.dev
+    isRequired: (flags, input) => {
+      // Only required if running server command and not in dev mode
+      const serverCmd = input[0] === 'server'
+      return !flags.dev && serverCmd
     },
   },
   publicUrl: {
     type: 'string',
     alias: 'u',
-    isRequired: (flags) => {
-      return !flags.dev
+    isRequired: (flags, input) => {
+      // Only required if running server command and not in dev mode
+      const serverCmd = input[0] === 'server'
+      return !flags.dev && serverCmd
     },
   },
   passphrase: {
@@ -50,8 +54,10 @@ const FLAG_DEFINITIONS = {
   providerId: {
     type: 'number',
     alias: 'i',
-    isRequired: (flags) => {
-      return !flags.dev
+    isRequired: (flags, input) => {
+      // Only required if running server command and not in dev mode
+      const serverCmd = input[0] === 'server'
+      return !flags.dev && serverCmd
     },
   },
 }

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -65,7 +65,7 @@ class RuntimeApi {
 
     // Ok, create individual APIs
     this.identities = await IdentitiesApi.create(this, {
-      account_file: options.account_file,
+      accountFile: options.account_file,
       passphrase: options.passphrase,
       canPromptForPassphrase: options.canPromptForPassphrase,
     })


### PR DESCRIPTION
- Small bug fix with passing keyFile option to create identities api
- discovery command, doesn't require keyFile, publicUrl, and providerId arguments