### PR TITLE
Update the proposals test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f8140122fa0d5dcb9fc8627cfce2b37cc1500f752636d46ea28bc26785c2f9"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fs-swap"
@@ -2502,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95a7e7cfbce0e99ebbf5356a085d3b5e320a7ef300f77cd50a7148aa362e7c2"
+checksum = "256489d4d106cd2bc9e98ed0337402db0044de0621745d5d9eb70a14295ff77b"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -2517,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a615a1ad92048ad5d9633251edb7492b8abc057d7a679a9898476aef173935"
+checksum = "826e14e8643cb12103b56efb963e5f9640b69b0f7bdcc460002092df4b0e959f"
 dependencies = [
  "cfg-if",
  "proc-macro2 1.0.10",

--- a/runtime-modules/hiring/Cargo.toml
+++ b/runtime-modules/hiring/Cargo.toml
@@ -15,7 +15,7 @@ srml-support-procedural = { package = 'srml-support-procedural', git = 'https://
 system = { package = 'srml-system', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'}
 balances = { package = 'srml-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'}
 codec = { package = 'parity-scale-codec', version = '1.0.0', default-features = false, features = ['derive'] }
-mockall = {version = "0.6.0", optional = true}
+mockall = {version = "0.7.1", optional = true}
 # https://users.rust-lang.org/t/failure-derive-compilation-error/39062
 quote = '<=1.0.2'
 
@@ -39,7 +39,7 @@ rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'
 [dev-dependencies]
 runtime-io = { package = 'sr-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'}
 primitives = { package = 'substrate-primitives', git = 'https://github.com/paritytech/substrate.git', rev = 'c37bb08535c49a12320af7facfd555ce05cce2e8'}
-mockall = "0.6.0"
+mockall = "0.7.1"
 
 
 [features]

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -860,6 +860,70 @@ fn set_default_proposal_parameters_succeeded() {
             <SpendingProposalGracePeriod<Test>>::get(),
             p.spending_proposal_grace_period as u64
         );
+        assert_eq!(
+            <AddWorkingGroupOpeningProposalVotingPeriod<Test>>::get(),
+            p.add_working_group_opening_proposal_voting_period as u64
+        );
+        assert_eq!(
+            <AddWorkingGroupOpeningProposalGracePeriod<Test>>::get(),
+            p.add_working_group_opening_proposal_grace_period as u64
+        );
+        assert_eq!(
+            <BeginReviewWorkingGroupLeaderApplicationsProposalVotingPeriod<Test>>::get(),
+            p.begin_review_working_group_leader_applications_proposal_voting_period as u64
+        );
+        assert_eq!(
+            <BeginReviewWorkingGroupLeaderApplicationsProposalGracePeriod<Test>>::get(),
+            p.begin_review_working_group_leader_applications_proposal_grace_period as u64
+        );
+        assert_eq!(
+            <FillWorkingGroupLeaderOpeningProposalVotingPeriod<Test>>::get(),
+            p.fill_working_group_leader_opening_proposal_voting_period as u64
+        );
+        assert_eq!(
+            <FillWorkingGroupLeaderOpeningProposalGracePeriod<Test>>::get(),
+            p.fill_working_group_leader_opening_proposal_grace_period as u64
+        );
+        assert_eq!(
+            <SetWorkingGroupMintCapacityProposalVotingPeriod<Test>>::get(),
+            p.set_working_group_mint_capacity_proposal_voting_period as u64
+        );
+        assert_eq!(
+            <SetWorkingGroupMintCapacityProposalGracePeriod<Test>>::get(),
+            p.set_working_group_mint_capacity_proposal_grace_period as u64
+        );
+        assert_eq!(
+            <DecreaseWorkingGroupLeaderStakeProposalVotingPeriod<Test>>::get(),
+            p.decrease_working_group_leader_stake_proposal_voting_period as u64
+        );
+        assert_eq!(
+            <DecreaseWorkingGroupLeaderStakeProposalGracePeriod<Test>>::get(),
+            p.decrease_working_group_leader_stake_proposal_grace_period as u64
+        );
+        assert_eq!(
+            <SlashWorkingGroupLeaderStakeProposalVotingPeriod<Test>>::get(),
+            p.slash_working_group_leader_stake_proposal_voting_period as u64
+        );
+        assert_eq!(
+            <SlashWorkingGroupLeaderStakeProposalGracePeriod<Test>>::get(),
+            p.slash_working_group_leader_stake_proposal_grace_period as u64
+        );
+        assert_eq!(
+            <SetWorkingGroupLeaderRewardProposalVotingPeriod<Test>>::get(),
+            p.set_working_group_leader_reward_proposal_voting_period as u64
+        );
+        assert_eq!(
+            <SetWorkingGroupLeaderRewardProposalGracePeriod<Test>>::get(),
+            p.set_working_group_leader_reward_proposal_grace_period as u64
+        );
+        assert_eq!(
+            <TerminateWorkingGroupLeaderRoleProposalVotingPeriod<Test>>::get(),
+            p.terminate_working_group_leader_role_proposal_voting_period as u64
+        );
+        assert_eq!(
+            <TerminateWorkingGroupLeaderRoleProposalGracePeriod<Test>>::get(),
+            p.terminate_working_group_leader_role_proposal_grace_period as u64
+        );
     });
 }
 

--- a/runtime-modules/proposals/engine/Cargo.toml
+++ b/runtime-modules/proposals/engine/Cargo.toml
@@ -96,7 +96,7 @@ package = 'substrate-common-module'
 path = '../../common'
 
 [dev-dependencies]
-mockall = "0.6.0"
+mockall = "0.7.1"
 
 [dev-dependencies.runtime-io]
 default_features = false


### PR DESCRIPTION
Add missing default config values checks for the grace and voting proposal periods.
Also fixes the compiler warning after the update to the Rust 1.45

The problem mentioned [here](https://github.com/Joystream/joystream/pull/969).