### PR TITLE
Multiple working team pallet improvements.

### DIFF
--- a/runtime-modules/working-team/src/checks.rs
+++ b/runtime-modules/working-team/src/checks.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BalanceOfCurrency, Instance, JobOpening, JobOpeningType, MemberId, StakePolicy, TeamWorker,
-    TeamWorkerId, Trait,
+    BalanceOfCurrency, Instance, JobOpening, JobOpeningType, MemberId, RewardPolicy, StakePolicy,
+    TeamWorker, TeamWorkerId, Trait,
 };
 
 use super::Error;
@@ -195,6 +195,20 @@ pub(crate) fn ensure_valid_stake_policy<T: Trait<I>, I: Instance>(
         ensure!(
             stake_policy.stake_amount != Zero::zero(),
             Error::<T, I>::CannotStakeZero
+        )
+    }
+
+    Ok(())
+}
+
+// Check opening: verifies reward policy for the opening.
+pub(crate) fn ensure_valid_reward_policy<T: Trait<I>, I: Instance>(
+    reward_policy: &Option<RewardPolicy<BalanceOfCurrency<T>>>,
+) -> Result<(), DispatchError> {
+    if let Some(reward_policy) = reward_policy {
+        ensure!(
+            reward_policy.reward_per_block != Zero::zero(),
+            Error::<T, I>::CannotRewardWithZero
         )
     }
 

--- a/runtime-modules/working-team/src/checks.rs
+++ b/runtime-modules/working-team/src/checks.rs
@@ -260,3 +260,12 @@ pub(crate) fn ensure_application_stake_match_opening<T: Trait<I>, I: Instance>(
 
     Ok(())
 }
+
+// Check worker: verifies that worker has recurring rewards.
+pub(crate) fn ensure_worker_has_recurring_reward<T: Trait<I>, I: Instance>(
+    worker: &TeamWorker<T>,
+) -> DispatchResult {
+    worker
+        .reward_per_block
+        .map_or(Err(Error::<T, I>::WorkerHasNoReward.into()), |_| Ok(()))
+}

--- a/runtime-modules/working-team/src/checks.rs
+++ b/runtime-modules/working-team/src/checks.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::Error;
 use frame_support::dispatch::{DispatchError, DispatchResult};
-use frame_support::traits::{Currency, WithdrawReasons};
+use frame_support::traits::{Currency, Get, WithdrawReasons};
 use frame_support::{ensure, StorageMap, StorageValue};
 use sp_arithmetic::traits::Zero;
 use sp_std::collections::btree_set::BTreeSet;
@@ -195,7 +195,12 @@ pub(crate) fn ensure_valid_stake_policy<T: Trait<I>, I: Instance>(
         ensure!(
             stake_policy.stake_amount != Zero::zero(),
             Error::<T, I>::CannotStakeZero
-        )
+        );
+
+        ensure!(
+            stake_policy.unstaking_period > T::MinUnstakingPeriodLimit::get(),
+            Error::<T, I>::UnstakingPeriodLessThanMinimum
+        );
     }
 
     Ok(())

--- a/runtime-modules/working-team/src/checks.rs
+++ b/runtime-modules/working-team/src/checks.rs
@@ -117,7 +117,9 @@ fn ensure_is_lead_account<T: Trait<I>, I: Instance>(
 }
 
 // Check leader: ensures origin is signed by the leader.
-fn ensure_origin_is_active_leader<T: Trait<I>, I: Instance>(origin: T::Origin) -> DispatchResult {
+pub(crate) fn ensure_origin_is_active_leader<T: Trait<I>, I: Instance>(
+    origin: T::Origin,
+) -> DispatchResult {
     // Ensure is signed
     let signer = ensure_signed(origin)?;
 

--- a/runtime-modules/working-team/src/errors.rs
+++ b/runtime-modules/working-team/src/errors.rs
@@ -59,5 +59,8 @@ decl_error! {
 
         /// Invalid operation - worker is leaving.
         WorkerIsLeaving,
+
+        /// Reward could not be zero.
+        CannotRewardWithZero,
     }
 }

--- a/runtime-modules/working-team/src/errors.rs
+++ b/runtime-modules/working-team/src/errors.rs
@@ -65,5 +65,8 @@ decl_error! {
 
         /// Staking account contains conflicting stakes.
         ConflictStakesOnAccount,
+
+        /// Worker has no recurring reward.
+        WorkerHasNoReward,
     }
 }

--- a/runtime-modules/working-team/src/errors.rs
+++ b/runtime-modules/working-team/src/errors.rs
@@ -74,5 +74,11 @@ decl_error! {
 
         /// Requested operation with stake is impossible because of stake was not defined for the role.
         CannotChangeStakeWithoutStakingAccount,
+
+        /// Invalid spending amount.
+        CannotSpendZero,
+
+        /// It's not enough budget for this spending.
+        InsufficientBudgetForSpending,
     }
 }

--- a/runtime-modules/working-team/src/errors.rs
+++ b/runtime-modules/working-team/src/errors.rs
@@ -71,5 +71,8 @@ decl_error! {
 
         /// Specified unstaking period is less then minimum set for the team.
         UnstakingPeriodLessThanMinimum,
+
+        /// Requested operation with stake is impossible because of stake was not defined for the role.
+        CannotChangeStakeWithoutStakingAccount,
     }
 }

--- a/runtime-modules/working-team/src/errors.rs
+++ b/runtime-modules/working-team/src/errors.rs
@@ -68,5 +68,8 @@ decl_error! {
 
         /// Worker has no recurring reward.
         WorkerHasNoReward,
+
+        /// Specified unstaking period is less then minimum set for the team.
+        UnstakingPeriodLessThanMinimum,
     }
 }

--- a/runtime-modules/working-team/src/errors.rs
+++ b/runtime-modules/working-team/src/errors.rs
@@ -56,5 +56,8 @@ decl_error! {
 
         /// Origin is not applicant.
         OriginIsNotApplicant,
+
+        /// Invalid operation - worker is leaving.
+        WorkerIsLeaving,
     }
 }

--- a/runtime-modules/working-team/src/lib.rs
+++ b/runtime-modules/working-team/src/lib.rs
@@ -38,7 +38,7 @@ use frame_support::{decl_event, decl_module, decl_storage, ensure, Parameter, St
 use sp_arithmetic::traits::{BaseArithmetic, One, Zero};
 use sp_runtime::traits::{Hash, MaybeSerialize, Member};
 use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
-use system::ensure_signed;
+use system::{ensure_root, ensure_signed};
 
 pub use errors::Error;
 use types::{ApplicationInfo, BalanceOfCurrency, MemberId, TeamWorker, TeamWorkerId, WorkerInfo};
@@ -167,6 +167,11 @@ decl_event!(
         /// Params:
         /// - Opening id
         OpeningCanceled(OpeningId),
+
+        /// Emits on setting the budget for the working team.
+        /// Params:
+        /// - new budget
+        BudgetSet(Balance),
     }
 );
 
@@ -618,6 +623,26 @@ decl_module! {
 
             // Trigger event
             Self::deposit_event(RawEvent::OpeningCanceled(opening_id));
+        }
+
+        /// Sets a new budget for the working team.
+        /// Requires root origin.
+        #[weight = 10_000_000] // TODO: adjust weight
+        pub fn set_budget(
+            origin,
+            new_budget: BalanceOfCurrency<T>,
+        ) {
+            ensure_root(origin)?;
+
+            //
+            // == MUTATION SAFE ==
+            //
+
+            // Update the budget.
+            <Budget::<T, I>>::put(new_budget);
+
+            // Trigger event
+            Self::deposit_event(RawEvent::BudgetSet(new_budget));
         }
     }
 }

--- a/runtime-modules/working-team/src/lib.rs
+++ b/runtime-modules/working-team/src/lib.rs
@@ -326,6 +326,7 @@ decl_module! {
             // Make regular/lead application.
             let application = JobApplication::<T>::new(
                 &p.role_account_id,
+                &p.reward_account_id,
                 &p.staking_account_id,
                 &p.member_id,
                 hashed_description.as_ref().to_vec(),
@@ -693,6 +694,7 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
         let worker = TeamWorker::<T>::new(
             &application_info.application.member_id,
             &application_info.application.role_account_id,
+            &application_info.application.reward_account_id,
             &application_info.application.staking_account_id,
             opening
                 .stake_policy

--- a/runtime-modules/working-team/src/lib.rs
+++ b/runtime-modules/working-team/src/lib.rs
@@ -17,6 +17,7 @@
 //! - [increase_stake](./struct.Module.html#method.increase_stake) - Increases the regular worker/lead stake.
 //! - [cancel_opening](./struct.Module.html#method.cancel_opening) - Cancel opening for a regular worker/lead.
 //! - [withdraw_application](./struct.Module.html#method.withdraw_application) - Withdraw the regular worker/lead application.
+//! - [set_budget](./struct.Module.html#method.set_budget) - Sets the working team budget.
 //!
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -283,6 +284,7 @@ decl_module! {
             member_id: T::MemberId,
             opening_id: T::OpeningId,
             role_account_id: T::AccountId,
+            reward_account_id: T::AccountId,
             staking_account_id: T::AccountId,
             description: Vec<u8>,
             stake: Option<BalanceOfCurrency<T>>,

--- a/runtime-modules/working-team/src/lib.rs
+++ b/runtime-modules/working-team/src/lib.rs
@@ -87,6 +87,9 @@ pub trait Trait<I: Instance>:
 
     /// Validates member id and origin combination
     type MemberOriginValidator: ActorOriginValidator<Self::Origin, MemberId<Self>, Self::AccountId>;
+
+    /// Defines min unstaking period in the team.
+    type MinUnstakingPeriodLimit: Get<Self::BlockNumber>;
 }
 
 decl_event!(

--- a/runtime-modules/working-team/src/tests/fixtures.rs
+++ b/runtime-modules/working-team/src/tests/fixtures.rs
@@ -227,6 +227,7 @@ impl ApplyOnOpeningFixture {
             let expected_hash = <Test as system::Trait>::Hashing::hash(&self.description);
             let expected_application = JobApplication::<Test> {
                 role_account_id: self.role_account_id,
+                reward_account_id: self.reward_account_id,
                 staking_account_id: self.staking_account_id,
                 member_id: self.member_id,
                 description_hash: expected_hash.as_ref().to_vec(),
@@ -262,6 +263,7 @@ pub struct FillOpeningFixture {
     opening_id: u64,
     successful_application_ids: BTreeSet<u64>,
     role_account_id: u64,
+    reward_account_id: u64,
     staking_account_id: u64,
     stake_policy: Option<StakePolicy<u64, u64>>,
     reward_policy: Option<RewardPolicy<u64>>,
@@ -276,6 +278,7 @@ impl FillOpeningFixture {
             opening_id,
             successful_application_ids: application_ids,
             role_account_id: 1,
+            reward_account_id: 1,
             staking_account_id: 1,
             stake_policy: None,
             reward_policy: None,
@@ -336,6 +339,7 @@ impl FillOpeningFixture {
             let expected_worker = TeamWorker::<Test> {
                 member_id: 1,
                 role_account_id: self.role_account_id,
+                reward_account_id: self.reward_account_id,
                 staking_account_id: self.staking_account_id,
                 started_leaving_at: None,
                 job_unstaking_period: self

--- a/runtime-modules/working-team/src/tests/fixtures.rs
+++ b/runtime-modules/working-team/src/tests/fixtures.rs
@@ -841,3 +841,51 @@ impl CancelOpeningFixture {
         }
     }
 }
+
+pub struct SetBudgetFixture {
+    origin: RawOrigin<u64>,
+    new_budget: u64,
+}
+
+impl Default for SetBudgetFixture {
+    fn default() -> Self {
+        Self {
+            origin: RawOrigin::Root,
+            new_budget: 1000000,
+        }
+    }
+}
+
+impl SetBudgetFixture {
+    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+        Self { origin, ..self }
+    }
+
+    pub fn with_budget(self, new_budget: u64) -> Self {
+        Self { new_budget, ..self }
+    }
+
+    pub fn execute(self) {
+        self.call().unwrap();
+    }
+
+    pub fn call(&self) -> DispatchResult {
+        TestWorkingTeam::set_budget(self.origin.clone().into(), self.new_budget)
+    }
+
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let old_budget = TestWorkingTeam::budget();
+
+        let actual_result = self.call().map(|_| ());
+
+        assert_eq!(actual_result.clone(), expected_result);
+
+        let new_budget = TestWorkingTeam::budget();
+
+        if actual_result.is_ok() {
+            assert_eq!(new_budget, self.new_budget);
+        } else {
+            assert_eq!(new_budget, old_budget);
+        }
+    }
+}

--- a/runtime-modules/working-team/src/tests/fixtures.rs
+++ b/runtime-modules/working-team/src/tests/fixtures.rs
@@ -267,6 +267,7 @@ pub struct FillOpeningFixture {
     staking_account_id: Option<u64>,
     stake_policy: Option<StakePolicy<u64, u64>>,
     reward_policy: Option<RewardPolicy<u64>>,
+    created_at: u64,
 }
 
 impl FillOpeningFixture {
@@ -282,11 +283,16 @@ impl FillOpeningFixture {
             staking_account_id: None,
             stake_policy: None,
             reward_policy: None,
+            created_at: 0,
         }
     }
 
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
         Self { origin, ..self }
+    }
+
+    pub fn with_created_at(self, created_at: u64) -> Self {
+        Self { created_at, ..self }
     }
 
     pub fn with_stake_policy(self, stake_policy: Option<StakePolicy<u64, u64>>) -> Self {
@@ -355,6 +361,7 @@ impl FillOpeningFixture {
                     .map_or(0, |sp| sp.unstaking_period),
                 reward_per_block: self.reward_policy.as_ref().map(|rp| rp.reward_per_block),
                 missed_reward: None,
+                created_at: self.created_at,
             };
 
             let actual_worker = TestWorkingTeam::worker_by_id(worker_id);

--- a/runtime-modules/working-team/src/tests/fixtures.rs
+++ b/runtime-modules/working-team/src/tests/fixtures.rs
@@ -945,3 +945,47 @@ impl UpdateRewardAccountFixture {
         }
     }
 }
+
+pub struct UpdateRewardAmountFixture {
+    worker_id: u64,
+    reward_per_block: Option<u64>,
+    origin: RawOrigin<u64>,
+}
+
+impl UpdateRewardAmountFixture {
+    pub fn default_for_worker_id(worker_id: u64) -> Self {
+        let lead_account_id = get_current_lead_account_id();
+
+        Self {
+            worker_id,
+            reward_per_block: None,
+            origin: RawOrigin::Signed(lead_account_id),
+        }
+    }
+    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+        Self { origin, ..self }
+    }
+
+    pub fn with_reward_per_block(self, reward_per_block: Option<u64>) -> Self {
+        Self {
+            reward_per_block,
+            ..self
+        }
+    }
+
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let actual_result = TestWorkingTeam::update_reward_amount(
+            self.origin.clone().into(),
+            self.worker_id,
+            self.reward_per_block,
+        );
+
+        assert_eq!(actual_result.clone(), expected_result);
+
+        if actual_result.is_ok() {
+            let worker = TestWorkingTeam::worker_by_id(self.worker_id);
+
+            assert_eq!(worker.reward_per_block, self.reward_per_block);
+        }
+    }
+}

--- a/runtime-modules/working-team/src/tests/fixtures.rs
+++ b/runtime-modules/working-team/src/tests/fixtures.rs
@@ -9,7 +9,8 @@ use super::mock::{
     Balances, LockId, Membership, System, Test, TestEvent, TestWorkingTeam, TestWorkingTeamInstance,
 };
 use crate::{
-    JobApplication, JobOpening, JobOpeningType, RawEvent, RewardPolicy, StakePolicy, TeamWorker,
+    ApplyOnOpeningParameters, JobApplication, JobOpening, JobOpeningType, RawEvent, RewardPolicy,
+    StakePolicy, TeamWorker,
 };
 
 pub struct EventFixture;
@@ -145,6 +146,7 @@ pub struct ApplyOnOpeningFixture {
     member_id: u64,
     opening_id: u64,
     role_account_id: u64,
+    reward_account_id: u64,
     staking_account_id: u64,
     description: Vec<u8>,
     stake: Option<u64>,
@@ -183,6 +185,7 @@ impl ApplyOnOpeningFixture {
             member_id: 1,
             opening_id,
             role_account_id: 1,
+            reward_account_id: 1,
             staking_account_id: 1,
             description: b"human_text".to_vec(),
             stake: None,
@@ -193,12 +196,15 @@ impl ApplyOnOpeningFixture {
         let saved_application_next_id = TestWorkingTeam::next_application_id();
         TestWorkingTeam::apply_on_opening(
             self.origin.clone().into(),
-            self.member_id,
-            self.opening_id,
-            self.role_account_id,
-            self.staking_account_id,
-            self.description.clone(),
-            self.stake,
+            ApplyOnOpeningParameters::<Test, TestWorkingTeamInstance> {
+                member_id: self.member_id,
+                opening_id: self.opening_id,
+                role_account_id: self.role_account_id,
+                reward_account_id: self.reward_account_id,
+                staking_account_id: self.staking_account_id,
+                description: self.description.clone(),
+                stake: self.stake,
+            },
         )?;
 
         Ok(saved_application_next_id)

--- a/runtime-modules/working-team/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-team/src/tests/hiring_workflow.rs
@@ -5,7 +5,7 @@ use crate::tests::fixtures::{
     setup_members, AddOpeningFixture, ApplyOnOpeningFixture, FillOpeningFixture, HireLeadFixture,
 };
 use crate::tests::mock::TestWorkingTeam;
-use crate::{JobOpeningType, StakePolicy};
+use crate::{JobOpeningType, RewardPolicy, StakePolicy};
 
 #[derive(Clone)]
 struct HiringWorkflowApplication {
@@ -20,6 +20,7 @@ pub struct HiringWorkflow {
     opening_type: JobOpeningType,
     expected_result: DispatchResult,
     stake_policy: Option<StakePolicy<u64, u64>>,
+    reward_policy: Option<RewardPolicy<u64>>,
     applications: Vec<HiringWorkflowApplication>,
     setup_environment: bool,
 }
@@ -30,6 +31,7 @@ impl Default for HiringWorkflow {
             opening_type: JobOpeningType::Regular,
             expected_result: Ok(()),
             stake_policy: None,
+            reward_policy: None,
             applications: Vec::new(),
             setup_environment: true,
         }
@@ -40,6 +42,13 @@ impl HiringWorkflow {
     pub fn with_stake_policy(self, stake_policy: Option<StakePolicy<u64, u64>>) -> Self {
         Self {
             stake_policy,
+            ..self
+        }
+    }
+
+    pub fn with_reward_policy(self, reward_policy: Option<RewardPolicy<u64>>) -> Self {
+        Self {
+            reward_policy,
             ..self
         }
     }
@@ -134,6 +143,7 @@ impl HiringWorkflow {
         // create the opening
         let add_worker_opening_fixture = AddOpeningFixture::default()
             .with_stake_policy(self.stake_policy.clone())
+            .with_reward_policy(self.reward_policy.clone())
             .with_opening_type(self.opening_type)
             .with_origin(origin.clone());
 

--- a/runtime-modules/working-team/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-team/src/tests/hiring_workflow.rs
@@ -5,15 +5,15 @@ use crate::tests::fixtures::{
     setup_members, AddOpeningFixture, ApplyOnOpeningFixture, FillOpeningFixture, HireLeadFixture,
 };
 use crate::tests::mock::TestWorkingTeam;
+use crate::types::StakeParameters;
 use crate::{JobOpeningType, RewardPolicy, StakePolicy};
 
 #[derive(Clone)]
 struct HiringWorkflowApplication {
-    stake: Option<u64>,
+    stake_parameters: Option<StakeParameters<u64, u64>>,
     worker_handle: Vec<u8>,
     origin: RawOrigin<u64>,
     member_id: u64,
-    staking_account_id: u64,
 }
 
 pub struct HiringWorkflow {
@@ -81,7 +81,7 @@ impl HiringWorkflow {
     }
 
     pub fn add_application(self, worker_handle: Vec<u8>) -> Self {
-        self.add_application_full(worker_handle, RawOrigin::Signed(1), 1, 1)
+        self.add_application_full(worker_handle, RawOrigin::Signed(1), 1, Some(1))
     }
 
     pub fn add_application_full(
@@ -89,15 +89,23 @@ impl HiringWorkflow {
         worker_handle: Vec<u8>,
         origin: RawOrigin<u64>,
         member_id: u64,
-        staking_account_id: u64,
+        staking_account_id: Option<u64>,
     ) -> Self {
+        let stake_parameters = staking_account_id.map(|staking_account_id| StakeParameters {
+            stake: self
+                .stake_policy
+                .clone()
+                .map(|policy| policy.stake_amount)
+                .unwrap_or_default(),
+            staking_account_id,
+        });
+
         let mut applications = self.applications;
         applications.push(HiringWorkflowApplication {
             worker_handle,
-            stake: self.stake_policy.clone().map(|policy| policy.stake_amount),
             origin,
             member_id,
-            staking_account_id,
+            stake_parameters,
         });
 
         Self {
@@ -154,8 +162,7 @@ impl HiringWorkflow {
         for application in self.applications.clone() {
             let apply_on_worker_opening_fixture =
                 ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-                    .with_stake(application.stake)
-                    .with_stake_account_id(application.staking_account_id)
+                    .with_stake_parameters(application.stake_parameters)
                     .with_text(application.worker_handle)
                     .with_origin(application.origin, application.member_id);
 

--- a/runtime-modules/working-team/src/tests/mock.rs
+++ b/runtime-modules/working-team/src/tests/mock.rs
@@ -108,6 +108,7 @@ pub type Balances = balances::Module<Test>;
 pub type System = system::Module<Test>;
 
 parameter_types! {
+    pub const RewardPeriod: u32 = 2;
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const MinUnstakingPeriodLimit: u64 = 3;
     pub const LockId: [u8; 8] = [1; 8];
@@ -121,6 +122,7 @@ impl Trait<TestWorkingTeamInstance> for Test {
     type StakingHandler = Test;
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
+    type RewardPeriod = RewardPeriod;
 }
 
 pub const ACTOR_ORIGIN_ERROR: &'static str = "Invalid membership";

--- a/runtime-modules/working-team/src/tests/mock.rs
+++ b/runtime-modules/working-team/src/tests/mock.rs
@@ -109,6 +109,7 @@ pub type System = system::Module<Test>;
 
 parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
+    pub const MinUnstakingPeriodLimit: u64 = 3;
     pub const LockId: [u8; 8] = [1; 8];
 }
 
@@ -119,6 +120,7 @@ impl Trait<TestWorkingTeamInstance> for Test {
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
     type StakingHandler = Test;
     type MemberOriginValidator = ();
+    type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
 }
 
 pub const ACTOR_ORIGIN_ERROR: &'static str = "Invalid membership";

--- a/runtime-modules/working-team/src/tests/mock.rs
+++ b/runtime-modules/working-team/src/tests/mock.rs
@@ -145,6 +145,7 @@ pub type TestWorkingTeam = Module<Test, TestWorkingTeamInstance>;
 pub const STAKING_ACCOUNT_ID_FOR_FAILED_VALIDITY_CHECK: u64 = 111;
 pub const STAKING_ACCOUNT_ID_FOR_FAILED_AMOUNT_CHECK: u64 = 222;
 pub const STAKING_ACCOUNT_ID_FOR_CONFLICTING_STAKES: u64 = 333;
+pub const STAKING_ACCOUNT_ID_FOR_ZERO_STAKE: u64 = 444;
 pub const LOCK_ID: LockIdentifier = [1; 8];
 
 impl StakingHandler<Test> for Test {
@@ -235,6 +236,14 @@ impl StakingHandler<Test> for Test {
         }
 
         true
+    }
+
+    fn current_stake(account_id: &u64) -> u64 {
+        if *account_id == STAKING_ACCOUNT_ID_FOR_ZERO_STAKE {
+            return 0;
+        }
+
+        100 // random non-zero value
     }
 }
 

--- a/runtime-modules/working-team/src/tests/mod.rs
+++ b/runtime-modules/working-team/src/tests/mod.rs
@@ -1759,7 +1759,7 @@ fn rewards_payments_with_no_budget() {
 }
 
 #[test]
-fn rewards_payments_with_insufficient_budget() {
+fn rewards_payments_with_insufficient_budget_and_restored_budget() {
     build_test_externalities().execute_with(|| {
         let reward_per_block = 10;
         let reward_policy = Some(RewardPolicy { reward_per_block });
@@ -1770,7 +1770,7 @@ fn rewards_payments_with_insufficient_budget() {
 
         let worker = TestWorkingTeam::worker_by_id(worker_id);
 
-        let account_id = worker.role_account_id;
+        let account_id = worker.reward_account_id;
 
         assert_eq!(Balances::usable_balance(&account_id), 0);
 
@@ -1792,6 +1792,17 @@ fn rewards_payments_with_insufficient_budget() {
         assert_eq!(
             worker.missed_reward.unwrap(),
             (block_number - paid_blocks) * reward_per_block
+        );
+
+        SetBudgetFixture::default().with_budget(1000000).execute();
+
+        // Checkpoint with restored budget.
+        let block_number2 = 20;
+        run_to_block(block_number2);
+
+        assert_eq!(
+            Balances::usable_balance(&account_id),
+            block_number2 * reward_per_block
         );
     });
 }

--- a/runtime-modules/working-team/src/tests/mod.rs
+++ b/runtime-modules/working-team/src/tests/mod.rs
@@ -1303,32 +1303,6 @@ fn decrease_worker_stake_fails_with_invalid_worker_id() {
 }
 
 #[test]
-fn decrease_worker_stake_fails_external_check() {
-    build_test_externalities().execute_with(|| {
-        let account_id = 1;
-        let total_balance = 300;
-        let stake = 200;
-
-        let stake_policy = Some(StakePolicy {
-            stake_amount: stake,
-            unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let worker_id = HireRegularWorkerFixture::default()
-            .with_stake_policy(stake_policy)
-            .hire();
-
-        let invalid_new_stake = 2000;
-        let decrease_stake_fixture = DecreaseWorkerStakeFixture::default_for_worker_id(worker_id)
-            .with_balance(invalid_new_stake);
-
-        decrease_stake_fixture.call_and_assert(Err(DispatchError::Other("External check failed")));
-    });
-}
-
-#[test]
 fn decrease_worker_stake_fails_with_not_set_lead() {
     build_test_externalities().execute_with(|| {
         let invalid_worker_id = 11;

--- a/runtime-modules/working-team/src/types.rs
+++ b/runtime-modules/working-team/src/types.rs
@@ -237,3 +237,37 @@ pub trait StakingHandler<T: system::Trait + membership::Trait + GovernanceCurren
     fn is_enough_balance_for_stake(account_id: &T::AccountId, amount: BalanceOfCurrency<T>)
         -> bool;
 }
+
+/// Parameters container for the apply_on_opening extrinsic.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Debug, Clone, Default, PartialEq, Eq)]
+pub struct ApplyOnOpeningParams<MemberId, OpeningId, AccountId, Balance> {
+    /// Applying member id.
+    pub member_id: MemberId,
+
+    /// Opening id to apply on.
+    pub opening_id: OpeningId,
+
+    /// Role account id.
+    pub role_account_id: AccountId,
+
+    /// Reward account id.
+    pub reward_account_id: AccountId,
+
+    /// Staking account id.
+    pub staking_account_id: AccountId,
+
+    /// Application description.
+    pub description: Vec<u8>,
+
+    /// Stake balance.
+    pub stake: Option<Balance>,
+}
+
+/// ApplyOnOpeningParams type alias.
+pub type ApplyOnOpeningParameters<T, I> = ApplyOnOpeningParams<
+    MemberId<T>,
+    <T as crate::Trait<I>>::OpeningId,
+    <T as system::Trait>::AccountId,
+    BalanceOfCurrency<T>,
+>;

--- a/runtime-modules/working-team/src/types.rs
+++ b/runtime-modules/working-team/src/types.rs
@@ -98,6 +98,9 @@ pub struct Application<AccountId, MemberId> {
     /// Account used to authenticate in this role.
     pub role_account_id: AccountId,
 
+    /// Reward account id.
+    pub reward_account_id: AccountId,
+
     /// Account used to stake in this role.
     pub staking_account_id: AccountId,
 
@@ -112,12 +115,14 @@ impl<AccountId: Clone, MemberId: Clone> Application<AccountId, MemberId> {
     /// Creates a new job application using parameters.
     pub fn new(
         role_account_id: &AccountId,
+        reward_account_id: &AccountId,
         staking_account_id: &AccountId,
         member_id: &MemberId,
         description_hash: Vec<u8>,
     ) -> Self {
         Application {
             role_account_id: role_account_id.clone(),
+            reward_account_id: reward_account_id.clone(),
             staking_account_id: staking_account_id.clone(),
             member_id: member_id.clone(),
             description_hash,
@@ -137,6 +142,9 @@ pub struct Worker<AccountId, MemberId, BlockNumber, Balance> {
 
     /// Account used to stake in this role.
     pub staking_account_id: AccountId,
+
+    /// Reward account id.
+    pub reward_account_id: AccountId,
 
     /// Specifies the block when the worker chose to leave.
     pub started_leaving_at: Option<BlockNumber>,
@@ -159,6 +167,7 @@ impl<AccountId: Clone, MemberId: Clone, BlockNumber, Balance>
     pub fn new(
         member_id: &MemberId,
         role_account_id: &AccountId,
+        reward_account_id: &AccountId,
         staking_account_id: &AccountId,
         job_unstaking_period: BlockNumber,
         reward_per_block: Option<Balance>,
@@ -166,6 +175,7 @@ impl<AccountId: Clone, MemberId: Clone, BlockNumber, Balance>
         Worker {
             member_id: member_id.clone(),
             role_account_id: role_account_id.clone(),
+            reward_account_id: reward_account_id.clone(),
             staking_account_id: staking_account_id.clone(),
             started_leaving_at: None,
             job_unstaking_period,

--- a/runtime-modules/working-team/src/types.rs
+++ b/runtime-modules/working-team/src/types.rs
@@ -158,6 +158,9 @@ pub struct Worker<AccountId, MemberId, BlockNumber, Balance> {
 
     /// Total missed reward amount.
     pub missed_reward: Option<Balance>,
+
+    /// Specifies the block when the worker was created.
+    pub created_at: BlockNumber,
 }
 
 impl<AccountId: Clone, MemberId: Clone, BlockNumber, Balance>
@@ -171,6 +174,7 @@ impl<AccountId: Clone, MemberId: Clone, BlockNumber, Balance>
         staking_account_id: &Option<AccountId>,
         job_unstaking_period: BlockNumber,
         reward_per_block: Option<Balance>,
+        created_at: BlockNumber,
     ) -> Self {
         Worker {
             member_id: member_id.clone(),
@@ -181,6 +185,7 @@ impl<AccountId: Clone, MemberId: Clone, BlockNumber, Balance>
             job_unstaking_period,
             reward_per_block,
             missed_reward: None,
+            created_at,
         }
     }
 

--- a/runtime-modules/working-team/src/types.rs
+++ b/runtime-modules/working-team/src/types.rs
@@ -102,7 +102,7 @@ pub struct Application<AccountId, MemberId> {
     pub reward_account_id: AccountId,
 
     /// Account used to stake in this role.
-    pub staking_account_id: AccountId,
+    pub staking_account_id: Option<AccountId>,
 
     /// Member applying.
     pub member_id: MemberId,
@@ -116,7 +116,7 @@ impl<AccountId: Clone, MemberId: Clone> Application<AccountId, MemberId> {
     pub fn new(
         role_account_id: &AccountId,
         reward_account_id: &AccountId,
-        staking_account_id: &AccountId,
+        staking_account_id: &Option<AccountId>,
         member_id: &MemberId,
         description_hash: Vec<u8>,
     ) -> Self {
@@ -141,7 +141,7 @@ pub struct Worker<AccountId, MemberId, BlockNumber, Balance> {
     pub role_account_id: AccountId,
 
     /// Account used to stake in this role.
-    pub staking_account_id: AccountId,
+    pub staking_account_id: Option<AccountId>,
 
     /// Reward account id.
     pub reward_account_id: AccountId,
@@ -168,7 +168,7 @@ impl<AccountId: Clone, MemberId: Clone, BlockNumber, Balance>
         member_id: &MemberId,
         role_account_id: &AccountId,
         reward_account_id: &AccountId,
-        staking_account_id: &AccountId,
+        staking_account_id: &Option<AccountId>,
         job_unstaking_period: BlockNumber,
         reward_per_block: Option<Balance>,
     ) -> Self {
@@ -264,14 +264,22 @@ pub struct ApplyOnOpeningParams<MemberId, OpeningId, AccountId, Balance> {
     /// Reward account id.
     pub reward_account_id: AccountId,
 
-    /// Staking account id.
-    pub staking_account_id: AccountId,
-
     /// Application description.
     pub description: Vec<u8>,
 
+    /// Stake information for the application.
+    pub stake_parameters: Option<StakeParameters<AccountId, Balance>>,
+}
+
+/// Contains information for the stakes when applying for opening.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Debug, Clone, Default, PartialEq, Eq)]
+pub struct StakeParameters<AccountId, Balance> {
     /// Stake balance.
-    pub stake: Option<Balance>,
+    pub stake: Balance,
+
+    /// Staking account id.
+    pub staking_account_id: AccountId,
 }
 
 /// ApplyOnOpeningParams type alias.

--- a/runtime-modules/working-team/src/types.rs
+++ b/runtime-modules/working-team/src/types.rs
@@ -281,3 +281,14 @@ pub type ApplyOnOpeningParameters<T, I> = ApplyOnOpeningParams<
     <T as system::Trait>::AccountId,
     BalanceOfCurrency<T>,
 >;
+
+/// Contains information for the slashing.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Debug, Clone, Default, PartialEq, Eq)]
+pub struct Penalty<Balance> {
+    /// Slashing rationale
+    pub slashing_text: Vec<u8>,
+
+    /// Slashing balance
+    pub slashing_amount: Balance,
+}

--- a/runtime-modules/working-team/src/types.rs
+++ b/runtime-modules/working-team/src/types.rs
@@ -141,6 +141,11 @@ impl<AccountId: Clone, MemberId: Clone, BlockNumber> Worker<AccountId, MemberId,
             job_unstaking_period,
         }
     }
+
+    /// Defines whether the worker is leaving the role.
+    pub fn is_leaving(&self) -> bool {
+        self.started_leaving_at.is_some()
+    }
 }
 
 /// Stake policy for the job opening.

--- a/runtime-modules/working-team/src/types.rs
+++ b/runtime-modules/working-team/src/types.rs
@@ -211,7 +211,7 @@ pub struct StakePolicy<BlockNumber, Balance> {
     pub stake_amount: Balance,
 
     /// Unstaking period for the stake. Zero means no unstaking period.
-    pub unstaking_period: BlockNumber,
+    pub leaving_unstaking_period: BlockNumber,
 }
 
 /// Defines abstract staking handler to manage user stakes for different activities

--- a/runtime-modules/working-team/src/types.rs
+++ b/runtime-modules/working-team/src/types.rs
@@ -251,6 +251,9 @@ pub trait StakingHandler<T: system::Trait + membership::Trait + GovernanceCurren
     /// is 'already locked funds' + 'usable funds'.
     fn is_enough_balance_for_stake(account_id: &T::AccountId, amount: BalanceOfCurrency<T>)
         -> bool;
+
+    /// Returns the current stake on the account.
+    fn current_stake(account_id: &T::AccountId) -> BalanceOfCurrency<T>;
 }
 
 /// Parameters container for the apply_on_opening extrinsic.


### PR DESCRIPTION
Changes:
- change membership validity check to `ensure_actor_origin`
- pay when we can unpaid money automatically
- slashing with a sum on termination
- slashing text on slashing and termination with slashing
- [new storage field which is set by leader](https://github.com/Joystream/joystream/issues/1479)
- `staking_account_id` should be demanded only when an opening has stakes
- pay unpaid money during the worker deactivation (termination or leaving)
- add missing extrinsics: `update_reward_account` and `update_reward_amount`
- payment should be once in several blocks
- if stakes decrease to zero we should prevent unstaking period to happen