### PR TITLE
Fix chain spec builder.

### DIFF
--- a/utils/chain-spec-builder/src/main.rs
+++ b/utils/chain-spec-builder/src/main.rs
@@ -353,7 +353,8 @@ fn generate_authority_keys_and_store(seeds: &[String], keystore_path: &Path) -> 
         let keystore = Keystore::open(keystore_path.join(format!("auth-{}", n)), None)
             .map_err(|err| err.to_string())?;
 
-        let (_, _, grandpa, babe, im_online, _) = chain_spec::get_authority_keys_from_seed(seed);
+        let (_, _, grandpa, babe, im_online, authority_discovery) =
+            chain_spec::get_authority_keys_from_seed(seed);
 
         let insert_key = |key_type, public| {
             keystore
@@ -367,6 +368,11 @@ fn generate_authority_keys_and_store(seeds: &[String], keystore_path: &Path) -> 
         insert_key(sp_core::crypto::key_types::GRANDPA, grandpa.as_slice())?;
 
         insert_key(sp_core::crypto::key_types::IM_ONLINE, im_online.as_slice())?;
+
+        insert_key(
+            sp_core::crypto::key_types::AUTHORITY_DISCOVERY,
+            authority_discovery.as_slice(),
+        )?;
     }
 
     Ok(())


### PR DESCRIPTION
Add `authority_discovery` key to the chain_spec_builder.