### PR TITLE
Storage node/improve sign and send

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -42,7 +42,8 @@
     "typescript": "^3.8.3"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.18.0",
+    "yarn": "^1.22.0"
   },
   "files": [
     "/bin",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,9 @@
       "pre-commit": "devops/git-hooks/pre-commit",
       "pre-push": "devops/git-hooks/pre-push"
     }
+  },
+  "engines": {
+    "node": ">=12.18.0",
+    "yarn": "^1.22.0"
   }
 }

--- a/pioneer/package.json
+++ b/pioneer/package.json
@@ -2,8 +2,8 @@
   "version": "0.37.0-beta.63",
   "private": true,
   "engines": {
-    "node": ">=10.13.0",
-    "yarn": "^1.10.1"
+    "node": ">=12.18.0",
+    "yarn": "^1.22.0"
   },
   "homepage": ".",
   "name": "pioneer",

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -3,8 +3,8 @@
   "name": "storage-node",
   "version": "1.0.0",
   "engines": {
-    "node": ">=10.15.3",
-    "yarn": "^1.15.2"
+    "node": ">=12.18.0",
+    "yarn": "^1.22.0"
   },
   "homepage": "https://github.com/Joystream/joystream/",
   "bugs": {

--- a/storage-node/packages/cli/package.json
+++ b/storage-node/packages/cli/package.json
@@ -24,7 +24,7 @@
     "linux"
   ],
   "engines": {
-    "node": ">=10.15.3"
+    "node": ">=12.18.0"
   },
   "scripts": {
     "test": "mocha 'dist/test/**/*.js'",

--- a/storage-node/packages/cli/src/cli.ts
+++ b/storage-node/packages/cli/src/cli.ts
@@ -124,7 +124,7 @@ export async function main() {
     try {
       await commands[command](api, ...args)
     } catch (err) {
-      console.error(`Command Failed: ${err}`)
+      console.error('Command Failed:', err)
       process.exit(-1)
     }
   } else {

--- a/storage-node/packages/cli/src/cli.ts
+++ b/storage-node/packages/cli/src/cli.ts
@@ -121,7 +121,12 @@ export async function main() {
   if (Object.prototype.hasOwnProperty.call(commands, command)) {
     // Command recognized
     const args = _.clone(cli.input).slice(1)
-    await commands[command](api, ...args)
+    try {
+      await commands[command](api, ...args)
+    } catch (err) {
+      console.error(`Command Failed: ${err}`)
+      process.exit(-1)
+    }
   } else {
     showUsageAndExit(`Command "${command}" not recognized.`)
   }

--- a/storage-node/packages/cli/src/commands/dev.ts
+++ b/storage-node/packages/cli/src/commands/dev.ts
@@ -45,14 +45,14 @@ const batchDispatchCalls = async (
 
   debug(`dispatching ${rawCalls.length} transactions.`)
 
-  await rawCalls
-    .map((call) => {
+  // promise.all to avoid unhandled promise rejection
+  return Promise.all(
+    rawCalls.map((call) => {
       const { methodName, sectionName, args } = call
       const tx = api.tx[sectionName][methodName](...args)
       return runtimeApi.signAndSend(senderAddress, tx)
     })
-    .reverse()
-    .shift()
+  )
 }
 
 // Dispatch pre-prepared calls to runtime to initialize the versioned store

--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -111,13 +111,13 @@ function startExpressApp(app, port) {
 
 // Start app
 function startAllServices({ store, api, port }) {
-  const app = require('../lib/app')(PROJECT_ROOT, store, api) // reduce falgs to only needed values
+  const app = require('../lib/app')(PROJECT_ROOT, store, api)
   return startExpressApp(app, port)
 }
 
 // Start discovery service app only
 function startDiscoveryService({ api, port }) {
-  const app = require('../lib/discovery')(PROJECT_ROOT, api) // reduce flags to only needed values
+  const app = require('../lib/discovery')(PROJECT_ROOT, api)
   return startExpressApp(app, port)
 }
 
@@ -244,14 +244,14 @@ if (!command) {
   command = 'server'
 }
 
-async function startColossus({ api, publicUrl, port, flags }) {
+async function startColossus({ api, publicUrl, port }) {
   // TODO: check valid url, and valid port number
   const store = getStorage(api)
   banner()
   const { startSyncing } = require('../lib/sync')
   startSyncing(api, { syncPeriod: SYNC_PERIOD_MS }, store)
   announcePublicUrl(api, publicUrl)
-  return startAllServices({ store, api, port, flags }) // dont pass all flags only required values
+  return startAllServices({ store, api, port })
 }
 
 const commands = {

--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -205,6 +205,8 @@ function getServiceInformation(publicUrl) {
   }
 }
 
+// TODO: instead of recursion use while/async-await and use promise/setTimout based sleep
+// or cleaner code with generators?
 async function announcePublicUrl(api, publicUrl) {
   // re-announce in future
   const reannounce = function (timeoutMs) {

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -66,7 +66,7 @@ async function syncCallback(api, storage) {
       // create relationship
       debug(`Creating new storage relationship for ${contentId.encode()}`)
       try {
-        relationshipId = await api.assets.createAndReturnStorageRelationship(roleAddress, providerId, contentId)
+        relationshipId = await api.assets.createStorageRelationship(roleAddress, providerId, contentId)
         await api.assets.toggleStorageRelationshipReady(roleAddress, providerId, relationshipId, true)
       } catch (err) {
         debug(`Error creating new storage relationship ${contentId.encode()}: ${err.stack}`)

--- a/storage-node/packages/colossus/package.json
+++ b/storage-node/packages/colossus/package.json
@@ -29,7 +29,7 @@
     "linux"
   ],
   "engines": {
-    "node": ">=10.15.3"
+    "node": ">=12.18.0"
   },
   "scripts": {
     "test": "mocha 'test/**/*.js'",

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -157,7 +157,7 @@ module.exports = function (storage, runtime) {
 
             debug('creating storage relationship for newly uploaded content')
             // Create storage relationship and flip it to ready.
-            const dosrId = await runtime.assets.createAndReturnStorageRelationship(roleAddress, providerId, id)
+            const dosrId = await runtime.assets.createStorageRelationship(roleAddress, providerId, id)
 
             debug('toggling storage relationship for newly uploaded content')
             await runtime.assets.toggleStorageRelationshipReady(roleAddress, providerId, dosrId, true)

--- a/storage-node/packages/discovery/package.json
+++ b/storage-node/packages/discovery/package.json
@@ -29,7 +29,7 @@
     "linux"
   ],
   "engines": {
-    "node": ">=10.15.3"
+    "node": ">=12.18.0"
   },
   "main": "./index.js",
   "scripts": {

--- a/storage-node/packages/runtime-api/assets.js
+++ b/storage-node/packages/runtime-api/assets.js
@@ -122,7 +122,7 @@ class AssetsApi {
     contentId = parseContentId(contentId)
     const tx = this.base.api.tx.dataObjectStorageRegistry.addRelationship(storageProviderId, contentId)
 
-    return this.base.signAndSendThen(providerAccountId, tx, {
+    return this.base.signAndSendThenGetEventResult(providerAccountId, tx, {
       eventModule: 'dataObjectStorageRegistry',
       eventName: 'DataObjectStorageRelationshipAdded',
       eventProperty: 'DataObjectStorageRelationshipId', // index 0

--- a/storage-node/packages/runtime-api/assets.js
+++ b/storage-node/packages/runtime-api/assets.js
@@ -123,9 +123,10 @@ class AssetsApi {
     const tx = this.base.api.tx.dataObjectStorageRegistry.addRelationship(storageProviderId, contentId)
 
     return this.base.signAndSendThenGetEventResult(providerAccountId, tx, {
-      eventModule: 'dataObjectStorageRegistry',
-      eventName: 'DataObjectStorageRelationshipAdded',
-      eventProperty: 'DataObjectStorageRelationshipId', // index 0
+      module: 'dataObjectStorageRegistry',
+      event: 'DataObjectStorageRelationshipAdded',
+      type: 'DataObjectStorageRelationshipId',
+      index: 0,
     })
   }
 

--- a/storage-node/packages/runtime-api/assets.js
+++ b/storage-node/packages/runtime-api/assets.js
@@ -96,17 +96,6 @@ class AssetsApi {
   }
 
   /*
-   * Creates storage relationship for a data object and provider
-   */
-  async createStorageRelationship(providerAccountId, storageProviderId, contentId, callback) {
-    contentId = parseContentId(contentId)
-    const tx = this.base.api.tx.dataObjectStorageRegistry.addRelationship(storageProviderId, contentId)
-
-    const subscribed = [['dataObjectStorageRegistry', 'DataObjectStorageRelationshipAdded']]
-    return this.base.signAndSend(providerAccountId, tx, subscribed, callback)
-  }
-
-  /*
    * Gets storage relationship for contentId for the given provider
    */
   async getStorageRelationshipAndId(storageProviderId, contentId) {
@@ -126,22 +115,17 @@ class AssetsApi {
   }
 
   /*
-   * Creates storage relationship for a data object and provider and returns the relationship id
+   * Creates storage relationship for a data object and provider and
+   * returns the relationship id
    */
-  async createAndReturnStorageRelationship(providerAccountId, storageProviderId, contentId) {
+  async createStorageRelationship(providerAccountId, storageProviderId, contentId) {
     contentId = parseContentId(contentId)
-    // TODO: rewrite this method to async-await style
-    // eslint-disable-next-line  no-async-promise-executor
-    return new Promise(async (resolve, reject) => {
-      try {
-        await this.createStorageRelationship(providerAccountId, storageProviderId, contentId, (events) => {
-          events.forEach((event) => {
-            resolve(event[1].DataObjectStorageRelationshipId)
-          })
-        })
-      } catch (err) {
-        reject(err)
-      }
+    const tx = this.base.api.tx.dataObjectStorageRegistry.addRelationship(storageProviderId, contentId)
+
+    return this.base.signAndSendThen(providerAccountId, tx, {
+      eventModule: 'dataObjectStorageRegistry',
+      eventName: 'DataObjectStorageRelationshipAdded',
+      eventProperty: 'DataObjectStorageRelationshipId', // index 0
     })
   }
 

--- a/storage-node/packages/runtime-api/assets.js
+++ b/storage-node/packages/runtime-api/assets.js
@@ -103,7 +103,7 @@ class AssetsApi {
     const tx = this.base.api.tx.dataObjectStorageRegistry.addRelationship(storageProviderId, contentId)
 
     const subscribed = [['dataObjectStorageRegistry', 'DataObjectStorageRelationshipAdded']]
-    return this.base.signAndSend(providerAccountId, tx, 3, subscribed, callback)
+    return this.base.signAndSend(providerAccountId, tx, subscribed, callback)
   }
 
   /*

--- a/storage-node/packages/runtime-api/identities.js
+++ b/storage-node/packages/runtime-api/identities.js
@@ -188,7 +188,7 @@ class IdentitiesApi {
     return this.base.signAndSendThenGetEventResult(accountId, tx, {
       eventModule: 'members',
       eventName: 'MemberRegistered',
-      eventProperty: 'MemberId',
+      eventProperty: 'MemberId', // index 0
     })
   }
 

--- a/storage-node/packages/runtime-api/identities.js
+++ b/storage-node/packages/runtime-api/identities.js
@@ -186,9 +186,10 @@ class IdentitiesApi {
     const tx = this.base.api.tx.members.buyMembership(0, userInfo)
 
     return this.base.signAndSendThenGetEventResult(accountId, tx, {
-      eventModule: 'members',
-      eventName: 'MemberRegistered',
-      eventProperty: 'MemberId', // index 0
+      module: 'members',
+      event: 'MemberRegistered',
+      type: 'MemberId',
+      index: 0,
     })
   }
 

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -171,6 +171,7 @@ class RuntimeApi {
 
       if (result.isError) {
         unsubscribe()
+        debug('Tx Error', status.type)
         onFinalizedFailed &&
           onFinalizedFailed({ err: status.type, result, tx: status.isUsurped ? status.asUsurped : undefined })
       } else if (result.isFinalized) {

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -30,7 +30,6 @@ const { DiscoveryApi } = require('@joystream/storage-runtime-api/discovery')
 const { SystemApi } = require('@joystream/storage-runtime-api/system')
 const AsyncLock = require('async-lock')
 const Promise = require('bluebird')
-const { GenericExtrinsicPayloadV2 } = require('../../../pioneer/packages/apps/build/main.a723bde4')
 
 Promise.config({
   cancellation: true,

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -108,7 +108,7 @@ class RuntimeApi {
       // Loop through each of the parameters, displaying the type and data
       const payload = {}
       event.data.forEach((data, index) => {
-        debug(`\t\t\t${types[index].type}: ${data.toString()}`)
+        debug(`\t${types[index].type}: ${data.toString()}`)
         payload[types[index].type] = data
       })
 
@@ -116,7 +116,7 @@ class RuntimeApi {
       return [fullName, payload]
     })
 
-    debug('Mapped', mapped)
+    debug('Matched Events', JSON.stringify(mapped))
 
     return mapped
   }
@@ -153,7 +153,6 @@ class RuntimeApi {
       try {
         if (subscribed && callback) {
           const matched = RuntimeApi.matchingEvents(subscribed, events)
-          debug('Matching events:', matched)
           if (matched.length) {
             callback(matched)
           }

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -182,9 +182,7 @@ class RuntimeApi {
         onFinalizedFailed && onFinalizedFailed({ err: 'Dropped', result, tx: status.asFinalized })
       }
 
-      // My gutt says this comes before isReady and causes await send() to throw
-      // and therefore onFinalizedFailed isn't initialized.
-      // We don't need to do anything other than log it?
+      // When is this status emitted?
       if (status.isInvalid) {
         debug(status.type)
         debug(JSON.stringify(status.asInvalid))

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -189,7 +189,7 @@ class RuntimeApi {
       if (status.isInvalid) {
         debug(status.type)
         debug(JSON.stringify(status.asInvalid))
-        onFinalizedFailed && onFinalizedFailed({ err: 'Dropped', result, tx: status.asFinalized })
+        onFinalizedFailed && onFinalizedFailed({ err: 'Invalid', result, tx: status.asFinalized })
       }
 
       if (status.isFinalized) {

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -97,13 +97,15 @@ class RuntimeApi {
 
       // Skip events we're not interested in.
       const matching = subscribed.filter((value) => {
-        if (value[0] === '*') {
+        if (value[0] === '*' && value[1] === '*') {
           return true
+        } else if (value[0] === '*') {
+          return event.method === value[1]
+        } else if (value[1] === '*') {
+          return event.section === value[0]
+        } else {
+          return event.section === value[0] && event.method === value[1]
         }
-        if (value[0] === event.section) {
-          if (value[1] === '*') return true
-        }
-        return event.section === value[0] && event.method === value[1]
       })
       return matching.length > 0
     })

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -129,7 +129,7 @@ class RuntimeApi {
    * If the subscribed events are given, and a callback as well, then the
    * callback is invoked with matching events.
    */
-  async signAndSend(accountId, tx, attempts, subscribed, callback) {
+  async signAndSend(accountId, tx, subscribed, callback) {
     accountId = this.identities.keyring.encodeAddress(accountId)
 
     // Key must be unlocked
@@ -237,7 +237,7 @@ class RuntimeApi {
     // eslint-disable-next-line  no-async-promise-executor
     return new Promise(async (resolve, reject) => {
       try {
-        await this.signAndSend(senderAccountId, tx, 1, subscribed, (events) => {
+        await this.signAndSend(senderAccountId, tx, subscribed, (events) => {
           events.forEach((event) => {
             // fix - we may not necessarily want the first event
             // if there are multiple events emitted,

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -36,7 +36,6 @@ Promise.config({
   cancellation: true,
 })
 
-// const ASYNC_LOCK_TIMEOUT = 30 * 1000
 const TX_TIMEOUT = 20 * 1000
 
 /*
@@ -62,7 +61,6 @@ class RuntimeApi {
     // Create the API instrance
     this.api = await ApiPromise.create({ provider })
 
-    // this.asyncLock = new AsyncLock({ timeout: ASYNC_LOCK_TIMEOUT, maxPending: 100 })
     this.asyncLock = new AsyncLock()
 
     // Keep track locally of account nonces.

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -241,6 +241,8 @@ class RuntimeApi {
     // synchronize access to nonce
     await this.executeWithAccountLock(accountId, async () => {
       const nonce = this.nonces[accountId] || (await this.api.query.system.accountNonce(accountId))
+      // In future use this rpc method to take the pending tx pool into account when fetching the nonce
+      // const nonce = await this.api.rpc.system.accountNextIndex(accountId)
 
       try {
         unsubscribe = await tx.sign(fromKey, { nonce }).send(handleTxUpdates)

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -30,7 +30,6 @@ const { DiscoveryApi } = require('@joystream/storage-runtime-api/discovery')
 const { SystemApi } = require('@joystream/storage-runtime-api/system')
 const AsyncLock = require('async-lock')
 const Promise = require('bluebird')
-const { startsWith } = require('lodash')
 
 Promise.config({
   cancellation: true,
@@ -226,19 +225,19 @@ class RuntimeApi {
           if (sudid) {
             const dispatchSuccess = sudid.event.data[0]
             if (dispatchSuccess.isTrue) {
-              onFinalizedSuccess({ mappedEvents, result, tx: status.asFinalized })
+              onFinalizedSuccess({ mappedEvents, result, block: status.asFinalized })
             } else {
-              onFinalizedFailed({ err: 'SudoFailed', mappedEvents, result, tx: status.asFinalized })
+              onFinalizedFailed({ err: 'SudoFailed', mappedEvents, result, block: status.asFinalized })
             }
           } else if (sudoAsDone) {
             const dispatchSuccess = sudoAsDone.event.data[0]
             if (dispatchSuccess.isTrue) {
-              onFinalizedSuccess({ mappedEvents, result, tx: status.asFinalized })
+              onFinalizedSuccess({ mappedEvents, result, block: status.asFinalized })
             } else {
-              onFinalizedFailed({ err: 'SudoAsFailed', mappedEvents, result, tx: status.asFinalized })
+              onFinalizedFailed({ err: 'SudoAsFailed', mappedEvents, result, block: status.asFinalized })
             }
           } else {
-            onFinalizedSuccess({ mappedEvents, result, tx: status.asFinalized })
+            onFinalizedSuccess({ mappedEvents, result, block: status.asFinalized })
           }
         }
       }

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -113,13 +113,16 @@ class RuntimeApi {
       const { event } = record
       const types = event.typeDef
       const payload = new Map()
-      event.data.forEach((data, index) => {
-        const type = types[index].type
-        payload.set(index, { type, data })
-      })
 
+      // this check may be un-necessary but doing it just incase
+      if (event.data) {
+        event.data.forEach((data, index) => {
+          const type = types[index].type
+          payload.set(index, { type, data })
+        })
+      }
       const fullName = `${event.section}.${event.method}`
-      debug(`matched event: ${fullName} =>`, ...event.data.map((data) => `${data},`))
+      debug(`matched event: ${fullName} =>`, event.data && event.data.join(', '))
       return [fullName, payload]
     })
   }

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -97,6 +97,12 @@ class RuntimeApi {
 
       // Skip events we're not interested in.
       const matching = subscribed.filter((value) => {
+        if (value[0] === '*') {
+          return true
+        }
+        if (value[0] === event.section) {
+          if (value[1] === '*') return true
+        }
         return event.section === value[0] && event.method === value[1]
       })
       return matching.length > 0
@@ -106,9 +112,8 @@ class RuntimeApi {
       const { event } = record
       const types = event.typeDef
 
-      // Loop through each of the event data items.
-      // FIX: we are loosing however some items if they have the same type
-      // only the first occurance is saved in the payload map, as the cost of convenience
+      // FIX: we are loosing some items if they have the same type
+      // only the first occurance is saved in the payload map. This is the cost of convenience
       // to get a value "by name" - why not just return the original EventRecord
       // and let the calller use the index to get the value desired?
       const payload = {}

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -84,26 +84,15 @@ class RuntimeApi {
     return this.asyncLock.acquire(`${accountId}`, func)
   }
 
-  /*
-   * Wait for an event. Filters out any events that don't match the module and
-   * event name.
-   *
-   * The result of the Promise is an array containing first the full event
-   * name, and then the event fields as an object.
-   */
-  async waitForEvent(module, name) {
-    return this.waitForEvents([[module, name]])
-  }
-
   static matchingEvents(subscribed, events) {
-    debug(`Number of events: ${events.length} subscribed to ${subscribed}`)
+    if (!events.length) return []
 
     const filtered = events.filter((record) => {
       const { event, phase } = record
 
       // Show what we are busy with
-      debug(`\t${event.section}:${event.method}:: (phase=${phase.toString()})`)
-      debug(`\t\t${event.meta.documentation.toString()}`)
+      // debug(`\t${event.section}:${event.method}:: (phase=${phase.toString()})`)
+      // debug(`\t\t${event.meta.documentation.toString()}`)
 
       // Skip events we're not interested in.
       const matching = subscribed.filter((value) => {
@@ -111,7 +100,6 @@ class RuntimeApi {
       })
       return matching.length > 0
     })
-    debug(`Filtered: ${filtered.length}`)
 
     const mapped = filtered.map((record) => {
       const { event } = record
@@ -127,27 +115,10 @@ class RuntimeApi {
       const fullName = `${event.section}.${event.method}`
       return [fullName, payload]
     })
+
     debug('Mapped', mapped)
 
     return mapped
-  }
-
-  /*
-   * Same as waitForEvent, but filter on multiple events. The parameter is an
-   * array of arrays containing module and name. Calling waitForEvent is
-   * identical to calling this with [[module, name]].
-   *
-   * Returns the first matched event *only*.
-   */
-  async waitForEvents(subscribed) {
-    return new Promise((resolve) => {
-      this.api.query.system.events((events) => {
-        const matches = RuntimeApi.matchingEvents(subscribed, events)
-        if (matches && matches.length) {
-          resolve(matches)
-        }
-      })
-    })
   }
 
   /*

--- a/storage-node/packages/runtime-api/package.json
+++ b/storage-node/packages/runtime-api/package.json
@@ -30,7 +30,7 @@
     "linux"
   ],
   "engines": {
-    "node": ">=10.15.3"
+    "node": ">=12.18.0"
   },
   "scripts": {
     "test": "mocha 'test/**/*.js' --exit",

--- a/storage-node/packages/runtime-api/workers.js
+++ b/storage-node/packages/runtime-api/workers.js
@@ -206,9 +206,10 @@ class WorkersApi {
    */
   async devSubmitAddOpeningTx(tx, senderAccount) {
     return this.base.signAndSendThenGetEventResult(senderAccount, tx, {
-      eventModule: 'storageWorkingGroup',
-      eventName: 'OpeningAdded',
-      eventProperty: 'OpeningId', // index 0
+      module: 'storageWorkingGroup',
+      event: 'OpeningAdded',
+      type: 'OpeningId',
+      index: 0,
     })
   }
 
@@ -226,9 +227,10 @@ class WorkersApi {
     )
 
     return this.base.signAndSendThenGetEventResult(memberAccount, applyTx, {
-      eventModule: 'storageWorkingGroup',
-      eventName: 'AppliedOnOpening',
-      eventProperty: 'ApplicationId', // index 1
+      module: 'storageWorkingGroup',
+      event: 'AppliedOnOpening',
+      type: 'ApplicationId',
+      index: 1,
     })
   }
 
@@ -287,9 +289,10 @@ class WorkersApi {
    */
   async devSubmitFillOpeningTx(senderAccount, tx) {
     return this.base.signAndSendThenGetEventResult(senderAccount, tx, {
-      eventModule: 'storageWorkingGroup',
-      eventName: 'OpeningFilled',
-      eventProperty: 'ApplicationIdToWorkerIdMap', // index 1
+      module: 'storageWorkingGroup',
+      event: 'OpeningFilled',
+      type: 'ApplicationIdToWorkerIdMap',
+      index: 1,
     })
   }
 }

--- a/storage-node/packages/runtime-api/workers.js
+++ b/storage-node/packages/runtime-api/workers.js
@@ -208,7 +208,7 @@ class WorkersApi {
     return this.base.signAndSendThenGetEventResult(senderAccount, tx, {
       eventModule: 'storageWorkingGroup',
       eventName: 'OpeningAdded',
-      eventProperty: 'OpeningId',
+      eventProperty: 'OpeningId', // index 0
     })
   }
 
@@ -228,7 +228,7 @@ class WorkersApi {
     return this.base.signAndSendThenGetEventResult(memberAccount, applyTx, {
       eventModule: 'storageWorkingGroup',
       eventName: 'AppliedOnOpening',
-      eventProperty: 'ApplicationId',
+      eventProperty: 'ApplicationId', // index 1
     })
   }
 
@@ -289,7 +289,7 @@ class WorkersApi {
     return this.base.signAndSendThenGetEventResult(senderAccount, tx, {
       eventModule: 'storageWorkingGroup',
       eventName: 'OpeningFilled',
-      eventProperty: 'ApplicationIdToWorkerIdMap',
+      eventProperty: 'ApplicationIdToWorkerIdMap', // index 1
     })
   }
 }

--- a/storage-node/packages/storage/package.json
+++ b/storage-node/packages/storage/package.json
@@ -30,7 +30,7 @@
     "linux"
   ],
   "engines": {
-    "node": ">=10.15.3"
+    "node": ">=12.18.0"
   },
   "scripts": {
     "test": "mocha --exit 'test/**/*.js'",

--- a/storage-node/packages/util/package.json
+++ b/storage-node/packages/util/package.json
@@ -30,7 +30,7 @@
     "linux"
   ],
   "engines": {
-    "node": ">=10.15.3"
+    "node": ">=12.18.0"
   },
   "scripts": {
     "test": "mocha 'test/**/*.js'",

--- a/types/package.json
+++ b/types/package.json
@@ -26,7 +26,8 @@
     "typescript": "^3.7.2"
   },
   "engines": {
-    "node": ">=10.0"
+    "node": ">=12.18.0",
+    "yarn": "^1.22.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
- In general the `RuntimeApi.signAndSend` was poorly written and hard to read. So it has been refactored for clarity.
- Added a timeout on waiting for extrinsic to finalize to deal with api disconnecting from the joystream-node.
- Dropped use of the externallyControllerPromise which was causing some unexpected behavior that appeared when I initially added the timeout on it. Specifically that the timeout wouldn't be realized until after the application was exiting by `Ctrl-C`.
- General improvements to error handling and event matching.
- I also bumped the minimum engine versions for node and yarn.