### PR TITLE
Fix dependencies/resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "resolutions": {
     "@polkadot/api": "1.26.1",
     "@polkadot/api-contract": "1.26.1",
-    "@polkadot/keyring": "3.0.1",
+    "@polkadot/keyring": "^3.0.1",
     "@polkadot/types": "1.26.1",
-    "@polkadot/util": "3.0.1",
-    "@polkadot/util-crypto": "3.0.1",
-    "@polkadot/wasm-crypto": "1.2.1",
+    "@polkadot/util": "^3.0.1",
+    "@polkadot/util-crypto": "^3.0.1",
+    "@polkadot/wasm-crypto": "^1.2.1",
     "babel-core": "^7.0.0-bridge.0",
     "typescript": "^3.9.7"
   },

--- a/types/package.json
+++ b/types/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@polkadot/api": "1.26.1",
     "@polkadot/types": "1.26.1",
-    "@polkadot/keyring": "3.0.1",
+    "@polkadot/keyring": "^3.0.1",
     "@types/lodash": "^4.14.157",
     "@types/vfile": "^4.0.0",
     "ajv": "^6.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2012,7 +2012,7 @@
   version "0.13.0"
   dependencies:
     "@polkadot/api" "1.26.1"
-    "@polkadot/keyring" "3.0.1"
+    "@polkadot/keyring" "^3.0.1"
     "@polkadot/types" "1.26.1"
     "@types/lodash" "^4.14.157"
     "@types/vfile" "^4.0.0"
@@ -3271,7 +3271,7 @@
   dependencies:
     "@babel/runtime" "^7.10.5"
 
-"@polkadot/keyring@3.0.1", "@polkadot/keyring@^1.7.0-beta.5", "@polkadot/keyring@^3.0.1":
+"@polkadot/keyring@^1.7.0-beta.5", "@polkadot/keyring@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-3.0.1.tgz#3944079697c15b2af81e1f57b1c4aeab703a4fef"
   integrity sha512-vAHSBnisiDYHsBbEzAgIpuwQp3vIDN2uWQ/1wAE2BrKzXCBQM7RrF3LRcLFySk0xzQoDs7AP1TlPoakxJ/C/Qw==
@@ -3477,7 +3477,7 @@
     chalk "^4.1.0"
     yargs "^15.4.1"
 
-"@polkadot/wasm-crypto@1.2.1", "@polkadot/wasm-crypto@^1.2.1":
+"@polkadot/wasm-crypto@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-1.2.1.tgz#2189702447acd28d763886359576c87562241767"
   integrity sha512-nckIoZBV4nBZdeKwFwH5t7skS7L7GO5EFUl5B1F6uCjUfdNpDz3DtqbYQHcLdCZNmG4TDLg6w/1J+rkl2SiUZw==


### PR DESCRIPTION
**Reason behind the change:**

`@polkadot/api` depends on `"@polkadot/keyring": "^3.0.1"` (see: https://github.com/polkadot-js/api/blob/v1.26.1/packages/api/package.json) while `@joystream/types` now depends on the exact version `3.0.1`.

This is a mistake introduced when locking `@polkadot/api` and `@polkadot/types` to `1.26.1`.

It causes problems in projects which consume `@joystream/types` externally and also include `@polkadot/api` as a dependency (ie. status server):
```
Multiple instances of @polkadot/keyring detected, ensure that there is only one package in your dependency tree.
	3.4.1	/home/leszek/projects/joystream/status-endpoint-joystream/node_modules/@polkadot/keyring
	3.0.1	/home/leszek/projects/joystream/status-endpoint-joystream/node_modules/@joystream/types/node_modules/@polkadot/keyring
```