### PR TITLE
storage-node sync: use proper key in Map()

### DIFF
--- a/storage-node/packages/colossus/package.json
+++ b/storage-node/packages/colossus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/colossus",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Colossus - Joystream Storage Node",
   "author": "Joystream",
   "homepage": "https://github.com/Joystream/joystream",


### PR DESCRIPTION
Problem: Using and object instance of `ContentId` as the key in a javascript `Map` was causing the `.has()` method on the map to always return false, because on each call to `api.assets.getKnownContentIds()` we are getting new instances of `ContentId`. The result was on subsequent runs of the syncing process all content ids were considered not sycned and not syncing, because `candidatesForSync` always contained all the `knownContentIds`.

So I simply used the 'string' encoding of the ContentId as the key in the maps to make the checks behave correctly.