### PR TITLE
Qnode indexer should index all events

### DIFF
--- a/query-node/substrate-query-framework/cli/src/templates/indexer.package.json
+++ b/query-node/substrate-query-framework/cli/src/templates/indexer.package.json
@@ -7,8 +7,7 @@
       "start": "ts-node index.ts",
         "start:dev": "DEBUG=index-builder:* ts-node index.ts --bootstrap",
         "bootstrap": "ts-node index.ts --no-start --bootstrap",
-        "bootstrap:dev": "DEBUG=index-builder:* ts-node index.ts --no-start --bootstrap",
-        "postinstall": "rm -rf node_modules/index-builder/node_modules"
+        "bootstrap:dev": "DEBUG=index-builder:* ts-node index.ts --no-start --bootstrap"
     },
     "dependencies": {
       "@types/bn.js": "^4.11.6",

--- a/query-node/substrate-query-framework/index-builder/package.json
+++ b/query-node/substrate-query-framework/index-builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "index-builder",
   "description": "Block index builder for substrate based chains",
-  "version": "0.0.3-alpha",
+  "version": "0.0.6-alpha",
   "main": "index.js",
   "license": "MIT",
   "repository": "git@github.com:Joystream/joystream.git",

--- a/query-node/substrate-query-framework/index-builder/src/IndexBuilder.ts
+++ b/query-node/substrate-query-framework/index-builder/src/IndexBuilder.ts
@@ -78,37 +78,39 @@ export default class IndexBuilder {
     debug(`Yay, block producer at height: #${query_event_block.block_number}`);
 
     asyncForEach(query_event_block.query_events, async (query_event: QueryEvent) => {
-      if (!this._processing_pack[query_event.event_method]) {
-        debug(`Unrecognized: ` + query_event.event_name);
+      
+      debug(`Processing event ${query_event.event_name}`)
+      query_event.log(0, debug);
+  
 
-        query_event.log(0, debug);
-      } else {
-        debug(`Recognized: ` + query_event.event_name);
+      const queryRunner = getConnection().createQueryRunner();
+      try {
+        // establish real database connection
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
 
-        const queryRunner = getConnection().createQueryRunner();
-        try {
-          // establish real database connection
-          await queryRunner.connect();
-          await queryRunner.startTransaction();
-
-          // Call event handler
+        // Call event handler
+        if (this._processing_pack[query_event.event_method]) {
+          debug(`Recognized: ` + query_event.event_name);
           await this._processing_pack[query_event.event_method](makeDatabaseManager(queryRunner.manager), query_event);
-
-          // Update last processed event
-          await SavedEntityEvent.update(query_event, queryRunner.manager);
-
-          await queryRunner.commitTransaction();
-        } catch (error) {
-          debug(`There are errors. Rolling back the transaction. Reason: ${error.message}`);
-
-          // Since we have errors lets rollback changes we made
-          await queryRunner.rollbackTransaction();
-          throw new Error(error);
-        } finally {
-          // Query runner needs to be released manually.
-          await queryRunner.release();
+        } else {
+          debug(`No mapping for  ${query_event.event_name}, skipping`);
         }
+        // Update last processed event
+        await SavedEntityEvent.update(query_event, queryRunner.manager);
+
+        await queryRunner.commitTransaction();
+      } catch (error) {
+        debug(`There are errors. Rolling back the transaction. Reason: ${error.message}`);
+
+        // Since we have errors lets rollback changes we made
+        await queryRunner.rollbackTransaction();
+        throw new Error(error);
+      } finally {
+        // Query runner needs to be released manually.
+        await queryRunner.release();
       }
+      
     });
   }
 }


### PR DESCRIPTION
This PR fixes https://github.com/Joystream/joystream/issues/1128

It updates the `SavedEntityEvent` even if the event does not trigger any mapping.
The version of the index-builder lib is bumped to 0.0.6-alpha
