### PR TITLE
CLI - fix bugs arising from entities without a schema

### DIFF
--- a/cli/src/commands/content-directory/entity.ts
+++ b/cli/src/commands/content-directory/entity.ts
@@ -15,7 +15,7 @@ export default class EntityCommand extends ContentDirectoryCommandBase {
 
   async run() {
     const { id } = this.parse(EntityCommand).args
-    const entity = await this.getEntity(id)
+    const entity = await this.getEntity(id, undefined, undefined, false)
     const { controller, frozen, referenceable } = entity.entity_permissions
     const [classId, entityClass] = await this.classEntryByNameOrId(entity.class_id.toString())
     const propertyValues = this.parseEntityPropertyValues(entity, entityClass)


### PR DESCRIPTION
While doing some tests with `createEntity` and `addSchemaSupportToEntity` I noticed that entities without a schema can cause some issues in the CLI:
- `content-directory:entities` command would sometimes fail because it was running under the wrong assumption that all entities (presented in a table) will have the same properties in `entity.values` (while entities with no schema support have no `values` at all)
- Commands like `updateChannel`/`updateVideo` etc. didn't check if the entity has any schema support, which resulted in some unexpected behaviour

This PR tries to address those issues