### PR TITLE
Chain spec bug fix (Invalid periods for working group).

### DIFF
--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -357,9 +357,9 @@ pub fn testnet_genesis(
             fill_working_group_leader_opening_proposal_grace_period: cpcp
                 .fill_working_group_leader_opening_proposal_grace_period,
             set_working_group_mint_capacity_proposal_voting_period: cpcp
-                .set_content_working_group_mint_capacity_proposal_voting_period,
+                .set_working_group_mint_capacity_proposal_voting_period,
             set_working_group_mint_capacity_proposal_grace_period: cpcp
-                .set_content_working_group_mint_capacity_proposal_grace_period,
+                .set_working_group_mint_capacity_proposal_grace_period,
             decrease_working_group_leader_stake_proposal_voting_period: cpcp
                 .decrease_working_group_leader_stake_proposal_voting_period,
             decrease_working_group_leader_stake_proposal_grace_period: cpcp


### PR DESCRIPTION
Current chain_spec code contains invalid settings for the working group. It specifies content_working_group_* settings instead of working_group_*.