### PR TITLE
runtime: bump version and build chainspec builder in docker image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "7.3.0"
+version = "7.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/devops/dockerfiles/node-and-runtime/Dockerfile
+++ b/devops/dockerfiles/node-and-runtime/Dockerfile
@@ -3,14 +3,15 @@ LABEL description="Compiles all workspace artifacts"
 WORKDIR /joystream
 COPY . /joystream
 
-# Build joystream-node and its dependencies - runtime
-RUN WASM_BUILD_TOOLCHAIN=nightly-2020-05-23 cargo build --release -p joystream-node
+# Build all cargo crates
+RUN WASM_BUILD_TOOLCHAIN=nightly-2020-05-23 cargo build --release
 
 FROM debian:stretch
 LABEL description="Joystream node"
 WORKDIR /joystream
 COPY --from=builder /joystream/target/release/joystream-node /joystream/node
 COPY --from=builder /joystream/target/release/wbuild/joystream-node-runtime/joystream_node_runtime.compact.wasm /joystream/runtime.compact.wasm
+COPY --from=builder /joystream/target/release/chain-spec-builder /joystream/chain-spec-builder
 
 # confirm it works
 RUN /joystream/node --version

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '3.1.0'
+version = '3.2.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -1,11 +1,14 @@
-### Version 6.21.0 - Constantinople runtime upgrade B (Nicaea) - July 29 2020
+### Version 7.4.0 - Alexandria - new chain - September 21 2020
+- Update to substrate v2.0.0-rc4
+
+### Version 6.21.0 - (Constantinople) runtime upgrade B (Nicaea) - July 29 2020
 
 - Introduction of general Working Group runtime module
 - Adds a new instance of the working group module - the Storage Working Group which
   replaces the old actors module for managing the Storge Provider enrollment process
 - New governance proposals to support new working groups
 
-### Version 6.15.0 - Constantinople runtime upgrade A - June 2020
+### Version 6.15.0 - (Constantinople) runtime upgrade A - June 2020
 
 - Updated runtime to sort out type name clashes between the proposal discussion module
   and forum module, in preparing to roll out proposal discussion system in pioneer.

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '7.3.0'
+version = '7.4.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -70,7 +70,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 7,
-    spec_version: 3,
+    spec_version: 4,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
After #1253 we should have updated spec version.

I'm also including chain-spec-builder binary in joystream/node docker image build to be used in the integration tests.