### PR TITLE
Pioneer: Working groups block link fix

### DIFF
--- a/pioneer/packages/joy-roles/src/transport.substrate.ts
+++ b/pioneer/packages/joy-roles/src/transport.substrate.ts
@@ -570,7 +570,7 @@ export class Transport extends TransportBase implements ITransport {
   }
 
   async blockHash (height: number): Promise<string> {
-    const blockHash = await this.cachedApi.query.system.blockHash(height);
+    const blockHash = await this.api.rpc.chain.getBlockHash(height);
     return blockHash.toString();
   }
 


### PR DESCRIPTION
Fixes links in working groups opportinity boxes by using `api.rpc.chain.getBlockHash(height)` instead of `api.query.system.blockHash(height)` to fetch block hash in `joy-roles` transport (the latter doesn't work for older blocks)