### PR TITLE
storage-node linting: turn off @typescript-eslint/naming-convention

### DIFF
--- a/storage-node/.eslintrc.js
+++ b/storage-node/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     'no-console': 'off', // we use console in the project
     '@typescript-eslint/no-var-requires': 'warn',
     '@typescript-eslint/camelcase': 'warn',
+    '@typescript-eslint/naming-convention': 'off',
   },
   overrides: [
     {


### PR DESCRIPTION
Make an exception for new incoming rules to avoid doing last minute refactoring ahead of release.
Incoming rules changes are here: https://github.com/Joystream/joystream/pull/976 and the detected problems when these rules are applied: https://github.com/Joystream/joystream/pull/976#issuecomment-662272543