### PR TITLE
Runtime: add pallet-utility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -2095,6 +2095,7 @@ dependencies = [
  "pallet-token-mint",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-utility",
  "pallet-versioned-store",
  "pallet-versioned-store-permissions",
  "pallet-working-group",
@@ -3822,6 +3823,22 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-api",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-utility"
+version = "2.0.0-rc4"
+source = "git+https://github.com/paritytech/substrate.git?rev=00768a1f21a579c478fe5d4f51e1fa71f7db9fd4#00768a1f21a579c478fe5d4f51e1fa71f7db9fd4"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '7.2.0'
+version = '7.3.0'
 
 [dependencies]
 # Third-party dependencies
@@ -51,6 +51,7 @@ pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git
 pallet-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
 pallet-im-online = { package = 'pallet-im-online', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
 pallet-collective = { package = 'pallet-collective', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
+pallet-utility = { package = 'pallet-utility', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
 
 # Benchmarking
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4', default-features = false, optional = true }
@@ -132,6 +133,7 @@ std = [
     'pallet-im-online/std',
     'pallet-collective/std',
     'pallet-offences/std',
+    'pallet-utility/std',
 
     # Joystream
     'common/std',
@@ -166,6 +168,7 @@ runtime-benchmarks = [
     "frame-system-benchmarking",
     "pallet-offences-benchmarking",
 	"pallet-session-benchmarking",
+    "pallet-utility/runtime-benchmarks",
 ]
 
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -70,7 +70,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 7,
-    spec_version: 2,
+    spec_version: 3,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -125,6 +125,11 @@ impl system::Trait for Runtime {
     type AccountData = pallet_balances::AccountData<Balance>;
     type OnNewAccount = ();
     type OnKilledAccount = ();
+}
+
+impl pallet_utility::Trait for Runtime {
+    type Event = Event;
+    type Call = Call;
 }
 
 parameter_types! {
@@ -578,6 +583,7 @@ construct_runtime!(
     {
         // Substrate
         System: system::{Module, Call, Storage, Config, Event<T>},
+        Utility: pallet_utility::{Module, Call, Event},
         Babe: pallet_babe::{Module, Call, Storage, Config, Inherent(Timestamp)},
         Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
         Authorship: pallet_authorship::{Module, Call, Storage, Inherent},


### PR DESCRIPTION
Pioneer Staking Payouts requires the `utility.batch()` dispatchable to do batch payouts.
So this PR adds the runtime module to our configuration.

Background: https://github.com/Joystream/joystream/issues/1257#issuecomment-691617912

It is used here: https://github.com/Joystream/joystream/blob/afd7f8da4c7145e17d96af683d69a2efbf0c9b9c/pioneer/packages/page-staking/src/Payouts/PayButton.tsx#L37