### PR TITLE
Prevent the block indexer from hanging after a websocket connection failure

### DIFF
--- a/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/index-builder-entry.mst
@@ -143,7 +143,7 @@ async function main() {
       process.exit(0);
   }
 
-  node.start({
+  await node.start({
     wsProviderURI: providerUri,
     processingPack: getProcessingPack(),
     atBlock: atBlock && atBlock !== '0' ? new BN(atBlock) : undefined,

--- a/query-node/substrate-query-framework/index-builder/src/IndexBuilder.ts
+++ b/query-node/substrate-query-framework/index-builder/src/IndexBuilder.ts
@@ -43,12 +43,21 @@ export default class IndexBuilder {
 
     debug('Spawned worker.');
 
+    if (atBlock) {
+      debug(`Got block height hint: ${atBlock}`);
+    }
+    
     const lastProcessedEvent = await getRepository(SavedEntityEvent).findOne({ where: { id: 1 } });
 
+    if (lastProcessedEvent) {
+      debug(`Found the most recent processed event at block ${lastProcessedEvent.blockNumber.toString()}`);
+    }
+
     if (atBlock && lastProcessedEvent) {
-      throw new Error(
-        `Existing processed history detected on the database!
-        Last processed block is ${lastProcessedEvent.blockNumber.toString()}`
+      debug(
+        `WARNING! Existing processed history detected on the database!
+        Last processed block is ${lastProcessedEvent.blockNumber.toString()}. The indexer 
+        will continue from block ${lastProcessedEvent.blockNumber.toString()} and ignore the block height hints.`
       );
     }
 

--- a/query-node/substrate-query-framework/index-builder/src/QueryBlockProducer.ts
+++ b/query-node/substrate-query-framework/index-builder/src/QueryBlockProducer.ts
@@ -79,8 +79,9 @@ export default class QueryBlockProducer extends EventEmitter {
       this._OnNewHeads(header);
     });
 
+    debug(`Starting the block producer, next block: ${this._block_to_be_produced_next}`);
     // Start producing blocks right away
-    if (!this._producing_blocks_blocks) this._produce_blocks();
+    if (!this._producing_blocks_blocks) await this._produce_blocks();
   }
 
   async stop() {


### PR DESCRIPTION
This PR fixes the following bug observed on production. 

After the connection to the Substrate web-service (e.g. `wss://kusama-rpc.polkadot.io/`), the block producer stops processing new blocks, even after the connection is restored. 
This PR wraps each API call in `_withTimeout` call which forces the corresponding Promises to reject after 5 seconds. Then the main producer loop retries to produce the current block with exponentially increasing delays between the retries (up to 30 mins).

Note, that such a defensive mechanism would block the producer if there is e.g. a syntactically invalid block, in which case it will try to decode it for an indefinite time. In this case, the node operator is expected to manually resolve the issue and restart the indexer.