### PR TITLE
Use bn.js for numeric types

### DIFF
--- a/query-node/substrate-query-framework/cli/src/generate/field-context.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/field-context.ts
@@ -42,11 +42,11 @@ export const TYPE_FIELDS: { [key: string]: { [key: string]: string } } = {
   },
   numeric: {
     decorator: 'NumericField',
-    tsType: 'string',
+    tsType: 'BN',
   },
   decimal: {
     decorator: 'NumericField',
-    tsType: 'string',
+    tsType: 'BN',
   },
   oto: {
     decorator: 'OneToOne',

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -17,6 +17,8 @@ import {
   StringField
 } from 'warthog';  {{! we don't need extra twists here }}
 
+{{#has.numeric}}import * as BN from 'bn.js' {{/has.numeric}}
+
 {{#has.union}}
 import { Column } from 'typeorm';
 import { Field } from 'type-graphql';


### PR DESCRIPTION
This PR sets `BN`(bn.js) for the database `numeric` type, it depends on the latest warthog release https://github.com/metmirr/warthog/releases/tag/v2.9.7 