### PR TITLE
Schema refactoring

### DIFF
--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -980,12 +980,12 @@ impl<T: Trait> PropertyType<T> {
     }
 
     pub fn single_text(text_max_len: TextMaxLength) -> PropertyType<Runtime> {
-        let text_type = SingleValuePropertyType(Type::<Runtime>::Text(text_max_len));
+        let text_type = Type::<Runtime>::Text(text_max_len);
         PropertyType::<Runtime>::Single(text_type)
     }
 
     pub fn single_text_hash(text_hash_max_len: HashedTextMaxLength) -> PropertyType<Runtime> {
-        let text_type = SingleValuePropertyType(Type::<Runtime>::Hash(text_hash_max_len));
+        let text_type = Type::<Runtime>::Hash(text_hash_max_len);
         PropertyType::<Runtime>::Single(text_type)
     }
 

--- a/runtime-modules/content-directory/src/tests/transaction.rs
+++ b/runtime-modules/content-directory/src/tests/transaction.rs
@@ -7,8 +7,7 @@ fn transaction_success() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create single reference property
-        let property_type_reference =
-            SingleValuePropertyType(Type::Reference(FIRST_CLASS_ID, true));
+        let property_type_reference = Type::Reference(FIRST_CLASS_ID, true);
         let property = Property::<Runtime>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             PropertyType::Single(property_type_reference),


### PR DESCRIPTION
This PR removes obsolete `SingleValuePropertyType` abstraction. 

Refactoring have mostly been done for the purpose of making `ensure_property_type_size_is_valid` check reusable among `Single` and `Vector` `PropertyType`s

https://github.com/Joystream/joystream/pull/1076 should be merged before to minimize merge conflict potential