### PR TITLE
Content directory refactoring

### DIFF
--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -330,6 +330,8 @@ pub fn testnet_genesis(
         }),
         content_directory: Some({
             ContentDirectoryConfig {
+                class_by_id: vec![],
+                entity_by_id: vec![],
                 curator_group_by_id: vec![],
                 next_class_id: 1,
                 next_entity_id: 1,

--- a/runtime-modules/content-directory/src/class.rs
+++ b/runtime-modules/content-directory/src/class.rs
@@ -3,8 +3,8 @@ use super::*;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(Encode, Decode, Eq, PartialEq, Default, Clone)]
 pub struct Class<
-    EntityId: Default + BaseArithmetic,
-    ClassId: Default + BaseArithmetic + Clone,
+    EntityId: Default + BaseArithmetic + Clone + Copy,
+    ClassId: Default + BaseArithmetic + Clone + Copy,
     CuratorGroupId: Ord + Default,
 > {
     /// Permissions for an instance of a Class.
@@ -31,24 +31,9 @@ pub struct Class<
     default_entity_creation_voucher_upper_bound: EntityId,
 }
 
-// impl<T: Trait> Default for Class<T> {
-//     fn default() -> Self {
-//         Self {
-//             class_permissions: ClassPermissions::<T>::default(),
-//             properties: vec![],
-//             schemas: vec![],
-//             name: vec![],
-//             description: vec![],
-//             maximum_entities_count: T::EntityId::default(),
-//             current_number_of_entities: T::EntityId::default(),
-//             default_entity_creation_voucher_upper_bound: T::EntityId::default(),
-//         }
-//     }
-// }
-
 impl<
-        EntityId: Default + BaseArithmetic,
-        ClassId: Default + BaseArithmetic + Clone,
+        EntityId: Default + BaseArithmetic + Clone + Copy,
+        ClassId: Default + BaseArithmetic + Clone + Copy,
         CuratorGroupId: Ord + Default,
     > Class<EntityId, ClassId, CuratorGroupId>
 {

--- a/runtime-modules/content-directory/src/class.rs
+++ b/runtime-modules/content-directory/src/class.rs
@@ -1,14 +1,18 @@
 use super::*;
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Eq, PartialEq, Clone)]
-pub struct Class<T: Trait> {
+#[derive(Encode, Decode, Eq, PartialEq, Default, Clone)]
+pub struct Class<
+    EntityId: Default + BaseArithmetic,
+    ClassId: Default + BaseArithmetic,
+    CuratorGroupId: Ord + Default,
+> {
     /// Permissions for an instance of a Class.
-    class_permissions: ClassPermissions<T>,
+    class_permissions: ClassPermissions<CuratorGroupId>,
     /// All properties that have been used on this class across different class schemas.
     /// Unlikely to be more than roughly 20 properties per class, often less.
     /// For Person, think "height", "weight", etc.
-    properties: Vec<Property<T>>,
+    properties: Vec<Property<ClassId>>,
 
     /// All schemas that are available for this class, think v0.0 Person, v.1.0 Person, etc.
     schemas: Vec<Schema>,
@@ -18,38 +22,43 @@ pub struct Class<T: Trait> {
     description: Vec<u8>,
 
     /// The maximum number of entities which can be created.
-    maximum_entities_count: T::EntityId,
+    maximum_entities_count: EntityId,
 
     /// The current number of entities which exist.
-    current_number_of_entities: T::EntityId,
+    current_number_of_entities: EntityId,
 
     /// How many entities a given controller may create at most.
-    default_entity_creation_voucher_upper_bound: T::EntityId,
+    default_entity_creation_voucher_upper_bound: EntityId,
 }
 
-impl<T: Trait> Default for Class<T> {
-    fn default() -> Self {
-        Self {
-            class_permissions: ClassPermissions::<T>::default(),
-            properties: vec![],
-            schemas: vec![],
-            name: vec![],
-            description: vec![],
-            maximum_entities_count: T::EntityId::default(),
-            current_number_of_entities: T::EntityId::default(),
-            default_entity_creation_voucher_upper_bound: T::EntityId::default(),
-        }
-    }
-}
+// impl<T: Trait> Default for Class<T> {
+//     fn default() -> Self {
+//         Self {
+//             class_permissions: ClassPermissions::<T>::default(),
+//             properties: vec![],
+//             schemas: vec![],
+//             name: vec![],
+//             description: vec![],
+//             maximum_entities_count: T::EntityId::default(),
+//             current_number_of_entities: T::EntityId::default(),
+//             default_entity_creation_voucher_upper_bound: T::EntityId::default(),
+//         }
+//     }
+// }
 
-impl<T: Trait> Class<T> {
+impl<
+        EntityId: Default + BaseArithmetic,
+        ClassId: Default + BaseArithmetic,
+        CuratorGroupId: Ord + Default,
+    > Class<EntityId, ClassId, CuratorGroupId>
+{
     /// Create new `Class` with provided parameters
     pub fn new(
-        class_permissions: ClassPermissions<T>,
+        class_permissions: ClassPermissions<CuratorGroupId>,
         name: Vec<u8>,
         description: Vec<u8>,
-        maximum_entities_count: T::EntityId,
-        default_entity_creation_voucher_upper_bound: T::EntityId,
+        maximum_entities_count: EntityId,
+        default_entity_creation_voucher_upper_bound: EntityId,
     ) -> Self {
         Self {
             class_permissions,
@@ -58,7 +67,7 @@ impl<T: Trait> Class<T> {
             name,
             description,
             maximum_entities_count,
-            current_number_of_entities: T::EntityId::zero(),
+            current_number_of_entities: EntityId::zero(),
             default_entity_creation_voucher_upper_bound,
         }
     }
@@ -87,7 +96,7 @@ impl<T: Trait> Class<T> {
     }
 
     /// Used to update `Class` permissions
-    pub fn update_permissions(&mut self, permissions: ClassPermissions<T>) {
+    pub fn update_permissions(&mut self, permissions: ClassPermissions<CuratorGroupId>) {
         self.class_permissions = permissions
     }
 
@@ -103,72 +112,75 @@ impl<T: Trait> Class<T> {
 
     /// Increment number of entities, associated with this class
     pub fn increment_entities_count(&mut self) {
-        self.current_number_of_entities += T::EntityId::one();
+        self.current_number_of_entities += EntityId::one();
     }
 
     /// Decrement number of entities, associated with this class
     pub fn decrement_entities_count(&mut self) {
-        self.current_number_of_entities -= T::EntityId::one();
+        self.current_number_of_entities -= EntityId::one();
     }
 
     /// Retrieve `ClassPermissions` by mutable reference
-    pub fn get_permissions_mut(&mut self) -> &mut ClassPermissions<T> {
+    pub fn get_permissions_mut(&mut self) -> &mut ClassPermissions<CuratorGroupId> {
         &mut self.class_permissions
     }
 
     /// Retrieve `ClassPermissions` by reference
-    pub fn get_permissions_ref(&self) -> &ClassPermissions<T> {
+    pub fn get_permissions_ref(&self) -> &ClassPermissions<CuratorGroupId> {
         &self.class_permissions
     }
 
     /// Retrieve `ClassPermissions` by value
-    pub fn get_permissions(self) -> ClassPermissions<T> {
+    pub fn get_permissions(self) -> ClassPermissions<CuratorGroupId> {
         self.class_permissions
     }
 
     /// Retrieve `Class` properties by value  
-    pub fn get_properties(self) -> Vec<Property<T>> {
+    pub fn get_properties(self) -> Vec<Property<ClassId>> {
         self.properties
     }
 
     /// Replace `Class` properties with updated_class_properties
-    pub fn set_properties(&mut self, updated_class_properties: Vec<Property<T>>) {
+    pub fn set_properties(&mut self, updated_class_properties: Vec<Property<ClassId>>) {
         self.properties = updated_class_properties;
     }
 
     /// Get per controller `Class`- specific limit
-    pub fn get_default_entity_creation_voucher_upper_bound(&self) -> T::EntityId {
+    pub fn get_default_entity_creation_voucher_upper_bound(&self) -> EntityId {
         self.default_entity_creation_voucher_upper_bound
     }
 
     /// Retrive the maximum entities count, which can be created for given `Class`
-    pub fn get_maximum_entities_count(&self) -> T::EntityId {
+    pub fn get_maximum_entities_count(&self) -> EntityId {
         self.maximum_entities_count
     }
 
     /// Set per controller `Class`- specific limit
     pub fn set_default_entity_creation_voucher_upper_bound(
         &mut self,
-        new_default_entity_creation_voucher_upper_bound: T::EntityId,
+        new_default_entity_creation_voucher_upper_bound: EntityId,
     ) {
         self.default_entity_creation_voucher_upper_bound =
             new_default_entity_creation_voucher_upper_bound;
     }
 
     /// Set the maximum entities count, which can be created for given `Class`
-    pub fn set_maximum_entities_count(&mut self, maximum_entities_count: T::EntityId) {
+    pub fn set_maximum_entities_count(&mut self, maximum_entities_count: EntityId) {
         self.maximum_entities_count = maximum_entities_count;
     }
 
     /// Ensure `Class` `Schema` under given index exist, return corresponding `Schema`
-    pub fn ensure_schema_exists(&self, schema_index: SchemaId) -> Result<&Schema, Error<T>> {
+    pub fn ensure_schema_exists<T: Trait>(
+        &self,
+        schema_index: SchemaId,
+    ) -> Result<&Schema, Error<T>> {
         self.schemas
             .get(schema_index as usize)
             .ok_or(Error::<T>::UnknownClassSchemaId)
     }
 
     /// Ensure `schema_id` is a valid index of `Class` schemas vector
-    pub fn ensure_schema_id_exists(&self, schema_id: SchemaId) -> Result<(), Error<T>> {
+    pub fn ensure_schema_id_exists<T: Trait>(&self, schema_id: SchemaId) -> Result<(), Error<T>> {
         ensure!(
             schema_id < self.schemas.len() as SchemaId,
             Error::<T>::UnknownClassSchemaId
@@ -177,7 +189,7 @@ impl<T: Trait> Class<T> {
     }
 
     /// Ensure `Schema`s limit per `Class` not reached
-    pub fn ensure_schemas_limit_not_reached(&self) -> Result<(), Error<T>> {
+    pub fn ensure_schemas_limit_not_reached<T: Trait>(&self) -> Result<(), Error<T>> {
         ensure!(
             (self.schemas.len() as MaxNumber) < T::MaxNumberOfSchemasPerClass::get(),
             Error::<T>::ClassSchemasLimitReached
@@ -186,9 +198,9 @@ impl<T: Trait> Class<T> {
     }
 
     /// Ensure properties limit per `Schema` not reached
-    pub fn ensure_properties_limit_not_reached(
+    pub fn ensure_properties_limit_not_reached<T: Trait>(
         &self,
-        new_properties: &[Property<T>],
+        new_properties: &[Property<ClassId>],
     ) -> Result<(), Error<T>> {
         ensure!(
             T::MaxNumberOfPropertiesPerSchema::get()
@@ -199,7 +211,9 @@ impl<T: Trait> Class<T> {
     }
 
     /// Ensure `Class` specific entities limit not reached
-    pub fn ensure_maximum_entities_count_limit_not_reached(&self) -> Result<(), Error<T>> {
+    pub fn ensure_maximum_entities_count_limit_not_reached<T: Trait>(
+        &self,
+    ) -> Result<(), Error<T>> {
         ensure!(
             self.current_number_of_entities < self.maximum_entities_count,
             Error::<T>::NumberOfEntitiesPerClassLimitReached
@@ -209,11 +223,11 @@ impl<T: Trait> Class<T> {
 
     /// Ensure `Property` under given `PropertyId` is unlocked from actor with given `EntityAccessLevel`
     /// return corresponding `Property` by value
-    pub fn ensure_class_property_type_unlocked_from(
+    pub fn ensure_class_property_type_unlocked_from<T: Trait>(
         &self,
         in_class_schema_property_id: PropertyId,
         entity_access_level: EntityAccessLevel,
-    ) -> Result<Property<T>, Error<T>> {
+    ) -> Result<Property<ClassId>, Error<T>> {
         // Ensure property values were not locked on Class level
         self.ensure_property_values_unlocked()?;
 
@@ -226,13 +240,13 @@ impl<T: Trait> Class<T> {
             .ok_or(Error::<T>::ClassPropertyNotFound)?;
 
         // Ensure Property is unlocked from Actor with given EntityAccessLevel
-        class_property.ensure_unlocked_from(entity_access_level)?;
+        class_property.ensure_unlocked_from::<T>(entity_access_level)?;
 
         Ok(class_property.to_owned())
     }
 
     /// Ensure property values were not locked on `Class` level
-    pub fn ensure_property_values_unlocked(&self) -> Result<(), Error<T>> {
+    pub fn ensure_property_values_unlocked<T: Trait>(&self) -> Result<(), Error<T>> {
         ensure!(
             !self
                 .get_permissions_ref()

--- a/runtime-modules/content-directory/src/class.rs
+++ b/runtime-modules/content-directory/src/class.rs
@@ -4,7 +4,7 @@ use super::*;
 #[derive(Encode, Decode, Eq, PartialEq, Default, Clone)]
 pub struct Class<
     EntityId: Default + BaseArithmetic,
-    ClassId: Default + BaseArithmetic,
+    ClassId: Default + BaseArithmetic + Clone,
     CuratorGroupId: Ord + Default,
 > {
     /// Permissions for an instance of a Class.
@@ -48,7 +48,7 @@ pub struct Class<
 
 impl<
         EntityId: Default + BaseArithmetic,
-        ClassId: Default + BaseArithmetic,
+        ClassId: Default + BaseArithmetic + Clone,
         CuratorGroupId: Ord + Default,
     > Class<EntityId, ClassId, CuratorGroupId>
 {
@@ -224,7 +224,7 @@ impl<
     /// Ensure `Property` under given `PropertyId` is unlocked from actor with given `EntityAccessLevel`
     /// return corresponding `Property` by value
     pub fn ensure_class_property_type_unlocked_from<T: Trait>(
-        &self,
+        self,
         in_class_schema_property_id: PropertyId,
         entity_access_level: EntityAccessLevel,
     ) -> Result<Property<ClassId>, Error<T>> {
@@ -242,7 +242,7 @@ impl<
         // Ensure Property is unlocked from Actor with given EntityAccessLevel
         class_property.ensure_unlocked_from::<T>(entity_access_level)?;
 
-        Ok(class_property.to_owned())
+        Ok(class_property.clone())
     }
 
     /// Ensure property values were not locked on `Class` level

--- a/runtime-modules/content-directory/src/entity.rs
+++ b/runtime-modules/content-directory/src/entity.rs
@@ -2,13 +2,19 @@ use super::*;
 
 /// Represents `Entity`, related to a specific `Class`
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Clone, PartialEq, Eq)]
-pub struct Entity<T: Trait> {
+#[derive(Encode, Decode, Default, Clone, PartialEq, Eq)]
+pub struct Entity<
+    ClassId: Default + BaseArithmetic,
+    MemberId: Default,
+    Hash: Default,
+    EntityId: Default,
+    Nonce: Default + BaseArithmetic,
+> {
     /// Permissions for an instance of an Entity.
-    entity_permissions: EntityPermissions<T>,
+    entity_permissions: EntityPermissions<MemberId>,
 
     /// The class id of this entity.
-    class_id: T::ClassId,
+    class_id: ClassId,
 
     /// What schemas under which entity of the respective class is available, think
     /// v.2.0 Person schema for John, v3.0 Person schema for John
@@ -18,34 +24,41 @@ pub struct Entity<T: Trait> {
 
     /// Values for properties on class that are used by some schema used by this entity
     /// Length is no more than Class.properties.
-    values: BTreeMap<PropertyId, StoredPropertyValue<T>>,
+    values: BTreeMap<PropertyId, StoredPropertyValue<Hash, EntityId, Nonce>>,
 
     /// Number of property values referencing current entity
     reference_counter: InboundReferenceCounter,
 }
 
-impl<T: Trait> Default for Entity<T> {
-    fn default() -> Self {
-        Self {
-            entity_permissions: EntityPermissions::<T>::default(),
-            class_id: T::ClassId::default(),
-            supported_schemas: BTreeSet::new(),
-            values: BTreeMap::new(),
-            reference_counter: InboundReferenceCounter::default(),
-        }
-    }
-}
+// impl<T: Trait> Default for Entity<T> {
+//     fn default() -> Self {
+//         Self {
+//             entity_permissions: EntityPermissions::<T>::default(),
+//             class_id: T::ClassId::default(),
+//             supported_schemas: BTreeSet::new(),
+//             values: BTreeMap::new(),
+//             reference_counter: InboundReferenceCounter::default(),
+//         }
+//     }
+// }
 
-impl<T: Trait> Entity<T> {
+impl<
+        ClassId: Default + BaseArithmetic,
+        MemberId: Default,
+        Hash: Default,
+        EntityId: Default,
+        Nonce: Default + BaseArithmetic,
+    > Entity<ClassId, MemberId, Hash, EntityId, Nonce>
+{
     /// Create new `Entity` instance, related to a given `class_id` with provided parameters,  
     pub fn new(
-        controller: EntityController<T>,
-        class_id: T::ClassId,
+        controller: EntityController<MemberId>,
+        class_id: ClassId,
         supported_schemas: BTreeSet<SchemaId>,
-        values: BTreeMap<PropertyId, StoredPropertyValue<T>>,
+        values: BTreeMap<PropertyId, StoredPropertyValue<Hash, EntityId, Nonce>>,
     ) -> Self {
         Self {
-            entity_permissions: EntityPermissions::<T>::default_with_controller(controller),
+            entity_permissions: EntityPermissions::<MemberId>::default_with_controller(controller),
             class_id,
             supported_schemas,
             values,
@@ -54,7 +67,7 @@ impl<T: Trait> Entity<T> {
     }
 
     /// Get `class_id` of this `Entity`
-    pub fn get_class_id(&self) -> T::ClassId {
+    pub fn get_class_id(&self) -> ClassId {
         self.class_id
     }
 
@@ -64,54 +77,64 @@ impl<T: Trait> Entity<T> {
     }
 
     /// Get `Entity` values by value
-    pub fn get_values(self) -> BTreeMap<PropertyId, StoredPropertyValue<T>> {
+    pub fn get_values(self) -> BTreeMap<PropertyId, StoredPropertyValue<Hash, EntityId, Nonce>> {
         self.values
     }
 
     /// Get `Entity` values by reference
-    pub fn get_values_ref(&self) -> &BTreeMap<PropertyId, StoredPropertyValue<T>> {
+    pub fn get_values_ref(
+        &self,
+    ) -> &BTreeMap<PropertyId, StoredPropertyValue<Hash, EntityId, Nonce>> {
         &self.values
     }
 
     /// Get `Entity` values by mutable reference
-    pub fn get_values_mut(&mut self) -> &mut BTreeMap<PropertyId, StoredPropertyValue<T>> {
+    pub fn get_values_mut(
+        &mut self,
+    ) -> &mut BTreeMap<PropertyId, StoredPropertyValue<Hash, EntityId, Nonce>> {
         &mut self.values
     }
 
     /// Get mutable reference to `Entity` values
-    pub fn set_values(&mut self, new_values: BTreeMap<PropertyId, StoredPropertyValue<T>>) {
+    pub fn set_values(
+        &mut self,
+        new_values: BTreeMap<PropertyId, StoredPropertyValue<Hash, EntityId, Nonce>>,
+    ) {
         self.values = new_values;
     }
 
     /// Get mutable `EntityPermissions` reference, related to given `Entity`
-    pub fn get_permissions_mut(&mut self) -> &mut EntityPermissions<T> {
+    pub fn get_permissions_mut(&mut self) -> &mut EntityPermissions<MemberId> {
         &mut self.entity_permissions
     }
 
     /// Get `EntityPermissions` reference, related to given `Entity`
-    pub fn get_permissions_ref(&self) -> &EntityPermissions<T> {
+    pub fn get_permissions_ref(&self) -> &EntityPermissions<MemberId> {
         &self.entity_permissions
     }
 
     /// Get `EntityPermissions`, related to given `Entity` by value
-    pub fn get_permissions(self) -> EntityPermissions<T> {
+    pub fn get_permissions(self) -> EntityPermissions<MemberId> {
         self.entity_permissions
     }
 
     /// Update existing `EntityPermissions` with newly provided
-    pub fn update_permissions(&mut self, permissions: EntityPermissions<T>) {
+    pub fn update_permissions(&mut self, permissions: EntityPermissions<MemberId>) {
         self.entity_permissions = permissions
     }
 
     /// Ensure `Schema` under given id is not added to given `Entity` yet
-    pub fn ensure_schema_id_is_not_added(&self, schema_id: SchemaId) -> Result<(), Error<T>> {
+    pub fn ensure_schema_id_is_not_added<T: Trait>(
+        &self,
+        schema_id: SchemaId,
+    ) -> Result<(), Error<T>> {
         let schema_not_added = !self.supported_schemas.contains(&schema_id);
         ensure!(schema_not_added, Error::<T>::SchemaAlreadyAddedToTheEntity);
         Ok(())
     }
 
     /// Ensure provided `property_values` are not added to the `Entity` `values` map yet
-    pub fn ensure_property_values_are_not_added(
+    pub fn ensure_property_values_are_not_added<T: Trait>(
         &self,
         property_values: &BTreeMap<PropertyId, InputPropertyValue<T>>,
     ) -> Result<(), Error<T>> {
@@ -125,10 +148,10 @@ impl<T: Trait> Entity<T> {
     }
 
     /// Ensure InputPropertyValue under given `in_class_schema_property_id` is Vector
-    pub fn ensure_property_value_is_vec(
+    pub fn ensure_property_value_is_vec<T: Trait>(
         &self,
         in_class_schema_property_id: PropertyId,
-    ) -> Result<VecStoredPropertyValue<T>, Error<T>> {
+    ) -> Result<VecStoredPropertyValue<Hash, EntityId, Nonce>, Error<T>> {
         self.values
             .get(&in_class_schema_property_id)
             // Throw an error if a property was not found on entity
@@ -141,7 +164,7 @@ impl<T: Trait> Entity<T> {
     }
 
     /// Ensure any `InputPropertyValue` from external entity does not point to the given `Entity`
-    pub fn ensure_rc_is_zero(&self) -> Result<(), Error<T>> {
+    pub fn ensure_rc_is_zero<T: Trait>(&self) -> Result<(), Error<T>> {
         ensure!(
             self.reference_counter.is_total_equal_to_zero(),
             Error::<T>::EntityRcDoesNotEqualToZero
@@ -150,7 +173,7 @@ impl<T: Trait> Entity<T> {
     }
 
     /// Ensure any inbound `InputPropertyValue` with `same_owner` flag set points to the given `Entity`
-    pub fn ensure_inbound_same_owner_rc_is_zero(&self) -> Result<(), Error<T>> {
+    pub fn ensure_inbound_same_owner_rc_is_zero<T: Trait>(&self) -> Result<(), Error<T>> {
         ensure!(
             self.reference_counter.is_same_owner_equal_to_zero(),
             Error::<T>::EntityInboundSameOwnerRcDoesNotEqualToZero

--- a/runtime-modules/content-directory/src/helpers.rs
+++ b/runtime-modules/content-directory/src/helpers.rs
@@ -78,12 +78,15 @@ impl<'a, T: Trait> InputValuesForExistingProperties<'a, T> {
 /// Wrapper for existing `StoredPropertyValue` and its respective `Class` `Property`
 pub struct StoredValueForExistingProperty<'a, T: Trait>(
     &'a Property<T::ClassId>,
-    &'a StoredPropertyValue<T>,
+    &'a StoredPropertyValue<T::Hash, T::EntityId, T::Nonce>,
 );
 
 impl<'a, T: Trait> StoredValueForExistingProperty<'a, T> {
     /// Create single instance of `StoredValueForExistingProperty` from provided `property` and `value`
-    pub fn new(property: &'a Property<T::ClassId>, value: &'a StoredPropertyValue<T>) -> Self {
+    pub fn new(
+        property: &'a Property<T::ClassId>,
+        value: &'a StoredPropertyValue<T::Hash, T::EntityId, T::Nonce>,
+    ) -> Self {
         Self(property, value)
     }
 
@@ -93,12 +96,17 @@ impl<'a, T: Trait> StoredValueForExistingProperty<'a, T> {
     }
 
     /// Retrieve `StoredPropertyValue` reference
-    pub fn get_value(&self) -> &StoredPropertyValue<T> {
+    pub fn get_value(&self) -> &StoredPropertyValue<T::Hash, T::EntityId, T::Nonce> {
         self.1
     }
 
     /// Retrieve `Property` and `StoredPropertyValue` references
-    pub fn unzip(&self) -> (&Property<T::ClassId>, &StoredPropertyValue<T>) {
+    pub fn unzip(
+        &self,
+    ) -> (
+        &Property<T::ClassId>,
+        &StoredPropertyValue<T::Hash, T::EntityId, T::Nonce>,
+    ) {
         (self.0, self.1)
     }
 
@@ -138,7 +146,10 @@ impl<'a, T: Trait> StoredValuesForExistingProperties<'a, T> {
     /// Create `StoredValuesForExistingProperties` helper structure from provided `property_values` and their corresponding `Class` properties.
     pub fn from(
         properties: &'a [Property<T::ClassId>],
-        property_values: &'a BTreeMap<PropertyId, StoredPropertyValue<T>>,
+        property_values: &'a BTreeMap<
+            PropertyId,
+            StoredPropertyValue<T::Hash, T::EntityId, T::Nonce>,
+        >,
     ) -> Result<Self, Error<T>> {
         let mut values_for_existing_properties = StoredValuesForExistingProperties::<T>::default();
 
@@ -165,7 +176,9 @@ impl<'a, T: Trait> StoredValuesForExistingProperties<'a, T> {
             .map(|(&property_id, property_value)| {
                 (
                     property_id,
-                    property_value.get_value().compute_unique_hash(property_id),
+                    property_value
+                        .get_value()
+                        .compute_unique_hash::<T>(property_id),
                 )
             })
             .collect()

--- a/runtime-modules/content-directory/src/helpers.rs
+++ b/runtime-modules/content-directory/src/helpers.rs
@@ -2,16 +2,19 @@ use crate::*;
 use core::ops::{Deref, DerefMut};
 
 /// Wrapper for existing `InputPropertyValue` and its respective `Class` `Property`
-pub struct InputValueForExistingProperty<'a, T: Trait>(&'a Property<T>, &'a InputPropertyValue<T>);
+pub struct InputValueForExistingProperty<'a, T: Trait>(
+    &'a Property<T::ClassId>,
+    &'a InputPropertyValue<T>,
+);
 
 impl<'a, T: Trait> InputValueForExistingProperty<'a, T> {
     /// Create single instance of `InputValueForExistingProperty` from provided `property` and `value`
-    fn new(property: &'a Property<T>, value: &'a InputPropertyValue<T>) -> Self {
+    fn new(property: &'a Property<T::ClassId>, value: &'a InputPropertyValue<T>) -> Self {
         Self(property, value)
     }
 
     /// Retrieve `Property` reference
-    pub fn get_property(&self) -> &Property<T> {
+    pub fn get_property(&self) -> &Property<T::ClassId> {
         self.0
     }
 
@@ -21,7 +24,7 @@ impl<'a, T: Trait> InputValueForExistingProperty<'a, T> {
     }
 
     /// Retrieve `Property` and `InputPropertyValue` references
-    pub fn unzip(&self) -> (&Property<T>, &InputPropertyValue<T>) {
+    pub fn unzip(&self) -> (&Property<T::ClassId>, &InputPropertyValue<T>) {
         (self.0, self.1)
     }
 }
@@ -55,7 +58,7 @@ impl<'a, T: Trait> InputValuesForExistingProperties<'a, T> {
     /// Create `InputValuesForExistingProperties` helper structure from provided `property_values` and their corresponding `Class` properties.
     /// Throws an error, when `Class` `Property` under `property_id`, corresponding to provided `property_value` not found
     pub fn from(
-        properties: &'a [Property<T>],
+        properties: &'a [Property<T::ClassId>],
         property_values: &'a BTreeMap<PropertyId, InputPropertyValue<T>>,
     ) -> Result<Self, Error<T>> {
         let mut values_for_existing_properties = InputValuesForExistingProperties::<T>::default();
@@ -74,18 +77,18 @@ impl<'a, T: Trait> InputValuesForExistingProperties<'a, T> {
 
 /// Wrapper for existing `StoredPropertyValue` and its respective `Class` `Property`
 pub struct StoredValueForExistingProperty<'a, T: Trait>(
-    &'a Property<T>,
+    &'a Property<T::ClassId>,
     &'a StoredPropertyValue<T>,
 );
 
 impl<'a, T: Trait> StoredValueForExistingProperty<'a, T> {
     /// Create single instance of `StoredValueForExistingProperty` from provided `property` and `value`
-    pub fn new(property: &'a Property<T>, value: &'a StoredPropertyValue<T>) -> Self {
+    pub fn new(property: &'a Property<T::ClassId>, value: &'a StoredPropertyValue<T>) -> Self {
         Self(property, value)
     }
 
     /// Retrieve `Property` reference
-    pub fn get_property(&self) -> &Property<T> {
+    pub fn get_property(&self) -> &Property<T::ClassId> {
         self.0
     }
 
@@ -95,7 +98,7 @@ impl<'a, T: Trait> StoredValueForExistingProperty<'a, T> {
     }
 
     /// Retrieve `Property` and `StoredPropertyValue` references
-    pub fn unzip(&self) -> (&Property<T>, &StoredPropertyValue<T>) {
+    pub fn unzip(&self) -> (&Property<T::ClassId>, &StoredPropertyValue<T>) {
         (self.0, self.1)
     }
 
@@ -134,7 +137,7 @@ impl<'a, T: Trait> DerefMut for StoredValuesForExistingProperties<'a, T> {
 impl<'a, T: Trait> StoredValuesForExistingProperties<'a, T> {
     /// Create `StoredValuesForExistingProperties` helper structure from provided `property_values` and their corresponding `Class` properties.
     pub fn from(
-        properties: &'a [Property<T>],
+        properties: &'a [Property<T::ClassId>],
         property_values: &'a BTreeMap<PropertyId, StoredPropertyValue<T>>,
     ) -> Result<Self, Error<T>> {
         let mut values_for_existing_properties = StoredValuesForExistingProperties::<T>::default();

--- a/runtime-modules/content-directory/src/helpers.rs
+++ b/runtime-modules/content-directory/src/helpers.rs
@@ -113,7 +113,8 @@ impl<'a, T: Trait> StoredValueForExistingProperty<'a, T> {
     /// Check if Property is default and non `required`
     pub fn is_default(&self) -> bool {
         let (property, property_value) = self.unzip();
-        !property.required && *property_value == StoredPropertyValue::<T>::default()
+        !property.required
+            && *property_value == StoredPropertyValue::<T::Hash, T::EntityId, T::Nonce>::default()
     }
 }
 

--- a/runtime-modules/content-directory/src/lib.rs
+++ b/runtime-modules/content-directory/src/lib.rs
@@ -289,13 +289,15 @@ decl_storage! {
 
 decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+        /// Predefined errors
+        type Error = Error<T>;
+
+        /// Initializing events
+        fn deposit_event() = default;
 
         // ======
         // Next set of extrinsics can only be invoked by lead.
         // ======
-
-        /// Initializing events
-        fn deposit_event() = default;
 
         /// Add new curator group to runtime storage
         #[weight = 10_000_000] // TODO: adjust weight

--- a/runtime-modules/content-directory/src/lib.rs
+++ b/runtime-modules/content-directory/src/lib.rs
@@ -260,10 +260,10 @@ decl_storage! {
     trait Store for Module<T: Trait> as ContentDirectory {
 
         /// Map, representing ClassId -> Class relation
-        pub ClassById get(fn class_by_id): map hasher(blake2_128_concat) T::ClassId => Class<T::EntityId, T::ClassId, T::CuratorGroupId>;
+        pub ClassById get(fn class_by_id) config(): map hasher(blake2_128_concat) T::ClassId => Class<T::EntityId, T::ClassId, T::CuratorGroupId>;
 
         /// Map, representing EntityId -> Entity relation
-        pub EntityById get(fn entity_by_id): map hasher(blake2_128_concat) T::EntityId => Entity<T::ClassId, T::MemberId, T::Hash, T::EntityId, T::Nonce>;
+        pub EntityById get(fn entity_by_id) config(): map hasher(blake2_128_concat) T::EntityId => Entity<T::ClassId, T::MemberId, T::Hash, T::EntityId, T::Nonce>;
 
         /// Map, representing  CuratorGroupId -> CuratorGroup relation
         pub CuratorGroupById get(fn curator_group_by_id) config(): map hasher(blake2_128_concat) T::CuratorGroupId => CuratorGroup<T>;

--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -377,6 +377,8 @@ impl ExtBuilder {
 
 fn default_content_directory_genesis_config() -> GenesisConfig<Runtime> {
     GenesisConfig {
+        class_by_id: vec![],
+        entity_by_id: vec![],
         curator_group_by_id: vec![],
         next_class_id: 1,
         next_entity_id: 1,

--- a/runtime-modules/content-directory/src/mock.rs
+++ b/runtime-modules/content-directory/src/mock.rs
@@ -17,13 +17,14 @@ use std::cell::RefCell;
 
 /// Runtime Types
 
-type ClassId = <Runtime as Trait>::ClassId;
-type EntityId = <Runtime as Trait>::EntityId;
-type Nonce = <Runtime as Trait>::Nonce;
+pub type ClassId = <Runtime as Trait>::ClassId;
+pub type EntityId = <Runtime as Trait>::EntityId;
+pub type Nonce = <Runtime as Trait>::Nonce;
+pub type Hashed = <Runtime as system::Trait>::Hash;
 
-type CuratorId = <Runtime as ActorAuthenticator>::CuratorId;
+pub type CuratorId = <Runtime as ActorAuthenticator>::CuratorId;
 pub type CuratorGroupId = <Runtime as ActorAuthenticator>::CuratorGroupId;
-type MemberId = <Runtime as ActorAuthenticator>::MemberId;
+pub type MemberId = <Runtime as ActorAuthenticator>::MemberId;
 
 /// Origins
 
@@ -404,7 +405,7 @@ pub fn generate_text(len: usize) -> Vec<u8> {
     vec![b'x'; len]
 }
 
-impl<T: Trait> Property<T> {
+impl<ClassId: Default + BaseArithmetic + Clone + Copy> Property<ClassId> {
     pub fn required(mut self) -> Self {
         self.required = true;
         self
@@ -423,10 +424,10 @@ type RawTestEvent = RawEvent<
     CuratorId,
     ClassId,
     EntityId,
-    EntityController<Runtime>,
+    EntityController<MemberId>,
     EntityCreationVoucher<Runtime>,
     bool,
-    Actor<Runtime>,
+    Actor<CuratorGroupId, CuratorId, MemberId>,
     Nonce,
     Option<ReferenceCounterSideEffects<Runtime>>,
     Option<(EntityId, EntityReferenceCounterSideEffect)>,
@@ -581,7 +582,7 @@ pub fn create_simple_class(lead_origin: u64, class_type: ClassType) -> DispatchR
     )
 }
 
-pub fn create_class_with_default_permissions() -> Class<Runtime> {
+pub fn create_class_with_default_permissions() -> Class<EntityId, ClassId, CuratorGroupId> {
     Class::new(
         ClassPermissions::default(),
         generate_text(ClassNameLengthConstraint::get().max() as usize),
@@ -633,7 +634,7 @@ pub fn add_class_schema(
     lead_origin: u64,
     class_id: ClassId,
     existing_properties: BTreeSet<PropertyId>,
-    new_properties: Vec<Property<Runtime>>,
+    new_properties: Vec<Property<ClassId>>,
 ) -> DispatchResult {
     TestModule::add_class_schema(
         Origin::signed(lead_origin),
@@ -656,7 +657,7 @@ pub fn next_class_id() -> ClassId {
     TestModule::next_class_id()
 }
 
-pub fn class_by_id(class_id: ClassId) -> Class<Runtime> {
+pub fn class_by_id(class_id: ClassId) -> Class<EntityId, ClassId, CuratorGroupId> {
     TestModule::class_by_id(class_id)
 }
 
@@ -669,7 +670,7 @@ pub fn class_exists(class_id: ClassId) -> bool {
 pub fn update_entity_creation_voucher(
     lead_origin: u64,
     class_id: ClassId,
-    controller: EntityController<Runtime>,
+    controller: EntityController<MemberId>,
     maximum_entities_count: EntityId,
 ) -> DispatchResult {
     TestModule::update_entity_creation_voucher(
@@ -682,14 +683,14 @@ pub fn update_entity_creation_voucher(
 
 pub fn entity_creation_vouchers(
     class_id: ClassId,
-    entity_controller: &EntityController<Runtime>,
+    entity_controller: &EntityController<MemberId>,
 ) -> EntityCreationVoucher<Runtime> {
     TestModule::entity_creation_vouchers(class_id, entity_controller)
 }
 
 pub fn entity_creation_voucher_exists(
     class_id: ClassId,
-    entity_controller: &EntityController<Runtime>,
+    entity_controller: &EntityController<MemberId>,
 ) -> bool {
     EntityCreationVouchers::<Runtime>::contains_key(class_id, entity_controller)
 }
@@ -700,7 +701,7 @@ pub fn entity_exists(entity_id: EntityId) -> bool {
     EntityById::<Runtime>::contains_key(entity_id)
 }
 
-pub fn entity_by_id(entity_id: EntityId) -> Entity<Runtime> {
+pub fn entity_by_id(entity_id: EntityId) -> Entity<ClassId, MemberId, Hashed, EntityId, Nonce> {
     TestModule::entity_by_id(entity_id)
 }
 
@@ -708,11 +709,19 @@ pub fn next_entity_id() -> EntityId {
     TestModule::next_entity_id()
 }
 
-pub fn create_entity(origin: u64, class_id: ClassId, actor: Actor<Runtime>) -> DispatchResult {
+pub fn create_entity(
+    origin: u64,
+    class_id: ClassId,
+    actor: Actor<CuratorGroupId, CuratorId, MemberId>,
+) -> DispatchResult {
     TestModule::create_entity(Origin::signed(origin), class_id, actor)
 }
 
-pub fn remove_entity(origin: u64, actor: Actor<Runtime>, entity_id: EntityId) -> DispatchResult {
+pub fn remove_entity(
+    origin: u64,
+    actor: Actor<CuratorGroupId, CuratorId, MemberId>,
+    entity_id: EntityId,
+) -> DispatchResult {
     TestModule::remove_entity(Origin::signed(origin), actor, entity_id)
 }
 
@@ -732,7 +741,7 @@ pub fn update_entity_permissions(
 
 pub fn add_schema_support_to_entity(
     origin: u64,
-    actor: Actor<Runtime>,
+    actor: Actor<CuratorGroupId, CuratorId, MemberId>,
     entity_id: EntityId,
     schema_id: SchemaId,
     new_property_values: BTreeMap<PropertyId, InputPropertyValue<Runtime>>,
@@ -748,7 +757,7 @@ pub fn add_schema_support_to_entity(
 
 pub fn update_entity_property_values(
     origin: u64,
-    actor: Actor<Runtime>,
+    actor: Actor<CuratorGroupId, CuratorId, MemberId>,
     entity_id: EntityId,
     new_property_values: BTreeMap<PropertyId, InputPropertyValue<Runtime>>,
 ) -> DispatchResult {
@@ -762,7 +771,7 @@ pub fn update_entity_property_values(
 
 pub fn clear_entity_property_vector(
     origin: u64,
-    actor: Actor<Runtime>,
+    actor: Actor<CuratorGroupId, CuratorId, MemberId>,
     entity_id: EntityId,
     in_class_schema_property_id: PropertyId,
 ) -> DispatchResult {
@@ -776,7 +785,7 @@ pub fn clear_entity_property_vector(
 
 pub fn insert_at_entity_property_vector(
     origin: u64,
-    actor: Actor<Runtime>,
+    actor: Actor<CuratorGroupId, CuratorId, MemberId>,
     entity_id: EntityId,
     in_class_schema_property_id: PropertyId,
     index_in_property_vector: VecMaxLength,
@@ -796,7 +805,7 @@ pub fn insert_at_entity_property_vector(
 
 pub fn remove_at_entity_property_vector(
     origin: u64,
-    actor: Actor<Runtime>,
+    actor: Actor<CuratorGroupId, CuratorId, MemberId>,
     entity_id: EntityId,
     in_class_schema_property_id: PropertyId,
     index_in_property_vector: VecMaxLength,
@@ -815,7 +824,7 @@ pub fn remove_at_entity_property_vector(
 pub fn transfer_entity_ownership(
     origin: u64,
     entity_id: EntityId,
-    new_controller: EntityController<Runtime>,
+    new_controller: EntityController<MemberId>,
     new_property_value_references_with_same_owner_flag_set: BTreeMap<
         PropertyId,
         InputPropertyValue<Runtime>,
@@ -833,7 +842,7 @@ pub fn transfer_entity_ownership(
 
 pub fn transaction(
     origin: u64,
-    actor: Actor<Runtime>,
+    actor: Actor<CuratorGroupId, CuratorId, MemberId>,
     operations: Vec<OperationType<Runtime>>,
 ) -> DispatchResult {
     TestModule::transaction(Origin::signed(origin), actor, operations)
@@ -849,20 +858,20 @@ pub enum InvalidPropertyType {
     VecIsTooLong,
 }
 
-impl<T: Trait> Property<T> {
+impl Property<ClassId> {
     pub fn default_with_name(name_len: usize) -> Self {
         let name = generate_text(name_len);
         let description = generate_text(PropertyDescriptionLengthConstraint::get().min() as usize);
         Self {
             name,
             description,
-            ..Property::<T>::default()
+            ..Property::<ClassId>::default()
         }
     }
 
     pub fn with_name_and_type(
         name_len: usize,
-        property_type: PropertyType<T>,
+        property_type: PropertyType<ClassId>,
         required: bool,
         unique: bool,
     ) -> Self {
@@ -874,12 +883,12 @@ impl<T: Trait> Property<T> {
             property_type,
             required,
             unique,
-            ..Property::<T>::default()
+            ..Property::<ClassId>::default()
         }
     }
 
-    pub fn invalid(invalid_property_type: InvalidPropertyType) -> Property<Runtime> {
-        let mut default_property = Property::<Runtime>::default_with_name(
+    pub fn invalid(invalid_property_type: InvalidPropertyType) -> Property<ClassId> {
+        let mut default_property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().min() as usize,
         );
         match invalid_property_type {
@@ -901,16 +910,16 @@ impl<T: Trait> Property<T> {
             }
             InvalidPropertyType::TextIsTooLong => {
                 default_property.property_type =
-                    PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get() + 1);
+                    PropertyType::<ClassId>::single_text(TextMaxLengthConstraint::get() + 1);
             }
             InvalidPropertyType::TextHashIsTooLong => {
                 if let Some(hashed_text_max_len) = HashedTextMaxLengthConstraint::get() {
                     default_property.property_type =
-                        PropertyType::<Runtime>::single_text_hash(Some(hashed_text_max_len + 1));
+                        PropertyType::<ClassId>::single_text_hash(Some(hashed_text_max_len + 1));
                 }
             }
             InvalidPropertyType::VecIsTooLong => {
-                default_property.property_type = PropertyType::<Runtime>::vec_reference(
+                default_property.property_type = PropertyType::<ClassId>::vec_reference(
                     FIRST_CLASS_ID,
                     true,
                     VecMaxLengthConstraint::get() + 1,
@@ -921,43 +930,43 @@ impl<T: Trait> Property<T> {
     }
 }
 
-impl<T: Trait> PropertyType<T> {
+impl PropertyType<ClassId> {
     pub fn vec_reference(
         class_id: ClassId,
         same_controller: bool,
         max_length: VecMaxLength,
-    ) -> PropertyType<Runtime> {
-        let vec_type = Type::<Runtime>::Reference(class_id, same_controller);
-        let vec_reference = VecPropertyType::<Runtime>::new(vec_type, max_length);
-        PropertyType::<Runtime>::Vector(vec_reference)
+    ) -> PropertyType<ClassId> {
+        let vec_type = Type::<ClassId>::Reference(class_id, same_controller);
+        let vec_reference = VecPropertyType::<ClassId>::new(vec_type, max_length);
+        PropertyType::<ClassId>::Vector(vec_reference)
     }
 
     pub fn vec_text(
         text_max_len: TextMaxLength,
         vec_max_length: VecMaxLength,
-    ) -> PropertyType<Runtime> {
-        let vec_type = Type::<Runtime>::Text(text_max_len);
-        let vec_text = VecPropertyType::<Runtime>::new(vec_type, vec_max_length);
-        PropertyType::<Runtime>::Vector(vec_text)
+    ) -> PropertyType<ClassId> {
+        let vec_type = Type::<ClassId>::Text(text_max_len);
+        let vec_text = VecPropertyType::<ClassId>::new(vec_type, vec_max_length);
+        PropertyType::<ClassId>::Vector(vec_text)
     }
 
-    pub fn single_text(text_max_len: TextMaxLength) -> PropertyType<Runtime> {
-        let text_type = Type::<Runtime>::Text(text_max_len);
-        PropertyType::<Runtime>::Single(text_type)
+    pub fn single_text(text_max_len: TextMaxLength) -> PropertyType<ClassId> {
+        let text_type = Type::<ClassId>::Text(text_max_len);
+        PropertyType::<ClassId>::Single(text_type)
     }
 
-    pub fn single_text_hash(text_hash_max_len: HashedTextMaxLength) -> PropertyType<Runtime> {
-        let text_type = Type::<Runtime>::Hash(text_hash_max_len);
-        PropertyType::<Runtime>::Single(text_type)
+    pub fn single_text_hash(text_hash_max_len: HashedTextMaxLength) -> PropertyType<ClassId> {
+        let text_type = Type::<ClassId>::Hash(text_hash_max_len);
+        PropertyType::<ClassId>::Single(text_type)
     }
 
     pub fn vec_text_hash(
         text_hash_max_len: HashedTextMaxLength,
         vec_max_length: VecMaxLength,
-    ) -> PropertyType<Runtime> {
-        let vec_type = Type::<Runtime>::Hash(text_hash_max_len);
-        let vec_text_hash = VecPropertyType::<Runtime>::new(vec_type, vec_max_length);
-        PropertyType::<Runtime>::Vector(vec_text_hash)
+    ) -> PropertyType<ClassId> {
+        let vec_type = Type::<ClassId>::Hash(text_hash_max_len);
+        let vec_text_hash = VecPropertyType::<ClassId>::new(vec_type, vec_max_length);
+        PropertyType::<ClassId>::Vector(vec_text_hash)
     }
 }
 

--- a/runtime-modules/content-directory/src/permissions.rs
+++ b/runtime-modules/content-directory/src/permissions.rs
@@ -106,22 +106,31 @@ pub fn ensure_is_lead<T: Trait>(origin: T::Origin) -> DispatchResult {
 }
 
 /// Enum, representing all possible `Actor`s
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
 #[derive(Encode, Decode, Eq, PartialEq, Clone, Copy)]
-pub enum Actor<T: Trait> {
-    Curator(T::CuratorGroupId, T::CuratorId),
-    Member(T::MemberId),
+pub enum Actor<
+    CuratorGroupId: Default + Clone + Copy,
+    CuratorId: Default + Clone + Copy,
+    MemberId: Default + Clone + Copy,
+> {
+    Curator(CuratorGroupId, CuratorId),
+    Member(MemberId),
     Lead,
 }
 
-impl<T: Trait> Default for Actor<T> {
+impl<
+        CuratorGroupId: Default + Clone + Copy,
+        CuratorId: Default + Clone + Copy,
+        MemberId: Default + Clone + Copy,
+    > Default for Actor<CuratorGroupId, CuratorId, MemberId>
+{
     fn default() -> Self {
         Self::Lead
     }
 }
 
-impl<T: Trait> core::fmt::Debug for Actor<T> {
-    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(formatter, "Actor {:?}", self)
-    }
-}
+// impl<T: Trait> core::fmt::Debug for Actor<T> {
+//     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+//         write!(formatter, "Actor {:?}", self)
+//     }
+// }

--- a/runtime-modules/content-directory/src/permissions.rs
+++ b/runtime-modules/content-directory/src/permissions.rs
@@ -106,8 +106,8 @@ pub fn ensure_is_lead<T: Trait>(origin: T::Origin) -> DispatchResult {
 }
 
 /// Enum, representing all possible `Actor`s
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Eq, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Eq, PartialEq, Clone, Copy, Debug)]
 pub enum Actor<
     CuratorGroupId: Default + Clone + Copy,
     CuratorId: Default + Clone + Copy,
@@ -128,9 +128,3 @@ impl<
         Self::Lead
     }
 }
-
-// impl<T: Trait> core::fmt::Debug for Actor<T> {
-//     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-//         write!(formatter, "Actor {:?}", self)
-//     }
-// }

--- a/runtime-modules/content-directory/src/permissions/class.rs
+++ b/runtime-modules/content-directory/src/permissions/class.rs
@@ -83,40 +83,6 @@ impl<CuratorGroupId: Ord + Default> ClassPermissions<CuratorGroupId> {
         self.maintainers = maintainers
     }
 
-    /// Ensure provided actor can create entities of current `Class`
-    pub fn ensure_can_create_entities<T: Trait>(
-        &self,
-        account_id: &T::AccountId,
-        actor: &Actor<T>,
-    ) -> Result<(), Error<T>> {
-        let can_create = match &actor {
-            Actor::Lead => {
-                // Ensure lead authorization performed succesfully
-                ensure_lead_auth_success::<T>(account_id)?;
-                true
-            }
-            Actor::Member(member_id) if self.any_member => {
-                // Ensure member authorization performed succesfully
-                ensure_member_auth_success::<T>(member_id, account_id)?;
-                true
-            }
-            Actor::Curator(curator_group_id, curator_id)
-                if self.maintainers.contains(curator_group_id) =>
-            {
-                // Authorize curator, performing all checks to ensure curator can act
-                CuratorGroup::<T>::perform_curator_in_group_auth(
-                    curator_id,
-                    curator_group_id,
-                    account_id,
-                )?;
-                true
-            }
-            _ => false,
-        };
-        ensure!(can_create, Error::<T>::ActorCanNotCreateEntities);
-        Ok(())
-    }
-
     /// Ensure entities creation is not blocked on `Class` level
     pub fn ensure_entity_creation_not_blocked<T: Trait>(&self) -> Result<(), Error<T>> {
         ensure!(

--- a/runtime-modules/content-directory/src/permissions/class.rs
+++ b/runtime-modules/content-directory/src/permissions/class.rs
@@ -23,17 +23,6 @@ pub struct ClassPermissions<CuratorGroupId: Ord + Default> {
     maintainers: BTreeSet<CuratorGroupId>,
 }
 
-// impl<CuratorGroupId: Ord> Default for ClassPermissions<T> {
-//     fn default() -> Self {
-//         Self {
-//             any_member: false,
-//             entity_creation_blocked: false,
-//             all_entity_property_values_locked: false,
-//             maintainers: BTreeSet::new(),
-//         }
-//     }
-// }
-
 impl<CuratorGroupId: Ord + Default> ClassPermissions<CuratorGroupId> {
     /// Retieve `all_entity_property_values_locked` status
     pub fn all_entity_property_values_locked(&self) -> bool {

--- a/runtime-modules/content-directory/src/permissions/entity.rs
+++ b/runtime-modules/content-directory/src/permissions/entity.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 /// Owner of an `Entity`.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
 pub enum EntityController<MemberId: Default + PartialEq + Clone + Copy> {
     Maintainers,
     Member(MemberId),
@@ -25,12 +25,6 @@ impl<MemberId: Default + PartialEq + Clone + Copy> Default for EntityController<
         Self::Lead
     }
 }
-
-// impl<T: Trait> core::fmt::Debug for EntityController<MemberId> {
-//     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-//         write!(formatter, "EntityController {:?}", self)
-//     }
-// }
 
 /// Permissions for a given entity.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]

--- a/runtime-modules/content-directory/src/permissions/entity.rs
+++ b/runtime-modules/content-directory/src/permissions/entity.rs
@@ -139,7 +139,7 @@ impl EntityAccessLevel {
     pub fn derive<T: Trait>(
         account_id: &T::AccountId,
         entity_permissions: &EntityPermissions<T>,
-        class_permissions: &ClassPermissions<T>,
+        class_permissions: &ClassPermissions<T::CuratorGroupId>,
         actor: &Actor<T>,
     ) -> Result<Self, Error<T>> {
         let controller = EntityController::<T>::from_actor(actor);

--- a/runtime-modules/content-directory/src/schema/convert.rs
+++ b/runtime-modules/content-directory/src/schema/convert.rs
@@ -1,7 +1,7 @@
 use super::*;
 use sp_runtime::traits::Hash;
 
-impl<T: Trait> From<InputPropertyValue<T>> for StoredPropertyValue<T> {
+impl<T: Trait> From<InputPropertyValue<T>> for StoredPropertyValue<T::Hash, T::EntityId, T::Nonce> {
     fn from(input_property_value: InputPropertyValue<T>) -> Self {
         match input_property_value {
             InputPropertyValue::Single(input_value) => {
@@ -16,7 +16,7 @@ impl<T: Trait> From<InputPropertyValue<T>> for StoredPropertyValue<T> {
     }
 }
 
-impl<T: Trait> From<InputValue<T>> for StoredValue<T> {
+impl<T: Trait> From<InputValue<T>> for StoredValue<T::Hash, T::EntityId> {
     fn from(input_value: InputValue<T>) -> Self {
         match input_value {
             InputValue::Bool(value) => StoredValue::Bool(value),
@@ -37,7 +37,7 @@ impl<T: Trait> From<InputValue<T>> for StoredValue<T> {
     }
 }
 
-impl<T: Trait> From<VecInputValue<T>> for VecStoredValue<T> {
+impl<T: Trait> From<VecInputValue<T>> for VecStoredValue<T::Hash, T::EntityId> {
     fn from(vec_input_value: VecInputValue<T>) -> Self {
         match vec_input_value {
             VecInputValue::Bool(vec_value) => VecStoredValue::Bool(vec_value),

--- a/runtime-modules/content-directory/src/schema/property.rs
+++ b/runtime-modules/content-directory/src/schema/property.rs
@@ -16,8 +16,8 @@ pub type HashedTextMaxLength = Option<u16>;
 type SameController = bool;
 
 /// Locking policy, representing `Property` locking status for both controller and maintainer
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Default, Decode, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Default, Decode, Clone, Copy, PartialEq, Eq, Debug)]
 pub struct PropertyLockingPolicy {
     /// If property is locked from maintainer
     pub is_locked_from_maintainer: bool,
@@ -26,8 +26,8 @@ pub struct PropertyLockingPolicy {
 }
 
 /// Enum, used for `PropertyType` representation
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Type<ClassId: Default + BaseArithmetic + Clone + Copy> {
     Bool,
     Uint16,
@@ -71,8 +71,8 @@ impl<ClassId: Default + BaseArithmetic + Clone + Copy> Type<ClassId> {
 }
 
 /// Vector property type representation
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Clone, Default, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, Default, Copy, PartialEq, Eq, Debug)]
 pub struct VecPropertyType<ClassId: Default + BaseArithmetic + Clone + Copy> {
     vec_type: Type<ClassId>,
     /// Max length of vector, corresponding to a given type
@@ -110,8 +110,8 @@ impl<ClassId: Default + BaseArithmetic + Clone + Copy> VecPropertyType<ClassId> 
 }
 
 /// Enum, representing either `Type` or `VecPropertyType`
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize, Debug))]
-#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PropertyType<ClassId: Default + BaseArithmetic + Clone + Copy> {
     Single(Type<ClassId>),
     Vector(VecPropertyType<ClassId>),
@@ -189,12 +189,6 @@ impl<ClassId: Default + BaseArithmetic + Clone + Copy> Default for Property<Clas
         }
     }
 }
-
-// impl<ClassId: Default + BaseArithmetic> core::fmt::Debug for Property<ClassId> {
-//     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-//         write!(formatter, "Property {:?}", self)
-//     }
-// }
 
 impl<ClassId: Default + BaseArithmetic + Clone + Copy> Property<ClassId> {
     /// Check if property is locked from actor with provided `EntityAccessLevel`

--- a/runtime-modules/content-directory/src/schema/property.rs
+++ b/runtime-modules/content-directory/src/schema/property.rs
@@ -236,7 +236,7 @@ impl<ClassId: Default + BaseArithmetic> Property<ClassId> {
     pub fn ensure_property_value_to_update_is_valid<T: Trait>(
         &self,
         value: &InputPropertyValue<T>,
-        current_entity_controller: &EntityController<T>,
+        current_entity_controller: &EntityController<T::MemberId>,
     ) -> Result<(), Error<T>> {
         // Ensure provided InputPropertyValue matches its Type
         self.ensure_property_value_matches_its_type(value)?;
@@ -269,9 +269,9 @@ impl<ClassId: Default + BaseArithmetic> Property<ClassId> {
     pub fn ensure_property_value_can_be_inserted_at_property_vector<T: Trait>(
         &self,
         single_value: &InputValue<T>,
-        vec_value: &VecStoredPropertyValue<T>,
+        vec_value: &VecStoredPropertyValue<T::Hash, T::EntityId, T::Nonce>,
         index_in_property_vec: VecMaxLength,
-        current_entity_controller: &EntityController<T>,
+        current_entity_controller: &EntityController<T::MemberId>,
     ) -> Result<(), Error<T>> {
         // Ensure, provided index_in_property_vec is valid index of VecInputValue
         vec_value.ensure_index_in_property_vector_is_valid(index_in_property_vec)?;
@@ -519,7 +519,7 @@ impl<ClassId: Default + BaseArithmetic> Property<ClassId> {
     pub fn ensure_property_value_is_valid_reference<T: Trait>(
         &self,
         value: &InputPropertyValue<T>,
-        current_entity_controller: &EntityController<T>,
+        current_entity_controller: &EntityController<T::MemberId>,
     ) -> Result<(), Error<T>> {
         match (value, &self.property_type) {
             (
@@ -578,7 +578,7 @@ impl<ClassId: Default + BaseArithmetic> Property<ClassId> {
     pub fn ensure_referenced_entity_match_its_class<T: Trait>(
         entity_id: T::EntityId,
         class_id: ClassId,
-    ) -> Result<Entity<T>, Error<T>> {
+    ) -> Result<Entity<T::ClassId, T::MemberId, T::Hash, T::EntityId, T::Nonce>, Error<T>> {
         // Ensure Entity under given id exists
         let entity = Module::<T>::ensure_known_entity_id(entity_id)?;
 
@@ -591,9 +591,9 @@ impl<ClassId: Default + BaseArithmetic> Property<ClassId> {
 
     /// Ensure `Entity` can be referenced.
     pub fn ensure_entity_can_be_referenced<T: Trait>(
-        entity: Entity<T>,
+        entity: Entity<T::ClassId, T::MemberId, T::Hash, T::EntityId, T::Nonce>,
         same_controller_status: bool,
-        current_entity_controller: &EntityController<T>,
+        current_entity_controller: &EntityController<T::MemberId>,
     ) -> Result<(), Error<T>> {
         let entity_permissions = entity.get_permissions();
 

--- a/runtime-modules/content-directory/src/tests.rs
+++ b/runtime-modules/content-directory/src/tests.rs
@@ -25,7 +25,10 @@ use super::*;
 use crate::mock::*;
 use core::iter::FromIterator;
 
-pub fn add_entity_schemas_support() -> (Entity<Runtime>, Entity<Runtime>) {
+pub fn add_entity_schemas_support() -> (
+    Entity<ClassId, MemberId, Hashed, EntityId, Nonce>,
+    Entity<ClassId, MemberId, Hashed, EntityId, Nonce>,
+) {
     // Create first class with default permissions
     assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
@@ -46,12 +49,12 @@ pub fn add_entity_schemas_support() -> (Entity<Runtime>, Entity<Runtime>) {
 
     // Create first property
     let first_property =
-        Property::<Runtime>::default_with_name(PropertyNameLengthConstraint::get().max() as usize);
+        Property::<ClassId>::default_with_name(PropertyNameLengthConstraint::get().max() as usize);
 
     // Create second property
-    let second_property_type = PropertyType::<Runtime>::vec_reference(SECOND_CLASS_ID, true, 5);
+    let second_property_type = PropertyType::<ClassId>::vec_reference(SECOND_CLASS_ID, true, 5);
 
-    let second_property = Property::<Runtime>::with_name_and_type(
+    let second_property = Property::<ClassId>::with_name_and_type(
         (PropertyNameLengthConstraint::get().max() - 1) as usize,
         second_property_type,
         true,
@@ -162,7 +165,7 @@ pub enum EntityAccessStateFailureType {
 
 pub fn emulate_entity_access_state_for_failure_case(
     entity_access_level_failure_type: EntityAccessStateFailureType,
-) -> Actor<Runtime> {
+) -> Actor<CuratorGroupId, CuratorId, MemberId> {
     // Create class with default permissions
     assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
@@ -305,9 +308,9 @@ pub fn emulate_entity_access_state_for_failure_case(
 pub fn add_unique_class_reference_schema() {
     // Create property
     let property_type =
-        PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, VecMaxLengthConstraint::get());
+        PropertyType::<ClassId>::vec_reference(FIRST_CLASS_ID, true, VecMaxLengthConstraint::get());
 
-    let property = Property::<Runtime>::with_name_and_type(
+    let property = Property::<ClassId>::with_name_and_type(
         (PropertyNameLengthConstraint::get().max() - 1) as usize,
         property_type,
         true,
@@ -325,7 +328,7 @@ pub fn add_unique_class_reference_schema() {
 
 ///  Create class reference schema and add corresponding schema support to the Entity
 pub fn add_unique_class_reference_schema_and_entity_schema_support(
-    actor: &Actor<Runtime>,
+    actor: &Actor<CuratorGroupId, CuratorId, MemberId>,
     origin: u64,
 ) {
     add_unique_class_reference_schema();

--- a/runtime-modules/content-directory/src/tests/add_class_schema.rs
+++ b/runtime-modules/content-directory/src/tests/add_class_schema.rs
@@ -303,7 +303,7 @@ fn add_class_schema_property_name_too_long() {
         // Events number before tested calls
         let number_of_events_before_call = System::events().len();
 
-        let property = Property::<Runtime>::invalid(InvalidPropertyType::NameTooLong);
+        let property = Property::<ClassId>::invalid(InvalidPropertyType::NameTooLong);
 
         // Make an attempt to add class schema, providing property with name, which length exceeds PropertyNameLengthConstraint
         let add_class_schema_result =
@@ -329,7 +329,7 @@ fn add_class_schema_property_name_too_short() {
         // Events number before tested calls
         let number_of_events_before_call = System::events().len();
 
-        let property = Property::<Runtime>::invalid(InvalidPropertyType::NameTooShort);
+        let property = Property::<ClassId>::invalid(InvalidPropertyType::NameTooShort);
 
         // Make an attempt to add class schema, providing property with name, which length is less than min value of PropertyNameLengthConstraint
         let add_class_schema_result =
@@ -355,7 +355,7 @@ fn add_class_schema_property_description_too_long() {
         // Events number before tested calls
         let number_of_events_before_call = System::events().len();
 
-        let property = Property::<Runtime>::invalid(InvalidPropertyType::DescriptionTooLong);
+        let property = Property::<ClassId>::invalid(InvalidPropertyType::DescriptionTooLong);
 
         // Make an attempt to add class schema, providing property with description, which length exceeds PropertyDescriptionLengthConstraint
         let add_class_schema_result =
@@ -381,7 +381,7 @@ fn add_class_schema_property_description_too_short() {
         // Events number before tested calls
         let number_of_events_before_call = System::events().len();
 
-        let property = Property::<Runtime>::invalid(InvalidPropertyType::DescriptionTooShort);
+        let property = Property::<ClassId>::invalid(InvalidPropertyType::DescriptionTooShort);
 
         // Make an attempt to add class schema, providing property with description, which length is less than min value of PropertyDescriptionLengthConstraint
         let add_class_schema_result =
@@ -407,7 +407,7 @@ fn add_class_schema_text_property_is_too_long() {
         // Events number before tested calls
         let number_of_events_before_call = System::events().len();
 
-        let property = Property::<Runtime>::invalid(InvalidPropertyType::TextIsTooLong);
+        let property = Property::<ClassId>::invalid(InvalidPropertyType::TextIsTooLong);
 
         // Make an attempt to add class schema, providing property with Text type, which TextMaxLength exceeds corresponding TextMaxLengthConstraint
         let add_class_schema_result =
@@ -433,7 +433,7 @@ fn add_class_schema_text_hash_property_is_too_long() {
         // Events number before tested calls
         let number_of_events_before_call = System::events().len();
 
-        let property = Property::<Runtime>::invalid(InvalidPropertyType::TextHashIsTooLong);
+        let property = Property::<ClassId>::invalid(InvalidPropertyType::TextHashIsTooLong);
 
         // Make an attempt to add class schema, providing property with Hash type,
         // which HashedTextMaxLength exceeds corresponding HashedTextMaxLengthConstraint
@@ -460,7 +460,7 @@ fn add_class_schema_property_vec_property_is_too_long() {
         // Events number before tested calls
         let number_of_events_before_call = System::events().len();
 
-        let property = Property::<Runtime>::invalid(InvalidPropertyType::VecIsTooLong);
+        let property = Property::<ClassId>::invalid(InvalidPropertyType::VecIsTooLong);
 
         // Make an attempt to add class schema, providing Vector property, which VecMaxLength exceeds corresponding VecMaxLengthConstraint
         let add_class_schema_result =
@@ -486,12 +486,12 @@ fn add_class_schema_property_refers_unknown_class() {
         // Events number before tested calls
         let number_of_events_before_call = System::events().len();
 
-        let reference_vec_type = PropertyType::<Runtime>::vec_reference(
+        let reference_vec_type = PropertyType::<ClassId>::vec_reference(
             UNKNOWN_CLASS_ID,
             true,
             VecMaxLengthConstraint::get(),
         );
-        let property = Property::<Runtime>::with_name_and_type(1, reference_vec_type, true, true);
+        let property = Property::<ClassId>::with_name_and_type(1, reference_vec_type, true, true);
 
         // Make an attempt to add class schema, providing property with Type::Reference, which refers to unknown ClassId
         let add_class_schema_result =

--- a/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
+++ b/runtime-modules/content-directory/src/tests/add_schema_support_to_entity.rs
@@ -22,7 +22,7 @@ fn add_schema_support_to_non_existent_entity() {
         );
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -68,7 +68,7 @@ fn add_schema_support_lead_auth_failed() {
         );
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -114,7 +114,7 @@ fn add_schema_support_member_auth_failed() {
         );
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -167,7 +167,7 @@ fn add_schema_support_curator_group_is_not_active() {
         ));
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -213,7 +213,7 @@ fn add_schema_support_curator_auth_failed() {
         );
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -260,7 +260,7 @@ fn add_schema_support_curator_not_found_in_curator_group() {
         );
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -307,7 +307,7 @@ fn add_schema_support_access_denied() {
         );
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -391,7 +391,7 @@ fn add_schema_support_to_entity_class_property_not_found() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -442,7 +442,7 @@ fn add_schema_support_already_added_to_the_entity() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -501,7 +501,7 @@ fn add_schema_support_already_contains_given_property_id() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create first property
-        let first_property = Property::<Runtime>::default_with_name(
+        let first_property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -515,8 +515,8 @@ fn add_schema_support_already_contains_given_property_id() {
 
         // Create second property
         let second_property_type =
-            PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
-        let second_property = Property::<Runtime>::with_name_and_type(
+            PropertyType::<ClassId>::single_text(TextMaxLengthConstraint::get());
+        let second_property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize - 1,
             second_property_type,
             true,
@@ -583,7 +583,7 @@ fn add_schema_support_is_not_active() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -642,7 +642,7 @@ fn add_schema_support_does_not_contain_provided_property_id() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create first property
-        let first_property = Property::<Runtime>::default_with_name(
+        let first_property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -655,7 +655,7 @@ fn add_schema_support_does_not_contain_provided_property_id() {
         ));
 
         // Create second property
-        let second_property = Property::<Runtime>::default_with_name(
+        let second_property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize - 1,
         );
 
@@ -706,14 +706,14 @@ fn add_schema_support_missing_required_property() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create first property
-        let first_property = Property::<Runtime>::default_with_name(
+        let first_property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
         // Create second property
         let second_property_type =
-            PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
-        let second_property = Property::<Runtime>::with_name_and_type(
+            PropertyType::<ClassId>::single_text(TextMaxLengthConstraint::get());
+        let second_property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize - 1,
             second_property_type,
             true,
@@ -766,8 +766,8 @@ fn add_schema_support_dont_match_type() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
-        let property = Property::<Runtime>::with_name_and_type(
+        let property_type = PropertyType::<ClassId>::single_text(TextMaxLengthConstraint::get());
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize - 1,
             property_type,
             true,
@@ -836,9 +836,9 @@ fn add_schema_support_referenced_entity_does_not_match_class() {
         ));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+        let property_type = PropertyType::<ClassId>::vec_reference(FIRST_CLASS_ID, true, 5);
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -898,9 +898,9 @@ fn add_schema_support_referenced_entity_does_not_exist() {
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(SECOND_CLASS_ID, true, 5);
+        let property_type = PropertyType::<ClassId>::vec_reference(SECOND_CLASS_ID, true, 5);
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -970,9 +970,9 @@ fn add_schema_support_entity_can_not_be_referenced() {
         ));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+        let property_type = PropertyType::<ClassId>::vec_reference(FIRST_CLASS_ID, true, 5);
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -1046,9 +1046,9 @@ fn add_schema_support_same_controller_constraint_violation() {
         ));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+        let property_type = PropertyType::<ClassId>::vec_reference(FIRST_CLASS_ID, true, 5);
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -1105,9 +1105,9 @@ fn add_schema_support_text_property_is_too_long() {
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
 
         // Create text property
-        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let property_type = PropertyType::<ClassId>::single_text(TextMaxLengthConstraint::get());
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             property_type,
             true,
@@ -1168,9 +1168,9 @@ fn add_schema_support_text_hash_property_is_too_long() {
 
         // Create hash property
         let property_type =
-            PropertyType::<Runtime>::single_text_hash(hashed_text_max_length_constraint);
+            PropertyType::<ClassId>::single_text_hash(hashed_text_max_length_constraint);
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             property_type,
             true,
@@ -1239,13 +1239,13 @@ fn add_schema_support_vec_property_is_too_long() {
         ));
 
         // Create vec property
-        let property_type = PropertyType::<Runtime>::vec_reference(
+        let property_type = PropertyType::<ClassId>::vec_reference(
             SECOND_CLASS_ID,
             true,
             VecMaxLengthConstraint::get(),
         );
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -1306,11 +1306,11 @@ fn add_schema_support_property_should_be_unique() {
         // Create second entity
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
 
-        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let property_type = PropertyType::<ClassId>::single_text(TextMaxLengthConstraint::get());
 
         // Create text property
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             property_type,
             true,
@@ -1382,11 +1382,11 @@ fn add_schema_support_properties_should_be_unique() {
         // Create third entity
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
 
-        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let property_type = PropertyType::<ClassId>::single_text(TextMaxLengthConstraint::get());
 
         // Create text property
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             property_type,
             true,

--- a/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/clear_entity_property_vector.rs
@@ -359,9 +359,9 @@ fn clear_entity_property_vector_is_locked_for_given_actor() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+        let property_type = PropertyType::<ClassId>::vec_reference(FIRST_CLASS_ID, true, 5);
 
-        let mut property = Property::<Runtime>::with_name_and_type(
+        let mut property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -457,7 +457,7 @@ fn clear_entity_property_vector_value_under_given_index_is_not_a_vector() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 

--- a/runtime-modules/content-directory/src/tests/create_entity.rs
+++ b/runtime-modules/content-directory/src/tests/create_entity.rs
@@ -47,7 +47,7 @@ fn create_entity_success() {
             EntityCreationVoucher::new(class.get_default_entity_creation_voucher_upper_bound());
         entity_voucher.increment_created_entities_count();
 
-        let entity_controller = EntityController::from_actor(&actor);
+        let entity_controller = EntityController::<MemberId>::from_actor::<Runtime>(&actor);
 
         assert_eq!(
             entity_creation_vouchers(FIRST_CLASS_ID, &entity_controller),
@@ -55,7 +55,7 @@ fn create_entity_success() {
         );
 
         // Ensure new entity created
-        let entity = Entity::<Runtime>::new(
+        let entity = Entity::<ClassId, MemberId, Hashed, EntityId, Nonce>::new(
             entity_controller,
             FIRST_CLASS_ID,
             BTreeSet::new(),

--- a/runtime-modules/content-directory/src/tests/insert_at_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/insert_at_entity_property_vector.rs
@@ -456,9 +456,9 @@ fn insert_at_entity_property_vector_is_locked_for_given_actor() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+        let property_type = PropertyType::<ClassId>::vec_reference(FIRST_CLASS_ID, true, 5);
 
-        let mut property = Property::<Runtime>::with_name_and_type(
+        let mut property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -579,7 +579,7 @@ fn insert_at_entity_property_vector_value_under_given_index_is_not_a_vector() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 
@@ -818,12 +818,12 @@ fn insert_at_entity_property_vector_text_prop_is_too_long() {
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_text(
+        let property_type = PropertyType::<ClassId>::vec_text(
             TextMaxLengthConstraint::get(),
             VecMaxLengthConstraint::get(),
         );
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -898,12 +898,12 @@ fn insert_at_entity_property_vector_hashed_text_prop_is_too_long() {
         let hashed_text_max_length_constraint = HashedTextMaxLengthConstraint::get();
 
         // Create vec text hash property
-        let property_type = PropertyType::<Runtime>::vec_text_hash(
+        let property_type = PropertyType::<ClassId>::vec_text_hash(
             hashed_text_max_length_constraint,
             VecMaxLengthConstraint::get(),
         );
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             property_type,
             true,
@@ -977,12 +977,12 @@ fn insert_at_entity_property_vector_prop_type_does_not_match_internal_vec_proper
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.clone()));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_text(
+        let property_type = PropertyType::<ClassId>::vec_text(
             TextMaxLengthConstraint::get(),
             VecMaxLengthConstraint::get(),
         );
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,

--- a/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
+++ b/runtime-modules/content-directory/src/tests/remove_at_entity_property_vector.rs
@@ -430,9 +430,9 @@ fn remove_at_entity_property_vector_is_locked_for_given_actor() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+        let property_type = PropertyType::<ClassId>::vec_reference(FIRST_CLASS_ID, true, 5);
 
-        let mut property = Property::<Runtime>::with_name_and_type(
+        let mut property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -549,7 +549,7 @@ fn remove_at_entity_property_vector_value_under_given_index_is_not_a_vector() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property = Property::<Runtime>::default_with_name(
+        let property = Property::<ClassId>::default_with_name(
             PropertyNameLengthConstraint::get().max() as usize,
         );
 

--- a/runtime-modules/content-directory/src/tests/remove_entity.rs
+++ b/runtime-modules/content-directory/src/tests/remove_entity.rs
@@ -27,7 +27,7 @@ fn remove_entity_success() {
         // Ensure number of entities_created under respective entity creation voucher decremented succesfully.
         let entity_voucher = EntityCreationVoucher::new(IndividualEntitiesCreationLimit::get());
 
-        let entity_controller = EntityController::from_actor(&actor);
+        let entity_controller = EntityController::<MemberId>::from_actor::<Runtime>(&actor);
 
         assert_eq!(
             entity_creation_vouchers(FIRST_CLASS_ID, &entity_controller),

--- a/runtime-modules/content-directory/src/tests/transaction.rs
+++ b/runtime-modules/content-directory/src/tests/transaction.rs
@@ -8,7 +8,7 @@ fn transaction_success() {
 
         // Create single reference property
         let property_type_reference = Type::Reference(FIRST_CLASS_ID, true);
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             PropertyType::Single(property_type_reference),
             true,

--- a/runtime-modules/content-directory/src/tests/transfer_entity_ownership.rs
+++ b/runtime-modules/content-directory/src/tests/transfer_entity_ownership.rs
@@ -616,13 +616,13 @@ fn transfer_entity_ownership_unique_constraint_violation() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create unique reference property with same_controller flag set
-        let property_type = PropertyType::<Runtime>::vec_reference(
+        let property_type = PropertyType::<ClassId>::vec_reference(
             FIRST_CLASS_ID,
             true,
             VecMaxLengthConstraint::get(),
         );
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             property_type,
             true,

--- a/runtime-modules/content-directory/src/tests/update_entity_creation_voucher.rs
+++ b/runtime-modules/content-directory/src/tests/update_entity_creation_voucher.rs
@@ -65,7 +65,7 @@ fn update_entity_creation_voucher_success() {
             None
         ));
 
-        let entity_controller = EntityController::from_actor(&actor);
+        let entity_controller = EntityController::<MemberId>::from_actor::<Runtime>(&actor);
 
         // Create entity
         assert_ok!(create_entity(FIRST_MEMBER_ORIGIN, FIRST_CLASS_ID, actor));

--- a/runtime-modules/content-directory/src/tests/update_entity_property_values.rs
+++ b/runtime-modules/content-directory/src/tests/update_entity_property_values.rs
@@ -391,9 +391,9 @@ fn update_entity_property_values_is_locked_for_given_actor() {
         assert_ok!(create_simple_class(LEAD_ORIGIN, ClassType::Valid));
 
         // Create property
-        let property_type = PropertyType::<Runtime>::vec_reference(FIRST_CLASS_ID, true, 5);
+        let property_type = PropertyType::<ClassId>::vec_reference(FIRST_CLASS_ID, true, 5);
 
-        let mut property = Property::<Runtime>::with_name_and_type(
+        let mut property = Property::<ClassId>::with_name_and_type(
             (PropertyNameLengthConstraint::get().max() - 1) as usize,
             property_type,
             true,
@@ -605,9 +605,9 @@ fn update_entity_property_values_text_prop_is_too_long() {
         assert_ok!(create_entity(LEAD_ORIGIN, FIRST_CLASS_ID, actor.to_owned()));
 
         // Create text property
-        let property_type = PropertyType::<Runtime>::single_text(TextMaxLengthConstraint::get());
+        let property_type = PropertyType::<ClassId>::single_text(TextMaxLengthConstraint::get());
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             property_type,
             true,
@@ -682,9 +682,9 @@ fn update_entity_property_values_hashed_text_prop_is_too_long() {
 
         // Create hash property
         let property_type =
-            PropertyType::<Runtime>::single_text_hash(hashed_text_max_length_constraint);
+            PropertyType::<ClassId>::single_text_hash(hashed_text_max_length_constraint);
 
-        let property = Property::<Runtime>::with_name_and_type(
+        let property = Property::<ClassId>::with_name_and_type(
             PropertyNameLengthConstraint::get().max() as usize,
             property_type,
             true,


### PR DESCRIPTION
The PR reworks `ClassById` and `EntityById` related runtime storage entities to make them configurable through `chain_spec` config. 

Closes: https://github.com/Joystream/joystream/issues/1357