### PR TITLE
Allow empty passwords.

### DIFF
--- a/pioneer/packages/page-accounts/src/Accounts/PasswordInput.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/PasswordInput.tsx
@@ -4,6 +4,7 @@
 
 import { Modal, Password } from '@polkadot/react-components';
 // import keyring from '@polkadot/ui-keyring';
+import { isPasswordValid } from '@polkadot/joy-utils/functions/accounts';
 
 import React, { useCallback, useState } from 'react';
 
@@ -22,6 +23,8 @@ export default function PasswordInput ({ onChange, onEnter, password }: Props): 
 
   const _onPasswordChange = useCallback(
     (password: string) => {
+      const isPassValid = isPasswordValid(password);
+
       setPassValid(isPassValid);
 
       const isValid = isPassValid && isPass2Valid;
@@ -33,7 +36,7 @@ export default function PasswordInput ({ onChange, onEnter, password }: Props): 
 
   const onPassword2Change = useCallback(
     (password2: string) => {
-      const isPass2Valid = password2 === password;
+      const isPass2Valid = isPasswordValid(password2) && (password2 === password);
 
       setPassword2({ isPass2Valid, password2 });
 

--- a/pioneer/packages/page-accounts/src/Accounts/PasswordInput.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/PasswordInput.tsx
@@ -3,7 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import { Modal, Password } from '@polkadot/react-components';
-import keyring from '@polkadot/ui-keyring';
+// import keyring from '@polkadot/ui-keyring';
 
 import React, { useCallback, useState } from 'react';
 
@@ -17,13 +17,11 @@ type Props = {
 
 export default function PasswordInput ({ onChange, onEnter, password }: Props): React.ReactElement {
   const { t } = useTranslation();
-  const [isPassValid, setPassValid] = useState<boolean>(false);
-  const [{ isPass2Valid, password2 }, setPassword2] = useState({ isPass2Valid: false, password2: '' });
+  const [isPassValid, setPassValid] = useState<boolean>(true);
+  const [{ isPass2Valid, password2 }, setPassword2] = useState({ isPass2Valid: true, password2: '' });
 
   const _onPasswordChange = useCallback(
     (password: string) => {
-      const isPassValid = keyring.isPassValid(password);
-
       setPassValid(isPassValid);
 
       const isValid = isPassValid && isPass2Valid;
@@ -35,7 +33,7 @@ export default function PasswordInput ({ onChange, onEnter, password }: Props): 
 
   const onPassword2Change = useCallback(
     (password2: string) => {
-      const isPass2Valid = keyring.isPassValid(password2) && (password2 === password);
+      const isPass2Valid = password2 === password;
 
       setPassword2({ isPass2Valid, password2 });
 

--- a/pioneer/packages/page-accounts/src/Accounts/modals/Backup.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/Backup.tsx
@@ -6,6 +6,7 @@ import FileSaver from 'file-saver';
 import React, { useCallback, useState } from 'react';
 import { AddressRow, Button, Modal, Password } from '@polkadot/react-components';
 import keyring from '@polkadot/ui-keyring';
+import { isPasswordValid } from '@polkadot/joy-utils/functions/accounts';
 
 import { useTranslation } from '../../translate';
 
@@ -19,7 +20,7 @@ function Backup ({ address, onClose }: Props): React.ReactElement<Props> {
   const [isBusy, setIsBusy] = useState(false);
   const [{ isPassTouched, password }, setPassword] = useState({ isPassTouched: true, password: '' });
   const [backupFailed, setBackupFailed] = useState(false);
-  const isPassValid = !backupFailed;
+  const isPassValid = !backupFailed && isPasswordValid(password);
 
   const _onChangePass = useCallback(
     (password: string): void => {

--- a/pioneer/packages/page-accounts/src/Accounts/modals/Backup.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/Backup.tsx
@@ -17,9 +17,9 @@ interface Props {
 function Backup ({ address, onClose }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [isBusy, setIsBusy] = useState(false);
-  const [{ isPassTouched, password }, setPassword] = useState({ isPassTouched: false, password: '' });
+  const [{ isPassTouched, password }, setPassword] = useState({ isPassTouched: true, password: '' });
   const [backupFailed, setBackupFailed] = useState(false);
-  const isPassValid = !backupFailed && keyring.isPassValid(password);
+  const isPassValid = !backupFailed;
 
   const _onChangePass = useCallback(
     (password: string): void => {

--- a/pioneer/packages/page-accounts/src/Accounts/modals/ChangePass.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/ChangePass.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useState } from 'react';
 import { AddressRow, Button, Modal, Password } from '@polkadot/react-components';
 import keyring from '@polkadot/ui-keyring';
+import { isPasswordValid } from '@polkadot/joy-utils/functions/accounts';
 
 import { useTranslation } from '../../translate';
 
@@ -33,18 +34,18 @@ function ChangePass ({ address, className = '', onClose }: Props): React.ReactEl
 
   const _onChangeNew1 = useCallback(
     (password: string) =>
-      setNewPass1({ isValid: true, password }),
+      setNewPass1({ isValid: isPasswordValid(password), password }),
     []
   );
 
   const _onChangeNew2 = useCallback(
     (password: string) =>
-      setNewPass2({ isValid: newPass1.password === password, password }),
+      setNewPass2({ isValid: isPasswordValid(password) && (newPass1.password === password), password }),
     [newPass1]
   );
 
   const _onChangeOld = useCallback(
-    (oldPass: string) => setOldPass({ isOldValid: true, oldPass }),
+    (oldPass: string) => setOldPass({ isOldValid: isPasswordValid(oldPass), oldPass }),
     []
   );
 

--- a/pioneer/packages/page-accounts/src/Accounts/modals/ChangePass.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/ChangePass.tsx
@@ -27,24 +27,24 @@ interface OldPass {
 function ChangePass ({ address, className = '', onClose }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [isBusy, setIsBusy] = useState(false);
-  const [newPass1, setNewPass1] = useState<NewPass>({ isValid: false, password: '' });
-  const [newPass2, setNewPass2] = useState<NewPass>({ isValid: false, password: '' });
-  const [{ isOldValid, oldPass }, setOldPass] = useState<OldPass>({ isOldValid: false, oldPass: '' });
+  const [newPass1, setNewPass1] = useState<NewPass>({ isValid: true, password: '' });
+  const [newPass2, setNewPass2] = useState<NewPass>({ isValid: true, password: '' });
+  const [{ isOldValid, oldPass }, setOldPass] = useState<OldPass>({ isOldValid: true, oldPass: '' });
 
   const _onChangeNew1 = useCallback(
     (password: string) =>
-      setNewPass1({ isValid: keyring.isPassValid(password), password }),
+      setNewPass1({ isValid: true, password }),
     []
   );
 
   const _onChangeNew2 = useCallback(
     (password: string) =>
-      setNewPass2({ isValid: keyring.isPassValid(password) && (newPass1.password === password), password }),
+      setNewPass2({ isValid: newPass1.password === password, password }),
     [newPass1]
   );
 
   const _onChangeOld = useCallback(
-    (oldPass: string) => setOldPass({ isOldValid: keyring.isPassValid(oldPass), oldPass }),
+    (oldPass: string) => setOldPass({ isOldValid: true, oldPass }),
     []
   );
 

--- a/pioneer/packages/page-accounts/src/Accounts/modals/Create.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/Create.tsx
@@ -170,7 +170,7 @@ function Create ({ className = '', onClose, onStatusChange, seed: propsSeed, typ
   const [isConfirmationOpen, toggleConfirmation] = useToggle();
   const [isBusy, setIsBusy] = useState(false);
   const [{ isNameValid, name }, setName] = useState({ isNameValid: false, name: '' });
-  const [{ isPasswordValid, password }, setPassword] = useState({ isPasswordValid: false, password: '' });
+  const [{ isPasswordValid, password }, setPassword] = useState({ isPasswordValid: true, password: '' });
   const isValid = !!address && !deriveError && isNameValid && isPasswordValid && isSeedValid;
   const seedOpt = useMemo(() => (
     isDevelopment

--- a/pioneer/packages/page-accounts/src/Accounts/modals/Derive.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/Derive.tsx
@@ -11,6 +11,7 @@ import { AddressRow, Button, Input, InputAddress, Modal, Password, StatusContext
 import { useApi, useDebounce, useToggle } from '@polkadot/react-hooks';
 import keyring from '@polkadot/ui-keyring';
 import { keyExtractPath } from '@polkadot/util-crypto';
+import { isPasswordValid } from '@polkadot/joy-utils/functions/accounts';
 
 import { useTranslation } from '../../translate';
 import { downloadAccount } from './Create';
@@ -85,7 +86,7 @@ function Derive ({ className = '', from, onClose }: Props): React.ReactElement {
   const [{ isNameValid, name }, setName] = useState({ isNameValid: false, name: '' });
   const [{ isPassValid, password }, setPassword] = useState({ isPassValid: true, password: '' });
   const [{ isPass2Valid, password2 }, setPassword2] = useState({ isPass2Valid: true, password2: '' });
-  const [{ isRootValid, rootPass }, setRootPass] = useState({ isRootValid: false, rootPass: '' });
+  const [{ isRootValid, rootPass }, setRootPass] = useState({ isRootValid: true, rootPass: '' });
   const [suri, setSuri] = useState('');
   const debouncedSuri = useDebounce(suri);
   const isValid = !!address && !deriveError && isNameValid && isPassValid && isPass2Valid;
@@ -115,12 +116,12 @@ function Derive ({ className = '', from, onClose }: Props): React.ReactElement {
   );
 
   const _onChangePass = useCallback(
-    (password: string) => setPassword({ isPassValid: true, password }),
+    (password: string) => setPassword({ isPassValid: isPasswordValid(password), password }),
     []
   );
 
   const _onChangePass2 = useCallback(
-    (password2: string) => setPassword2({ isPass2Valid: password2 === password, password2 }),
+    (password2: string) => setPassword2({ isPass2Valid: isPasswordValid(password2) && (password2 === password), password2 }),
     [password]
   );
 

--- a/pioneer/packages/page-accounts/src/Accounts/modals/Derive.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/Derive.tsx
@@ -83,8 +83,8 @@ function Derive ({ className = '', from, onClose }: Props): React.ReactElement {
   const [isConfirmationOpen, toggleConfirmation] = useToggle();
   const [{ isLocked, lockedError }, setIsLocked] = useState<LockState>({ isLocked: source.isLocked, lockedError: null });
   const [{ isNameValid, name }, setName] = useState({ isNameValid: false, name: '' });
-  const [{ isPassValid, password }, setPassword] = useState({ isPassValid: false, password: '' });
-  const [{ isPass2Valid, password2 }, setPassword2] = useState({ isPass2Valid: false, password2: '' });
+  const [{ isPassValid, password }, setPassword] = useState({ isPassValid: true, password: '' });
+  const [{ isPass2Valid, password2 }, setPassword2] = useState({ isPass2Valid: true, password2: '' });
   const [{ isRootValid, rootPass }, setRootPass] = useState({ isRootValid: false, rootPass: '' });
   const [suri, setSuri] = useState('');
   const debouncedSuri = useDebounce(suri);
@@ -115,12 +115,12 @@ function Derive ({ className = '', from, onClose }: Props): React.ReactElement {
   );
 
   const _onChangePass = useCallback(
-    (password: string) => setPassword({ isPassValid: keyring.isPassValid(password), password }),
+    (password: string) => setPassword({ isPassValid: true, password }),
     []
   );
 
   const _onChangePass2 = useCallback(
-    (password2: string) => setPassword2({ isPass2Valid: keyring.isPassValid(password2) && (password2 === password), password2 }),
+    (password2: string) => setPassword2({ isPass2Valid: password2 === password, password2 }),
     [password]
   );
 

--- a/pioneer/packages/page-accounts/src/Accounts/modals/Derive.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/Derive.tsx
@@ -127,7 +127,7 @@ function Derive ({ className = '', from, onClose }: Props): React.ReactElement {
 
   const _onChangeRootPass = useCallback(
     (rootPass: string): void => {
-      setRootPass({ isRootValid: !!rootPass, rootPass });
+      setRootPass({ isRootValid: isPasswordValid(rootPass), rootPass });
       setIsLocked(({ isLocked }) => ({ isLocked, lockedError: null }));
     },
     []

--- a/pioneer/packages/page-accounts/src/Accounts/modals/Import.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/Import.tsx
@@ -55,7 +55,7 @@ function Import ({ className = '', onClose, onStatusChange }: Props): React.Reac
   const { t } = useTranslation();
   const [isBusy, setIsBusy] = useState(false);
   const [{ address, isFileValid, json }, setFile] = useState<FileState>({ address: null, isFileValid: false, json: null });
-  const [{ isPassValid, password }, setPass] = useState<PassState>({ isPassValid: false, password: '' });
+  const [{ isPassValid, password }, setPass] = useState<PassState>({ isPassValid: true, password: '' });
 
   const _onChangeFile = useCallback(
     (file: Uint8Array) => setFile(parseFile(file)),
@@ -63,7 +63,7 @@ function Import ({ className = '', onClose, onStatusChange }: Props): React.Reac
   );
 
   const _onChangePass = useCallback(
-    (password: string) => setPass({ isPassValid: keyring.isPassValid(password), password }),
+    (password: string) => setPass({ isPassValid: true, password }),
     []
   );
 

--- a/pioneer/packages/page-accounts/src/Accounts/modals/Import.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/Import.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useState } from 'react';
 import { AddressRow, Button, InputAddress, InputFile, Modal, Password } from '@polkadot/react-components';
 import { isObject, u8aToString } from '@polkadot/util';
 import keyring from '@polkadot/ui-keyring';
+import { isPasswordValid } from '@polkadot/joy-utils/functions/accounts';
 
 import { useTranslation } from '../../translate';
 
@@ -63,7 +64,7 @@ function Import ({ className = '', onClose, onStatusChange }: Props): React.Reac
   );
 
   const _onChangePass = useCallback(
-    (password: string) => setPass({ isPassValid: true, password }),
+    (password: string) => setPass({ isPassValid: isPasswordValid(password), password }),
     []
   );
 


### PR DESCRIPTION
Initial changes for issue #1301.

Note:
- This should work for the most part fairly well. Where it falls short is in components that utilize some internal polkadot code. When this happens, one should refresh the page and it should work again.

The code in question: 
```
page-accounts/src/Accounts/modals/Backup.tsx

          const addressKeyring = address && keyring.getPair(address);
          const json = addressKeyring && keyring.backupAccount(addressKeyring, password);
          const blob = new Blob([JSON.stringify(json)], { type: 'application/json; charset=utf-8' });

          FileSaver.saveAs(blob, `${address}.json`);

page-accounts/src/Accounts/modals/ChangePass.tsx

          account.decodePkcs8(oldPass);      
```

If it's ok with @bwhm for the most part, it might be a good idea to have someone else check this out further.