### PR TITLE
referendum - reintroduce multiple winners

### DIFF
--- a/runtime-modules/referendum/src/lib.rs
+++ b/runtime-modules/referendum/src/lib.rs
@@ -526,74 +526,85 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
         option_id: &u64,
         cast_vote: EzCastVote<T, I>,
     ) -> Result<(), Error<T, I>> {
-        /// Tries to insert option to the winners list
+        /// Tries to place record to temporary place in the winning list.
+        fn place_record_to_winner_list<T: Trait<I>, I: Instance>(
+            option_result: OptionResult<T::VotePower>,
+            current_winners: &[OptionResult<T::VotePower>],
+            winning_target_count: u64,
+        ) -> (Vec<OptionResult<T::VotePower>>, Option<usize>) {
+            let current_winners_count = current_winners.len();
+
+            // check if option is already somewhere in list
+            let current_winners_index_of_vote_recipient: Option<usize> = current_winners
+                .iter()
+                .enumerate()
+                .find(|(_, value)| option_result.option_id == value.option_id)
+                .map(|(index, _)| index);
+
+            // espace when item is currently not in winning list and still has not enough vote power to make it to already full list
+            if current_winners_index_of_vote_recipient.is_none()
+                && current_winners_count as u64 == winning_target_count
+                && option_result.vote_power <= current_winners[current_winners_count - 1].vote_power
+            {
+                return (current_winners.to_vec(), None);
+            }
+
+            let mut new_winners = current_winners.to_vec();
+
+            // update record in list when it is already present
+            if let Some(index) = current_winners_index_of_vote_recipient {
+                let old_option_total = T::get_option_power(&option_result.option_id);
+                let new_option_total = old_option_total + option_result.vote_power;
+
+                new_winners[index] = OptionResult {
+                    option_id: option_result.option_id,
+                    vote_power: new_option_total,
+                };
+
+                return (new_winners, Some(index));
+            }
+
+            // at this point record needs to be added to list
+
+            // replace last winner if list is already full
+            if current_winners_count as u64 == winning_target_count {
+                let last_index = current_winners_count - 1;
+                new_winners[last_index] = option_result;
+
+                return (new_winners, Some(last_index));
+            }
+
+            // append winner to incomplete list
+            new_winners.push(option_result);
+
+            (new_winners, Some(current_winners_count))
+        }
+
+        /// Tries to insert option to the proper place in the winners list.
         fn try_winner_insert<T: Trait<I>, I: Instance>(
             option_result: OptionResult<T::VotePower>,
             current_winners: &[OptionResult<T::VotePower>],
             winning_target_count: u64,
         ) -> Vec<OptionResult<T::VotePower>> {
-            let current_winners_count = current_winners.len();
-
             // if there are no winners right now return list with only current option
-            if current_winners_count == 0 {
+            if current_winners.is_empty() {
                 return vec![option_result];
             }
 
-            // check if option is already somewhere in list
-            let mut already_existing_index: Option<usize> = None;
-            for (index, value) in current_winners.iter().enumerate() {
-                if option_result.option_id == value.option_id {
-                    already_existing_index = Some(index);
-                    break;
-                }
-            }
+            // get new possibly updated list and record's position in it
+            let (mut new_winners, current_record_index) = place_record_to_winner_list::<T, I>(
+                option_result,
+                current_winners,
+                winning_target_count,
+            );
 
-            let mut new_winners = current_winners.to_vec();
-
-            // insert record to list when needed and return it's index
-            let new_virtual_index = match already_existing_index {
-                // update record in list
-                Some(index) => {
-                    let old_option_total = T::get_option_power(&option_result.option_id);
-                    let new_option_total = old_option_total + option_result.vote_power;
-
-                    new_winners[index] = OptionResult {
-                        option_id: option_result.option_id,
-                        vote_power: new_option_total,
-                    };
-
-                    index
-                }
-                // put record to end of list
-                None => match current_winners_count as u64 == winning_target_count {
-                    // list already full
-                    true => {
-                        // don't change list when new record has less vote power then last winner in list
-                        if option_result.vote_power
-                            <= current_winners[current_winners_count - 1].vote_power
-                        {
-                            return current_winners.to_vec();
-                        }
-
-                        // update record in list
-                        let virtual_index = current_winners_count - 1;
-                        new_winners[virtual_index] = option_result;
-
-                        virtual_index
+            // resort list in case it was updated
+            if let Some(index) = current_record_index {
+                for i in (1..=index).rev() {
+                    if new_winners[i].vote_power <= new_winners[i - 1].vote_power {
+                        break;
                     }
-                    // list not full yet
-                    false => {
-                        // append winner to list
-                        new_winners.push(option_result);
 
-                        current_winners_count
-                    }
-                },
-            };
-
-            // resort list
-            for i in (1..=new_virtual_index).rev() {
-                if new_winners[i].vote_power > new_winners[i - 1].vote_power {
                     new_winners.swap(i, i - 1);
                 }
             }

--- a/runtime-modules/referendum/src/lib.rs
+++ b/runtime-modules/referendum/src/lib.rs
@@ -17,7 +17,6 @@ use frame_support::{
 };
 use sp_arithmetic::traits::BaseArithmetic;
 use sp_runtime::traits::{MaybeSerialize, Member};
-use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use system::ensure_signed;
 
@@ -57,13 +56,11 @@ pub struct ReferendumStageRevealing<BlockNumber, VotePower> {
     started: BlockNumber,      // block in which referendum started
     winning_target_count: u64, // target number of winners
     intermediate_winners: Vec<OptionResult<VotePower>>, // intermediate winning options
-    //intermediate_results: HashMap<u64, VotePower>, // votes that options have recieved at a given time
-    intermediate_results: BTreeMap<u64, VotePower>, // votes that options have recieved at a given time
 }
 
 #[derive(Encode, Decode, PartialEq, Eq, Debug, Default, Clone)]
 pub struct OptionResult<VotePower> {
-    option_index: u64,
+    option_id: u64,
     vote_power: VotePower,
 }
 
@@ -88,10 +85,6 @@ type EzCastVote<T, I> = CastVote<<T as system::Trait>::Hash, Balance<T, I>>;
 type EzReferendumStageVoting<T> = ReferendumStageVoting<<T as system::Trait>::BlockNumber>;
 type EzReferendumStageRevealing<T, I> =
     ReferendumStageRevealing<<T as system::Trait>::BlockNumber, <T as Trait<I>>::VotePower>;
-type ConcludeResult<T, I> = (
-    Vec<OptionResult<<T as Trait<I>>::VotePower>>,
-    BTreeMap<u64, <T as Trait<I>>::VotePower>,
-);
 
 // types aliases for check functions return values
 type CanRevealResult<T, I> = (
@@ -116,7 +109,7 @@ pub trait ReferendumManager<T: Trait<I>, I: Instance> {
         account_id: &<T as system::Trait>::AccountId,
         salt: &[u8],
         cycle_id: &u64,
-        vote_option_index: &u64,
+        vote_option_id: &u64,
     ) -> T::Hash;
 }
 
@@ -165,13 +158,16 @@ pub trait Trait<I: Instance>: system::Trait /* + ReferendumManager<Self, I>*/ {
     fn can_unstake(vote: &CastVote<Self::Hash, Balance<Self, I>>) -> bool;
 
     /// Gives runtime an ability to react on referendum result.
-    fn process_results(
-        winners: &[OptionResult<Self::VotePower>],
-        all_options_results: &BTreeMap<u64, Self::VotePower>, // list of votes each option recieved
-    );
+    fn process_results(winners: &[OptionResult<Self::VotePower>]);
 
     /// Check if an option a user is voting for actually exists.
-    fn is_valid_option_id(option_index: &u64) -> bool;
+    fn is_valid_option_id(option_id: &u64) -> bool;
+
+    // If the id is a valid alternative, the current total voting mass backing it is returned, otherwise nothing.
+    fn get_option_power(option_id: &u64) -> Self::VotePower;
+
+    // Increases voting mass behind given alternative by given amount, if present and return true, otherwise return false.
+    fn increase_option_power(option_id: &u64, amount: &Self::VotePower);
 }
 
 decl_storage! {
@@ -212,7 +208,7 @@ decl_event! {
         RevealingStageStarted(),
 
         /// Referendum ended and winning option was selected
-        ReferendumFinished(Vec<OptionResult<VotePower>>, BTreeMap<u64, VotePower>),
+        ReferendumFinished(Vec<OptionResult<VotePower>>),
 
         /// User cast a vote in referendum
         VoteCast(AccountId, Hash, Balance),
@@ -318,18 +314,18 @@ decl_module! {
 
         /// Reveal a sealed vote in the referendum.
         #[weight = 10_000_000]
-        pub fn reveal_vote(origin, salt: Vec<u8>, vote_option_index: u64) -> Result<(), Error<T, I>> {
-            let (stage_data, account_id, cast_vote) = EnsureChecks::<T, I>::can_reveal_vote::<Self>(origin, &salt, &vote_option_index)?;
+        pub fn reveal_vote(origin, salt: Vec<u8>, vote_option_id: u64) -> Result<(), Error<T, I>> {
+            let (stage_data, account_id, cast_vote) = EnsureChecks::<T, I>::can_reveal_vote::<Self>(origin, &salt, &vote_option_id)?;
 
             //
             // == MUTATION SAFE ==
             //
 
             // reveal the vote - it can return error when stake fails to unlock
-            Mutations::<T, I>::reveal_vote(stage_data, &account_id, &vote_option_index, cast_vote)?;
+            Mutations::<T, I>::reveal_vote(stage_data, &account_id, &vote_option_id, cast_vote)?;
 
             // emit event
-            Self::deposit_event(RawEvent::VoteRevealed(account_id, vote_option_index));
+            Self::deposit_event(RawEvent::VoteRevealed(account_id, vote_option_id));
 
             Ok(())
         }
@@ -387,13 +383,13 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
     /// Conclude the referendum.
     fn end_reveal_period(stage_data: EzReferendumStageRevealing<T, I>) {
         // conclude referendum
-        let (winners, all_options_results) = Mutations::<T, I>::conclude_referendum(stage_data);
+        let winners = Mutations::<T, I>::conclude_referendum(stage_data);
 
         // let runtime know about referendum results
-        T::process_results(&winners, &all_options_results);
+        T::process_results(&winners);
 
         // emit event
-        Self::deposit_event(RawEvent::ReferendumFinished(winners, all_options_results));
+        Self::deposit_event(RawEvent::ReferendumFinished(winners));
     }
 }
 
@@ -428,14 +424,14 @@ impl<T: Trait<I>, I: Instance> ReferendumManager<T, I> for Module<T, I> {
         account_id: &<T as system::Trait>::AccountId,
         salt: &[u8],
         cycle_id: &u64,
-        vote_option_index: &u64,
+        vote_option_id: &u64,
     ) -> T::Hash {
         let mut payload = account_id.encode();
-        let mut mut_option_index = vote_option_index.encode();
+        let mut mut_option_id = vote_option_id.encode();
         let mut mut_salt = salt.encode(); //.to_vec();
         let mut mut_cycle_id = cycle_id.encode(); //.to_vec();
 
-        payload.append(&mut mut_option_index);
+        payload.append(&mut mut_option_id);
         payload.append(&mut mut_salt);
         payload.append(&mut mut_cycle_id);
 
@@ -471,7 +467,6 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
             started: <system::Module<T>>::block_number(),
             winning_target_count: old_stage.winning_target_count,
             intermediate_winners: vec![],
-            intermediate_results: BTreeMap::new(),
         }));
     }
 
@@ -479,15 +474,12 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
     //fn conclude_referendum(revealing_stage: EzReferendumStageRevealing<T, I>) -> Vec<OptionResult<T::VotePower>> {
     fn conclude_referendum(
         revealing_stage: EzReferendumStageRevealing<T, I>,
-    ) -> ConcludeResult<T, I> {
+    ) -> Vec<OptionResult<<T as Trait<I>>::VotePower>> {
         // reset referendum state
         Self::reset_referendum();
 
         // return winning option
-        (
-            revealing_stage.intermediate_winners,
-            revealing_stage.intermediate_results,
-        )
+        revealing_stage.intermediate_winners
     }
 
     /// Change the referendum stage from revealing to the inactive stage.
@@ -528,7 +520,7 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
     fn reveal_vote(
         stage_data: EzReferendumStageRevealing<T, I>,
         account_id: &<T as system::Trait>::AccountId,
-        option_index: &u64,
+        option_id: &u64,
         cast_vote: EzCastVote<T, I>,
     ) -> Result<(), Error<T, I>> {
         /// Moves winner to new position in winners list. Expects `target_index` to be always smaller or equal to `current_index`.
@@ -586,7 +578,7 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
             // check if option is already somewhere in list
             let mut already_existing_index: Option<usize> = None;
             for (index, value) in current_winners.iter().enumerate() {
-                if option_result.option_index == value.option_index {
+                if option_result.option_id == value.option_id {
                     already_existing_index = Some(index);
                     break;
                 }
@@ -623,13 +615,10 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
 
         // prepare new values
         let vote_power = T::caclulate_vote_power(&account_id, &cast_vote.stake);
-        let new_option_total = vote_power
-            + match stage_data.intermediate_results.get(option_index) {
-                Some(value) => *value,
-                None => 0.into(),
-            };
+        let old_option_total = T::get_option_power(option_id);
+        let new_option_total = old_option_total + vote_power;
         let option_result = OptionResult {
-            option_index: *option_index,
+            option_id: *option_id,
             vote_power: new_option_total,
         };
         let new_winners = match try_winner_insert::<T, I>(
@@ -640,20 +629,18 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
             Some(tmp_winners) => tmp_winners,
             None => stage_data.intermediate_winners.clone(),
         };
-
-        let mut intermediate_results = stage_data.intermediate_results;
-        intermediate_results.insert(*option_index, new_option_total);
         let new_stage_data = ReferendumStageRevealing {
             intermediate_winners: new_winners,
-            intermediate_results,
             ..stage_data
         };
+
+        T::increase_option_power(option_id, &vote_power);
 
         // store revealed vote
         Stage::<T, I>::mutate(|stage| *stage = ReferendumStage::Revealing(new_stage_data));
 
         // remove user commitment to prevent repeated revealing
-        Votes::<T, I>::mutate(account_id, |vote| (*vote).vote_for = Some(*option_index));
+        Votes::<T, I>::mutate(account_id, |vote| (*vote).vote_for = Some(*option_id));
 
         Ok(())
     }
@@ -725,7 +712,7 @@ impl<T: Trait<I>, I: Instance> EnsureChecks<T, I> {
     fn can_reveal_vote<R: ReferendumManager<T, I>>(
         origin: T::Origin,
         salt: &[u8],
-        vote_option_index: &u64,
+        vote_option_id: &u64,
     ) -> Result<CanRevealResult<T, I>, Error<T, I>> {
         let cycle_id = CurrentCycleId::<I>::get();
 
@@ -742,7 +729,7 @@ impl<T: Trait<I>, I: Instance> EnsureChecks<T, I> {
 
         let cast_vote = Self::ensure_vote_exists(&account_id)?;
 
-        if !T::is_valid_option_id(vote_option_index) {
+        if !T::is_valid_option_id(vote_option_id) {
             return Err(Error::InvalidVote);
         }
 
@@ -757,7 +744,7 @@ impl<T: Trait<I>, I: Instance> EnsureChecks<T, I> {
         }
 
         // ensure commitment corresponds to salt and vote option
-        let commitment = R::calculate_commitment(&account_id, salt, &cycle_id, vote_option_index);
+        let commitment = R::calculate_commitment(&account_id, salt, &cycle_id, vote_option_id);
         if commitment != cast_vote.commitment {
             return Err(Error::InvalidReveal);
         }

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -91,7 +91,7 @@ impl Trait<Instance0> for Runtime {
         stake
     }
 
-    fn can_unstake(_vote: &CastVote<Self::Hash, Balance<Self, Instance0>>) -> bool {
+    fn can_release_voting_stake(_vote: &CastVote<Self::Hash, Balance<Self, Instance0>>) -> bool {
         // trigger fail when requested to do so
         if !IS_UNSTAKE_ENABLED.with(|value| value.borrow().0) {
             return false;

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -2,8 +2,9 @@
 
 /////////////////// Configuration //////////////////////////////////////////////
 use crate::{
-    Balance, CastVote, CurrentCycleId, Error, Instance, Module, RawEvent, ReferendumManager,
-    ReferendumStage, ReferendumStageRevealing, ReferendumStageVoting, Stage, Trait, Votes,
+    Balance, CastVote, CurrentCycleId, Error, Instance, Module, OptionResult, RawEvent,
+    ReferendumManager, ReferendumStage, ReferendumStageRevealing, ReferendumStageVoting, Stage,
+    Trait, Votes,
 };
 
 use frame_support::traits::{Currency, LockIdentifier, OnFinalize};
@@ -19,6 +20,8 @@ use sp_runtime::{
     Perbill,
 };
 use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::iter::FromIterator;
 use std::marker::PhantomData;
 use system::{EnsureOneOf, EnsureRoot, EnsureSigned, RawOrigin};
 
@@ -43,7 +46,6 @@ pub struct Runtime;
 pub struct Instance0;
 
 parameter_types! {
-    pub const MaxReferendumOptions: u64 = 10;
     pub const MaxSaltLength: u64 = 32; // use some multiple of 8 for ez testing
     pub const VoteStageDuration: u64 = 5;
     pub const RevealStageDuration: u64 = 5;
@@ -53,12 +55,12 @@ parameter_types! {
 
 thread_local! {
     pub static IS_UNSTAKE_ENABLED: RefCell<(bool, )> = RefCell::new((true, )); // global switch for stake locking features; use it to simulate lock fails
+    pub static IS_OPTION_ID_VALID: RefCell<(bool, )> = RefCell::new((true, )); // global switch used to test is_valid_option_id()
 }
 
 impl Trait<Instance0> for Runtime {
     type Event = TestEvent;
 
-    type MaxReferendumOptions = MaxReferendumOptions;
     type MaxSaltLength = MaxSaltLength;
 
     type Currency = pallet_balances::Module<Runtime>;
@@ -95,8 +97,19 @@ impl Trait<Instance0> for Runtime {
         true
     }
 
-    fn process_results(_all_options_results: &[Self::VotePower]) {
+    fn process_results(
+        _winners: &[OptionResult<Self::VotePower>],
+        _all_options_results: &BTreeMap<u64, Self::VotePower>,
+    ) {
         // not used right now
+    }
+
+    fn is_valid_option_id(_option_index: &u64) -> bool {
+        if !IS_OPTION_ID_VALID.with(|value| value.borrow().0) {
+            return false;
+        }
+
+        true
     }
 }
 
@@ -116,6 +129,12 @@ impl Runtime {
     pub fn feature_stack_lock(unstake_enabled: bool) -> () {
         IS_UNSTAKE_ENABLED.with(|value| {
             *value.borrow_mut() = (unstake_enabled,);
+        });
+    }
+
+    pub fn feature_option_id_valid(is_valid: bool) -> () {
+        IS_OPTION_ID_VALID.with(|value| {
+            *value.borrow_mut() = (is_valid,);
         });
     }
 }
@@ -327,6 +346,17 @@ where
             salt.to_vec(),
         )
     }
+
+    pub fn transform_results(input: Vec<T::VotePower>) -> BTreeMap<u64, T::VotePower> {
+        BTreeMap::from_iter(
+            input
+                .into_iter()
+                .enumerate()
+                .map(|(k, v)| (k as u64, v))
+                .filter(|(_, v)| v != &Into::<T::VotePower>::into(0))
+                .collect::<Vec<(u64, T::VotePower)>>(),
+        )
+    }
 }
 
 /////////////////// Mocks of Module's actions //////////////////////////////////
@@ -338,74 +368,76 @@ pub struct InstanceMocks<T: Trait<I>, I: Instance> {
 impl InstanceMocks<Runtime, Instance0> {
     pub fn start_referendum_extrinsic(
         origin: OriginType<<Runtime as system::Trait>::AccountId>,
-        options_count: u64,
+        winning_target_count: u64,
         expected_result: Result<(), Error<Runtime, Instance0>>,
     ) -> () {
-        let extra_options_count = options_count - 1;
+        let extra_winning_target_count = winning_target_count - 1;
 
         // check method returns expected result
         assert_eq!(
             Module::<Runtime, Instance0>::start_referendum(
                 InstanceMockUtils::<Runtime, Instance0>::mock_origin(origin),
-                extra_options_count,
+                extra_winning_target_count,
             ),
             expected_result,
         );
 
-        Self::start_referendum_inner(extra_options_count, expected_result)
+        Self::start_referendum_inner(extra_winning_target_count, expected_result)
     }
 
     pub fn start_referendum_manager(
-        options_count: u64,
+        winning_target_count: u64,
         expected_result: Result<(), Error<Runtime, Instance0>>,
     ) -> () {
-        let extra_options_count = options_count - 1;
+        let extra_winning_target_count = winning_target_count - 1;
 
         // check method returns expected result
         assert_eq!(
             <Module::<Runtime, Instance0> as ReferendumManager<Runtime, Instance0>>::start_referendum(
                 InstanceMockUtils::<Runtime, Instance0>::mock_origin(OriginType::Root),
-                extra_options_count,
+                extra_winning_target_count,
             ),
             expected_result,
         );
 
-        Self::start_referendum_inner(extra_options_count, expected_result)
+        Self::start_referendum_inner(extra_winning_target_count, expected_result)
     }
 
     fn start_referendum_inner(
-        extra_options_count: u64,
+        extra_winning_target_count: u64,
         expected_result: Result<(), Error<Runtime, Instance0>>,
     ) {
         if expected_result.is_err() {
             return;
         }
 
-        let total_options = extra_options_count + 1;
+        let winning_target_count = extra_winning_target_count + 1;
         let block_number = system::Module::<Runtime>::block_number();
 
         assert_eq!(
             Stage::<Runtime, Instance0>::get(),
             ReferendumStage::Voting(ReferendumStageVoting {
                 started: block_number,
-                extra_options_count,
+                winning_target_count,
             }),
         );
 
         assert_eq!(
             system::Module::<Runtime>::events().last().unwrap().event,
-            TestEvent::from(RawEvent::ReferendumStarted(total_options))
+            TestEvent::from(RawEvent::ReferendumStarted(winning_target_count))
         );
     }
 
-    pub fn check_voting_finished(options_count: u64) {
+    pub fn check_voting_finished(winning_target_count: u64) {
         let block_number = system::Module::<Runtime>::block_number();
 
         assert_eq!(
             Stage::<Runtime, Instance0>::get(),
             ReferendumStage::Revealing(ReferendumStageRevealing {
                 started: block_number - 1,
-                intermediate_results: (0..options_count).map(|_| 0).collect(),
+                winning_target_count,
+                intermediate_winners: vec![],
+                intermediate_results: BTreeMap::new(),
             }),
         );
 
@@ -417,7 +449,8 @@ impl InstanceMocks<Runtime, Instance0> {
     }
 
     pub fn check_revealing_finished(
-        expected_referendum_result: Vec<<Runtime as Trait<Instance0>>::VotePower>,
+        expected_winners: Vec<OptionResult<<Runtime as Trait<Instance0>>::VotePower>>,
+        expected_referendum_result: BTreeMap<u64, <Runtime as Trait<Instance0>>::VotePower>,
     ) {
         assert_eq!(
             Stage::<Runtime, Instance0>::get(),
@@ -428,7 +461,8 @@ impl InstanceMocks<Runtime, Instance0> {
         assert_eq!(
             system::Module::<Runtime>::events().last().unwrap().event,
             TestEvent::event_mod_Instance0(RawEvent::ReferendumFinished(
-                expected_referendum_result.clone()
+                expected_winners,
+                expected_referendum_result,
             ))
         );
     }
@@ -478,6 +512,7 @@ impl InstanceMocks<Runtime, Instance0> {
         vote_option_index: u64,
         expected_result: Result<(), Error<Runtime, Instance0>>,
     ) -> () {
+        println!("{:?}", vote_option_index);
         // check method returns expected result
         assert_eq!(
             Module::<Runtime, Instance0>::reveal_vote(

--- a/runtime-modules/referendum/src/tests.rs
+++ b/runtime-modules/referendum/src/tests.rs
@@ -619,9 +619,9 @@ fn winners_multiple_winners() {
     });
 }
 
-/// Test that winners are properly selected when there is a important tie. N-th option and (N+1)-th option has the same amount of votes but only N winners are expected.
+/// Test that winners are properly selected when there is a important tie.
+/// N-th option and (N+1)-th option has the same amount of votes but only N winners are expected.
 #[test]
-#[ignore]
 fn winners_multiple_winners_extra() {
     let config = default_genesis_config();
 
@@ -678,14 +678,20 @@ fn winners_multiple_winners_extra() {
         );
         MockUtils::increase_block_number(reveal_stage_duration + 1);
 
-        // TODO: handle multiple winners
-        // Mocks::check_revealing_finished(vec![stake, stake, 0]);
+        let expected_winners = vec![OptionResult {
+            option_index: option_to_vote_for1,
+            vote_power: stake,
+        }];
+        assert!((expected_winners.len() as u64) == winning_target_count); // sanity check - check that there will be expected number of winners
+        Mocks::check_revealing_finished(
+            expected_winners,
+            MockUtils::transform_results(vec![stake, stake]),
+        );
     });
 }
 
 // Test that winners are properly selected when there only votes for fewer options than expected winners.
 #[test]
-#[ignore]
 fn winners_multiple_not_enough() {
     let config = default_genesis_config();
 
@@ -696,7 +702,7 @@ fn winners_multiple_not_enough() {
         let account_id1 = USER_REGULAR;
         let origin = OriginType::Signed(account_superuser);
         let origin_voter1 = OriginType::Signed(account_id1);
-        let winning_target_count = 1;
+        let winning_target_count = 3;
 
         let option_to_vote_for = 0;
         let stake = <Runtime as Trait<Instance0>>::MinimumStake::get();
@@ -723,8 +729,15 @@ fn winners_multiple_not_enough() {
         );
         MockUtils::increase_block_number(reveal_stage_duration + 1);
 
-        // TODO: handle less than expected winners
-        //Mocks::check_revealing_finished(vec![stake, 0, 0]);
+        let expected_winners = vec![OptionResult {
+            option_index: option_to_vote_for,
+            vote_power: stake,
+        }];
+        assert!((expected_winners.len() as u64) < winning_target_count); // sanity check - check that there will be less winners than expected
+        Mocks::check_revealing_finished(
+            expected_winners,
+            MockUtils::transform_results(vec![stake]),
+        );
     });
 }
 

--- a/runtime-modules/referendum/src/tests.rs
+++ b/runtime-modules/referendum/src/tests.rs
@@ -139,7 +139,7 @@ fn voting_stake_too_low() {
     });
 }
 
-/// Test that a user can change his vote/stake during the voting stage.
+/// Test that a user is prevented from voting multiple times in the same cycle.
 #[test]
 fn voting_user_repeated_vote() {
     let config = default_genesis_config();
@@ -168,7 +168,7 @@ fn voting_user_repeated_vote() {
             account_id,
             commitment,
             different_stake.clone(),
-            Ok(()),
+            Err(Error::AlreadyVotedThisCycle),
         );
     });
 }

--- a/runtime-modules/referendum/src/tests.rs
+++ b/runtime-modules/referendum/src/tests.rs
@@ -423,7 +423,7 @@ fn finish_revealing_period() {
 
         Mocks::check_revealing_finished(
             vec![OptionResult {
-                option_index: option_to_vote_for,
+                option_id: option_to_vote_for,
                 vote_power: stake,
             }],
             MockUtils::transform_results(vec![1 * stake, 0, 0]),
@@ -493,7 +493,7 @@ fn finish_revealing_period_vote_power() {
         // option 2 should win because prominent user has more powerfull vote with the same stake
         Mocks::check_revealing_finished(
             vec![OptionResult {
-                option_index: option_to_vote_for2,
+                option_id: option_to_vote_for2,
                 vote_power: stake_smaller * POWER_VOTE_STRENGTH,
             }],
             MockUtils::transform_results(vec![
@@ -606,11 +606,11 @@ fn winners_multiple_winners() {
         Mocks::check_revealing_finished(
             vec![
                 OptionResult {
-                    option_index: option_to_vote_for1,
+                    option_id: option_to_vote_for1,
                     vote_power: 2 * stake,
                 },
                 OptionResult {
-                    option_index: option_to_vote_for2,
+                    option_id: option_to_vote_for2,
                     vote_power: stake,
                 },
             ],
@@ -679,7 +679,7 @@ fn winners_multiple_winners_extra() {
         MockUtils::increase_block_number(reveal_stage_duration + 1);
 
         let expected_winners = vec![OptionResult {
-            option_index: option_to_vote_for1,
+            option_id: option_to_vote_for1,
             vote_power: stake,
         }];
         assert!((expected_winners.len() as u64) == winning_target_count); // sanity check - check that there will be expected number of winners
@@ -730,7 +730,7 @@ fn winners_multiple_not_enough() {
         MockUtils::increase_block_number(reveal_stage_duration + 1);
 
         let expected_winners = vec![OptionResult {
-            option_index: option_to_vote_for,
+            option_id: option_to_vote_for,
             vote_power: stake,
         }];
         assert!((expected_winners.len() as u64) < winning_target_count); // sanity check - check that there will be less winners than expected
@@ -781,7 +781,7 @@ fn referendum_release_stake() {
 
         Mocks::check_revealing_finished(
             vec![OptionResult {
-                option_index: option_to_vote_for,
+                option_id: option_to_vote_for,
                 vote_power: stake,
             }],
             MockUtils::transform_results(vec![stake, 0, 0]),


### PR DESCRIPTION
This PR adds the possibility to provide an unlimited amount of options for the referendum and set an expected number of winners. Options can be restricted via runtime function `is_valid_option_id(...)`.