### PR TITLE
storage liasison selection includes lead

### DIFF
--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -1395,6 +1395,13 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
             .collect()
     }
 
+    /// Returns all existing worker id list.
+    pub fn get_all_worker_ids() -> Vec<WorkerId<T>> {
+        <WorkerById<T, I>>::iter()
+            .map(|(worker_id, _)| worker_id)
+            .collect()
+    }
+
     fn make_stake_opt_imbalance(
         opt_balance: &Option<BalanceOf<T>>,
         source_account: &T::AccountId,

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -2157,7 +2157,7 @@ fn slash_worker_stake_fails_with_not_set_lead() {
 }
 
 #[test]
-fn get_all_worker_ids_succeeds() {
+fn get_regular_worker_ids_succeeds() {
     build_test_externalities().execute_with(|| {
         let worker_ids = TestWorkingGroup::get_regular_worker_ids();
         assert_eq!(worker_ids, Vec::new());
@@ -2179,6 +2179,30 @@ fn get_all_worker_ids_succeeds() {
         <crate::WorkerById<Test, TestWorkingGroupInstance>>::remove(worker_id1);
         let worker_ids = TestWorkingGroup::get_regular_worker_ids();
         assert_eq!(worker_ids, vec![worker_id2]);
+    });
+}
+
+#[test]
+fn get_all_worker_ids_succeeds() {
+    build_test_externalities().execute_with(|| {
+        let worker_ids = TestWorkingGroup::get_all_worker_ids();
+        assert_eq!(worker_ids, Vec::new());
+
+        let leader_worker_id = HireLeadFixture::default().hire_lead();
+
+        let worker_id1 = fill_worker_position(None, None, false, OpeningType::Worker, None);
+        let worker_id2 = fill_worker_position(None, None, false, OpeningType::Worker, None);
+
+        let mut expected_ids = vec![leader_worker_id, worker_id1, worker_id2];
+        expected_ids.sort();
+
+        let mut worker_ids = TestWorkingGroup::get_all_worker_ids();
+        worker_ids.sort();
+        assert_eq!(worker_ids, expected_ids);
+
+        <crate::WorkerById<Test, TestWorkingGroupInstance>>::remove(worker_id1);
+        let worker_ids = TestWorkingGroup::get_all_worker_ids();
+        assert_eq!(worker_ids, vec![leader_worker_id, worker_id2]);
     });
 }
 

--- a/runtime/src/integration/storage.rs
+++ b/runtime/src/integration/storage.rs
@@ -8,7 +8,7 @@ pub struct StorageProviderHelper;
 
 impl storage::data_directory::StorageProviderHelper<Runtime> for StorageProviderHelper {
     fn get_random_storage_provider() -> Result<ActorId, &'static str> {
-        let ids = crate::StorageWorkingGroup::get_regular_worker_ids();
+        let ids = crate::StorageWorkingGroup::get_all_worker_ids();
 
         let live_ids: Vec<ActorId> = ids
             .into_iter()


### PR DESCRIPTION
Do not exclude the storage lead worker id from selection of liaison.

Addresses https://github.com/Joystream/joystream/issues/1211