### PR TITLE
Expose missing @joystream/types in module index files

### DIFF
--- a/types/src/versioned-store/permissions/index.ts
+++ b/types/src/versioned-store/permissions/index.ts
@@ -5,6 +5,13 @@ import { ReferenceConstraint} from './reference-constraint';
 import ClassPermissionsType from './ClassPermissions';
 import { Operation } from './batching/';
 
+export {
+  EntityPermissions,
+  ReferenceConstraint,
+  ClassPermissionsType,
+  Operation
+};
+
 export function registerVersionedStorePermissionsTypes () {
     try {
       getTypeRegistry().register({


### PR DESCRIPTION
Adds a few missing exports in `versioned-store/permissions/index.ts` in order to make all types exposed in module index files following https://github.com/Joystream/joystream/pull/884