### PR TITLE
All initial mints created at genesis with capacity 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "7.0.0"
+version = "7.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/node/src/chain_spec/content_config.rs
+++ b/node/src/chain_spec/content_config.rs
@@ -309,7 +309,7 @@ pub fn data_directory_config_from_json(data_file: &Path) -> DataDirectoryConfig 
 /// curator lead or channels.
 pub fn empty_content_working_group_config() -> ContentWorkingGroupConfig {
     ContentWorkingGroupConfig {
-        mint_capacity: 100_000,
+        mint_capacity: 0,
         curator_opening_by_id: vec![],
         next_curator_opening_id: 0,
         curator_application_by_id: vec![],

--- a/runtime-modules/governance/src/council.rs
+++ b/runtime-modules/governance/src/council.rs
@@ -34,9 +34,7 @@ decl_storage! {
 
         pub TermEndsAt get(fn term_ends_at) config() : T::BlockNumber = T::BlockNumber::from(1);
 
-        /// The mint that funds council member rewards and spending proposals budget. It is an Option
-        /// because it was introduced in a runtime upgrade. It will be automatically created when
-        /// a successful call to set_council_mint_capacity() is made.
+        /// The mint that funds council member rewards and spending proposals budget
         pub CouncilMint get(fn council_mint) : <T as minting::Trait>::MintId;
 
         /// The reward relationships currently in place. There may not necessarily be a 1-1 correspondance with

--- a/runtime-modules/governance/src/council.rs
+++ b/runtime-modules/governance/src/council.rs
@@ -54,6 +54,21 @@ decl_storage! {
         /// How many blocks after the reward is created, the first payout will be made
         pub FirstPayoutAfterRewardCreated get(fn first_payout_after_reward_created): T::BlockNumber;
     }
+    add_extra_genesis {
+        build(|_config: &GenesisConfig<T>| {
+            // Create the council mint.
+            let mint_id_result = <minting::Module<T>>::add_mint(
+                minting::BalanceOf::<T>::from(0),
+                None
+            );
+
+            if let Ok(mint_id) = mint_id_result {
+                <CouncilMint<T>>::put(mint_id);
+            } else {
+                panic!("Failed to create a mint for the council");
+            }
+        });
+    }
 }
 
 // Event for this module.

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -8,7 +8,7 @@ use sp_core::H256;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
-    Perbill,
+    BuildStorage, Perbill,
 };
 pub use system;
 
@@ -140,6 +140,13 @@ pub fn initial_test_ext() -> sp_io::TestExternalities {
         .build()
         .assimilate_storage(&mut t)
         .unwrap();
+
+    // build the council config to initialize the mint
+    let council_config = council::GenesisConfig::<Test>::default()
+        .build_storage()
+        .unwrap();
+
+    council_config.assimilate_storage(&mut t).unwrap();
 
     t.into()
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '7.0.0'
+version = '7.1.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -70,7 +70,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 7,
-    spec_version: 0,
+    spec_version: 1,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -4,11 +4,19 @@
 
 mod proposals_integration;
 mod storage_integration;
+use sp_runtime::BuildStorage;
 
 pub(crate) fn initial_test_ext() -> sp_io::TestExternalities {
-    let t = system::GenesisConfig::default()
+    let mut t = system::GenesisConfig::default()
         .build_storage::<crate::Runtime>()
         .unwrap();
+
+    // build the council config to initialize the mint
+    let council_config = governance::council::GenesisConfig::<crate::Runtime>::default()
+        .build_storage()
+        .unwrap();
+
+    council_config.assimilate_storage(&mut t).unwrap();
 
     t.into()
 }


### PR DESCRIPTION
- Create the council mint at genesis (with capacity 0)
- Make the council mint not an Option
   - simplified code dealing with whether mint exists or not. 
   - and fix tests that depend on council mint
- Set working group initial mint capacity to 0

Part of initializing genesis https://github.com/Joystream/joystream/issues/1217
Now Content WG, Storage WG and Council all start with a mint at genesis, with 0 capacity.