### PR TITLE
Reading old chain state + example usage

### DIFF
--- a/joystream-js/.gitignore
+++ b/joystream-js/.gitignore
@@ -1,0 +1,3 @@
+lib
+examples/**/*.js
+examples/**/*.d.ts

--- a/joystream-js/examples/index.ts
+++ b/joystream-js/examples/index.ts
@@ -1,4 +1,4 @@
-import readOldState from './read-old-state';
+import readOldState from "./read-old-state";
 export default {
-	readOldState
+	readOldState,
 };

--- a/joystream-js/examples/index.ts
+++ b/joystream-js/examples/index.ts
@@ -1,0 +1,4 @@
+import readOldState from './read-old-state';
+export default {
+	readOldState
+};

--- a/joystream-js/examples/package.json
+++ b/joystream-js/examples/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@joystream/js-examples",
+	"version": "0.0.0",
+	"description": "Joystream JavaScript utilities library example usages",
+	"main": "lib/index.js",
+	"license": "MIT",
+	"scripts": {
+	  "build": "yarn workspace @joystream/js build && tsc --build tsconfig.json",
+	  "run-example": "node run.js"
+	},
+	"dependencies": {
+	  "@joystream/js": "0.0.0",
+	  "@nicaea/types@npm:@joystream/types": "^0.12.0",
+	  "@constantinopole/types@npm:@joystream/types": "^0.10.0"
+	},
+	"devDependencies": {
+	  "typescript": "3.7.2"
+	}
+}

--- a/joystream-js/examples/read-old-state/index.ts
+++ b/joystream-js/examples/read-old-state/index.ts
@@ -1,0 +1,27 @@
+import { registerJoystreamTypes as registerConstantinopoleTypes } from '@constantinopole/types';
+import { registerJoystreamTypes as registerNicaeaTypes } from '@nicaea/types';
+import { createOldStateApi } from '@joystream/js';
+
+// Those can be overriden with args
+const NODE_URI = 'wss://rome-rpc-endpoint.joystream.org:9944/';
+const BLOCK_BEFORE_RUNTIME_UPGRADE = 1800000;
+
+export default async function main(
+	nodeUri = NODE_URI,
+	atBlock = BLOCK_BEFORE_RUNTIME_UPGRADE
+) {
+	const api = await createOldStateApi(
+		nodeUri,
+		registerNicaeaTypes,
+		registerConstantinopoleTypes,
+		atBlock
+	);
+
+	// Querying state using api method that no longer exists in Nicaea
+	const blockHash = await api.rpc.chain.getBlockHash(atBlock);
+    const res = await api.query.dataDirectory.primaryLiaisonAccountId.at(blockHash);
+    console.log(
+		`api.query.dataDirectory.primaryLiaisonAccountId at block #${atBlock}:`,
+		res.toJSON()
+	);
+}

--- a/joystream-js/examples/run.ts
+++ b/joystream-js/examples/run.ts
@@ -1,15 +1,14 @@
-import examples from './index';
+import examples from "./index";
 
-const scriptArg = process.argv[2]
-const script = Object.keys(examples).includes(scriptArg) ?
-	examples[scriptArg as keyof typeof examples]
-	: null;
+const scriptArg = process.argv[2];
+const script = Object.keys(examples).includes(scriptArg) ? examples[scriptArg as keyof typeof examples] : null;
 
 if (!scriptArg || !script) {
-  console.error('Please specify valid example name.')
-  console.error('Available examples:', Object.keys(examples))
-  process.exit();
-}
-else {
-	script(...process.argv.slice(3)).then(() => process.exit()).catch(console.error);
+	console.error("Please specify valid example name.");
+	console.error("Available examples:", Object.keys(examples));
+	process.exit();
+} else {
+	script(...process.argv.slice(3))
+		.then(() => process.exit())
+		.catch(console.error);
 }

--- a/joystream-js/examples/run.ts
+++ b/joystream-js/examples/run.ts
@@ -1,0 +1,15 @@
+import examples from './index';
+
+const scriptArg = process.argv[2]
+const script = Object.keys(examples).includes(scriptArg) ?
+	examples[scriptArg as keyof typeof examples]
+	: null;
+
+if (!scriptArg || !script) {
+  console.error('Please specify valid example name.')
+  console.error('Available examples:', Object.keys(examples))
+  process.exit();
+}
+else {
+	script(...process.argv.slice(3)).then(() => process.exit()).catch(console.error);
+}

--- a/joystream-js/examples/tsconfig.json
+++ b/joystream-js/examples/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+	  "target": "es2017",
+	  "module": "commonjs",
+	  "strict": true,
+	  "noImplicitAny": true,
+	  "noUnusedLocals": true,
+	  "noImplicitReturns": true,
+	  "moduleResolution": "node",
+	  "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+	  "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+	  "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
+	  "declaration": true,
+	  "resolveJsonModule": true,
+	  "types" : [
+		  "node"
+	  ]
+	},
+	"include": [
+	  "./**/*.ts"
+	],
+}

--- a/joystream-js/package.json
+++ b/joystream-js/package.json
@@ -1,0 +1,19 @@
+
+{
+	"name": "@joystream/js",
+	"version": "0.0.0",
+	"description": "Joystream JavaScript utilities library",
+	"main": "lib/index.js",
+	"license": "MIT",
+	"scripts": {
+	  "build": "tsc --build tsconfig.json"
+	},
+	"dependencies": {
+	  "@polkadot/api": "^0.96.1",
+	  "@types/bn.js": "^4.11.5",
+	  "bn.js": "^4.11.8"
+	},
+	"devDependencies": {
+	  "typescript": "3.7.2"
+	}
+}

--- a/joystream-js/src/OldStateApi.ts
+++ b/joystream-js/src/OldStateApi.ts
@@ -1,0 +1,30 @@
+import { ApiPromise, WsProvider } from '@polkadot/api'
+import MetadataVersioned from '@polkadot/types/Metadata/MetadataVersioned';
+
+export async function createOldStateApi(
+	newNodeUri: string,
+	registerNewTypes: () => void,
+	registerOldTypes: () => void,
+	oldBlockNumber: number
+): Promise<ApiPromise> {
+	// Create initial api instance
+	const initWsProvider = new WsProvider(newNodeUri);
+    registerNewTypes();
+	const initApi = await ApiPromise.create({ provider: initWsProvider });
+	// Get required data in order to initialize the final api
+	const oldBlockHash = await initApi.rpc.chain.getBlockHash(oldBlockNumber);
+    const [genesisHash, oldMetadata, runtimeVersion] = await Promise.all([
+		initApi.rpc.chain.getBlockHash(0),
+		initApi.rpc.state.getMetadata(oldBlockHash),
+        initApi.rpc.state.getRuntimeVersion()
+    ]);
+    // Create metadata key required by @polkadot/api and use it to create "metadataArg"
+    const metadataKey = `${genesisHash}-${runtimeVersion.specVersion}`;
+    const metadataArg = { [metadataKey]: new MetadataVersioned(oldMetadata.toJSON()).toHex() };
+    initApi.disconnect();
+    // Create final api (current node, old metadata and types)
+    const wsProvider = new WsProvider(newNodeUri);
+    registerOldTypes();
+    return await ApiPromise.create({ provider: wsProvider, metadata: metadataArg });
+  }
+

--- a/joystream-js/src/OldStateApi.ts
+++ b/joystream-js/src/OldStateApi.ts
@@ -1,5 +1,5 @@
-import { ApiPromise, WsProvider } from '@polkadot/api'
-import MetadataVersioned from '@polkadot/types/Metadata/MetadataVersioned';
+import { ApiPromise, WsProvider } from "@polkadot/api";
+import MetadataVersioned from "@polkadot/types/Metadata/MetadataVersioned";
 
 export async function createOldStateApi(
 	newNodeUri: string,
@@ -9,22 +9,21 @@ export async function createOldStateApi(
 ): Promise<ApiPromise> {
 	// Create initial api instance
 	const initWsProvider = new WsProvider(newNodeUri);
-    registerNewTypes();
+	registerNewTypes();
 	const initApi = await ApiPromise.create({ provider: initWsProvider });
 	// Get required data in order to initialize the final api
 	const oldBlockHash = await initApi.rpc.chain.getBlockHash(oldBlockNumber);
-    const [genesisHash, oldMetadata, runtimeVersion] = await Promise.all([
+	const [genesisHash, oldMetadata, runtimeVersion] = await Promise.all([
 		initApi.rpc.chain.getBlockHash(0),
 		initApi.rpc.state.getMetadata(oldBlockHash),
-        initApi.rpc.state.getRuntimeVersion()
-    ]);
-    // Create metadata key required by @polkadot/api and use it to create "metadataArg"
-    const metadataKey = `${genesisHash}-${runtimeVersion.specVersion}`;
-    const metadataArg = { [metadataKey]: new MetadataVersioned(oldMetadata.toJSON()).toHex() };
-    initApi.disconnect();
-    // Create final api (current node, old metadata and types)
-    const wsProvider = new WsProvider(newNodeUri);
-    registerOldTypes();
-    return await ApiPromise.create({ provider: wsProvider, metadata: metadataArg });
-  }
-
+		initApi.rpc.state.getRuntimeVersion(),
+	]);
+	// Create metadata key required by @polkadot/api and use it to create "metadataArg"
+	const metadataKey = `${genesisHash}-${runtimeVersion.specVersion}`;
+	const metadataArg = { [metadataKey]: new MetadataVersioned(oldMetadata.toJSON()).toHex() };
+	initApi.disconnect();
+	// Create final api (current node, old metadata and types)
+	const wsProvider = new WsProvider(newNodeUri);
+	registerOldTypes();
+	return await ApiPromise.create({ provider: wsProvider, metadata: metadataArg });
+}

--- a/joystream-js/src/index.ts
+++ b/joystream-js/src/index.ts
@@ -1,0 +1,1 @@
+export { createOldStateApi } from './OldStateApi';

--- a/joystream-js/src/index.ts
+++ b/joystream-js/src/index.ts
@@ -1,1 +1,1 @@
-export { createOldStateApi } from './OldStateApi';
+export { createOldStateApi } from "./OldStateApi";

--- a/joystream-js/tsconfig.json
+++ b/joystream-js/tsconfig.json
@@ -1,0 +1,24 @@
+{
+	"compilerOptions": {
+	  "target": "es2017",
+	  "module": "commonjs",
+	  "strict": true,
+	  "noImplicitAny": true,
+	  "noUnusedLocals": true,
+	  "noImplicitReturns": true,
+	  "moduleResolution": "node",
+	  "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+	  "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+	  "experimentalDecorators": true,           /* Enables experimental support for ES7 decorators. */
+	  "declaration": true,
+	  "outDir": "lib",
+	  "resolveJsonModule": true,
+	  "types" : [
+		  "node"
+	  ]
+
+	},
+	"include": [
+	  "src/**/*.ts"
+	],
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
 		"cli",
 		"types",
 		"pioneer",
-		"pioneer/packages/*"
+		"pioneer/packages/*",
+		"joystream-js",
+		"joystream-js/examples"
 	],
 	"resolutions": {
 		"@polkadot/api": "^0.96.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1355,7 +1355,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@constantinople/types@npm:@joystream/types@^0.10.0":
+"@constantinople/types@npm:@joystream/types@^0.10.0", "@constantinopole/types@npm:@joystream/types@^0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@joystream/types/-/types-0.10.0.tgz#7e98ef221410b26a7d952cfc3d1c03d28395ad69"
   integrity sha512-RDZizqGKWGYpLR5PnUWM4aGa7InpWNh2Txlr7Al3ROFYOHoyQf62/omPfEz29F6scwlFxysOdmEfQaLeVRaUxA==
@@ -2480,6 +2480,19 @@
   dependencies:
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
+
+"@nicaea/types@npm:@joystream/types@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@joystream/types/-/types-0.12.0.tgz#4033967ae2ac111f894fb4100e414f7cdbe95611"
+  integrity sha512-pHHYTbIa6V1C4k9aj+M6Fkwa2I2Br+4x7cuvREmrVh21GHjGuzoIwB74MfqFajdSTDQDZbjdixcYDES6uo3sUg==
+  dependencies:
+    "@polkadot/keyring" "^1.7.0-beta.5"
+    "@polkadot/types" "^0.96.1"
+    "@types/lodash" "^4.14.157"
+    "@types/vfile" "^4.0.0"
+    ajv "^6.11.0"
+    lodash "^4.17.15"
+    moment "^2.24.0"
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -3778,6 +3791,11 @@
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
+"@types/lodash@^4.14.157":
+  version "4.14.158"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.158.tgz#b38ea8b6fe799acd076d7a8d7ab71c26ef77f785"
+  integrity sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==
 
 "@types/marked@^0.7.0":
   version "0.7.2"


### PR DESCRIPTION
```
yarn workspace @joystream/js-examples build
yarn workspace @joystream/js-examples run-example readOldState
```
We can also provide endpoint and block number (which was before _Contantinopole => Nicaea_ upgrade in that case)
```
yarn workspace @joystream/js-examples run-example readOldState wss://rome-rpc-endpoint.joystream.org:9944/ 1500000
yarn workspace @joystream/js-examples run-example readOldState ws://localhost:3000/ 50
```

Feedback about more interesting cases of querying old chain data that could be tested with this script will be much appreciated.