### PR TITLE
network-tests: improve test runner

### DIFF
--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Ensure tests are runnable
         run: yarn workspace network-tests build
       - name: Execute network tests
-        run: tests/network-tests/run-tests.sh
+        run: RUNTIME=alexandria tests/network-tests/run-tests.sh full
 
   network_tests_2:
     name: Integration Tests (New Chain)
@@ -124,7 +124,7 @@ jobs:
       - name: Ensure tests are runnable
         run: yarn workspace network-tests build
       - name: Execute network tests
-        run: RUNTIME=latest tests/network-tests/run-tests.sh
+        run: tests/network-tests/run-tests.sh full
 
   network_tests_3:
     name: Content Directory Initialization
@@ -153,6 +153,30 @@ jobs:
         run: yarn workspace cd-schemas initialize:dev
 
   network_tests_4:
+    name: Content Direcotry Integration Tests
+    needs: build_images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Get artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ needs.build_images.outputs.use_artifact }}
+      - name: Install artifacts
+        run: |
+          docker load --input joystream-node-docker-image.tar.gz
+          docker images
+      - name: Install packages and dependencies
+        run: yarn install --frozen-lockfile
+      - name: Ensure tests are runnable
+        run: yarn workspace network-tests build
+      - name: Execute network tests
+        run: tests/network-tests/run-tests.sh content-directory
+  
+  network_tests_5:
     name: Storage Node Tests
     needs: build_images
     runs-on: ubuntu-latest

--- a/tests/network-tests/run-tests.sh
+++ b/tests/network-tests/run-tests.sh
@@ -12,7 +12,7 @@ ALICE_INITIAL_BALANCE=${ALICE_INITIAL_BALANCE:=100000000}
 
 # The docker image tag to use for joystream/node as the starting chain
 # that will be upgraded to the latest runtime.
-RUNTIME=${RUNTIME:=alexandria}
+RUNTIME=${RUNTIME:=latest}
 TARGET_RUNTIME=${TARGET_RUNTIME:=latest}
 
 mkdir -p ${DATA_PATH}
@@ -65,6 +65,10 @@ function cleanup() {
 
 trap cleanup EXIT
 
+# Initialize content-directory
+sleep 15
+yarn workspace cd-schemas initialize:dev
+
 if [ "$TARGET_RUNTIME" == "$RUNTIME" ]; then
   echo "Not Performing a runtime upgrade."
 else
@@ -88,5 +92,10 @@ fi
 # Display runtime version
 yarn workspace api-scripts tsnode-strict src/status.ts | grep Runtime
 
+# pass the scenario name without .ts extension
+SCENARIO=$1
+# fallback to full.ts scenario if not specified
+SCENARIO=${SCENARIO:=full}
+
 # Execute the tests
-time DEBUG=* yarn workspace network-tests test-run src/scenarios/full.ts
+time DEBUG=* yarn workspace network-tests test-run src/scenarios/${SCENARIO}.ts

--- a/tests/network-tests/run-tests.sh
+++ b/tests/network-tests/run-tests.sh
@@ -66,8 +66,11 @@ function cleanup() {
 trap cleanup EXIT
 
 # Initialize content-directory
-sleep 15
-yarn workspace cd-schemas initialize:dev
+# sleep 15
+# yarn workspace cd-schemas initialize:dev
+# NOTE: Skipping this step and let the scenarios do this setup instead
+# or align the scenario expectations of the initial state to match
+# with what we do here.
 
 if [ "$TARGET_RUNTIME" == "$RUNTIME" ]; then
   echo "Not Performing a runtime upgrade."

--- a/tests/network-tests/src/scenarios/content-directory.ts
+++ b/tests/network-tests/src/scenarios/content-directory.ts
@@ -1,0 +1,26 @@
+import { WsProvider } from '@polkadot/api'
+import { Api, WorkingGroups } from '../Api'
+import { config } from 'dotenv'
+import leaderSetup from '../flows/workingGroup/leaderSetup'
+
+const scenario = async () => {
+  // Load env variables
+  config()
+  const env = process.env
+
+  // Connect api to the chain
+  const nodeUrl: string = env.NODE_URL || 'ws://127.0.0.1:9944'
+  const provider = new WsProvider(nodeUrl)
+  const api: Api = await Api.create(provider, env.TREASURY_ACCOUNT_URI || '//Alice', env.SUDO_ACCOUNT_URI || '//Alice')
+
+  await leaderSetup(api, env, WorkingGroups.ContentDirectoryWorkingGroup)
+
+  // Some flows that use the curator lead to perform some tests...
+  //
+
+  // Note: disconnecting and then reconnecting to the chain in the same process
+  // doesn't seem to work!
+  api.close()
+}
+
+scenario()


### PR DESCRIPTION
script can take scenarion arg
initialize content-dir before executing scenario
add content-directory scenario
default now doesn't do a runtime upgrade, specify starting runtime with RUNTIME=alexandria if you want to test with a runtime upgrade.

From inside the `tests/network-tests` directory

To run the `full` test scenario: `src/scenarios/full.ts`
`./run-tests full`

To run the draft content-directory scenario: `src/scenarios/content-directory.ts`

`./run-tests content-directory`

I also added a job to the github workflows to run the new content-directory scenario