### PR TITLE
Qnode remove entity generation

### DIFF
--- a/query-node/substrate-query-framework/cli/src/commands/codegen.ts
+++ b/query-node/substrate-query-framework/cli/src/commands/codegen.ts
@@ -11,8 +11,8 @@ import execa = require('execa');
 import { createDir, getTemplatePath, createFile } from '../utils/utils';
 import { formatWithPrettier } from '../helpers/formatter';
 import WarthogWrapper from '../helpers/WarthogWrapper';
-import { getTypeormConfig, getTypeormModelGeneratorConnectionConfig, createSavedEntityEventTable } from '../helpers/db';
-import { upperFirst } from 'lodash'; 
+import { getTypeormConfig } from '../helpers/db';
+import { upperFirst } from 'lodash';
 import Listr = require('listr');
 
 export default class Codegen extends Command {
@@ -93,7 +93,7 @@ export default class Codegen extends Command {
         indexFileContent = Mustache.render(indexFileContent, {
           packageName: process.env.TYPE_REGISTER_PACKAGE_NAME,
           typeRegistrator: process.env.TYPE_REGISTER_FUNCTION,
-          projectName: upperFirst(process.env.PROJECT_NAME)
+          projectName: upperFirst(process.env.PROJECT_NAME),
         });
         createFile(path.resolve('index.ts'), formatWithPrettier(indexFileContent));
 
@@ -119,15 +119,7 @@ export default class Codegen extends Command {
       },
     };
 
-    const genEntities = {
-      title: 'Generate entity classes',
-      task: async () => {
-        await createSavedEntityEventTable();
-        await execa('npx', getTypeormModelGeneratorConnectionConfig());
-      },
-    };
-
-    const listr = new Listr([generateFiles, installDeps, genEntities]);
+    const listr = new Listr([generateFiles, installDeps]);
     await listr.run();
 
     process.chdir(goBackDir);

--- a/query-node/substrate-query-framework/cli/src/helpers/db.ts
+++ b/query-node/substrate-query-framework/cli/src/helpers/db.ts
@@ -22,31 +22,6 @@ export function getTypeormConfig(): string {
   return newEnvConfig;
 }
 
-export function getTypeormModelGeneratorConnectionConfig(): string[] {
-  const envConfig = dotenv.parse(fs.readFileSync('.env'));
-
-  const command = [
-    'typeorm-model-generator',
-    `--host`,
-    `${envConfig['TYPEORM_HOST']}`,
-    `--port`,
-    `${envConfig['TYPEORM_PORT']}`,
-    `--database`,
-    `${envConfig['TYPEORM_DATABASE']}`,
-    `--engine`,
-    `postgres`,
-    `--output`,
-    `entities`,
-    `--user`,
-    `${envConfig['TYPEORM_USERNAME']}`,
-    `--pass`,
-    `${envConfig['TYPEORM_PASSWORD']}`,
-    '--noConfig',
-    '--generateConstructor',
-  ];
-  return command;
-}
-
 export async function resetLastProcessedEvent(): Promise<void> {
   await createConnection();
   // get a connection and create a new query runner
@@ -67,27 +42,6 @@ export async function resetLastProcessedEvent(): Promise<void> {
     index = ${lastProcessedEvent.index},
     "eventName" = '${lastProcessedEvent.eventName}';`
   );
-
-  await queryRunner.release();
-}
-
-export async function createSavedEntityEventTable(): Promise<void> {
-  const query = `CREATE TABLE IF NOT EXISTS "saved_entity_event" (
-      "id" integer PRIMARY KEY DEFAULT 1,
-      "index" numeric,
-      "event_name" character varying NOT NULL,
-      "block_number" numeric NOT NULL,
-      "updated_at" TIMESTAMP NOT NULL DEFAULT now())`;
-
-  await createConnection();
-  // get a connection and create a new query runner
-  const queryRunner = getConnection().createQueryRunner();
-
-  // establish real database connection using our new query runner
-  await queryRunner.connect();
-
-  // now we can execute any queries on a query runner
-  await queryRunner.query(query);
 
   await queryRunner.release();
 }

--- a/query-node/substrate-query-framework/cli/src/templates/dotenv-ormconfig.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/dotenv-ormconfig.mst
@@ -6,4 +6,4 @@ TYPEORM_DATABASE=postgres
 TYPEORM_PORT=5432
 TYPEORM_SYNCHRONIZE=false
 TYPEORM_LOGGING=true
-TYPEORM_ENTITIES=entities/*.ts,node_modules/index-builder/lib/db/entities.js,../graphql-server/src/modules/**/*.model.ts
+TYPEORM_ENTITIES=node_modules/index-builder/lib/db/entities.js,../graphql-server/src/modules/**/*.model.ts

--- a/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
@@ -18,6 +18,7 @@ import {
   DatabaseManager,
   SubstrateEvent,
   createDBConnection,
+  SavedEntityEvent,
 } from "index-builder/lib";
 
 // Mappings use!
@@ -128,6 +129,7 @@ async function main() {
   }
 
   await createDBConnection();
+  await SavedEntityEvent.createTable();
 
   const node = new QueryNodeManager(process);
 

--- a/query-node/substrate-query-framework/cli/src/templates/indexer.package.json
+++ b/query-node/substrate-query-framework/cli/src/templates/indexer.package.json
@@ -19,7 +19,7 @@
       "chalk": "^4.0.0",
       "dotenv": "^8.0.0",
       "figlet": "^1.4.0",
-      "index-builder": "https://github.com/metmirr/joystream/releases/download/v0.0.3-alpha/index-builder-v0.0.3-alpha.tgz",
+      "index-builder": "https://github.com/metmirr/joystream/releases/download/v0.0.4-alpha/index-builder-v0.0.4-alpha.tgz",
       "lodash": "^4.17.15",
       "log4js": "^6.2.1",
       "pg": "^8.0.3",


### PR DESCRIPTION
This PR removes unnecessary entity generation for indexer and add a method to create `SavedEntityEvent`.