### PR TITLE
Travis: skip rust build in PRs that do not modify rust/cargo files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - |
     if [ "$TRAVIS_PULL_REQUEST" != "false" ]
       then
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qE "(.rs|cargo.(lock|toml))$"
+      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qE "(.rs|Cargo.(lock|toml))$"
         then
         echo "No changes to Rust or Cargo Files, CI not running."
         travis_terminate 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,18 @@ matrix:
     - os: linux
       env: TARGET=x86_64-unknown-linux-gnu
 
+# Skip Rust build in a pull request if no rust project files were modified
+before_install:
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" != "false" ]
+      then
+      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qE "(.rs|cargo.(lock|toml))$"
+        then
+        echo "No changes to Rust or Cargo Files, CI not running."
+        travis_terminate 0
+      fi
+    fi
+
 install:
   - rustup install nightly-2020-05-23
   - rustup target add wasm32-unknown-unknown --toolchain nightly-2020-05-23


### PR DESCRIPTION
Borrowing from @Gamaranto implementation in https://github.com/Joystream/joystream/blob/044a68e392e6227b3b4a9f2b6441ba49c57ae343/.travis.yml#L16

We can skip doing rust and cargo build checks in a PR only if no rust or cargo project files were modified.