### PR TITLE
types: fix README and bumped patch version

### DIFF
--- a/types/README.md
+++ b/types/README.md
@@ -15,37 +15,30 @@ yarn add @joystream/types
 npm install --save @joystream/types
 ```
 
-## Registering the types
-
-Call `registerJoystreamTypes()` before creating a Polkadot API client.
+## Example usage
 
 ```javascript
-import { registerJoystreamTypes } from '@joystream/types';
-import { ApiPromise, WsProvider } from '@polkadot/api';
+import { types } from '@joystream/types'
+import { ApiPromise, WsProvider } from '@polkadot/api'
 
-async function main () {
+async function main() {
   // Initialise the provider to connect to the local node
-  const provider = new WsProvider('ws://127.0.0.1:9944');
-
-  // Register types before creating the API
-  registerJoystreamTypes();
+  const provider = new WsProvider('ws://127.0.0.1:9944')
 
   // Create the API and wait until ready
-  const api = await ApiPromise.create({ provider });
+  const api = await ApiPromise.create({ provider, types })
 
-  // Retrieve the chain & node information information via RPC calls
+  await api.isReady
+
+  // Retrieve the chain & node information information via rpc calls
   const [chain, nodeName, nodeVersion] = await Promise.all([
     api.rpc.system.chain(),
     api.rpc.system.name(),
-    api.rpc.system.version()
-  ]);
+    api.rpc.system.version(),
+  ])
 
-  console.log(`Chain ${chain} using ${nodeName} v${nodeVersion}`);
+  console.log(`Chain ${chain} using ${nodeName} v${nodeVersion}`)
 }
 
-main();
+main()
 ```
-
-## Examples
-
-See [joystream-api-examples](https://github.com/Joystream/joystream-api-examples) for some additional examples on usage.

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/types",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Types for Joystream Substrate Runtime - Alexandria release",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Bumped patch version of types library to v0.13.1 and published to npm, so correct example code appears at https://www.npmjs.com/package/@joystream/types