### PR TITLE
TypeOrm transform for BigInt field

### DIFF
--- a/query-node/substrate-query-framework/cli/src/generate/field-context.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/field-context.ts
@@ -178,8 +178,8 @@ export function withTransformer(f: Field): GeneratorContext {
   if (TYPE_FIELDS[f.columnType()] && TYPE_FIELDS[f.columnType()].tsType === 'BN') {
     return {
       transformer: `{
-        to: (entityValue: BN) => entityValue.toString(10),
-        from: (dbValue: string): BN => new BN(dbValue, 10)
+        to: (entityValue: BN) => (entityValue !== undefined) ? entityValue.toString(10) : null,
+        from: (dbValue: string) => dbValue !== undefined && dbValue !== null && dbValue.length > 0 ? new BN(dbValue, 10): undefined,
       }`,
     };
   }

--- a/query-node/substrate-query-framework/cli/src/generate/field-context.ts
+++ b/query-node/substrate-query-framework/cli/src/generate/field-context.ts
@@ -82,6 +82,7 @@ export function buildFieldContext(f: Field, entity: ObjectType): GeneratorContex
     ...withTsTypeAndDecorator(f),
     ...withDerivedNames(f, entity),
     ...withDescription(f),
+    ...withTransformer(f),
   };
 }
 
@@ -171,4 +172,16 @@ export function withRelation(f: Field): GeneratorContext {
   return {
     relation: f.relation,
   };
+}
+
+export function withTransformer(f: Field): GeneratorContext {
+  if (TYPE_FIELDS[f.columnType()] && TYPE_FIELDS[f.columnType()].tsType === 'BN') {
+    return {
+      transformer: `{
+        to: (entityValue: BN) => entityValue.toString(10),
+        from: (dbValue: string): BN => new BN(dbValue, 10)
+      }`,
+    };
+  }
+  return {};
 }

--- a/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
+++ b/query-node/substrate-query-framework/cli/src/templates/entities/model.ts.mst
@@ -112,6 +112,7 @@ export {{#isInterface}}abstract{{/isInterface}} class {{className}}
       {{^required}}nullable: true,{{/required}}
       {{#description}}description: `{{{description}}}`,{{/description}}
       {{#unique}}unique: true,{{/unique}}
+      {{#transformer}} transformer: {{{transformer}}}, {{/transformer}}
     })
     {{camelName}}{{^required}}?{{/required}}{{#required}}!{{/required}}: {{tsType}};
   {{/is.scalar}}

--- a/query-node/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
+++ b/query-node/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
@@ -313,4 +313,18 @@ describe('ModelRenderer', () => {
     expect(rendered).to.include('(type) => Poor', 'Should render the correct union type');
     expect(rendered).to.include('status!: typeof Poor', 'Should render the correct union type');
   });
+
+  it('Should add transformer for BigInt fields', () => {
+    const model = fromStringSchema(`
+    type Tip @entity {
+      value: BigInt!
+    }
+    `);
+    generator = new ModelRenderer(model, model.lookupEntity('Tip'), enumCtxProvider);
+    const rendered = generator.render(modelTemplate);
+    expect(rendered).to.include(`transformer`);
+    expect(rendered).to.include(`to: (entityValue: BN) => entityValue.toString(10)`),
+    expect(rendered).to.include(`from: (dbValue: string): BN => new BN(dbValue, 10)`)
+
+  });
 });

--- a/query-node/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
+++ b/query-node/substrate-query-framework/cli/test/helpers/ModelRenderer.test.ts
@@ -323,8 +323,11 @@ describe('ModelRenderer', () => {
     generator = new ModelRenderer(model, model.lookupEntity('Tip'), enumCtxProvider);
     const rendered = generator.render(modelTemplate);
     expect(rendered).to.include(`transformer`);
-    expect(rendered).to.include(`to: (entityValue: BN) => entityValue.toString(10)`),
-    expect(rendered).to.include(`from: (dbValue: string): BN => new BN(dbValue, 10)`)
-
+    expect(rendered).to.include(
+      `to: (entityValue: BN) => (entityValue !== undefined ? entityValue.toString(10) : null)`
+    ),
+      expect(rendered).to.include(
+        `dbValue !== undefined && dbValue !== null && dbValue.length > 0 ? new BN(dbValue, 10) : undefined`
+      );
   });
 });


### PR DESCRIPTION
This PR fixes https://github.com/Joystream/joystream/issues/1143. Hydra codegen adds an additional `transformer` option to the `@NumericField` decorator.