### PR TITLE
storage-node: helios fix asset url in helios

### DIFF
--- a/storage-node/packages/helios/bin/cli.js
+++ b/storage-node/packages/helios/bin/cli.js
@@ -26,7 +26,7 @@ function mapInfoToStatus(providers, currentHeight) {
 
 function makeAssetUrl(contentId, source) {
   source = stripEndingSlash(source)
-  return `${source}/asset/v1/${encodeAddress(contentId)}`
+  return `${source}/asset/v0/${encodeAddress(contentId)}`
 }
 
 async function assetRelationshipState(api, contentId, providers) {


### PR DESCRIPTION
Forget to revert asset URL back to use `v0/` in last PR #1343 