### PR TITLE
Keep old enum variants for ProposalDetails and mark deprecated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "chain-spec-builder"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "ansi_term 0.12.1",
  "enum-utils",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "3.3.1"
+version = "3.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "7.5.2"
+version = "7.6.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '3.3.1'
+version = '3.4.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -255,8 +255,7 @@ decl_storage! {
             map hasher(blake2_128_concat) T::ProposalId => T::ThreadId;
 
         /// Map proposal id to proposal details
-        pub ProposalDetailsByProposalId get(fn proposal_details_by_proposal_id):
-            map hasher(blake2_128_concat) T::ProposalId => ProposalDetailsOf<T>;
+        pub ProposalDetailsByProposalId: map hasher(blake2_128_concat) T::ProposalId => ProposalDetailsOf<T>;
 
         /// Voting period for the 'set validator count' proposal
         pub SetValidatorCountProposalVotingPeriod get(fn set_validator_count_proposal_voting_period)

--- a/runtime-modules/proposals/codex/src/proposal_types/mod.rs
+++ b/runtime-modules/proposals/codex/src/proposal_types/mod.rs
@@ -26,6 +26,7 @@ pub type ProposalDetailsOf<T> = ProposalDetails<
     working_group::ApplicationId<T>,
     crate::BalanceOf<T>,
     working_group::WorkerId<T>,
+    crate::MemberId<T>,
 >;
 
 /// Proposal details provide voters the information required for the perceived voting.
@@ -40,6 +41,7 @@ pub enum ProposalDetails<
     ApplicationId,
     StakeBalance,
     WorkerId,
+    MemberId,
 > {
     /// The text of the `text` proposal
     Text(Vec<u8>),
@@ -53,10 +55,20 @@ pub enum ProposalDetails<
     /// Balance and destination account for the `spending` proposal
     Spending(MintedBalance, AccountId),
 
+    /// ********** Deprecated during the Babylon release.
+    /// It is kept only for backward compatibility in the Pioneer. **********
+    /// New leader memberId and account_id for the `set lead` proposal
+    DeprecatedSetLead(Option<(MemberId, AccountId)>),
+
+    /// ********** Deprecated during the Babylon release.
+    /// It is kept only for backward compatibility in the Pioneer. **********
+    /// Balance for the `set content working group mint capacity` proposal
+    DeprecatedSetContentWorkingGroupMintCapacity(MintedBalance),
+
     /// ********** Deprecated during the Nicaea release.
     /// It is kept only for backward compatibility in the Pioneer. **********
     /// AccountId for the `evict storage provider` proposal
-    EvictStorageProvider(AccountId),
+    DeprecatedEvictStorageProvider(AccountId),
 
     /// Validator count for the `set validator count` proposal
     SetValidatorCount(u32),
@@ -64,7 +76,7 @@ pub enum ProposalDetails<
     /// ********** Deprecated during the Nicaea release.
     /// It is kept only for backward compatibility in the Pioneer. **********
     /// Role parameters for the `set storage role parameters` proposal
-    SetStorageRoleParameters(RoleParameters<CurrencyBalance, BlockNumber>),
+    DeprecatedSetStorageRoleParameters(RoleParameters<CurrencyBalance, BlockNumber>),
 
     /// Add opening for the working group leader position.
     AddWorkingGroupLeaderOpening(AddOpeningParameters<BlockNumber, CurrencyBalance>),
@@ -102,6 +114,7 @@ impl<
         ApplicationId,
         StakeBalance,
         WorkerId,
+        MemberId,
     > Default
     for ProposalDetails<
         MintedBalance,
@@ -112,6 +125,7 @@ impl<
         ApplicationId,
         StakeBalance,
         WorkerId,
+        MemberId,
     >
 {
     fn default() -> Self {

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -42,7 +42,7 @@ where
     invalid_stake_call: InvalidStakeCall,
     successful_call: SuccessfulCall,
     proposal_parameters: ProposalParameters<u64, u64>,
-    proposal_details: ProposalDetails<u64, u64, u64, u64, u64, u64, u64, u64>,
+    proposal_details: ProposalDetails<u64, u64, u64, u64, u64, u64, u64, u64, u64>,
 }
 
 impl<InsufficientRightsCall, EmptyStakeCall, InvalidStakeCall, SuccessfulCall>

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '7.5.2'
+version = '7.6.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -47,15 +47,27 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
             ProposalDetails::RuntimeUpgrade(wasm_code) => Call::ProposalsCodex(
                 proposals_codex::Call::execute_runtime_upgrade_proposal(wasm_code),
             ),
+            // ********** Deprecated during the Babylon release.
+            ProposalDetails::DeprecatedSetLead(_) => {
+                print("Error: Calling deprecated SetLead encoding option.");
+                return Vec::new();
+            }
+            // ********** Deprecated during the Babylon release.
+            ProposalDetails::DeprecatedSetContentWorkingGroupMintCapacity(_) => {
+                print(
+                    "Error: Calling deprecated SetContentWorkingGroupMintCapacity encoding option.",
+                );
+                return Vec::new();
+            }
             // ********** Deprecated during the Nicaea release.
             // It is kept only for backward compatibility in the Pioneer. **********
-            ProposalDetails::EvictStorageProvider(_) => {
+            ProposalDetails::DeprecatedEvictStorageProvider(_) => {
                 print("Error: Calling deprecated EvictStorageProvider encoding option.");
                 return Vec::new();
             }
             // ********** Deprecated during the Nicaea release.
             // It is kept only for backward compatibility in the Pioneer. **********
-            ProposalDetails::SetStorageRoleParameters(_) => {
+            ProposalDetails::DeprecatedSetStorageRoleParameters(_) => {
                 print("Error: Calling deprecated SetStorageRoleParameters encoding option.");
                 return Vec::new();
             }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -75,8 +75,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 7,
-    spec_version: 5,
-    impl_version: 2,
+    spec_version: 6,
+    impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,
 };

--- a/utils/chain-spec-builder/Cargo.toml
+++ b/utils/chain-spec-builder/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'chain-spec-builder'
-version = '3.0.0'
+version = '3.1.0'
 
 [dependencies]
 ansi_term = "0.12.1"


### PR DESCRIPTION
The `ProposalDetails` enum is used to store the proposal details when a proposal is initially created and inserted into the `ProposalDetailsByProposalId` map. The runtime never reads or iterates this map from that point on, and therefore it is safe to remove/re-order the variants of `ProposalDetails`. (The proposal also stored as an encoded `Call` which is what actually gets read later to execute)

Pioneer and the joystream/cli are the clients that actually read from `ProposalDetailsByProposalId` map. If variant ordering changes between runtimes, the clients must be aware of it to decode the value correctly. We haven't yet added support for this.. see relevant [discussion here](https://github.com/Joystream/joystream/pull/1505#issuecomment-704165931)

So this PR just adds back the variants removed in https://github.com/Joystream/joystream/pull/1385 and bumps the runtime spec version.