### PR TITLE
Fix uncle rewards.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "7.1.0"
+version = "7.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '3.0.1'
+version = '3.1.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '7.1.0'
+version = '7.2.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -70,7 +70,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 7,
-    spec_version: 1,
+    spec_version: 2,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -232,14 +232,14 @@ impl pallet_sudo::Trait for Runtime {
 }
 
 parameter_types! {
-    pub const UncleGenerations: BlockNumber = 5;
+    pub const UncleGenerations: BlockNumber = 0;
 }
 
 impl pallet_authorship::Trait for Runtime {
     type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Babe>;
     type UncleGenerations = UncleGenerations;
     type FilterUncle = ();
-    type EventHandler = Staking;
+    type EventHandler = (Staking, ImOnline);
 }
 
 impl_opaque_keys! {


### PR DESCRIPTION
Our current network configuration has unexpected side-effect. In the list of validator who get reward-points for participating in network activities we have special account `5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM` in each era.

Example of rewards points for an era:

```
{
  total: 12,198,
  individual: {
    5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM: 66,
    5D5E3egY12qYrWP7tiAQHYTBzTVfUfFeV68EsKYSQz9FWadN: 6,236,
    5Gmi8oxKM4oV18RmUDyL7HVg494zNDdCE2HGAA12Vewp6ykw: 5,896
  }
```
}

Also neither Kusama nor Polkadot networks have same effects. In those networks all validators got 20xN points where N is blocks for a validator.

This behavior could affect validator payouts but appears to not cause any problems in the network itself. 

After an investigation we found out that `5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM` is '0x0' account (zero) and it got rewarded by uncle verification only.  

0x0 is a outcome of using `Default::default()` for account in case of any errors.

in some cases, 0x0 is because the node cannot determine an author() of the uncle block, which in turn is set by ImOnline EventHandler implementation.

Further investigation shows that both Kusama and Polkadot have a different configuration. 

```
parameter_types! {
	pub const UncleGenerations: u32 = 0;
}

// TODO: substrate#2986 implement this properly
impl authorship::Trait for Runtime {
	type FindAuthor = session::FindAccountFromAuthorIndex<Self, Babe>;
	type UncleGenerations = UncleGenerations;
	type FilterUncle = ();
	type EventHandler = (Staking, ImOnline);
}

```
Having set this configuration for our network we eliminate the issue.