### PR TITLE
Pioneer: reintroduce `joy` global into javascript playground app

### DIFF
--- a/pioneer/packages/page-js/src/Playground.tsx
+++ b/pioneer/packages/page-js/src/Playground.tsx
@@ -16,6 +16,7 @@ import uiKeyring from '@polkadot/ui-keyring';
 import * as types from '@polkadot/types';
 import * as util from '@polkadot/util';
 import * as hashing from '@polkadot/util-crypto';
+import * as joy from '@joystream/types';
 
 import { STORE_EXAMPLES, STORE_SELECTED, CUSTOM_LABEL } from './constants';
 import makeWrapper from './snippets/wrapping';
@@ -36,6 +37,7 @@ interface Injected {
   setIsRunning: (isRunning: boolean) => void;
   types: typeof types;
   util: typeof util;
+  joy: typeof joy;
   [name: string]: any;
 }
 
@@ -69,7 +71,8 @@ function setupInjected ({ api, isDevelopment }: ApiProps, setIsRunning: (isRunni
     uiKeyring: isDevelopment
       ? uiKeyring
       : null,
-    util
+    util,
+    joy
   };
 }
 

--- a/utils/api-examples/scripts/example.js
+++ b/utils/api-examples/scripts/example.js
@@ -24,7 +24,7 @@ const script = async ({ api, hashing, keyring, types, util, joy }) => {
 
 if (typeof module === 'undefined') {
   // Pioneer js-toolbox
-  // Available globals [api, hashing, keyring, types, util]
+  // Available globals [api, hashing, keyring, types, util, joy]
   script({ api, hashing, keyring, types, util, joy })
 } else {
   // Node

--- a/utils/api-examples/scripts/export-data-directory.js
+++ b/utils/api-examples/scripts/export-data-directory.js
@@ -1,4 +1,4 @@
-/* global api, hashing, keyring, types, util */
+/* global api, hashing, keyring, types, util, joy */
 
 // run this script with:
 // yarn script exportDataDirectory
@@ -42,7 +42,7 @@ const script = async ({ api }) => {
 
 if (typeof module === 'undefined') {
   // Pioneer js-toolbox
-  script({ api, hashing, keyring, types, util })
+  script({ api, hashing, keyring, types, util, joy })
 } else {
   // Node
   module.exports = script

--- a/utils/api-examples/scripts/inject-data-objects.js
+++ b/utils/api-examples/scripts/inject-data-objects.js
@@ -1,4 +1,4 @@
-/* global api, hashing, keyring, types, util, window */
+/* global api, hashing, keyring, types, util, joy, window */
 
 // run this script with:
 // yarn script injectDataObjects
@@ -53,7 +53,7 @@ const script = async ({ api, keyring }) => {
 
 if (typeof module === 'undefined') {
   // Pioneer js-toolbox
-  script({ api, hashing, keyring, types, util })
+  script({ api, hashing, keyring, types, util, joy })
 } else {
   // Node
   module.exports = script

--- a/utils/api-examples/scripts/list-data-directory.js
+++ b/utils/api-examples/scripts/list-data-directory.js
@@ -7,7 +7,7 @@
 // https://testnet.joystream.org/#/js
 // requires nicaea release+
 
-const script = async ({ api, joy }) => {
+const script = async ({ api }) => {
   const ids = await api.query.dataDirectory.knownContentIds()
 
   await Promise.all(

--- a/utils/api-examples/scripts/transfer.js
+++ b/utils/api-examples/scripts/transfer.js
@@ -1,4 +1,4 @@
-/* global api, hashing, keyring, types, util, window */
+/* global api, hashing, keyring, types, util, joy, window */
 
 // run this script with:
 // yarn script testTransfer
@@ -24,7 +24,7 @@ const script = async ({ api, keyring }) => {
 
 if (typeof module === 'undefined') {
   // Pioneer js-toolbox
-  script({ api, hashing, keyring, types, util })
+  script({ api, hashing, keyring, types, util, joy })
 } else {
   // Node
   module.exports = script


### PR DESCRIPTION
Just a quick fix, to make sure example scripts work if they use the `joy` global.

Although we can create all types using `api.createType()`, if there are some types not registered in the registry, or we need some static methods on the custom types, the export of `*` from `@joystream/types` can be used.