### PR TITLE
Pioneer: Ignore "genesisHash" when loading/creating accounts

### DIFF
--- a/pioneer/packages/page-accounts/src/Accounts/Account.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/Account.tsx
@@ -531,12 +531,13 @@ function Account ({ account: { address, meta }, className = '', delegation, filt
                 {t('Delegate democracy votes')}
               </Menu.Item>
             ])}
-            <ChainLock
+            {/* Joystream specific - disallow "Only this network" to avoid confusion */}
+            {/* <ChainLock
               className='accounts--network-toggle'
               genesisHash={genesisHash}
               isDisabled={api.isDevelopment}
               onChange={onSetGenesisHash}
-            />
+            /> */}
           </Menu>
         </Popup>
       </td>

--- a/pioneer/packages/page-accounts/src/Accounts/Account.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/Account.tsx
@@ -14,7 +14,7 @@ import React, { useCallback, useContext, useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { ApiPromise } from '@polkadot/api';
 import { getLedger } from '@polkadot/react-api';
-import { AddressInfo, AddressMini, AddressSmall, Badge, Button, ChainLock, CryptoType, Forget, Icon, IdentityIcon, LinkExternal, Menu, Popup, StatusContext, Tags } from '@polkadot/react-components';
+import { AddressInfo, AddressMini, AddressSmall, Badge, Button, CryptoType, Forget, Icon, IdentityIcon, LinkExternal, Menu, Popup, StatusContext, Tags } from '@polkadot/react-components';
 import { useAccountInfo, useApi, useCall, useToggle } from '@polkadot/react-hooks';
 import { Option } from '@polkadot/types';
 import keyring from '@polkadot/ui-keyring';
@@ -83,7 +83,7 @@ function Account ({ account: { address, meta }, className = '', delegation, filt
   });
   const multiInfos = useMultisigApprovals(address);
   const proxyInfo = useProxies(address);
-  const { flags: { isDevelopment, isExternal, isHardware, isInjected, isMultisig, isProxied }, genesisHash, identity, name: accName, onSetGenesisHash, tags } = useAccountInfo(address);
+  const { flags: { isDevelopment, isExternal, isHardware, isInjected, isMultisig, isProxied }, identity, name: accName, tags } = useAccountInfo(address);
   const [{ democracyUnlockTx }, setUnlockableIds] = useState<DemocracyUnlockable>({ democracyUnlockTx: null, ids: [] });
   const [vestingVestTx, setVestingTx] = useState<SubmittableExtrinsic<'promise'> | null>(null);
   const [isVisible, setIsVisible] = useState(true);

--- a/pioneer/packages/page-accounts/src/Accounts/modals/Create.tsx
+++ b/pioneer/packages/page-accounts/src/Accounts/modals/Create.tsx
@@ -138,12 +138,13 @@ export function downloadAccount ({ json, pair }: CreateResult): void {
   FileSaver.saveAs(blob, `${pair.address}.json`);
 }
 
-function createAccount (suri: string, pairType: KeypairType, { genesisHash, name, tags = [] }: CreateOptions, password: string, success: string): ActionStatus {
+function createAccount (suri: string, pairType: KeypairType, { name, tags = [] }: CreateOptions, password: string, success: string): ActionStatus {
   // we will fill in all the details below
   const status = { action: 'create' } as ActionStatus;
 
   try {
-    const result = keyring.addUri(suri, password, { genesisHash, name, tags }, pairType);
+    // Joystream-specific - ignore genesisHash when creating new accounts
+    const result = keyring.addUri(suri, password, { name, tags }, pairType);
     const { address } = result.pair;
 
     status.account = address;

--- a/pioneer/packages/react-api/src/Api.tsx
+++ b/pioneer/packages/react-api/src/Api.tsx
@@ -131,7 +131,7 @@ async function loadOnReady (api: ApiPromise, store: KeyringStore | undefined, ty
 
   // finally load the keyring
   keyring.loadAll({
-    genesisHash: api.genesisHash,
+    // genesisHash: api.genesisHash, Joystream-specific - Don't care about genesis hash when loading accounts
     isDevelopment,
     ss58Format,
     store,


### PR DESCRIPTION
Related issue: https://github.com/Joystream/joystream/issues/1383

PR content:
- Ignore `genesisHash` in local storage keys
- Don't save `genesisHash` when creating new keys
- Remove "Only this network" option from the accounts UI.