### PR TITLE
createType - TypeScript support

### DIFF
--- a/content-directory-schemas/src/helpers/InputParser.ts
+++ b/content-directory-schemas/src/helpers/InputParser.ts
@@ -143,16 +143,13 @@ export class InputParser {
         let value = customHandler && customHandler(schemaProperty, propertyValue)
         if (value === undefined) {
           value = createType('ParametrizedPropertyValue', {
-            InputPropertyValue: this.parsePropertyType(schemaProperty.property_type)
-              .toInputPropertyValue(propertyValue)
-              .toJSON(),
+            InputPropertyValue: this.parsePropertyType(schemaProperty.property_type).toInputPropertyValue(
+              propertyValue
+            ),
           })
         }
 
-        return {
-          in_class_index: schemaPropertyIndex,
-          value: value.toJSON(),
-        }
+        return { in_class_index: schemaPropertyIndex, value }
       })
   }
 

--- a/pioneer/packages/joy-forum/src/Context.tsx
+++ b/pioneer/packages/joy-forum/src/Context.tsx
@@ -232,10 +232,10 @@ function reducer (state: ForumState, action: ForumAction): ForumState {
         moderator_id: createType('AccountId', moderator),
         rationale: createType('Text', rationale)
       });
-      const threadUpd = createType('Thread', Object.assign(
-        thread.cloneValues(),
-        { moderation: createType('Option<ModerationAction>', moderation) }
-      ));
+      const threadUpd = createType('Thread', {
+        ...thread.cloneValues(),
+        moderation: createType('Option<ModerationAction>', moderation)
+      });
 
       threadById.set(id, threadUpd);
 

--- a/pioneer/packages/joy-forum/src/calls.tsx
+++ b/pioneer/packages/joy-forum/src/calls.tsx
@@ -17,12 +17,12 @@ const storage: StorageType = 'substrate';
 type EntityMapName = 'categoryById' | 'threadById' | 'replyById';
 
 const getReactValue = (state: ForumState, endpoint: string, paramValue: any) => {
-  function getEntityById<T extends keyof InterfaceTypes>
+  function getEntityById<T extends 'Category' | 'Thread' | 'Reply'>
   (mapName: EntityMapName, type: T): InterfaceTypes[T] {
     const id = (paramValue as u64).toNumber();
     const entity = state[mapName].get(id);
 
-    return createType(type, entity);
+    return createType(type, entity as any);
   }
 
   switch (endpoint) {

--- a/pioneer/packages/joy-proposals/src/stories/data/ProposalDetails.mock.ts
+++ b/pioneer/packages/joy-proposals/src/stories/data/ProposalDetails.mock.ts
@@ -20,8 +20,8 @@ const mockedProposal: ParsedProposal = {
   proposerId: 303,
   status: createType('ProposalStatus', {
     Active: {
-      stakeId: 0,
-      sourceAccountId: '5C4hrfkRjSLwQSFVtCvtbV6wctV1WFnkiexUZWLAh4Bc7jib'
+      stake_id: 0,
+      source_account_id: '5C4hrfkRjSLwQSFVtCvtbV6wctV1WFnkiexUZWLAh4Bc7jib'
     }
   }),
   proposer: {

--- a/pioneer/packages/joy-roles/src/classifiers.spec.ts
+++ b/pioneer/packages/joy-roles/src/classifiers.spec.ts
@@ -75,7 +75,7 @@ describe('hiring.Opening-> OpeningStageClassification', (): void => {
           stage: createType('OpeningStage', {
             Active: {
               stage: createType('ActiveOpeningStage', {
-                acceptingApplications: {
+                AcceptingApplications: {
                   started_accepting_applicants_at_block: 100
                 }
               })
@@ -101,7 +101,7 @@ describe('hiring.Opening-> OpeningStageClassification', (): void => {
           stage: createType('OpeningStage', {
             Active: {
               stage: createType('ActiveOpeningStage', {
-                reviewPeriod: {
+                ReviewPeriod: {
                   started_accepting_applicants_at_block: 100,
                   started_review_period_at_block: 100
                 }

--- a/pioneer/packages/joy-roles/src/tabs/Admin.controller.tsx
+++ b/pioneer/packages/joy-roles/src/tabs/Admin.controller.tsx
@@ -601,8 +601,10 @@ const NewOpening = (props: NewOpeningProps) => {
   };
 
   const onChangeExactBlock = (e: any, { value }: InputOnChangeData) => {
-    setExactBlock(typeof value === 'number' ? value : (parseInt(value) || 0));
-    setStart(createType('ActivateOpeningAt', { ExactBlock: value }));
+    const valueInt = typeof value === 'number' ? value : (parseInt(value) || 0);
+
+    setExactBlock(valueInt);
+    setStart(createType('ActivateOpeningAt', { ExactBlock: valueInt }));
   };
 
   const [policy, setPolicy] = useState(props.desc.policy);

--- a/types/src/JoyEnum.ts
+++ b/types/src/JoyEnum.ts
@@ -9,7 +9,7 @@ export interface ExtendedEnum<Types extends Record<string, Constructor>> extends
   type: keyof Types & string // More typesafe type for the original Enum property
 }
 
-export interface ExtendedEnumConstructor<Types extends Record<string, Constructor>>
+export interface ExtendedEnumConstructor<Types extends Record<string, Constructor> = Record<string, Constructor>>
   extends EnumConstructor<ExtendedEnum<Types>> {
   create<TypeKey extends keyof Types>(
     registry: Registry,

--- a/types/src/index.ts
+++ b/types/src/index.ts
@@ -1,4 +1,4 @@
-import { RegistryTypes } from '@polkadot/types/types'
+import { Codec, RegistryTypes } from '@polkadot/types/types'
 import common from './common'
 import members from './members'
 import council from './council'
@@ -15,7 +15,10 @@ import media from './media'
 import proposals from './proposals'
 import contentDirectory from './content-directory'
 import { InterfaceTypes } from '@polkadot/types/types/registry'
-import { TypeRegistry } from '@polkadot/types'
+import { TypeRegistry, Text, UInt, Null, bool, Option, Vec, BTreeSet } from '@polkadot/types'
+import { ExtendedEnum } from './JoyEnum'
+import { ExtendedStruct } from './JoyStruct'
+import BN from 'bn.js'
 
 export {
   common,
@@ -57,9 +60,44 @@ export const types: RegistryTypes = {
 export const registry = new TypeRegistry()
 registry.register(types)
 
+// Tweaked version of https://stackoverflow.com/a/62163715 for handling enum variants
+// Based on type (T) like: { a: string; b: number; c: Null; }
+// will create a type like: { a: string } | { b: number } | { c: Null } | "c"
+type EnumVariant<T> = keyof T extends infer K
+  ? K extends keyof T
+    ? T[K] extends Null
+      ? K
+      : { [I in K]: T[I] }
+    : never
+  : never
+
+// Create simple interface for any Codec type (inlcuding JoyEnums and JoyStructs)
+// Cannot handle Option here, since that would cause circular reference error
+type CreateInterface_NoOption<T extends Codec> =
+  | T
+  | (T extends ExtendedEnum<infer S>
+      ? EnumVariant<{ [K in keyof S]: CreateInterface<InstanceType<T['typeDefinitions'][K]>> }>
+      : T extends ExtendedStruct<infer S>
+      ? { [K in keyof S]?: CreateInterface<InstanceType<T['typeDefs'][K]>> }
+      : T extends Text
+      ? string
+      : T extends UInt
+      ? number | BN
+      : T extends bool
+      ? boolean
+      : T extends Vec<infer S> | BTreeSet<infer S>
+      ? CreateInterface<S>[]
+      : any)
+
+// Wrapper for CreateInterface_NoOption that includes resolving an Option
+// (nested Options like Option<Option<Codec>> will resolve to Option<any>, but there are very edge case)
+type CreateInterface<T extends Codec> =
+  | T
+  | (T extends Option<infer S> ? undefined | null | S | CreateInterface_NoOption<S> : CreateInterface_NoOption<T>)
+
 export function createType<TypeName extends keyof InterfaceTypes>(
   type: TypeName,
-  value: any
+  value: InterfaceTypes[TypeName] extends Codec ? CreateInterface<InterfaceTypes[TypeName]> : any
 ): InterfaceTypes[TypeName] {
   return registry.createType(type, value)
 }


### PR DESCRIPTION
Adds typescript support for `@joystream/types`' `createType` function.
We can now use it to more safely create very complex types, for example:
```
    createType('OperationType', {
      AddSchemaSupportToEntity: {
        entity_id: { ExistingEntity: 1 },
        parametrized_property_values: [
          {
            in_class_index: 1,
            value: {
              InputPropertyValue: {
                Single: { Reference: 2 },
              },
            },
          },
        ],
        schema_id: 0,
      },
    })
```
Assuming we're using agumentations from `/agument-codes/augment-types.ts` (which almost all TypeScript projects now use for `createType`), the object provided as second argument to `createType` in this example will be fully validated by TypeScript (even if we provide invalid value for `Reference`, which is very deeply nested, we will still get an error)