### PR TITLE
Forum mutability threshold 2

### DIFF
--- a/node/src/forum_config/from_serialized.rs
+++ b/node/src/forum_config/from_serialized.rs
@@ -11,11 +11,11 @@ use serde_json::Result;
 #[derive(Deserialize)]
 struct ForumData {
     categories: Vec<(CategoryId, Category<CategoryId, ThreadId, Hash>)>,
-    posts: Vec<(ThreadId, PostId, Post<ForumUserId, ThreadId, Hash>)>,
+    posts: Vec<(ThreadId, PostId, Post<ForumUserId, ThreadId, PostId, Hash>)>,
     threads: Vec<(
         CategoryId,
         ThreadId,
-        Thread<ForumUserId, CategoryId, Moment, Hash>,
+        Thread<ForumUserId, CategoryId, ThreadId, Moment, Hash>,
     )>,
 }
 

--- a/node/src/forum_config/from_serialized.rs
+++ b/node/src/forum_config/from_serialized.rs
@@ -11,11 +11,11 @@ use serde_json::Result;
 #[derive(Deserialize)]
 struct ForumData {
     categories: Vec<(CategoryId, Category<CategoryId, ThreadId, Hash>)>,
-    posts: Vec<(ThreadId, PostId, Post<ForumUserId, ThreadId, PostId, Hash>)>,
+    posts: Vec<(ThreadId, PostId, Post<ForumUserId, ThreadId, Hash>)>,
     threads: Vec<(
         CategoryId,
         ThreadId,
-        Thread<ForumUserId, CategoryId, ThreadId, Moment, Hash>,
+        Thread<ForumUserId, CategoryId, Moment, Hash>,
     )>,
 }
 

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -314,7 +314,7 @@ pub fn delete_thread_mock(
     assert_eq!(
         TestForumModule::delete_thread(
             mock_origin(origin.clone()),
-            moderator_id,
+            PrivilegedActor::Moderator(moderator_id),
             category_id,
             thread_id,
         ),
@@ -340,7 +340,7 @@ pub fn move_thread_mock(
     assert_eq!(
         TestForumModule::move_thread_to_category(
             mock_origin(origin.clone()),
-            moderator_id,
+            PrivilegedActor::Moderator(moderator_id),
             category_id,
             thread_id,
             new_category_id,
@@ -563,7 +563,7 @@ pub fn moderate_thread_mock(
     assert_eq!(
         TestForumModule::moderate_thread(
             mock_origin(origin),
-            moderator_id,
+            PrivilegedActor::Moderator(moderator_id),
             category_id,
             thread_id,
             rationale.clone(),
@@ -594,7 +594,7 @@ pub fn moderate_post_mock(
     assert_eq!(
         TestForumModule::moderate_post(
             mock_origin(origin),
-            moderator_id,
+            PrivilegedActor::Moderator(moderator_id),
             category_id,
             thread_id,
             post_id,
@@ -625,7 +625,7 @@ pub fn set_stickied_threads_mock(
     assert_eq!(
         TestForumModule::set_stickied_threads(
             mock_origin(origin),
-            moderator_id,
+            PrivilegedActor::Moderator(moderator_id),
             category_id,
             stickied_ids.clone(),
         ),

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -1020,7 +1020,7 @@ fn delete_thread() {
             moderators[1],
             category_id,
             thread_id,
-            Err(Error::ModeratorModerateCategory),
+            Err(Error::ModeratorCantUpdateCategory),
         );
 
         // moderator will delete thread
@@ -1660,7 +1660,7 @@ fn set_stickied_threads_wrong_moderator() {
             moderator_id,
             category_id,
             vec![thread_id],
-            Err(Error::ModeratorModerateCategory),
+            Err(Error::ModeratorCantUpdateCategory),
         );
     });
 }
@@ -1754,7 +1754,7 @@ fn test_migration_not_done() {
         assert_eq!(
             TestForumModule::moderate_thread(
                 mock_origin(origin.clone()),
-                moderator_id,
+                PrivilegedActor::Moderator(moderator_id),
                 category_id,
                 thread_id,
                 good_moderation_rationale(),
@@ -1765,7 +1765,7 @@ fn test_migration_not_done() {
         assert_eq!(
             TestForumModule::moderate_post(
                 mock_origin(origin.clone()),
-                moderator_id,
+                PrivilegedActor::Moderator(moderator_id),
                 category_id,
                 thread_id,
                 post_id,


### PR DESCRIPTION
Solves subtask of #766:
- ensure input parameters are not used after // == MUTATION SAFE == comment

Task originated in https://github.com/Joystream/joystream/pull/909#issuecomment-660870592 .

To minimize merge conflict potential, this PR assumes #980 will be merged first.