### PR TITLE
build scripts: use correct rust nightly toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ before_script:
 script:
   - export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
   - BUILD_DUMMY_WASM_BINARY=1 cargo clippy --all -- -D warnings
-  - travis_wait cargo test --verbose --all
-  - TRIGGER_WASM_BUILD=1 travis_wait cargo build --release
+  - BUILD_DUMMY_WASM_BINARY=1 cargo test --verbose --all
+  - TRIGGER_WASM_BUILD=1 travis_wait 45 cargo build --release
   - ls -l ./target/release/wbuild/joystream-node-runtime/
   - ./target/release/joystream-node --version
   - ./target/release/chain-spec-builder --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ before_script:
 
 script:
   - export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
-  - BUILD_DUMMY_WASM_BINARY=1 cargo clippy --all -- -D warnings
-  - BUILD_DUMMY_WASM_BINARY=1 cargo test --verbose --all
-  - TRIGGER_WASM_BUILD=1 travis_wait 45 cargo build --release
+  - BUILD_DUMMY_WASM_BINARY=1 cargo clippy --release --all -- -D warnings
+  - travis_wait 50 cargo test --release --verbose --all
+  - cargo build --release
   - ls -l ./target/release/wbuild/joystream-node-runtime/
   - ./target/release/joystream-node --version
   - ./target/release/chain-spec-builder --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_script:
   - cargo fmt --all -- --check
 
 script:
-  # we set release as build type for all steps to benefit from already compiled packages in prior steps
   - export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
   - cargo clippy --all -- -D warnings
   - cargo test --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
     fi
 
 install:
-  - rustup install nightly-2020-05-23
+  - rustup install nightly-2020-05-23 --force
   - rustup target add wasm32-unknown-unknown --toolchain nightly-2020-05-23
   # travis installs rust using rustup with the "minimal" profile so these tools are not installed by default
   - rustup component add rustfmt
@@ -35,8 +35,10 @@ before_script:
 
 script:
   # we set release as build type for all steps to benefit from already compiled packages in prior steps
-  - BUILD_DUMMY_WASM_BINARY=1 cargo clippy --release -- -D warnings
-  - BUILD_DUMMY_WASM_BINARY=1 cargo test --release --verbose --all
-  - TRIGGER_WASM_BUILD=1 WASM_BUILD_TOOLCHAIN=nightly-2020-05-23 cargo build --release -p joystream-node
+  - export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
+  - cargo clippy --all -- -D warnings
+  - cargo test --verbose --all
+  - cargo build --release
   - ls -l ./target/release/wbuild/joystream-node-runtime/
   - ./target/release/joystream-node --version
+  - ./target/release/chain-spec-builder --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ before_script:
 
 script:
   - export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
-  - cargo clippy --all -- -D warnings
+  - BUILD_DUMMY_WASM_BINARY=1 cargo clippy --all -- -D warnings
   - cargo test --verbose --all
-  - cargo build --release
+  - TRIGGER_WASM_BUILD=1 cargo build --release
   - ls -l ./target/release/wbuild/joystream-node-runtime/
   - ./target/release/joystream-node --version
   - ./target/release/chain-spec-builder --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ before_script:
 script:
   - export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
   - BUILD_DUMMY_WASM_BINARY=1 cargo clippy --all -- -D warnings
-  - cargo test --verbose --all
-  - TRIGGER_WASM_BUILD=1 cargo build --release
+  - travis_wait cargo test --verbose --all
+  - TRIGGER_WASM_BUILD=1 travis_wait cargo build --release
   - ls -l ./target/release/wbuild/joystream-node-runtime/
   - ./target/release/joystream-node --version
   - ./target/release/chain-spec-builder --version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ You can also run your our own joystream-node:
 
 ```sh
 git checkout master
-cargo build --release
-cargo run --release -- --pruning archive --chain testnets/rome.json
+WASM_BUILD_TOOLCHAIN=nightly-2020-05-23 cargo build --release
+./target/release/joystream-node -- --pruning archive --chain testnets/rome.json
 ```
 
 Wait for the node to sync to the latest block, then change pioneer settings "remote node" option to "Local Node", or follow the link below:

--- a/devops/dockerfiles/ansible-node/Dockerfile
+++ b/devops/dockerfiles/ansible-node/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /joystream
 COPY . /joystream
 
 # Build joystream-node and its dependencies - runtime
-RUN cargo build --release -p joystream-node
+RUN WASM_BUILD_TOOLCHAIN=nightly-2020-05-23 cargo build --release -p joystream-node
 RUN /joystream/scripts/create-test-chainspec.sh
 
 FROM debian:stretch

--- a/devops/dockerfiles/node-and-runtime/Dockerfile
+++ b/devops/dockerfiles/node-and-runtime/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /joystream
 COPY . /joystream
 
 # Build joystream-node and its dependencies - runtime
-RUN cargo build --release -p joystream-node
+RUN WASM_BUILD_TOOLCHAIN=nightly-2020-05-23 cargo build --release -p joystream-node
 
 FROM debian:stretch
 LABEL description="Joystream node"

--- a/devops/dockerfiles/rust-builder/Dockerfile
+++ b/devops/dockerfiles/rust-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM liuchong/rustup:1.43.0 AS builder
+FROM liuchong/rustup:1.46.0 AS builder
 LABEL description="Rust and WASM build environment for joystream and substrate"
 
 WORKDIR /setup

--- a/devops/git-hooks/pre-push
+++ b/devops/git-hooks/pre-push
@@ -7,6 +7,6 @@ echo '+cargo test --all'
 cargo test --all
 
 echo '+cargo clippy --all -- -D warnings'
-cargo clippy --all -- -D warnings
+BUILD_DUMMY_WASM_BINARY=1 cargo clippy --all -- -D warnings
 
 

--- a/devops/git-hooks/pre-push
+++ b/devops/git-hooks/pre-push
@@ -1,10 +1,12 @@
 #!/bin/sh
 set -e
 
-echo '+cargo test --release --all'
-BUILD_DUMMY_WASM_BINARY=1 cargo test --all
+export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
 
-echo '+cargo clippy --release --all -- -D warnings'
-BUILD_DUMMY_WASM_BINARY=1 cargo clippy --all -- -D warnings
+echo '+cargo test --all'
+cargo test --all
+
+echo '+cargo clippy --all -- -D warnings'
+cargo clippy --all -- -D warnings
 
 

--- a/devops/git-hooks/pre-push
+++ b/devops/git-hooks/pre-push
@@ -3,10 +3,8 @@ set -e
 
 export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
 
-echo '+cargo test --all'
-cargo test --all
-
 echo '+cargo clippy --all -- -D warnings'
-BUILD_DUMMY_WASM_BINARY=1 cargo clippy --all -- -D warnings
+BUILD_DUMMY_WASM_BINARY=1 cargo clippy --release --all -- -D warnings
 
-
+echo '+cargo test --all'
+cargo test --release --all

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '3.0.0'
+version = '3.0.1'
 default-run = "joystream-node"
 
 [[bin]]

--- a/node/README.md
+++ b/node/README.md
@@ -26,7 +26,7 @@ cd joystream/
 Compile the node and runtime:
 
 ```bash
-cargo build --release
+WASM_BUILD_TOOLCHAIN=nightly-2020-05-23 cargo build --release
 ```
 
 This produces the binary in `./target/release/joystream-node`
@@ -34,7 +34,7 @@ This produces the binary in `./target/release/joystream-node`
 ### Running local development chain
 
 ```bash
-cargo run --release -- --dev
+./target/release/joystream-node --dev
 ```
 
 If you repeatedly need to restart a new chain,
@@ -49,7 +49,7 @@ this script will build and run a fresh new local development chain (purging exis
 Use the `--chain` argument, and specify the path to the genesis `chain.json` file for that public network. The JSON "chain spec" files for Joystream public networks can be found in [../testnets/](../testnets/).
 
 ```bash
-cargo run --release -- --chain testnets/rome.json
+./target/release/joystream-node --chain testnets/rome.json
 ```
 
 ### Tests and code quality

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -7,9 +7,9 @@ The runtime is the code that defines the consensus rules of the Joystream protoc
 It is compiled to WASM and lives on chain.
 Joystream node execute the code's logic to validate transactions and blocks on the blockchain.
 
-When building joystream-node as described in [../node/README.md](../node/README.md) with `cargo build --release`, in addition to the joystream-node binary being built the WASM blob artifact is produced in:
+When building joystream-node as described in [../node/README.md](../node/README.md), in addition to the joystream-node binary being built the WASM blob artifact is produced in:
 
-`target/release/wbuild/joystream-node-runtime/joystream_node_runtime.compact.wasm`
+`./target/release/wbuild/joystream-node-runtime/joystream_node_runtime.compact.wasm`
 
 
 ### Deployment

--- a/scripts/cargo-build.sh
+++ b/scripts/cargo-build.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
+
 cargo build --release

--- a/scripts/create-test-chainspec.sh
+++ b/scripts/create-test-chainspec.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
+
 mkdir -p .tmp
 cargo run --release -p joystream-node build-spec --chain dev > .tmp/chainspec.json
 perl -i -pe's/"setValidatorCountProposalGracePeriod":.*/"setValidatorCountProposalGracePeriod": 0,/' .tmp/chainspec.json

--- a/scripts/run-dev-chain.sh
+++ b/scripts/run-dev-chain.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
+
 # Build release binary
 cargo build --release -p joystream-node
 

--- a/scripts/run-test-chain.sh
+++ b/scripts/run-test-chain.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
+
 sh ./scripts/create-test-chainspec.sh
 yes | cargo run --release -p joystream-node -- purge-chain --dev
 cargo run --release -p joystream-node -- --chain=.tmp/chainspec.json --alice --validator

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,15 @@ source ~/.cargo/env
 
 rustup component add rustfmt clippy
 
+# Current version of substrate requires an older version of nightly toolchain
+# to successfully compile the WASM runtime. We force install because rustfmt package
+# is not available for this nightly version.
+rustup install nightly-2020-05-23 --force
+rustup target add wasm32-unknown-unknown --toolchain nightly-2020-05-23
+
+# Ensure the stable toolchain is still the default
+rustup default stable
+
 # TODO: Install additional tools...
 
 # - b2sum


### PR DESCRIPTION
- [x] Update various build scripts and git hooks to use correct rust nightly toolchain for our runtime
- [x] update travis script
- [x] Update rust-builder to use correct toolchain