### PR TITLE
Storage node/balance and synched checks

### DIFF
--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -216,9 +216,14 @@ async function announcePublicUrl(api, publicUrl) {
   }
 
   const chainIsSyncing = await api.chainIsSyncing()
-
   if (chainIsSyncing) {
     debug('Chain is syncing. Postponing announcing public url.')
+    return reannounce(10 * 60 * 1000)
+  }
+
+  const sufficientBalance = await api.providerHasMinimumBalance(1)
+  if (!sufficientBalance) {
+    debug('Provider role account does not have sufficient balance. Postponing announcing public url.')
     return reannounce(10 * 60 * 1000)
   }
 

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -94,9 +94,19 @@ async function syncPeriodic(api, flags, storage) {
     debug('Starting sync run...')
 
     const chainIsSyncing = await api.chainIsSyncing()
-
     if (chainIsSyncing) {
       debug('Chain is syncing. Postponing sync run.')
+      return setTimeout(syncPeriodic, flags.syncPeriod, api, flags, storage)
+    }
+
+    const recommendedBalance = await api.providerHasMinimumBalance(300)
+    if (!recommendedBalance) {
+      debug('Warning: Provider role account is running low on balance.')
+    }
+
+    const sufficientBalance = await api.providerHasMinimumBalance(100)
+    if (!sufficientBalance) {
+      debug('Provider role account does not have sufficient balance. Postponing sync run!')
       return setTimeout(syncPeriodic, flags.syncPeriod, api, flags, storage)
     }
 

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -92,6 +92,14 @@ async function syncCallback(api, storage) {
 async function syncPeriodic(api, flags, storage) {
   try {
     debug('Starting sync run...')
+
+    const chainIsSyncing = await api.chainIsSyncing()
+
+    if (chainIsSyncing) {
+      debug('Chain is syncing. Postponing sync run.')
+      return setTimeout(syncPeriodic, flags.syncPeriod, api, flags, storage)
+    }
+
     await syncCallback(api, storage)
     debug('sync run complete')
   } catch (err) {

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -91,6 +91,13 @@ module.exports = function (storage, runtime) {
         return
       }
 
+      const sufficientBalance = await runtime.providerHasMinimumBalance(3)
+
+      if (!sufficientBalance) {
+        errorHandler(res, 'Insufficient balance to process upload!', 503)
+        return
+      }
+
       // We'll open a write stream to the backend, but reserve the right to
       // abort upload if the filters don't smell right.
       let stream

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -31,6 +31,7 @@ const { DiscoveryApi } = require('@joystream/storage-runtime-api/discovery')
 const { SystemApi } = require('@joystream/storage-runtime-api/system')
 const AsyncLock = require('async-lock')
 const Promise = require('bluebird')
+const { sleep } = require('@joystream/storage-utils/sleep')
 
 Promise.config({
   cancellation: true,
@@ -84,6 +85,24 @@ class RuntimeApi {
 
   disconnect() {
     this.api.disconnect()
+  }
+
+  async untilChainIsSynced() {
+    debug('Waiting for chain to be synced before proceeding.')
+    while (true) {
+      const isSyncing = await this.chainIsSyncing()
+      if (isSyncing) {
+        debug('Still waiting for chain to be synced.')
+        await sleep(1 * 30 * 1000)
+      } else {
+        return
+      }
+    }
+  }
+
+  async chainIsSyncing() {
+    const { isSyncing } = await this.api.rpc.system.health()
+    return isSyncing.isTrue
   }
 
   executeWithAccountLock(accountId, func) {

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -105,6 +105,11 @@ class RuntimeApi {
     return isSyncing.isTrue
   }
 
+  async providerHasMinimumBalance(minimumBalance) {
+    const providerAccountId = this.identities.key.address
+    return this.balances.hasMinimumBalanceOf(providerAccountId, minimumBalance)
+  }
+
   executeWithAccountLock(accountId, func) {
     return this.asyncLock.acquire(`${accountId}`, func)
   }

--- a/storage-node/packages/runtime-api/package.json
+++ b/storage-node/packages/runtime-api/package.json
@@ -45,6 +45,7 @@
     "temp": "^0.9.0"
   },
   "dependencies": {
+    "@joystream/storage-utils": "^0.1.0",
     "@joystream/types": "^0.12.0",
     "@polkadot/api": "^0.96.1",
     "async-lock": "^1.2.0",

--- a/storage-node/packages/util/sleep.js
+++ b/storage-node/packages/util/sleep.js
@@ -1,0 +1,9 @@
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+module.exports = {
+  sleep,
+}


### PR DESCRIPTION
Additional checks for chain state sync status and minimum free balance before proceeding with sending transactions.
Logs some warnings also on low balance.

Mainly to avoid situations as described in https://github.com/Joystream/joystream/pull/1070#pullrequestreview-456625480

During syncing, an improvement would be to do the balance check before each transaction submission rather than a catch all before the sync run. But this will have to do for now.