### PR TITLE
Benchmarking working_team

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,20 +24,21 @@ before_install:
     fi
 
 install:
+  - rustup install nightly-2020-07-12 --force
   - rustup install nightly-2020-05-23 --force
   - rustup target add wasm32-unknown-unknown --toolchain nightly-2020-05-23
   # travis installs rust using rustup with the "minimal" profile so these tools are not installed by default
   - rustup component add rustfmt
-  - rustup component add clippy
+  - rustup component add clippy --toolchain nightly-2020-07-12
 
 before_script:
   - cargo fmt --all -- --check
 
 script:
   - export WASM_BUILD_TOOLCHAIN=nightly-2020-05-23
-  - BUILD_DUMMY_WASM_BINARY=1 cargo clippy --release --all -- -D warnings
-  - travis_wait 75 cargo test --release --verbose --all -- --ignored
-  - cargo build --release
+  - BUILD_DUMMY_WASM_BINARY=1 cargo +nightly-2020-07-12 clippy --release --all -- -D warnings
+  - travis_wait 75 cargo +nightly-2020-07-12 test --release --verbose --all -- --ignored
+  - cargo +nightly-2020-07-12 build --release
   - ls -l ./target/release/wbuild/joystream-node-runtime/
   - ./target/release/joystream-node --version
   - ./target/release/chain-spec-builder --version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,6 +1691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-literal"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
+
+[[package]]
 name = "hex-literal-impl"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2067,7 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "hex-literal 0.3.1",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -2098,6 +2105,7 @@ dependencies = [
  "pallet-versioned-store",
  "pallet-versioned-store-permissions",
  "pallet-working-group",
+ "pallet-working-team",
  "parity-scale-codec",
  "serde",
  "sp-api",
@@ -3887,6 +3895,7 @@ dependencies = [
 name = "pallet-working-team"
 version = "1.0.0"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",
@@ -5048,7 +5057,7 @@ dependencies = [
  "fnv",
  "futures 0.3.4",
  "hash-db",
- "hex-literal",
+ "hex-literal 0.2.1",
  "kvdb",
  "lazy_static",
  "log",
@@ -5658,7 +5667,7 @@ dependencies = [
  "fdlimit",
  "futures 0.1.29",
  "futures 0.3.4",
- "hex-literal",
+ "hex-literal 0.2.1",
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,7 +2105,6 @@ dependencies = [
  "pallet-versioned-store",
  "pallet-versioned-store-permissions",
  "pallet-working-group",
- "pallet-working-team",
  "parity-scale-codec",
  "serde",
  "sp-api",
@@ -3893,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-working-team"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/runtime-modules/working-team/Cargo.toml
+++ b/runtime-modules/working-team/Cargo.toml
@@ -37,5 +37,4 @@ std = [
 	'common/std',
 	'membership/std',
 	'balances/std',
-  'frame-benchmarking/std',
 ]

--- a/runtime-modules/working-team/Cargo.toml
+++ b/runtime-modules/working-team/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-working-team"
-version = "1.0.0"
+version = "1.0.1"
 authors = ['Joystream contributors']
 edition = '2018'
 
@@ -15,7 +15,6 @@ sp-std = { package = 'sp-std', default-features = false, git = 'https://github.c
 common = { package = 'pallet-common', default-features = false, path = '../common'}
 membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
-
 frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4', optional = true}
 
 [dev-dependencies]

--- a/runtime-modules/working-team/Cargo.toml
+++ b/runtime-modules/working-team/Cargo.toml
@@ -16,6 +16,7 @@ common = { package = 'pallet-common', default-features = false, path = '../commo
 membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
 
+frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4', optional = true}
 
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
@@ -24,6 +25,7 @@ pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git
 
 [features]
 default = ['std']
+runtime-benchmarks = ["frame-benchmarking"]
 std = [
 	'serde',
 	'codec/std',
@@ -35,4 +37,5 @@ std = [
 	'common/std',
 	'membership/std',
 	'balances/std',
+  'frame-benchmarking/std',
 ]

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -584,7 +584,7 @@ benchmarks_instance! {
         );
     }
 
-    fill_opening_worker { // We can actually fill an opening with 0 applications?
+    fill_opening_worker {
         let i in 1 .. T::MaxWorkerNumberLimit::get();
         let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(
             StakingRole::WithoutStakes,

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -263,460 +263,632 @@ benchmarks_instance! {
     _ { }
 
     on_initialize_leaving {
-      let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let i in 1 .. T::MaxWorkerNumberLimit::get();
 
-      let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Leader, 0, None);
+        let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(
+            StakingRole::WithStakes,
+            JobOpeningType::Leader,
+            0,
+            None
+        );
 
-      let (opening_id, successful_application_ids, application_account_id) = add_opening_and_n_apply::<T, I>(
-        &(1..i).collect(),
-        &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
-        &StakingRole::WithStakes,
-        &JobOpeningType::Regular
-      );
+        let (opening_id, successful_application_ids, application_account_id) =
+            add_opening_and_n_apply::<T, I>(
+                &(1..i).collect(),
+                &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
+                &StakingRole::WithStakes,
+                &JobOpeningType::Regular
+            );
 
-      WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
-      successful_application_ids.clone()).unwrap();
+        WorkingTeam::<T, _>::fill_opening(
+            RawOrigin::Signed(lead_id.clone()).into(),
+            opening_id,
+            successful_application_ids.clone()
+        ).unwrap();
 
+        force_missed_reward::<T,I>();
 
-      force_missed_reward::<T,I>();
+        // Force all workers to leave (Including the lead)
+        // We should have every TeamWorkerId from 0 to i-1
+        // Corresponding to each account id
+        let mut worker_id = Zero::zero();
+        for id in application_account_id {
+            worker_id += One::one();
+            WorkingTeam::<T, _>::leave_role(RawOrigin::Signed(id).into(), worker_id).unwrap();
+        }
 
-      // Force all workers to leave (Including the lead)
-      // We should have every TeamWorkerId from 0 to i-1
-      // Corresponding to each account id
-      let mut worker_id = Zero::zero();
-      for id in application_account_id {
-        worker_id += One::one();
-        WorkingTeam::<T, _>::leave_role(RawOrigin::Signed(id).into(), worker_id).unwrap();
-      }
+        // Worst case scenario one of the leaving workers is the lead
+        WorkingTeam::<T, _>::leave_role(
+            RawOrigin::Signed(lead_id).into(),
+            lead_worker_id
+        ).unwrap();
 
-      // Worst case scenario one of the leaving workers is the lead
-      WorkingTeam::<T, _>::leave_role(RawOrigin::Signed(lead_id).into(), lead_worker_id).unwrap();
+        for i in 1..successful_application_ids.len() {
+            let worker = TeamWorkerId::<T>::from(i.try_into().unwrap());
+            assert!(WorkerById::<T, I>::contains_key(worker), "Not all workers added");
+            assert_eq!(
+                WorkingTeam::<T, _>::worker_by_id(worker).started_leaving_at,
+                Some(System::<T>::block_number()),
+                "Worker hasn't started leaving"
+            );
+        }
 
-      for i in 1..successful_application_ids.len() {
-        let worker = TeamWorkerId::<T>::from(i.try_into().unwrap());
-        assert!(WorkerById::<T, I>::contains_key(worker), "Not all workers
-        added");
-        assert_eq!(WorkingTeam::<T, _>::worker_by_id(worker).started_leaving_at, Some(System::<T>::block_number()), "Worker hasn't started leaving");
-      }
+        // Maintain consistency with add_opening_helper
+        let leaving_unstaking_period = T::MinUnstakingPeriodLimit::get() + One::one();
 
-      // Maintain consistency with add_opening_helper
-      let leaving_unstaking_period = T::MinUnstakingPeriodLimit::get() + One::one();
+        // Force unstaking period to have passed
+        let curr_block_number =
+            System::<T>::block_number().saturating_add(leaving_unstaking_period.into());
+        System::<T>::set_block_number(curr_block_number);
+        WorkingTeam::<T, _>::set_budget(
+            RawOrigin::Root.into(),
+            BalanceOfCurrency::<T>::max_value()
+        ).unwrap();
 
-      // Force unstaking period to have passed
-      let curr_block_number =
-          System::<T>::block_number().saturating_add(leaving_unstaking_period.into());
-      System::<T>::set_block_number(curr_block_number);
-      WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()).unwrap();
-      assert_eq!(WorkingTeam::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
+        assert_eq!(WorkingTeam::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
     }: { WorkingTeam::<T, _>::on_initialize(curr_block_number) }
     verify {
-      let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
-      WorkerById::<T, I>::iter().for_each(|(worker_id, _)| {
-        assert!(!WorkerById::<T, I>::contains_key(worker_id), "Worker hasn't left");
-      });
-      assert_eq!(WorkingTeam::<T, I>::budget(), BalanceOfCurrency::<T>::max_value().saturating_sub(BalanceOfCurrency::<T>::from(i) * reward_per_worker).saturating_sub(reward_per_worker), "Budget wasn't correctly updated, probably not all workers rewarded");
+        WorkerById::<T, I>::iter().for_each(|(worker_id, _)| {
+            assert!(!WorkerById::<T, I>::contains_key(worker_id), "Worker hasn't left");
+        });
+
+        let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
+
+        assert_eq!(
+            WorkingTeam::<T, I>::budget(),
+            BalanceOfCurrency::<T>::max_value()
+                .saturating_sub(BalanceOfCurrency::<T>::from(i) * reward_per_worker)
+                .saturating_sub(reward_per_worker),
+            "Budget wasn't correctly updated, probably not all workers rewarded"
+        );
     }
 
 
     on_initialize_rewarding_with_missing_reward {
-      let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let i in 1 .. T::MaxWorkerNumberLimit::get();
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Leader, 0, None);
+        let (lead_id, _) = insert_a_worker::<T, I>(
+            StakingRole::WithStakes,
+            JobOpeningType::Leader,
+            0,
+            None
+        );
 
-      let (opening_id, successful_application_ids, _) = add_opening_and_n_apply::<T, I>(
-        &(1..i).collect(),
-        &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
-        &StakingRole::WithStakes,
-        &JobOpeningType::Regular
-      );
+        let (opening_id, successful_application_ids, _) = add_opening_and_n_apply::<T, I>(
+            &(1..i).collect(),
+            &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
+            &StakingRole::WithStakes,
+            &JobOpeningType::Regular
+        );
 
-      WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
-      successful_application_ids.clone()).unwrap();
+        WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
+        successful_application_ids.clone()).unwrap();
 
-      for i in 1..successful_application_ids.len() {
-        assert!(WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())), "Not all workers
-        added");
-      }
+        for i in 1..successful_application_ids.len() {
+            assert!(
+                WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())),
+                "Not all workers added"
+            );
+        }
 
-      // Worst case scenario there is a missing reward
-      force_missed_reward::<T, I>();
+        // Worst case scenario there is a missing reward
+        force_missed_reward::<T, I>();
 
-      // Sets periods so that we can reward
-      let curr_block_number =
-          System::<T>::block_number().saturating_add(T::RewardPeriod::get().into());
-      System::<T>::set_block_number(curr_block_number);
+        // Sets periods so that we can reward
+        let curr_block_number =
+            System::<T>::block_number().saturating_add(T::RewardPeriod::get().into());
+        System::<T>::set_block_number(curr_block_number);
 
-      // Sets budget so that we can pay it
-      WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()).unwrap();
-      assert_eq!(WorkingTeam::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
+        // Sets budget so that we can pay it
+        WorkingTeam::<T, _>::set_budget(
+            RawOrigin::Root.into(),
+            BalanceOfCurrency::<T>::max_value()
+        ).unwrap();
 
+        assert_eq!(WorkingTeam::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
     }: { WorkingTeam::<T, _>::on_initialize(curr_block_number) }
     verify {
-      let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
-      assert_eq!(WorkingTeam::<T, _>::budget(),
-      // When creating a worker using `insert_a_worker` it gives the lead a number of block equating to
-      // reward period as missed reward(and the reward value is 1) therefore the additional discount of
-      // balance
-      BalanceOfCurrency::<T>::max_value().saturating_sub(BalanceOfCurrency::<T>::from(i) * reward_per_worker * BalanceOfCurrency::<T>::from(2)).saturating_sub(reward_per_worker),
-      "Budget wasn't correctly updated, probably not all workers rewarded");
+        let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
+
+        let reward_for_workers =
+            BalanceOfCurrency::<T>::from(i) * reward_per_worker * BalanceOfCurrency::<T>::from(2);
+
+        assert_eq!(
+            WorkingTeam::<T, _>::budget(),
+            // When creating a worker using `insert_a_worker` it gives the lead a number of block
+            // equating to reward period as missed reward(and the reward value is 1) therefore the
+            // additional discount of balance
+            BalanceOfCurrency::<T>::max_value()
+                .saturating_sub(reward_for_workers)
+                .saturating_sub(reward_per_worker),
+            "Budget wasn't correctly updated, probably not all workers rewarded"
+        );
     }
 
     on_initialize_rewarding_with_missing_reward_cant_pay {
-      let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let i in 1 .. T::MaxWorkerNumberLimit::get();
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Leader, 0, None);
+        let (lead_id, _) = insert_a_worker::<T, I>(
+            StakingRole::WithStakes,
+            JobOpeningType::Leader,
+            0,
+            None
+        );
 
-      let (opening_id, successful_application_ids, _) = add_opening_and_n_apply::<T, I>(
-        &(1..i).collect(),
-        &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
-        &StakingRole::WithStakes,
-        &JobOpeningType::Regular
-      );
+        let (opening_id, successful_application_ids, _) = add_opening_and_n_apply::<T, I>(
+            &(1..i).collect(),
+            &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
+            &StakingRole::WithStakes,
+            &JobOpeningType::Regular
+        );
 
-      WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
-      successful_application_ids.clone()).unwrap();
+        WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
+        successful_application_ids.clone()).unwrap();
 
-      for i in 1..successful_application_ids.len() {
-        assert!(WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())), "Not all workers
-        added");
-      }
+        for i in 1..successful_application_ids.len() {
+            assert!(
+                WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())),
+                "Not all workers added"
+            );
+        }
 
-      // Sets periods so that we can reward
-      let curr_block_number =
-          System::<T>::block_number().saturating_add(T::RewardPeriod::get().into());
-      System::<T>::set_block_number(curr_block_number);
+        // Sets periods so that we can reward
+        let curr_block_number =
+            System::<T>::block_number().saturating_add(T::RewardPeriod::get().into());
 
-      // Sets budget so that we can't pay it
-      WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), Zero::zero()).unwrap();
-      assert_eq!(WorkingTeam::<T, _>::budget(), Zero::zero());
+        System::<T>::set_block_number(curr_block_number);
+
+        // Sets budget so that we can't pay it
+        WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), Zero::zero()).unwrap();
+
+        assert_eq!(WorkingTeam::<T, _>::budget(), Zero::zero());
 
     }: { WorkingTeam::<T, _>::on_initialize(curr_block_number) }
     verify {
-      WorkerById::<T, I>::iter().for_each(|(_, worker)| {
-        assert!(worker.missed_reward.expect("There should be some missed reward") >= BalanceOfCurrency::<T>::from(T::RewardPeriod::get()), "At least one worker wasn't
-        rewarded");
-      });
+        WorkerById::<T, I>::iter().for_each(|(_, worker)| {
+            let missed_reward = worker.missed_reward.expect("There should be some missed reward");
+
+            assert!(
+                missed_reward >= BalanceOfCurrency::<T>::from(T::RewardPeriod::get()),
+                "At least one worker wasn't rewarded"
+            );
+        });
     }
 
     on_initialize_rewarding_without_missing_reward {
-      let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let i in 1 .. T::MaxWorkerNumberLimit::get();
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Leader, 0, None);
+        let (lead_id, _) = insert_a_worker::<T, I>(
+            StakingRole::WithStakes,
+            JobOpeningType::Leader,
+            0,
+            None
+        );
 
-      let (opening_id, successful_application_ids, _) = add_opening_and_n_apply::<T, I>(
-        &(1..i).collect(),
-        &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
-        &StakingRole::WithStakes,
-        &JobOpeningType::Regular
-      );
+        let (opening_id, successful_application_ids, _) = add_opening_and_n_apply::<T, I>(
+            &(1..i).collect(),
+            &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
+            &StakingRole::WithStakes,
+            &JobOpeningType::Regular
+        );
 
-      WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
-      successful_application_ids.clone()).unwrap();
+        WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
+        successful_application_ids.clone()).unwrap();
 
-      for i in 1..successful_application_ids.len() {
-        assert!(WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())), "Not all workers
-        added");
-      }
+        for i in 1..successful_application_ids.len() {
+            assert!(
+                WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())),
+                "Not all workers added"
+            );
+        }
 
-      // Sets periods so that we can reward
-      let curr_block_number =
-          System::<T>::block_number().saturating_add(T::RewardPeriod::get().into());
-      System::<T>::set_block_number(curr_block_number);
+        // Sets periods so that we can reward
+        let curr_block_number =
+            System::<T>::block_number().saturating_add(T::RewardPeriod::get().into());
+        System::<T>::set_block_number(curr_block_number);
 
-      // Sets budget so that we can pay it
-      WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()).unwrap();
-      assert_eq!(WorkingTeam::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
+        // Sets budget so that we can pay it
+        WorkingTeam::<T, _>::set_budget(
+            RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()
+        ).unwrap();
+        assert_eq!(WorkingTeam::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
 
     }: { WorkingTeam::<T, _>::on_initialize(curr_block_number) }
     verify {
-      let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
-      assert_eq!(WorkingTeam::<T, _>::budget(),
-      // When creating a worker using `insert_a_worker` it gives the lead a number of block equating to
-      // reward period as missed reward(and the reward value is 1) therefore the additional discount of
-      // balance
-      BalanceOfCurrency::<T>::max_value().saturating_sub(BalanceOfCurrency::<T>::from(i) * reward_per_worker).saturating_sub(reward_per_worker),
-      "Budget wasn't correctly updated, probably not all workers rewarded");
+        let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
+        let workers_total_reward = BalanceOfCurrency::<T>::from(i) * reward_per_worker;
+        assert_eq!(
+            WorkingTeam::<T, _>::budget(),
+            // When creating a worker using `insert_a_worker` it gives the lead a number of block
+            // equating to reward period as missed reward(and the reward value is 1) therefore the
+            // additional discount of balance
+            BalanceOfCurrency::<T>::max_value()
+                .saturating_sub(workers_total_reward)
+                .saturating_sub(reward_per_worker),
+            "Budget wasn't correctly updated, probably not all workers rewarded"
+        );
     }
 
     apply_on_opening {
-      let i in 1 .. 50000;
+        let i in 1 .. 50000;
 
-      let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0);
-      let opening_id = add_opening_helper::<T, I>(0, &T::Origin::from(RawOrigin::Root), &StakingRole::WithStakes, &JobOpeningType::Leader);
+        let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0);
+        let opening_id = add_opening_helper::<T, I>(
+            0,
+            &T::Origin::from(RawOrigin::Root),
+            &StakingRole::WithStakes,
+            &JobOpeningType::Leader
+        );
 
-      let apply_on_opening_params = ApplyOnOpeningParameters::<T, I> {
-        member_id: lead_member_id,
-        opening_id: opening_id.clone(),
-        role_account_id: lead_account_id.clone(),
-        reward_account_id: lead_account_id.clone(),
-        description: vec![0u8; i.try_into().unwrap()],
-        stake_parameters: Some(
-          // Make sure to keep consistency with the StakePolicy in add_opening_helper (we are safe as long as we are
-          // using max_value for stake)
-          StakeParameters {
-            stake: One::one(),
-            staking_account_id: lead_account_id.clone(),
-          }
-        ),
-      };
+        let apply_on_opening_params = ApplyOnOpeningParameters::<T, I> {
+            member_id: lead_member_id,
+            opening_id: opening_id.clone(),
+            role_account_id: lead_account_id.clone(),
+            reward_account_id: lead_account_id.clone(),
+            description: vec![0u8; i.try_into().unwrap()],
+            stake_parameters: Some(
+                // Make sure to keep consistency with the StakePolicy in add_opening_helper
+                // (we are safe as long as we are using max_value for stake)
+                StakeParameters {
+                    stake: One::one(),
+                    staking_account_id: lead_account_id.clone(),
+                }
+            ),
+        };
 
     }: _ (RawOrigin::Signed(lead_account_id.clone()), apply_on_opening_params)
     verify {
-      assert!(ApplicationById::<T, I>::contains_key(T::ApplicationId::from(0)), "Application not found");
-      assert_last_event::<T, I>(RawEvent::AppliedOnOpening(opening_id, Zero::zero()).into());
+        assert!(
+            ApplicationById::<T, I>::contains_key(T::ApplicationId::from(0)),
+            "Application not found"
+        );
+
+        assert_last_event::<T, I>(RawEvent::AppliedOnOpening(opening_id, Zero::zero()).into());
     }
 
     fill_opening_lead {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0);
-      let (opening_id, application_id) = add_and_apply_opening::<T, I>(0, &RawOrigin::Root.into(), &StakingRole::WithoutStakes, &lead_account_id,
-        &lead_member_id, &JobOpeningType::Leader);
+        let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0);
+        let (opening_id, application_id) = add_and_apply_opening::<T, I>(
+            0,
+            &RawOrigin::Root.into(),
+            &StakingRole::WithoutStakes,
+            &lead_account_id,
+            &lead_member_id,
+            &JobOpeningType::Leader
+        );
 
-      let mut successful_application_ids: BTreeSet<T::ApplicationId> = BTreeSet::new();
-      successful_application_ids.insert(application_id);
+        let mut successful_application_ids: BTreeSet<T::ApplicationId> = BTreeSet::new();
+        successful_application_ids.insert(application_id);
     }: fill_opening(RawOrigin::Root, opening_id, successful_application_ids)
     verify {
-      assert!(!OpeningById::<T, I>::contains_key(opening_id), "Opening still not filled");
-      assert_eq!(WorkingTeam::<T, I>::current_lead(), Some(Zero::zero()), "Opening for lead not filled");
+        assert!(!OpeningById::<T, I>::contains_key(opening_id), "Opening still not filled");
+        assert_eq!(
+            WorkingTeam::<T, I>::current_lead(),
+            Some(Zero::zero()),
+            "Opening for lead not filled"
+        );
     }
 
     fill_opening_worker { // We can actually fill an opening with 0 applications?
-      let i in 1 .. T::MaxWorkerNumberLimit::get();
-      let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(
+            StakingRole::WithoutStakes,
+            JobOpeningType::Leader,
+            0,
+            None
+        );
 
-      let (opening_id, successful_application_ids, _) = add_opening_and_n_apply::<T, I>(
-        &(1..i).collect(),
-        &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
-        &StakingRole::WithoutStakes,
-        &JobOpeningType::Regular
-      );
-    }: fill_opening(RawOrigin::Signed(lead_id.clone()), opening_id, successful_application_ids.clone())
+        let (opening_id, successful_application_ids, _) = add_opening_and_n_apply::<T, I>(
+            &(1..i).collect(),
+            &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
+            &StakingRole::WithoutStakes,
+            &JobOpeningType::Regular
+        );
+    }: fill_opening(
+            RawOrigin::Signed(lead_id.clone()),
+            opening_id,
+            successful_application_ids.clone()
+        )
     verify {
-      assert!(!OpeningById::<T, I>::contains_key(opening_id), "Opening still not filled");
+        assert!(!OpeningById::<T, I>::contains_key(opening_id), "Opening still not filled");
 
-      for i in 1..successful_application_ids.len() {
-        assert!(WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())), "Not all workers
-        added");
-      }
-
+        for i in 1..successful_application_ids.len() {
+            assert!(
+                WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())),
+                "Not all workers added"
+            );
+        }
     }
 
     update_role_account{
-      let i in 1 .. 10;
-      let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let new_account_id = account::<T::AccountId>("new_lead_account", 1, SEED);
+        let i in 1 .. 10;
+        let (lead_id, lead_worker_id) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let new_account_id = account::<T::AccountId>("new_lead_account", 1, SEED);
     }: _ (RawOrigin::Signed(lead_id), lead_worker_id, new_account_id.clone())
     verify {
-      assert_eq!(WorkingTeam::<T, I>::worker_by_id(lead_worker_id).role_account_id, new_account_id, "Role account not
-      updated");
-      assert_last_event::<T, I>(RawEvent::WorkerRoleAccountUpdated(lead_worker_id, new_account_id).into());
+        assert_eq!(
+            WorkingTeam::<T, I>::worker_by_id(lead_worker_id).role_account_id,
+            new_account_id,
+            "Role account notupdated"
+        );
+
+        assert_last_event::<T, I>(
+            RawEvent::WorkerRoleAccountUpdated(lead_worker_id, new_account_id).into()
+        );
     }
 
     cancel_opening {
-      let i in 1 .. 10;
+        let i in 1 .. 10;
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let opening_id = add_opening_helper::<T, I>(
-        1,
-        &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
-        &StakingRole::WithoutStakes,
-        &JobOpeningType::Regular
-      );
+        let (lead_id, _) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let opening_id = add_opening_helper::<T, I>(
+            1,
+            &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
+            &StakingRole::WithoutStakes,
+            &JobOpeningType::Regular
+        );
 
     }: _ (RawOrigin::Signed(lead_id.clone()), opening_id)
     verify {
-      assert!(!OpeningById::<T, I>::contains_key(opening_id), "Opening not removed");
-      assert_last_event::<T, I>(RawEvent::OpeningCanceled(opening_id).into());
+        assert!(!OpeningById::<T, I>::contains_key(opening_id), "Opening not removed");
+        assert_last_event::<T, I>(RawEvent::OpeningCanceled(opening_id).into());
     }
 
     withdraw_application {
-      let i in 1 .. 10;
+        let i in 1 .. 10;
 
-      let (caller_id, member_id) = member_funded_account::<T>("lead", 0);
-      let (_, application_id) = add_and_apply_opening::<T, I>(0,
-        &RawOrigin::Root.into(),
-        &StakingRole::WithStakes,
-        &caller_id,
-        &member_id,
-        &JobOpeningType::Leader
+        let (caller_id, member_id) = member_funded_account::<T>("lead", 0);
+        let (_, application_id) = add_and_apply_opening::<T, I>(0,
+            &RawOrigin::Root.into(),
+            &StakingRole::WithStakes,
+            &caller_id,
+            &member_id,
+            &JobOpeningType::Leader
         );
 
     }: _ (RawOrigin::Signed(caller_id.clone()), application_id)
     verify {
-      assert!(!ApplicationById::<T, I>::contains_key(application_id), "Application not removed");
-      assert_last_event::<T, I>(RawEvent::ApplicationWithdrawn(application_id).into());
+        assert!(!ApplicationById::<T, I>::contains_key(application_id), "Application not removed");
+        assert_last_event::<T, I>(RawEvent::ApplicationWithdrawn(application_id).into());
     }
 
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     slash_stake {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let (caller_id, worker_id) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Regular, 1, Some(lead_id.clone()));
-      let slashing_amount = One::one();
-      let penalty = Penalty {
-        slashing_text: vec![],
-        slashing_amount,
-      };
+        let (lead_id, lead_worker_id) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let (caller_id, worker_id) = insert_a_worker::<T, I>(
+            StakingRole::WithStakes,
+            JobOpeningType::Regular,
+            1,
+            Some(lead_id.clone())
+        );
+        let slashing_amount = One::one();
+        let penalty = Penalty {
+            slashing_text: vec![],
+            slashing_amount,
+        };
     }: _(RawOrigin::Signed(lead_id.clone()), worker_id, penalty)
     verify {
-      assert_last_event::<T, I>(RawEvent::StakeSlashed(worker_id, slashing_amount).into());
+        assert_last_event::<T, I>(RawEvent::StakeSlashed(worker_id, slashing_amount).into());
     }
 
     terminate_role_worker {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let (caller_id, worker_id) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Regular, 1, Some(lead_id.clone()));
-      // To be able to pay unpaid reward
-      let current_budget = BalanceOfCurrency::<T>::max_value();
-      WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
-      let penalty = Penalty {
-        slashing_text: vec![],
-        slashing_amount: One::one(),
-      };
+        let (lead_id, _) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let (caller_id, worker_id) = insert_a_worker::<T, I>(
+            StakingRole::WithStakes,
+            JobOpeningType::Regular,
+            1,
+            Some(lead_id.clone())
+        );
+        // To be able to pay unpaid reward
+        let current_budget = BalanceOfCurrency::<T>::max_value();
+        WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
+        let penalty = Penalty {
+            slashing_text: vec![],
+            slashing_amount: One::one(),
+        };
     }: terminate_role(RawOrigin::Signed(lead_id.clone()), worker_id, Some(penalty))
     verify {
-      assert!(!WorkerById::<T, I>::contains_key(worker_id), "Worker not terminated");
-      assert_last_event::<T, I>(RawEvent::TerminatedWorker(worker_id).into());
+        assert!(!WorkerById::<T, I>::contains_key(worker_id), "Worker not terminated");
+        assert_last_event::<T, I>(RawEvent::TerminatedWorker(worker_id).into());
     }
 
     terminate_role_lead {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let (_, lead_worker_id) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Leader, 0, None);
-      let current_budget = BalanceOfCurrency::<T>::max_value();
-      // To be able to pay unpaid reward
-      WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
-      let penalty = Penalty {
-        slashing_text: vec![],
-        slashing_amount: One::one(),
-      };
+        let (_, lead_worker_id) =
+            insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Leader, 0, None);
+        let current_budget = BalanceOfCurrency::<T>::max_value();
+        // To be able to pay unpaid reward
+        WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
+        let penalty = Penalty {
+            slashing_text: vec![],
+            slashing_amount: One::one(),
+        };
     }: terminate_role(RawOrigin::Root, lead_worker_id, Some(penalty))
     verify {
-      assert!(!WorkerById::<T, I>::contains_key(lead_worker_id), "Worker not terminated");
-      assert_last_event::<T, I>(RawEvent::TerminatedLeader(lead_worker_id).into());
+        assert!(!WorkerById::<T, I>::contains_key(lead_worker_id), "Worker not terminated");
+        assert_last_event::<T, I>(RawEvent::TerminatedLeader(lead_worker_id).into());
     }
 
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     increase_stake {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let (caller_id, worker_id) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Regular, 1, Some(lead_id.clone()));
+        let (lead_id, _) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let (caller_id, worker_id) = insert_a_worker::<T, I>(
+            StakingRole::WithStakes,
+            JobOpeningType::Regular,
+            1,
+            Some(lead_id.clone())
+        );
 
-      let old_stake = One::one();
-      WorkingTeam::<T, _>::decrease_stake(RawOrigin::Signed(lead_id.clone()).into(), worker_id.clone(), old_stake).unwrap();
-      let new_stake = old_stake + One::one();
+        let old_stake = One::one();
+        WorkingTeam::<T, _>::decrease_stake(
+            RawOrigin::Signed(lead_id.clone()).into(), worker_id.clone(), old_stake).unwrap();
+        let new_stake = old_stake + One::one();
     }: _ (RawOrigin::Signed(caller_id.clone()), worker_id.clone(), new_stake)
     verify {
-      assert_last_event::<T, I>(RawEvent::StakeIncreased(worker_id, new_stake).into());
+        assert_last_event::<T, I>(RawEvent::StakeIncreased(worker_id, new_stake).into());
     }
 
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     decrease_stake {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let (_, worker_id) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Regular, 1, Some(lead_id.clone()));
+        let (lead_id, _) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let (_, worker_id) = insert_a_worker::<T, I>(
+            StakingRole::WithStakes,
+            JobOpeningType::Regular,
+            1,
+            Some(lead_id.clone())
+        );
 
-      // I'm assuming that we will usually have MaxBalance > 1
-      let new_stake = One::one();
+        // I'm assuming that we will usually have MaxBalance > 1
+        let new_stake = One::one();
     }: _ (RawOrigin::Signed(lead_id), worker_id, new_stake)
     verify {
-      assert_last_event::<T, I>(RawEvent::StakeDecreased(worker_id, new_stake).into());
+        assert_last_event::<T, I>(RawEvent::StakeDecreased(worker_id, new_stake).into());
     }
 
     spend_from_budget {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let (lead_id, _) = insert_a_worker::<T, I>(
+            StakingRole::WithoutStakes,
+            JobOpeningType::Leader,
+            0,
+            None
+        );
 
-      let current_budget = BalanceOfCurrency::<T>::max_value();
-      WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
+        let current_budget = BalanceOfCurrency::<T>::max_value();
+        WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
     }: _ (RawOrigin::Signed(lead_id.clone()), lead_id.clone(), current_budget, None)
     verify {
-      assert_eq!(WorkingTeam::<T, I>::budget(), Zero::zero(), "Budget not updated");
-      assert_last_event::<T, I>(RawEvent::BudgetSpending(lead_id, current_budget).into());
+        assert_eq!(WorkingTeam::<T, I>::budget(), Zero::zero(), "Budget not updated");
+        assert_last_event::<T, I>(RawEvent::BudgetSpending(lead_id, current_budget).into());
     }
 
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     update_reward_amount {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let (_, worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Regular, 1, Some(lead_id.clone()));
-      let new_reward = Some(BalanceOfCurrency::<T>::max_value());
+        let (lead_id, _) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let (_, worker_id) = insert_a_worker::<T, I>(
+            StakingRole::WithoutStakes,
+            JobOpeningType::Regular,
+            1,
+            Some(lead_id.clone())
+        );
+
+        let new_reward = Some(BalanceOfCurrency::<T>::max_value());
     }: _ (RawOrigin::Signed(lead_id.clone()), worker_id, new_reward)
     verify {
-      assert_eq!(WorkingTeam::<T, I>::worker_by_id(worker_id).reward_per_block, new_reward, "Reward not updated");
-      assert_last_event::<T, I>(RawEvent::WorkerRewardAmountUpdated(worker_id, new_reward).into());
+        assert_eq!(
+            WorkingTeam::<T, I>::worker_by_id(worker_id).reward_per_block,
+            new_reward,
+            "Reward not updated"
+        );
+
+        assert_last_event::<T, I>(
+            RawEvent::WorkerRewardAmountUpdated(worker_id, new_reward).into()
+        );
     }
 
     set_status_text {
-      let i in 0 .. 50000; // TODO: We should have a bounded value for description
+        let i in 0 .. 50000; // TODO: We should have a bounded value for description
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let status_text = Some(vec![0u8; i.try_into().unwrap()]);
+        let (lead_id, _) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let status_text = Some(vec![0u8; i.try_into().unwrap()]);
 
     }: _ (RawOrigin::Signed(lead_id), status_text.clone())
     verify {
-      let status_text_hash = T::Hashing::hash(&status_text.unwrap()).as_ref().to_vec();
-      assert_eq!(WorkingTeam::<T, I>::status_text_hash(), status_text_hash, "Status text not updated");
-      assert_last_event::<T, I>(RawEvent::StatusTextChanged(status_text_hash).into());
+        let status_text_hash = T::Hashing::hash(&status_text.unwrap()).as_ref().to_vec();
+
+        assert_eq!(
+            WorkingTeam::<T, I>::status_text_hash(),
+            status_text_hash,
+            "Status text not updated"
+        );
+
+        assert_last_event::<T, I>(RawEvent::StatusTextChanged(status_text_hash).into());
     }
 
     update_reward_account {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let (caller_id, worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let new_id = account::<T::AccountId>("new_id", 1, 0);
+        let (caller_id, worker_id) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let new_id = account::<T::AccountId>("new_id", 1, 0);
 
     }: _ (RawOrigin::Signed(caller_id), worker_id, new_id.clone())
     verify {
-      assert_eq!(WorkingTeam::<T, I>::worker_by_id(worker_id).reward_account_id, new_id, "Reward account not updated");
-      assert_last_event::<T, I>(RawEvent::WorkerRewardAccountUpdated(worker_id, new_id).into());
+        assert_eq!(
+            WorkingTeam::<T, I>::worker_by_id(worker_id).reward_account_id,
+            new_id,
+            "Reward account not updated"
+        );
+
+        assert_last_event::<T, I>(RawEvent::WorkerRewardAccountUpdated(worker_id, new_id).into());
     }
 
     set_budget {
-      let i in 0 .. 10;
+        let i in 0 .. 10;
 
-      let new_budget = BalanceOfCurrency::<T>::max_value();
+        let new_budget = BalanceOfCurrency::<T>::max_value();
 
     }: _(RawOrigin::Root, new_budget)
     verify {
-      assert_eq!(WorkingTeam::<T, I>::budget(), new_budget, "Budget isn't updated");
-      assert_last_event::<T, I>(RawEvent::BudgetSet(new_budget).into());
+        assert_eq!(WorkingTeam::<T, I>::budget(), new_budget, "Budget isn't updated");
+        assert_last_event::<T, I>(RawEvent::BudgetSet(new_budget).into());
     }
 
     // Regular opening is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
-    add_opening{
-      let i in 0 .. 50000; // TODO: We should have a bounded value for description
+    add_opening {
+        let i in 0 .. 50000; // TODO: We should have a bounded value for description
 
-      let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let (lead_id, _) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
 
+        let stake_policy = StakePolicy {
+            stake_amount: BalanceOfCurrency::<T>::max_value(),
+            leaving_unstaking_period: T::BlockNumber::max_value(),
+        };
 
-      let stake_policy = StakePolicy {
-        stake_amount: BalanceOfCurrency::<T>::max_value(),
-        leaving_unstaking_period: T::BlockNumber::max_value(),
-      };
+        let reward_policy = RewardPolicy {
+            reward_per_block: BalanceOfCurrency::<T>::max_value(),
+        };
 
-      let reward_policy = RewardPolicy {
-        reward_per_block: BalanceOfCurrency::<T>::max_value(),
-      };
+        let description = vec![0u8; i.try_into().unwrap()];
 
-      let description = vec![0u8; i.try_into().unwrap()];
-
-    }: _(RawOrigin::Signed(lead_id), description, JobOpeningType::Regular, Some(stake_policy), Some(reward_policy))
+    }: _(
+            RawOrigin::Signed(lead_id),
+            description,
+            JobOpeningType::Regular,
+            Some(stake_policy),
+            Some(reward_policy)
+        )
     verify {
-      assert!(OpeningById::<T, I>::contains_key(T::OpeningId::from(1)));
-      assert_last_event::<T, I>(RawEvent::OpeningAdded(T::OpeningId::from(1)).into());
+        assert!(OpeningById::<T, I>::contains_key(T::OpeningId::from(1)));
+        assert_last_event::<T, I>(RawEvent::OpeningAdded(T::OpeningId::from(1)).into());
     }
 
     // This is always worse than leave_role_immediatly
@@ -725,16 +897,20 @@ benchmarks_instance! {
         // Worst case scenario there is a lead(this requires **always** more steps)
         // could separate into new branch to tighten weight
         // Also, workers without stake can leave immediatly
-        let (caller_id, lead_worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let (caller_id, lead_worker_id) =
+            insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
 
         // To be able to pay unpaid reward
-        WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()).unwrap();
+        WorkingTeam::<T, _>::set_budget(
+            RawOrigin::Root.into(),
+            BalanceOfCurrency::<T>::max_value()
+        ).unwrap();
+
     }: leave_role(RawOrigin::Signed(caller_id), lead_worker_id)
     verify {
-      assert!(!WorkerById::<T, I>::contains_key(lead_worker_id), "Worker hasn't left");
-      assert_last_event::<T, I>(RawEvent::WorkerExited(lead_worker_id).into());
+        assert!(!WorkerById::<T, I>::contains_key(lead_worker_id), "Worker hasn't left");
+        assert_last_event::<T, I>(RawEvent::WorkerExited(lead_worker_id).into());
     }
-
 
     // Generally speaking this seems to be always the best case scenario
     // but since it's so obviously a different branch I think it's a good idea
@@ -743,10 +919,19 @@ benchmarks_instance! {
         let i in 0 .. 10;
 
         // Workers with stake can't leave immediatly
-        let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Leader, 0, None);
+        let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(
+            StakingRole::WithStakes,
+            JobOpeningType::Leader,
+            0,
+            None
+        );
     }: leave_role(RawOrigin::Signed(caller_id), caller_worker_id)
     verify {
-      assert_eq!(WorkingTeam::<T, _>::worker_by_id(caller_worker_id).started_leaving_at, Some(System::<T>::block_number()), "Worker hasn't started leaving");
+        assert_eq!(
+            WorkingTeam::<T, _>::worker_by_id(caller_worker_id).started_leaving_at,
+            Some(System::<T>::block_number()),
+            "Worker hasn't started leaving"
+        );
     }
 }
 

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "runtime-benchmarks")]
 use super::*;
-use core::cmp::min;
 use core::convert::TryInto;
 use frame_benchmarking::{account, benchmarks_instance, Zero};
 use frame_support::traits::OnInitialize;
 use sp_runtime::traits::Bounded;
+use sp_std::cmp::min;
 use sp_std::prelude::*;
 use system as frame_system;
 use system::EventRecord;
@@ -162,13 +162,12 @@ fn add_and_apply_opening<T: Trait<I>, I: Instance>(
 // for a membership. For each index.
 fn handle_from_id<T: membership::Trait>(id: u32) -> Vec<u8> {
     let min_handle_length = Membership::<T>::min_handle_length();
-    // If the index is ever different from u32 change this
-    let mut handle = vec![
-        get_byte(id, 0),
-        get_byte(id, 1),
-        get_byte(id, 2),
-        get_byte(id, 3),
-    ];
+
+    let mut handle = vec![];
+
+    for i in 0..min(Membership::<T>::max_handle_length().try_into().unwrap(), 4) {
+        handle.push(get_byte(id, i));
+    }
 
     while handle.len() < (min_handle_length as usize) {
         handle.push(0u8);

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -159,7 +159,6 @@ fn add_and_apply_opening<T: Trait<I>, I: Instance>(
 
 // Method to generate a distintic valid handle
 // for a membership. For each index.
-// TODO: This will only work as long as max_handle_length >= 4
 fn handle_from_id<T: membership::Trait>(id: u32) -> Vec<u8> {
     let min_handle_length = Membership::<T>::min_handle_length();
     // If the index is ever different from u32 change this
@@ -513,7 +512,7 @@ benchmarks_instance! {
     }
 
     apply_on_opening {
-        let i in 1 .. 50000; // TODO: We should have a bounded value for description
+        let i in 1 .. 50000;
 
         let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0);
         let opening_id = add_opening_helper::<T, I>(
@@ -550,7 +549,6 @@ benchmarks_instance! {
     }
 
     fill_opening_lead {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0);
@@ -625,7 +623,6 @@ benchmarks_instance! {
     }
 
     update_role_account{
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
         let (lead_id, lead_worker_id) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
@@ -644,7 +641,6 @@ benchmarks_instance! {
     }
 
     cancel_opening {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         let (lead_id, _) =
@@ -663,7 +659,6 @@ benchmarks_instance! {
     }
 
     withdraw_application {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         let (caller_id, member_id) = member_funded_account::<T>("lead", 0);
@@ -684,7 +679,6 @@ benchmarks_instance! {
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     slash_stake {
-        // TODO: We should have a bounded value for the slashing_text
         let i in 0 .. 50000;
 
         let (lead_id, lead_worker_id) =
@@ -706,7 +700,6 @@ benchmarks_instance! {
     }
 
     terminate_role_worker {
-        // TODO: We should have a bounded value for the slashing_text
         let i in 0 .. 50000;
 
         let (lead_id, _) =
@@ -731,7 +724,6 @@ benchmarks_instance! {
     }
 
     terminate_role_lead {
-        // TODO: We should have a bounded value for the slashing_text
         let i in 0 .. 50000;
 
         let (_, lead_worker_id) =
@@ -752,7 +744,6 @@ benchmarks_instance! {
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     increase_stake {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         let (lead_id, _) =
@@ -776,7 +767,6 @@ benchmarks_instance! {
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     decrease_stake {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         let (lead_id, _) =
@@ -796,7 +786,6 @@ benchmarks_instance! {
     }
 
     spend_from_budget {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         let (lead_id, _) = insert_a_worker::<T, I>(
@@ -817,7 +806,6 @@ benchmarks_instance! {
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     update_reward_amount {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         let (lead_id, _) =
@@ -844,7 +832,7 @@ benchmarks_instance! {
     }
 
     set_status_text {
-        let i in 0 .. 50000; // TODO: We should have a bounded value for description
+        let i in 0 .. 50000;
 
         let (lead_id, _) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
@@ -864,7 +852,6 @@ benchmarks_instance! {
     }
 
     update_reward_account {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         let (caller_id, worker_id) =
@@ -883,7 +870,6 @@ benchmarks_instance! {
     }
 
     set_budget {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         let new_budget = BalanceOfCurrency::<T>::max_value();
@@ -897,7 +883,7 @@ benchmarks_instance! {
     // Regular opening is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     add_opening {
-        let i in 0 .. 50000; // TODO: We should have a bounded value for description
+        let i in 0 .. 50000;
 
         let (lead_id, _) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
@@ -927,7 +913,6 @@ benchmarks_instance! {
 
     // This is always worse than leave_role_immediatly
     leave_role_immediatly {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
         // Worst case scenario there is a lead(this requires **always** more steps)
         // could separate into new branch to tighten weight
@@ -951,7 +936,6 @@ benchmarks_instance! {
     // but since it's so obviously a different branch I think it's a good idea
     // to leave this branch and use tha max between these 2
     leave_role_later {
-        // TODO: This is needed only to run in the current version erase when upgrading
         let i in 0 .. 1;
 
         // Workers with stake can't leave immediatly

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -221,9 +221,41 @@ where
 benchmarks_instance! {
     _ { }
 
+    apply_on_opening {
+      let i in 1 .. 50000;
+
+      let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0, None);
+
+      WorkingTeam::<T, I>::add_opening(
+          RawOrigin::Root.into(),
+          vec![],
+          JobOpeningType::Leader,
+          Some(StakePolicy {
+            stake_amount: <BalanceOfCurrency<T> as One>::one(),
+            leaving_unstaking_period: T::BlockNumber::max_value(),
+          }),
+          None,
+      ).unwrap();
+
+      let apply_on_opening_params = ApplyOnOpeningParameters::<T, I> {
+        member_id: lead_member_id,
+        opening_id: Zero::zero(),
+        role_account_id: lead_account_id.clone(),
+        reward_account_id: lead_account_id.clone(),
+        description: vec![0u8].repeat(i as usize),
+        stake_parameters: Some(
+          StakeParameters {
+            stake: BalanceOfCurrency::<T>::max_value(),
+            staking_account_id: lead_account_id.clone(),
+          }
+        ),
+      };
+
+    }: _ (RawOrigin::Signed(lead_account_id.clone()), apply_on_opening_params)
+    verify { }
+
     fill_opening_lead {
       let i in 0 .. 10;
-
 
       WorkingTeam::<T, I>::add_opening(
           RawOrigin::Root.into(),
@@ -480,7 +512,7 @@ benchmarks_instance! {
       let i in 0 .. 50000; // TODO: We should have a bounded value for description
 
       let (lead_id, _) = create_lead::<T,I>(true);
-      let status_text = Some(vec![0u8][..].repeat(i as usize)); // TODO:don't use as
+      let status_text = Some(vec![0u8].repeat(i as usize)); // TODO:don't use as
 
     }: _ (RawOrigin::Signed(lead_id), status_text)
     verify {}
@@ -518,7 +550,7 @@ benchmarks_instance! {
         reward_per_block: BalanceOfCurrency::<T>::max_value(),
       };
 
-      let description = vec![0u8][..].repeat(i as usize); // TODO:don't use as
+      let description = vec![0u8].repeat(i as usize); // TODO:don't use as
 
     }: _(RawOrigin::Signed(lead_id), description, JobOpeningType::Regular, Some(stake_policy), Some(reward_policy))
     verify { }

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -1,11 +1,13 @@
 #![cfg(feature = "runtime-benchmarks")]
 use super::*;
+use core::cmp::min;
 use core::convert::TryInto;
 use frame_benchmarking::{account, benchmarks_instance, Zero};
 use frame_support::traits::OnInitialize;
 use sp_runtime::traits::Bounded;
 use sp_std::prelude::*;
 use system as frame_system;
+use system::EventRecord;
 use system::Module as System;
 use system::RawOrigin;
 
@@ -18,6 +20,14 @@ const SEED: u32 = 0;
 enum StakingRole {
     WithStakes,
     WithoutStakes,
+}
+
+fn assert_last_event<T: Trait<I>, I: Instance>(generic_event: <T as Trait<I>>::Event) {
+    let events = System::<T>::events();
+    let system_event: <T as frame_system::Trait>::Event = generic_event.into();
+    // compare to the last event record
+    let EventRecord { event, .. } = &events[events.len() - 1];
+    assert_eq!(event, &system_event);
 }
 
 fn get_byte(num: u32, byte_number: u8) -> u8 {
@@ -49,7 +59,14 @@ fn add_opening_helper<T: Trait<I>, I: Instance>(
     )
     .unwrap();
 
-    T::OpeningId::from(id.try_into().unwrap())
+    let opening_id = T::OpeningId::from(id.try_into().unwrap());
+
+    assert!(
+        OpeningById::<T, I>::contains_key(opening_id),
+        "Opening not added"
+    );
+
+    opening_id
 }
 
 fn apply_on_opening_helper<T: Trait<I>, I: Instance>(
@@ -61,7 +78,11 @@ fn apply_on_opening_helper<T: Trait<I>, I: Instance>(
 ) -> T::ApplicationId {
     let stake_parameters = match staking_role {
         StakingRole::WithStakes => Some(StakeParameters {
-            stake: BalanceOfCurrency::<T>::max_value(),
+            // Due to mock implementation of StakingHandler we can't go over 1000
+            stake: min(
+                BalanceOfCurrency::<T>::max_value(),
+                BalanceOfCurrency::<T>::from(1000),
+            ),
             staking_account_id: applicant_id.clone(),
         }),
         StakingRole::WithoutStakes => None,
@@ -80,7 +101,14 @@ fn apply_on_opening_helper<T: Trait<I>, I: Instance>(
     )
     .unwrap();
 
-    T::ApplicationId::from(id.try_into().unwrap())
+    let application_id = T::ApplicationId::from(id.try_into().unwrap());
+
+    assert!(
+        ApplicationById::<T, I>::contains_key(application_id),
+        "Application not added"
+    );
+
+    application_id
 }
 
 fn add_opening_and_n_apply<T: Trait<I>, I: Instance>(
@@ -224,7 +252,11 @@ where
     // remaining reward
     force_missed_reward::<T, I>();
 
-    (caller_id, TeamWorkerId::<T>::from(id.try_into().unwrap()))
+    let worker_id = TeamWorkerId::<T>::from(id.try_into().unwrap());
+
+    assert!(WorkerById::<T, I>::contains_key(worker_id));
+
+    (caller_id, worker_id)
 }
 
 benchmarks_instance! {
@@ -243,7 +275,8 @@ benchmarks_instance! {
       );
 
       WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
-      successful_application_ids).unwrap();
+      successful_application_ids.clone()).unwrap();
+
 
       force_missed_reward::<T,I>();
 
@@ -259,6 +292,13 @@ benchmarks_instance! {
       // Worst case scenario one of the leaving workers is the lead
       WorkingTeam::<T, _>::leave_role(RawOrigin::Signed(lead_id).into(), lead_worker_id).unwrap();
 
+      for i in 1..successful_application_ids.len() {
+        let worker = TeamWorkerId::<T>::from(i.try_into().unwrap());
+        assert!(WorkerById::<T, I>::contains_key(worker), "Not all workers
+        added");
+        assert_eq!(WorkingTeam::<T, _>::worker_by_id(worker).started_leaving_at, Some(System::<T>::block_number()), "Worker hasn't started leaving");
+      }
+
       // Maintain consistency with add_opening_helper
       let leaving_unstaking_period = T::MinUnstakingPeriodLimit::get() + One::one();
 
@@ -267,8 +307,15 @@ benchmarks_instance! {
           System::<T>::block_number().saturating_add(leaving_unstaking_period.into());
       System::<T>::set_block_number(curr_block_number);
       WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()).unwrap();
-
+      assert_eq!(WorkingTeam::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
     }: { WorkingTeam::<T, _>::on_initialize(curr_block_number) }
+    verify {
+      let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
+      WorkerById::<T, I>::iter().for_each(|(worker_id, _)| {
+        assert!(!WorkerById::<T, I>::contains_key(worker_id), "Worker hasn't left");
+      });
+      assert_eq!(WorkingTeam::<T, I>::budget(), BalanceOfCurrency::<T>::max_value().saturating_sub(BalanceOfCurrency::<T>::from(i) * reward_per_worker).saturating_sub(reward_per_worker), "Budget wasn't correctly updated, probably not all workers rewarded");
+    }
 
 
     on_initialize_rewarding_with_missing_reward {
@@ -284,7 +331,12 @@ benchmarks_instance! {
       );
 
       WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
-      successful_application_ids).unwrap();
+      successful_application_ids.clone()).unwrap();
+
+      for i in 1..successful_application_ids.len() {
+        assert!(WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())), "Not all workers
+        added");
+      }
 
       // Worst case scenario there is a missing reward
       force_missed_reward::<T, I>();
@@ -296,8 +348,18 @@ benchmarks_instance! {
 
       // Sets budget so that we can pay it
       WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()).unwrap();
+      assert_eq!(WorkingTeam::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
 
     }: { WorkingTeam::<T, _>::on_initialize(curr_block_number) }
+    verify {
+      let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
+      assert_eq!(WorkingTeam::<T, _>::budget(),
+      // When creating a worker using `insert_a_worker` it gives the lead a number of block equating to
+      // reward period as missed reward(and the reward value is 1) therefore the additional discount of
+      // balance
+      BalanceOfCurrency::<T>::max_value().saturating_sub(BalanceOfCurrency::<T>::from(i) * reward_per_worker * BalanceOfCurrency::<T>::from(2)).saturating_sub(reward_per_worker),
+      "Budget wasn't correctly updated, probably not all workers rewarded");
+    }
 
     on_initialize_rewarding_with_missing_reward_cant_pay {
       let i in 1 .. T::MaxWorkerNumberLimit::get();
@@ -312,9 +374,12 @@ benchmarks_instance! {
       );
 
       WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
-      successful_application_ids).unwrap();
+      successful_application_ids.clone()).unwrap();
 
-      force_missed_reward::<T, I>();
+      for i in 1..successful_application_ids.len() {
+        assert!(WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())), "Not all workers
+        added");
+      }
 
       // Sets periods so that we can reward
       let curr_block_number =
@@ -323,8 +388,15 @@ benchmarks_instance! {
 
       // Sets budget so that we can't pay it
       WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), Zero::zero()).unwrap();
+      assert_eq!(WorkingTeam::<T, _>::budget(), Zero::zero());
 
     }: { WorkingTeam::<T, _>::on_initialize(curr_block_number) }
+    verify {
+      WorkerById::<T, I>::iter().for_each(|(_, worker)| {
+        assert!(worker.missed_reward.expect("There should be some missed reward") >= BalanceOfCurrency::<T>::from(T::RewardPeriod::get()), "At least one worker wasn't
+        rewarded");
+      });
+    }
 
     on_initialize_rewarding_without_missing_reward {
       let i in 1 .. T::MaxWorkerNumberLimit::get();
@@ -339,7 +411,12 @@ benchmarks_instance! {
       );
 
       WorkingTeam::<T, _>::fill_opening(RawOrigin::Signed(lead_id.clone()).into(), opening_id,
-      successful_application_ids).unwrap();
+      successful_application_ids.clone()).unwrap();
+
+      for i in 1..successful_application_ids.len() {
+        assert!(WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())), "Not all workers
+        added");
+      }
 
       // Sets periods so that we can reward
       let curr_block_number =
@@ -348,8 +425,18 @@ benchmarks_instance! {
 
       // Sets budget so that we can pay it
       WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()).unwrap();
+      assert_eq!(WorkingTeam::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
 
     }: { WorkingTeam::<T, _>::on_initialize(curr_block_number) }
+    verify {
+      let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
+      assert_eq!(WorkingTeam::<T, _>::budget(),
+      // When creating a worker using `insert_a_worker` it gives the lead a number of block equating to
+      // reward period as missed reward(and the reward value is 1) therefore the additional discount of
+      // balance
+      BalanceOfCurrency::<T>::max_value().saturating_sub(BalanceOfCurrency::<T>::from(i) * reward_per_worker).saturating_sub(reward_per_worker),
+      "Budget wasn't correctly updated, probably not all workers rewarded");
+    }
 
     apply_on_opening {
       let i in 1 .. 50000;
@@ -359,21 +446,25 @@ benchmarks_instance! {
 
       let apply_on_opening_params = ApplyOnOpeningParameters::<T, I> {
         member_id: lead_member_id,
-        opening_id: opening_id,
+        opening_id: opening_id.clone(),
         role_account_id: lead_account_id.clone(),
         reward_account_id: lead_account_id.clone(),
-        description: vec![0u8].repeat(i as usize),
+        description: vec![0u8; i.try_into().unwrap()],
         stake_parameters: Some(
           // Make sure to keep consistency with the StakePolicy in add_opening_helper (we are safe as long as we are
           // using max_value for stake)
           StakeParameters {
-            stake: BalanceOfCurrency::<T>::max_value(),
+            stake: One::one(),
             staking_account_id: lead_account_id.clone(),
           }
         ),
       };
 
     }: _ (RawOrigin::Signed(lead_account_id.clone()), apply_on_opening_params)
+    verify {
+      assert!(ApplicationById::<T, I>::contains_key(T::ApplicationId::from(0)), "Application not found");
+      assert_last_event::<T, I>(RawEvent::AppliedOnOpening(opening_id, Zero::zero()).into());
+    }
 
     fill_opening_lead {
       let i in 0 .. 10;
@@ -385,6 +476,10 @@ benchmarks_instance! {
       let mut successful_application_ids: BTreeSet<T::ApplicationId> = BTreeSet::new();
       successful_application_ids.insert(application_id);
     }: fill_opening(RawOrigin::Root, opening_id, successful_application_ids)
+    verify {
+      assert!(!OpeningById::<T, I>::contains_key(opening_id), "Opening still not filled");
+      assert_eq!(WorkingTeam::<T, I>::current_lead(), Some(Zero::zero()), "Opening for lead not filled");
+    }
 
     fill_opening_worker { // We can actually fill an opening with 0 applications?
       let i in 1 .. T::MaxWorkerNumberLimit::get();
@@ -396,13 +491,27 @@ benchmarks_instance! {
         &StakingRole::WithoutStakes,
         &JobOpeningType::Regular
       );
-    }: fill_opening(RawOrigin::Signed(lead_id.clone()), opening_id, successful_application_ids)
+    }: fill_opening(RawOrigin::Signed(lead_id.clone()), opening_id, successful_application_ids.clone())
+    verify {
+      assert!(!OpeningById::<T, I>::contains_key(opening_id), "Opening still not filled");
+
+      for i in 1..successful_application_ids.len() {
+        assert!(WorkerById::<T, I>::contains_key(TeamWorkerId::<T>::from(i.try_into().unwrap())), "Not all workers
+        added");
+      }
+
+    }
 
     update_role_account{
       let i in 1 .. 10;
       let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
       let new_account_id = account::<T::AccountId>("new_lead_account", 1, SEED);
-    }: _ (RawOrigin::Signed(lead_id), lead_worker_id, new_account_id)
+    }: _ (RawOrigin::Signed(lead_id), lead_worker_id, new_account_id.clone())
+    verify {
+      assert_eq!(WorkingTeam::<T, I>::worker_by_id(lead_worker_id).role_account_id, new_account_id, "Role account not
+      updated");
+      assert_last_event::<T, I>(RawEvent::WorkerRoleAccountUpdated(lead_worker_id, new_account_id).into());
+    }
 
     cancel_opening {
       let i in 1 .. 10;
@@ -415,7 +524,11 @@ benchmarks_instance! {
         &JobOpeningType::Regular
       );
 
-    }: _ (RawOrigin::Signed(lead_id.clone()), One::one())
+    }: _ (RawOrigin::Signed(lead_id.clone()), opening_id)
+    verify {
+      assert!(!OpeningById::<T, I>::contains_key(opening_id), "Opening not removed");
+      assert_last_event::<T, I>(RawEvent::OpeningCanceled(opening_id).into());
+    }
 
     withdraw_application {
       let i in 1 .. 10;
@@ -430,6 +543,10 @@ benchmarks_instance! {
         );
 
     }: _ (RawOrigin::Signed(caller_id.clone()), application_id)
+    verify {
+      assert!(!ApplicationById::<T, I>::contains_key(application_id), "Application not removed");
+      assert_last_event::<T, I>(RawEvent::ApplicationWithdrawn(application_id).into());
+    }
 
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
@@ -438,11 +555,15 @@ benchmarks_instance! {
 
       let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
       let (caller_id, worker_id) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Regular, 1, Some(lead_id.clone()));
+      let slashing_amount = One::one();
       let penalty = Penalty {
         slashing_text: vec![],
-        slashing_amount: One::one(),
+        slashing_amount,
       };
     }: _(RawOrigin::Signed(lead_id.clone()), worker_id, penalty)
+    verify {
+      assert_last_event::<T, I>(RawEvent::StakeSlashed(worker_id, slashing_amount).into());
+    }
 
     terminate_role_worker {
       let i in 0 .. 10;
@@ -457,6 +578,10 @@ benchmarks_instance! {
         slashing_amount: One::one(),
       };
     }: terminate_role(RawOrigin::Signed(lead_id.clone()), worker_id, Some(penalty))
+    verify {
+      assert!(!WorkerById::<T, I>::contains_key(worker_id), "Worker not terminated");
+      assert_last_event::<T, I>(RawEvent::TerminatedWorker(worker_id).into());
+    }
 
     terminate_role_lead {
       let i in 0 .. 10;
@@ -470,6 +595,10 @@ benchmarks_instance! {
         slashing_amount: One::one(),
       };
     }: terminate_role(RawOrigin::Root, lead_worker_id, Some(penalty))
+    verify {
+      assert!(!WorkerById::<T, I>::contains_key(lead_worker_id), "Worker not terminated");
+      assert_last_event::<T, I>(RawEvent::TerminatedLeader(lead_worker_id).into());
+    }
 
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
@@ -481,8 +610,11 @@ benchmarks_instance! {
 
       let old_stake = One::one();
       WorkingTeam::<T, _>::decrease_stake(RawOrigin::Signed(lead_id.clone()).into(), worker_id.clone(), old_stake).unwrap();
-      let new_stake = BalanceOfCurrency::<T>::max_value();
+      let new_stake = old_stake + One::one();
     }: _ (RawOrigin::Signed(caller_id.clone()), worker_id.clone(), new_stake)
+    verify {
+      assert_last_event::<T, I>(RawEvent::StakeIncreased(worker_id, new_stake).into());
+    }
 
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
@@ -495,6 +627,9 @@ benchmarks_instance! {
       // I'm assuming that we will usually have MaxBalance > 1
       let new_stake = One::one();
     }: _ (RawOrigin::Signed(lead_id), worker_id, new_stake)
+    verify {
+      assert_last_event::<T, I>(RawEvent::StakeDecreased(worker_id, new_stake).into());
+    }
 
     spend_from_budget {
       let i in 0 .. 10;
@@ -504,6 +639,10 @@ benchmarks_instance! {
       let current_budget = BalanceOfCurrency::<T>::max_value();
       WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
     }: _ (RawOrigin::Signed(lead_id.clone()), lead_id.clone(), current_budget, None)
+    verify {
+      assert_eq!(WorkingTeam::<T, I>::budget(), Zero::zero(), "Budget not updated");
+      assert_last_event::<T, I>(RawEvent::BudgetSpending(lead_id, current_budget).into());
+    }
 
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
@@ -514,14 +653,23 @@ benchmarks_instance! {
       let (_, worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Regular, 1, Some(lead_id.clone()));
       let new_reward = Some(BalanceOfCurrency::<T>::max_value());
     }: _ (RawOrigin::Signed(lead_id.clone()), worker_id, new_reward)
+    verify {
+      assert_eq!(WorkingTeam::<T, I>::worker_by_id(worker_id).reward_per_block, new_reward, "Reward not updated");
+      assert_last_event::<T, I>(RawEvent::WorkerRewardAmountUpdated(worker_id, new_reward).into());
+    }
 
     set_status_text {
       let i in 0 .. 50000; // TODO: We should have a bounded value for description
 
       let (lead_id, _) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
-      let status_text = Some(vec![0u8].repeat(i.try_into().unwrap()));
+      let status_text = Some(vec![0u8; i.try_into().unwrap()]);
 
-    }: _ (RawOrigin::Signed(lead_id), status_text)
+    }: _ (RawOrigin::Signed(lead_id), status_text.clone())
+    verify {
+      let status_text_hash = T::Hashing::hash(&status_text.unwrap()).as_ref().to_vec();
+      assert_eq!(WorkingTeam::<T, I>::status_text_hash(), status_text_hash, "Status text not updated");
+      assert_last_event::<T, I>(RawEvent::StatusTextChanged(status_text_hash).into());
+    }
 
     update_reward_account {
       let i in 0 .. 10;
@@ -529,7 +677,11 @@ benchmarks_instance! {
       let (caller_id, worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
       let new_id = account::<T::AccountId>("new_id", 1, 0);
 
-    }: _ (RawOrigin::Signed(caller_id), worker_id, new_id)
+    }: _ (RawOrigin::Signed(caller_id), worker_id, new_id.clone())
+    verify {
+      assert_eq!(WorkingTeam::<T, I>::worker_by_id(worker_id).reward_account_id, new_id, "Reward account not updated");
+      assert_last_event::<T, I>(RawEvent::WorkerRewardAccountUpdated(worker_id, new_id).into());
+    }
 
     set_budget {
       let i in 0 .. 10;
@@ -537,6 +689,10 @@ benchmarks_instance! {
       let new_budget = BalanceOfCurrency::<T>::max_value();
 
     }: _(RawOrigin::Root, new_budget)
+    verify {
+      assert_eq!(WorkingTeam::<T, I>::budget(), new_budget, "Budget isn't updated");
+      assert_last_event::<T, I>(RawEvent::BudgetSet(new_budget).into());
+    }
 
     // Regular opening is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
@@ -555,9 +711,13 @@ benchmarks_instance! {
         reward_per_block: BalanceOfCurrency::<T>::max_value(),
       };
 
-      let description = vec![0u8].repeat(i.try_into().unwrap());
+      let description = vec![0u8; i.try_into().unwrap()];
 
     }: _(RawOrigin::Signed(lead_id), description, JobOpeningType::Regular, Some(stake_policy), Some(reward_policy))
+    verify {
+      assert!(OpeningById::<T, I>::contains_key(T::OpeningId::from(1)));
+      assert_last_event::<T, I>(RawEvent::OpeningAdded(T::OpeningId::from(1)).into());
+    }
 
     // This is always worse than leave_role_immediatly
     leave_role_immediatly {
@@ -570,6 +730,10 @@ benchmarks_instance! {
         // To be able to pay unpaid reward
         WorkingTeam::<T, _>::set_budget(RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()).unwrap();
     }: leave_role(RawOrigin::Signed(caller_id), lead_worker_id)
+    verify {
+      assert!(!WorkerById::<T, I>::contains_key(lead_worker_id), "Worker hasn't left");
+      assert_last_event::<T, I>(RawEvent::WorkerExited(lead_worker_id).into());
+    }
 
 
     // Generally speaking this seems to be always the best case scenario
@@ -579,9 +743,11 @@ benchmarks_instance! {
         let i in 0 .. 10;
 
         // Workers with stake can't leave immediatly
-        let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
+        let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Leader, 0, None);
     }: leave_role(RawOrigin::Signed(caller_id), caller_worker_id)
-    verify { assert_eq!(true, true); }
+    verify {
+      assert_eq!(WorkingTeam::<T, _>::worker_by_id(caller_worker_id).started_leaving_at, Some(System::<T>::block_number()), "Worker hasn't started leaving");
+    }
 }
 
 #[cfg(test)]
@@ -591,9 +757,165 @@ mod tests {
     use frame_support::assert_ok;
 
     #[test]
-    fn test_benchmarks() {
+    fn test_leave_role_later() {
         build_test_externalities().execute_with(|| {
             assert_ok!(test_benchmark_leave_role_later::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_leave_role_immediatly() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_leave_role_immediatly::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_add_opening() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_add_opening::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_set_budget() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_set_budget::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_update_reward_account() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_update_reward_account::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_set_status_text() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_set_status_text::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_update_reward_amount() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_update_reward_amount::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_spend_from_budget() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_spend_from_budget::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_decrease_stake() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_decrease_stake::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_increase_stake() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_increase_stake::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_terminate_role_lead() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_terminate_role_lead::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_terminate_role_worker() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_terminate_role_worker::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_slash_stake() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_slash_stake::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_withdraw_application() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_withdraw_application::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_cancel_opening() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_cancel_opening::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_update_role_account() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_update_role_account::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_fill_opening_worker() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_fill_opening_worker::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_fill_opening_lead() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_fill_opening_lead::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_apply_on_opening() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_apply_on_opening::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_on_inintialize_rewarding_without_missing_reward() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_on_initialize_rewarding_without_missing_reward::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_on_inintialize_rewarding_with_missing_reward_cant_pay() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(
+                test_benchmark_on_initialize_rewarding_with_missing_reward_cant_pay::<Test>()
+            );
+        });
+    }
+
+    #[test]
+    fn test_on_inintialize_rewarding_with_missing_reward() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_on_initialize_rewarding_with_missing_reward::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_on_inintialize_leaving() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_on_initialize_leaving::<Test>());
         });
     }
 }

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -1,27 +1,39 @@
 #![cfg(feature = "runtime-benchmarks")]
 use super::*;
-use frame_benchmarking::{benchmarks_instance, Zero};
+use frame_benchmarking::{account, benchmarks_instance, Zero};
+use sp_runtime::traits::Bounded;
 use sp_std::prelude::*;
 use system as frame_system;
 use system::RawOrigin;
+
+use crate::Module as WorkingTeam;
 
 fn create_a_worker<T: Trait<I>, I: Instance>(
     caller_id: &T::AccountId,
     member_id: &T::MemberId,
     can_leave_immediatly: bool,
 ) -> TeamWorker<T> {
+    // If job usntaking period is zero the worker can always
+    // leave immediatly. However for the ase the worker can't
+    // leave immmediatly we need a non-zero stake.
+    // This is handled by `T::StakingHandler::current_stake
+
+    T::StakingHandler::increase_stake(&caller_id, BalanceOfCurrency::<T>::max_value()).unwrap();
+    T::StakingHandler::lock(&caller_id, BalanceOfCurrency::<T>::max_value());
+
     let job_unstaking_period = if !can_leave_immediatly {
-        <T as system::Trait>::BlockNumber::from(1u32)
+        <T as system::Trait>::BlockNumber::max_value()
     } else {
         Zero::zero()
     };
+
     TeamWorker::<T>::new(
         &member_id,
         &caller_id,
         &caller_id,
-        &None,
+        &Some(caller_id.clone()),
         job_unstaking_period,
-        None,
+        Some(BalanceOfCurrency::<T>::max_value()),
         Zero::zero(),
     )
 }
@@ -32,9 +44,14 @@ fn insert_a_worker<T: Trait<I>, I: Instance>(
     /*
      * TODO: Be able to have a different name for each account/member
      */
-    let caller_id = frame_benchmarking::account::<T::AccountId>("caller", 0, 0);
-    let member_id = frame_benchmarking::account::<T::MemberId>("member", 0, 0);
+    let caller_id = account::<T::AccountId>("caller", 0, 0);
+    let member_id = account::<T::MemberId>("member", 0, 0);
 
+    /*
+     * TODO: Ideally it's better to create the workers using opening/apply/fill
+     * However, I couldn't find yet how to grab the RawEvent::OpeningAdded
+     * To find the add_opening event
+     */
     let worker_id = <NextWorkerId<T, I>>::get();
 
     let worker = create_a_worker::<T, I>(&caller_id, &member_id, can_leave_immediatly);
@@ -50,68 +67,39 @@ fn insert_a_worker<T: Trait<I>, I: Instance>(
 benchmarks_instance! {
     _ { }
 
+    // Might erase later
     leave_role_immediatly {
-        let i in 0 .. 10;
+        let i in 0 .. 10; // TODO: test not running if we don't set a range of values
 
         let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(true);
-        // Worst case scenario there is a lead(this requires **always** more steps)
-        // could separate into new branch to tighten weight
-        let (_, _) = insert_a_worker::<T, I>(false);
-
     }: leave_role(RawOrigin::Signed(caller_id), caller_worker_id)
     verify { }
 
+    // This is always worse than leave_role_immediatly
+    leave_lead_immediatly {
+        let i in 0 .. 10; // TODO: test not running if we don't set a range of values
+        // Worst case scenario there is a lead(this requires **always** more steps)
+        // could separate into new branch to tighten weight
+        let (caller_id, lead_worker_id) = insert_a_worker::<T, I>(true);
+        WorkingTeam::<T, I>::set_lead(lead_worker_id);
 
+        WorkingTeam::<T, I>::set_budget(RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()).unwrap();
+
+
+    }: leave_role(RawOrigin::Signed(caller_id), lead_worker_id)
+    verify { }
+
+
+    // Generally speaking this seems to be always the best case scenario
+    // but since it's so obviously a different branch I think it's a good idea
+    // to leave this branch and use tha max between these 2
     leave_role_later {
         let i in 0 .. 10;
 
         let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(false);
     }: leave_role(RawOrigin::Signed(caller_id), caller_worker_id)
     verify { }
-
-    /*
-    set_budget {
-      let i in 0 .. 10;
-
-      let balance = BalanceOfCurrency::<T>::from(0u32);
-
-    }: _ (RawOrigin::Root, balance)
-    verify { }
-
-    add_opening {
-      let i in 0 .. 10;
-
-      let description = vec![0u8];
-      let opening_type = JobOpeningType::Regular;
-      let stake_policy = None;
-      let reward_policy = None;
-      /*
-       * TODO: IMPLEMENT
-       */
-
-    }: _ (i, description, opening_type, stake_policy, reward_policy)
-    verify {}
-
-    apply_on_opening {
-      let i in 0 .. 10;
-
-      let member_id = frame_benchmarking::account::<T::MemberId>("member", 0, 0);
-      let
-      ApplyOnOpeningParameters<T, I> {
-        member_id
-      }
-
-    }: _ ()
-    verify {}
-    */
 }
-
-/*
-    on_initialize {
-      let i in 0 .. T::MaxWorkerNumberLimit::get();
-    }: _ ()
-    verify { }
-*/
 
 /*
 TODO: we need to implement new_test_ext that creates a `sp_io::TestExternalities`

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -16,6 +16,7 @@ use crate::Module as WorkingTeam;
 use membership::Module as Membership;
 
 const SEED: u32 = 0;
+const MAX_BYTES: u32 = 16384;
 
 enum StakingRole {
     WithStakes,
@@ -512,7 +513,7 @@ benchmarks_instance! {
     }
 
     apply_on_opening {
-        let i in 1 .. 50000;
+        let i in 1 .. MAX_BYTES;
 
         let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0);
         let opening_id = add_opening_helper::<T, I>(
@@ -679,7 +680,7 @@ benchmarks_instance! {
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     slash_stake {
-        let i in 0 .. 50000;
+        let i in 0 .. MAX_BYTES;
 
         let (lead_id, lead_worker_id) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
@@ -700,7 +701,7 @@ benchmarks_instance! {
     }
 
     terminate_role_worker {
-        let i in 0 .. 50000;
+        let i in 0 .. MAX_BYTES;
 
         let (lead_id, _) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
@@ -724,7 +725,7 @@ benchmarks_instance! {
     }
 
     terminate_role_lead {
-        let i in 0 .. 50000;
+        let i in 0 .. MAX_BYTES;
 
         let (_, lead_worker_id) =
             insert_a_worker::<T, I>(StakingRole::WithStakes, JobOpeningType::Leader, 0, None);
@@ -832,7 +833,7 @@ benchmarks_instance! {
     }
 
     set_status_text {
-        let i in 0 .. 50000;
+        let i in 0 .. MAX_BYTES;
 
         let (lead_id, _) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);
@@ -883,7 +884,7 @@ benchmarks_instance! {
     // Regular opening is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     add_opening {
-        let i in 0 .. 50000;
+        let i in 0 .. MAX_BYTES;
 
         let (lead_id, _) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, JobOpeningType::Leader, 0, None);

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -1,0 +1,131 @@
+#![cfg(feature = "runtime-benchmarks")]
+use super::*;
+use frame_benchmarking::{benchmarks_instance, Zero};
+use sp_std::prelude::*;
+use system as frame_system;
+use system::RawOrigin;
+
+fn create_a_worker<T: Trait<I>, I: Instance>(
+    caller_id: &T::AccountId,
+    member_id: &T::MemberId,
+    can_leave_immediatly: bool,
+) -> TeamWorker<T> {
+    let job_unstaking_period = if !can_leave_immediatly {
+        <T as system::Trait>::BlockNumber::from(1u32)
+    } else {
+        Zero::zero()
+    };
+    TeamWorker::<T>::new(
+        &member_id,
+        &caller_id,
+        &caller_id,
+        &None,
+        job_unstaking_period,
+        None,
+        Zero::zero(),
+    )
+}
+
+fn insert_a_worker<T: Trait<I>, I: Instance>(
+    can_leave_immediatly: bool,
+) -> (T::AccountId, TeamWorkerId<T>) {
+    /*
+     * TODO: Be able to have a different name for each account/member
+     */
+    let caller_id = frame_benchmarking::account::<T::AccountId>("caller", 0, 0);
+    let member_id = frame_benchmarking::account::<T::MemberId>("member", 0, 0);
+
+    let worker_id = <NextWorkerId<T, I>>::get();
+
+    let worker = create_a_worker::<T, I>(&caller_id, &member_id, can_leave_immediatly);
+
+    <NextWorkerId<T, I>>::mutate(|id| *id += <TeamWorkerId<T> as One>::one());
+    <ActiveWorkerCount<I>>::put(<ActiveWorkerCount<I>>::get() + 1);
+
+    <WorkerById<T, I>>::insert(worker_id, worker);
+
+    (caller_id, worker_id)
+}
+
+benchmarks_instance! {
+    _ { }
+
+    leave_role_immediatly {
+        let i in 0 .. 10;
+
+        let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(true);
+        // Worst case scenario there is a lead(this requires **always** more steps)
+        // could separate into new branch to tighten weight
+        let (_, _) = insert_a_worker::<T, I>(false);
+
+    }: leave_role(RawOrigin::Signed(caller_id), caller_worker_id)
+    verify { }
+
+
+    leave_role_later {
+        let i in 0 .. 10;
+
+        let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(false);
+    }: leave_role(RawOrigin::Signed(caller_id), caller_worker_id)
+    verify { }
+
+    /*
+    set_budget {
+      let i in 0 .. 10;
+
+      let balance = BalanceOfCurrency::<T>::from(0u32);
+
+    }: _ (RawOrigin::Root, balance)
+    verify { }
+
+    add_opening {
+      let i in 0 .. 10;
+
+      let description = vec![0u8];
+      let opening_type = JobOpeningType::Regular;
+      let stake_policy = None;
+      let reward_policy = None;
+      /*
+       * TODO: IMPLEMENT
+       */
+
+    }: _ (i, description, opening_type, stake_policy, reward_policy)
+    verify {}
+
+    apply_on_opening {
+      let i in 0 .. 10;
+
+      let member_id = frame_benchmarking::account::<T::MemberId>("member", 0, 0);
+      let
+      ApplyOnOpeningParameters<T, I> {
+        member_id
+      }
+
+    }: _ ()
+    verify {}
+    */
+}
+
+/*
+    on_initialize {
+      let i in 0 .. T::MaxWorkerNumberLimit::get();
+    }: _ ()
+    verify { }
+*/
+
+/*
+TODO: we need to implement new_test_ext that creates a `sp_io::TestExternalities`
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{new_test_ext, Test};
+    use frame_support::assert_ok;
+
+    #[test]
+    fn test_benchmarks() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_leave_role::<Test>());
+        });
+    }
+}
+*/

--- a/runtime-modules/working-team/src/benchmarking.rs
+++ b/runtime-modules/working-team/src/benchmarking.rs
@@ -152,6 +152,12 @@ where
 benchmarks_instance! {
     _ { }
 
+    update_role_account{
+      let i in 1 .. 10;
+      let (lead_id, lead_worker_id) = create_lead::<T, I>(true);
+      let new_account_id = account::<T::AccountId>("new_lead_account", 1, SEED);
+    }: _ (RawOrigin::Signed(lead_id), lead_worker_id, new_account_id)
+    verify {}
 
     cancel_opening {
       let i in 1 .. 10;

--- a/runtime-modules/working-team/src/checks.rs
+++ b/runtime-modules/working-team/src/checks.rs
@@ -9,6 +9,7 @@ use frame_support::traits::Get;
 use frame_support::{ensure, StorageMap, StorageValue};
 use sp_arithmetic::traits::Zero;
 use sp_std::collections::btree_set::BTreeSet;
+use sp_std::vec::Vec;
 use system::{ensure_root, ensure_signed};
 
 use crate::types::{ApplicationInfo, StakeParameters};

--- a/runtime-modules/working-team/src/lib.rs
+++ b/runtime-modules/working-team/src/lib.rs
@@ -48,8 +48,7 @@ use sp_std::vec::Vec;
 use system::{ensure_root, ensure_signed};
 
 pub use errors::Error;
-pub use types::BalanceOfCurrency;
-use types::{ApplicationInfo, MemberId, TeamWorker, TeamWorkerId, WorkerInfo};
+use types::{ApplicationInfo, BalanceOfCurrency, MemberId, TeamWorker, TeamWorkerId, WorkerInfo};
 pub use types::{
     ApplyOnOpeningParameters, JobApplication, JobOpening, JobOpeningType, Penalty, RewardPolicy,
     StakePolicy, StakingHandler,

--- a/runtime-modules/working-team/src/lib.rs
+++ b/runtime-modules/working-team/src/lib.rs
@@ -29,6 +29,7 @@
 // Do not delete! Cannot be uncommented by default, because of Parity decl_module! issue.
 //#![warn(missing_docs)]
 
+mod benchmarking;
 mod checks;
 mod errors;
 #[cfg(test)]
@@ -47,7 +48,12 @@ use sp_std::vec::Vec;
 use system::{ensure_root, ensure_signed};
 
 pub use errors::Error;
-use types::{ApplicationInfo, BalanceOfCurrency, MemberId, TeamWorker, TeamWorkerId, WorkerInfo};
+/*
+ * TODO: Change this back, this is only needed for the temporary implementation of `working_team` in the `Runtime`
+ */
+
+pub use types::BalanceOfCurrency;
+use types::{ApplicationInfo, MemberId, TeamWorker, TeamWorkerId, WorkerInfo};
 pub use types::{
     ApplyOnOpeningParameters, JobApplication, JobOpening, JobOpeningType, Penalty, RewardPolicy,
     StakePolicy, StakingHandler,

--- a/runtime-modules/working-team/src/lib.rs
+++ b/runtime-modules/working-team/src/lib.rs
@@ -48,10 +48,6 @@ use sp_std::vec::Vec;
 use system::{ensure_root, ensure_signed};
 
 pub use errors::Error;
-/*
- * TODO: Change this back, this is only needed for the temporary implementation of `working_team` in the `Runtime`
- */
-
 pub use types::BalanceOfCurrency;
 use types::{ApplicationInfo, MemberId, TeamWorker, TeamWorkerId, WorkerInfo};
 pub use types::{

--- a/runtime-modules/working-team/src/lib.rs
+++ b/runtime-modules/working-team/src/lib.rs
@@ -62,7 +62,7 @@ pub use types::{
 use common::origin::ActorOriginValidator;
 
 /// The _Team_ main _Trait_
-pub trait Trait<I: Instance>:
+pub trait Trait<I: Instance = DefaultInstance>:
     system::Trait + membership::Trait + balances::Trait + common::currency::GovernanceCurrency
 {
     /// OpeningId type
@@ -106,7 +106,7 @@ pub trait Trait<I: Instance>:
 
 decl_event!(
     /// _Team_ events
-    pub enum Event<T, I>
+    pub enum Event<T, I = DefaultInstance>
     where
        <T as Trait<I>>::OpeningId,
        <T as Trait<I>>::ApplicationId,
@@ -219,7 +219,7 @@ decl_event!(
 );
 
 decl_storage! {
-    trait Store for Module<T: Trait<I>, I: Instance> as WorkingTeam {
+    trait Store for Module<T: Trait<I>, I: Instance=DefaultInstance> as WorkingTeam {
         /// Next identifier value for new job opening.
         pub NextOpeningId get(fn next_opening_id): T::OpeningId;
 
@@ -257,7 +257,7 @@ decl_storage! {
 
 decl_module! {
     /// _Working group_ substrate module.
-    pub struct Module<T: Trait<I>, I: Instance> for enum Call where origin: T::Origin {
+    pub struct Module<T: Trait<I>, I: Instance=DefaultInstance> for enum Call where origin: T::Origin {
         /// Default deposit_event() handler
         fn deposit_event() = default;
 
@@ -267,7 +267,7 @@ decl_module! {
         /// Exports const -  max simultaneous active worker number.
         const MaxWorkerNumberLimit: u32 = T::MaxWorkerNumberLimit::get();
 
-        fn on_initialize() -> Weight{
+        fn on_initialize() -> Weight {
             let leaving_workers = Self::get_workers_with_finished_unstaking_period();
 
             leaving_workers.iter().for_each(|wi| {

--- a/runtime-modules/working-team/src/tests/fixtures.rs
+++ b/runtime-modules/working-team/src/tests/fixtures.rs
@@ -1,3 +1,4 @@
+#![cfg(test)]
 use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_support::StorageMap;
 use sp_runtime::traits::Hash;
@@ -5,29 +6,19 @@ use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
 use system::{EventRecord, Phase, RawOrigin};
 
 use super::hiring_workflow::HiringWorkflow;
-use super::mock::{
-    Balances, LockId, Membership, System, Test, TestEvent, TestWorkingTeam, TestWorkingTeamInstance,
-};
+use super::mock::{Balances, LockId, Membership, System, Test, TestEvent, TestWorkingTeam};
 use crate::types::StakeParameters;
 use crate::{
-    ApplyOnOpeningParameters, JobApplication, JobOpening, JobOpeningType, Penalty, RawEvent,
-    RewardPolicy, StakePolicy, TeamWorker,
+    ApplyOnOpeningParameters, DefaultInstance, JobApplication, JobOpening, JobOpeningType, Penalty,
+    RawEvent, RewardPolicy, StakePolicy, TeamWorker,
 };
 
 pub struct EventFixture;
 impl EventFixture {
     pub fn assert_last_crate_event(
-        expected_raw_event: RawEvent<
-            u64,
-            u64,
-            BTreeMap<u64, u64>,
-            u64,
-            u64,
-            u64,
-            TestWorkingTeamInstance,
-        >,
+        expected_raw_event: RawEvent<u64, u64, BTreeMap<u64, u64>, u64, u64, u64, DefaultInstance>,
     ) {
-        let converted_event = TestEvent::working_team_TestWorkingTeamInstance(expected_raw_event);
+        let converted_event = TestEvent::crate_DefaultInstance(expected_raw_event);
 
         Self::assert_last_global_event(converted_event)
     }
@@ -194,7 +185,7 @@ impl ApplyOnOpeningFixture {
         let saved_application_next_id = TestWorkingTeam::next_application_id();
         TestWorkingTeam::apply_on_opening(
             self.origin.clone().into(),
-            ApplyOnOpeningParameters::<Test, TestWorkingTeamInstance> {
+            ApplyOnOpeningParameters::<Test, DefaultInstance> {
                 member_id: self.member_id,
                 opening_id: self.opening_id,
                 role_account_id: self.role_account_id,
@@ -337,15 +328,13 @@ impl FillOpeningFixture {
             assert_eq!(TestWorkingTeam::next_worker_id(), saved_worker_next_id + 1);
             let worker_id = saved_worker_next_id;
 
-            assert!(
-                !<crate::OpeningById<Test, TestWorkingTeamInstance>>::contains_key(self.opening_id)
-            );
+            assert!(!<crate::OpeningById<Test, DefaultInstance>>::contains_key(
+                self.opening_id
+            ));
 
             for application_id in self.successful_application_ids.iter() {
                 assert!(
-                    !<crate::ApplicationById<Test, TestWorkingTeamInstance>>::contains_key(
-                        application_id
-                    )
+                    !<crate::ApplicationById<Test, DefaultInstance>>::contains_key(application_id)
                 );
             }
 
@@ -559,9 +548,9 @@ impl LeaveWorkerRoleFixture {
                 }
             }
 
-            assert!(
-                !<crate::WorkerById<Test, TestWorkingTeamInstance>>::contains_key(self.worker_id)
-            );
+            assert!(!<crate::WorkerById<Test, DefaultInstance>>::contains_key(
+                self.worker_id
+            ));
         }
     }
 }
@@ -598,11 +587,9 @@ impl TerminateWorkerRoleFixture {
 
         if actual_result.is_ok() {
             if actual_result.is_ok() {
-                assert!(
-                    !<crate::WorkerById<Test, TestWorkingTeamInstance>>::contains_key(
-                        self.worker_id
-                    )
-                );
+                assert!(!<crate::WorkerById<Test, DefaultInstance>>::contains_key(
+                    self.worker_id
+                ));
             }
         }
     }
@@ -866,9 +853,9 @@ impl CancelOpeningFixture {
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         if expected_result.is_ok() {
-            assert!(
-                <crate::OpeningById<Test, TestWorkingTeamInstance>>::contains_key(self.opening_id)
-            );
+            assert!(<crate::OpeningById<Test, DefaultInstance>>::contains_key(
+                self.opening_id
+            ));
         }
 
         let actual_result = self.call().map(|_| ());
@@ -876,9 +863,9 @@ impl CancelOpeningFixture {
         assert_eq!(actual_result.clone(), expected_result);
 
         if actual_result.is_ok() {
-            assert!(
-                !<crate::OpeningById<Test, TestWorkingTeamInstance>>::contains_key(self.opening_id)
-            );
+            assert!(!<crate::OpeningById<Test, DefaultInstance>>::contains_key(
+                self.opening_id
+            ));
         }
     }
 }

--- a/runtime-modules/working-team/src/tests/mock.rs
+++ b/runtime-modules/working-team/src/tests/mock.rs
@@ -10,7 +10,7 @@ use sp_runtime::{
 };
 use system;
 
-use crate::{BalanceOfCurrency, Module, StakingHandler, Trait};
+use crate::{BalanceOfCurrency, DefaultInstance, Module, StakingHandler, Trait};
 use common::currency::GovernanceCurrency;
 use frame_support::dispatch::DispatchResult;
 
@@ -19,7 +19,6 @@ impl_outer_origin! {
 }
 
 mod working_team {
-    pub use super::TestWorkingTeamInstance;
     pub use crate::Event;
 }
 
@@ -30,7 +29,7 @@ mod membership_mod {
 impl_outer_event! {
     pub enum TestEvent for Test {
         balances<T>,
-        working_team TestWorkingTeamInstance <T>,
+        crate DefaultInstance <T>,
         membership_mod<T>,
         system<T>,
     }
@@ -114,7 +113,7 @@ parameter_types! {
     pub const LockId: [u8; 8] = [1; 8];
 }
 
-impl Trait<TestWorkingTeamInstance> for Test {
+impl Trait for Test {
     type OpeningId = u64;
     type ApplicationId = u64;
     type Event = TestEvent;
@@ -139,8 +138,7 @@ impl common::origin::ActorOriginValidator<Origin, u64, u64> for () {
     }
 }
 
-pub type TestWorkingTeamInstance = crate::Instance1;
-pub type TestWorkingTeam = Module<Test, TestWorkingTeamInstance>;
+pub type TestWorkingTeam = Module<Test, DefaultInstance>;
 
 pub const STAKING_ACCOUNT_ID_FOR_FAILED_VALIDITY_CHECK: u64 = 111;
 pub const STAKING_ACCOUNT_ID_FOR_FAILED_AMOUNT_CHECK: u64 = 222;

--- a/runtime-modules/working-team/src/types.rs
+++ b/runtime-modules/working-team/src/types.rs
@@ -4,6 +4,7 @@ use codec::{Decode, Encode};
 use common::currency::GovernanceCurrency;
 use frame_support::dispatch::DispatchResult;
 use frame_support::traits::Currency;
+use sp_std::vec::Vec;
 
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -70,7 +70,6 @@ hiring = { package = 'pallet-hiring', default-features = false, path = '../runti
 minting = { package = 'pallet-token-mint', default-features = false, path = '../runtime-modules/token-minting'}
 recurring-rewards = { package = 'pallet-recurring-reward', default-features = false, path = '../runtime-modules/recurring-reward'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../runtime-modules/working-group'}
-working-team = { package = 'pallet-working-team', default-features = false, path = '../runtime-modules/working-team'}
 content-working-group = { package = 'pallet-content-working-group', default-features = false, path = '../runtime-modules/content-working-group'}
 versioned-store = { package = 'pallet-versioned-store', default-features = false, path = '../runtime-modules/versioned-store'}
 versioned-store-permissions = { package = 'pallet-versioned-store-permissions', default-features = false, path = '../runtime-modules/versioned-store-permissions'}
@@ -146,7 +145,6 @@ std = [
     'minting/std',
     'recurring-rewards/std',
     'working-group/std',
-    'working-team/std',
     'content-working-group/std',
     'versioned-store/std',
     'versioned-store-permissions/std',
@@ -169,7 +167,6 @@ runtime-benchmarks = [
     "frame-system-benchmarking",
     "pallet-offences-benchmarking",
     "pallet-session-benchmarking",
-    "working-team/runtime-benchmarks",
     "hex-literal",
 ]
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,6 +10,7 @@ version = '7.1.0'
 # Third-party dependencies
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 codec = { package = 'parity-scale-codec', version = '1.3.1', default-features = false, features = ['derive'] }
+hex-literal = { optional = true, version = '0.3.1' }
 
 # Substrate primitives
 sp-std = { package = 'sp-std', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
@@ -69,6 +70,7 @@ hiring = { package = 'pallet-hiring', default-features = false, path = '../runti
 minting = { package = 'pallet-token-mint', default-features = false, path = '../runtime-modules/token-minting'}
 recurring-rewards = { package = 'pallet-recurring-reward', default-features = false, path = '../runtime-modules/recurring-reward'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../runtime-modules/working-group'}
+working-team = { package = 'pallet-working-team', default-features = false, path = '../runtime-modules/working-team'}
 content-working-group = { package = 'pallet-content-working-group', default-features = false, path = '../runtime-modules/content-working-group'}
 versioned-store = { package = 'pallet-versioned-store', default-features = false, path = '../runtime-modules/versioned-store'}
 versioned-store-permissions = { package = 'pallet-versioned-store-permissions', default-features = false, path = '../runtime-modules/versioned-store-permissions'}
@@ -144,6 +146,7 @@ std = [
     'minting/std',
     'recurring-rewards/std',
     'working-group/std',
+    'working-team/std',
     'content-working-group/std',
     'versioned-store/std',
     'versioned-store-permissions/std',
@@ -155,17 +158,19 @@ std = [
 ]
 runtime-benchmarks = [
     "system/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
-	"pallet-balances/runtime-benchmarks",
-	"pallet-collective/runtime-benchmarks",
-	"pallet-im-online/runtime-benchmarks",
-	"pallet-staking/runtime-benchmarks",
-	"pallet-timestamp/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
+    "pallet-collective/runtime-benchmarks",
+    "pallet-im-online/runtime-benchmarks",
+    "pallet-staking/runtime-benchmarks",
+    "pallet-timestamp/runtime-benchmarks",
     "frame-benchmarking",
     "frame-system-benchmarking",
     "pallet-offences-benchmarking",
-	"pallet-session-benchmarking",
+    "pallet-session-benchmarking",
+    "working-team/runtime-benchmarks",
+    "hex-literal",
 ]
 
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -65,10 +65,6 @@ pub use versioned_store;
 pub use versioned_store_permissions;
 pub use working_group;
 
-/*
- * TODO: revert, used by temporary implementation for working_team for benchmark
- * ====================== Starts here =========================================
- */
 use frame_support::dispatch::DispatchResult;
 pub use working_team;
 use working_team::BalanceOfCurrency;
@@ -143,16 +139,13 @@ impl working_team::StakingHandler<Runtime> for Runtime {
         _account_id: &<Runtime as system::Trait>::AccountId,
     ) -> BalanceOfCurrency<Runtime> {
         /*
-         * TODO: We need to return more than zero for `leave_role` later to work
+         * We need to return more than zero for `leave_role` later to work
          * might need to implement more functions
          * see `working_team` benchmarking
          */
         BalanceOfCurrency::<Runtime>::max_value()
     }
 }
-/*
- * ====================== Ends here =========================================
- */
 
 /// This runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -142,7 +142,12 @@ impl working_team::StakingHandler<Runtime> for Runtime {
     fn current_stake(
         _account_id: &<Runtime as system::Trait>::AccountId,
     ) -> BalanceOfCurrency<Runtime> {
-        0
+        /*
+         * TODO: We need to return more than zero for `leave_role` later to work
+         * might need to implement more functions
+         * see `working_team` benchmarking
+         */
+        BalanceOfCurrency::<Runtime>::max_value()
     }
 }
 /*

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -65,88 +65,6 @@ pub use versioned_store;
 pub use versioned_store_permissions;
 pub use working_group;
 
-use frame_support::dispatch::DispatchResult;
-pub use working_team;
-use working_team::BalanceOfCurrency;
-pub type StorageWorkingTeamInstance = working_team::Instance1;
-
-parameter_types! {
-    pub const RewardPeriod: u32 = 3;
-    pub const MinUnstakingPeriodLimit: u32 = 3;
-}
-
-impl working_team::Trait<StorageWorkingTeamInstance> for Runtime {
-    type OpeningId = u64;
-    type ApplicationId = u64;
-    type Event = Event;
-    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
-    type StakingHandler = Runtime;
-    type MemberOriginValidator = MembershipOriginValidator<Self>;
-    type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
-    type RewardPeriod = RewardPeriod;
-}
-
-impl working_team::StakingHandler<Runtime> for Runtime {
-    fn lock(
-        _account_id: &<Runtime as system::Trait>::AccountId,
-        _amount: BalanceOfCurrency<Runtime>,
-    ) {
-    }
-
-    fn unlock(_account_id: &<Runtime as system::Trait>::AccountId) {}
-
-    fn slash(
-        _account_id: &<Runtime as system::Trait>::AccountId,
-        _amount: Option<BalanceOfCurrency<Runtime>>,
-    ) -> BalanceOfCurrency<Runtime> {
-        0
-    }
-
-    fn decrease_stake(
-        _account_id: &<Runtime as system::Trait>::AccountId,
-        _new_stake: BalanceOfCurrency<Runtime>,
-    ) {
-    }
-
-    fn increase_stake(
-        _account_id: &<Runtime as system::Trait>::AccountId,
-        _new_stake: BalanceOfCurrency<Runtime>,
-    ) -> DispatchResult {
-        Ok(())
-    }
-
-    fn is_member_staking_account(
-        _member_id: &<Runtime as membership::Trait>::MemberId,
-        _account_id: &<Runtime as system::Trait>::AccountId,
-    ) -> bool {
-        true
-    }
-
-    fn is_account_free_of_conflicting_stakes(
-        _account_id: &<Runtime as system::Trait>::AccountId,
-    ) -> bool {
-        true
-    }
-
-    fn is_enough_balance_for_stake(
-        _account_id: &<Runtime as system::Trait>::AccountId,
-        _amount: BalanceOfCurrency<Runtime>,
-    ) -> bool {
-        true
-    }
-
-    fn current_stake(
-        _account_id: &<Runtime as system::Trait>::AccountId,
-    ) -> BalanceOfCurrency<Runtime> {
-        /*
-         * We need to return more than zero for `leave_role` later to work
-         * might need to implement more functions
-         * see `working_team` benchmarking
-         */
-        BalanceOfCurrency::<Runtime>::max_value()
-    }
-}
-
 /// This runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
@@ -700,9 +618,5 @@ construct_runtime!(
         // --- Working groups
         // reserved for the future use: ForumWorkingGroup: working_group::<Instance1>::{Module, Call, Storage, Event<T>},
         StorageWorkingGroup: working_group::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
-        /*
-         * TODO: revert, used by temporary implementation for working_team for benchmark
-         */
-        WorkingTeam: working_team::<Instance1>::{Module, Call, Storage, Event<T>},
     }
 );

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -75,8 +75,8 @@ use working_team::BalanceOfCurrency;
 pub type StorageWorkingTeamInstance = working_team::Instance1;
 
 parameter_types! {
-  pub const RewardPeriod: u32 = 3;
-  pub const MinUnstakingPeriodLimit: u32 = 3;
+    pub const RewardPeriod: u32 = 3;
+    pub const MinUnstakingPeriodLimit: u32 = 3;
 }
 
 impl working_team::Trait<StorageWorkingTeamInstance> for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -65,6 +65,90 @@ pub use versioned_store;
 pub use versioned_store_permissions;
 pub use working_group;
 
+/*
+ * TODO: revert, used by temporary implementation for working_team for benchmark
+ * ====================== Starts here =========================================
+ */
+use frame_support::dispatch::DispatchResult;
+pub use working_team;
+use working_team::BalanceOfCurrency;
+pub type StorageWorkingTeamInstance = working_team::Instance1;
+
+parameter_types! {
+  pub const RewardPeriod: u32 = 3;
+  pub const MinUnstakingPeriodLimit: u32 = 3;
+}
+
+impl working_team::Trait<StorageWorkingTeamInstance> for Runtime {
+    type OpeningId = u64;
+    type ApplicationId = u64;
+    type Event = Event;
+    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
+    type StakingHandler = Runtime;
+    type MemberOriginValidator = MembershipOriginValidator<Self>;
+    type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
+    type RewardPeriod = RewardPeriod;
+}
+
+impl working_team::StakingHandler<Runtime> for Runtime {
+    fn lock(
+        _account_id: &<Runtime as system::Trait>::AccountId,
+        _amount: BalanceOfCurrency<Runtime>,
+    ) {
+    }
+
+    fn unlock(_account_id: &<Runtime as system::Trait>::AccountId) {}
+
+    fn slash(
+        _account_id: &<Runtime as system::Trait>::AccountId,
+        _amount: Option<BalanceOfCurrency<Runtime>>,
+    ) -> BalanceOfCurrency<Runtime> {
+        0
+    }
+
+    fn decrease_stake(
+        _account_id: &<Runtime as system::Trait>::AccountId,
+        _new_stake: BalanceOfCurrency<Runtime>,
+    ) {
+    }
+
+    fn increase_stake(
+        _account_id: &<Runtime as system::Trait>::AccountId,
+        _new_stake: BalanceOfCurrency<Runtime>,
+    ) -> DispatchResult {
+        Ok(())
+    }
+
+    fn is_member_staking_account(
+        _member_id: &<Runtime as membership::Trait>::MemberId,
+        _account_id: &<Runtime as system::Trait>::AccountId,
+    ) -> bool {
+        true
+    }
+
+    fn is_account_free_of_conflicting_stakes(
+        _account_id: &<Runtime as system::Trait>::AccountId,
+    ) -> bool {
+        true
+    }
+
+    fn is_enough_balance_for_stake(
+        _account_id: &<Runtime as system::Trait>::AccountId,
+        _amount: BalanceOfCurrency<Runtime>,
+    ) -> bool {
+        true
+    }
+
+    fn current_stake(
+        _account_id: &<Runtime as system::Trait>::AccountId,
+    ) -> BalanceOfCurrency<Runtime> {
+        0
+    }
+}
+/*
+ * ====================== Ends here =========================================
+ */
+
 /// This runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
@@ -618,5 +702,9 @@ construct_runtime!(
         // --- Working groups
         // reserved for the future use: ForumWorkingGroup: working_group::<Instance1>::{Module, Call, Storage, Event<T>},
         StorageWorkingGroup: working_group::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
+        /*
+         * TODO: revert, used by temporary implementation for working_team for benchmark
+         */
+        WorkingTeam: working_team::<Instance1>::{Module, Call, Storage, Event<T>},
     }
 );

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -226,7 +226,6 @@ impl_runtime_apis! {
 
             let whitelist: Vec<Vec<u8>> = vec![
                 // Block Number
-                // frame_system::Number::<Runtime>::hashed_key().to_vec(),
                 hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec(),
                 // Total Issuance
                 hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec(),

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -8,8 +8,6 @@ use sp_core::crypto::KeyTypeId;
 use sp_core::OpaqueMetadata;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, NumberFor};
 use sp_runtime::{generic, ApplyExtrinsicResult};
-#[cfg(feature = "runtime-benchmarks")]
-use sp_std::vec;
 use sp_std::vec::Vec;
 
 use crate::constants::PRIMARY_PROBABILITY;
@@ -218,6 +216,7 @@ impl_runtime_apis! {
             /*
              * TODO: remember to benchhmark every pallet
              */
+            use sp_std::vec;
             use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
             use frame_system_benchmarking::Module as SystemBench;
             impl frame_system_benchmarking::Trait for Runtime {}

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -8,6 +8,7 @@ use sp_core::crypto::KeyTypeId;
 use sp_core::OpaqueMetadata;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, NumberFor};
 use sp_runtime::{generic, ApplyExtrinsicResult};
+use sp_std::vec;
 use sp_std::vec::Vec;
 
 use crate::constants::PRIMARY_PROBABILITY;
@@ -199,6 +200,55 @@ impl_runtime_apis! {
             encoded: Vec<u8>,
         ) -> Option<Vec<(Vec<u8>, KeyTypeId)>> {
             SessionKeys::decode_into_raw_public_keys(&encoded)
+        }
+    }
+
+
+    #[cfg(feature = "runtime-benchmarks")]
+    impl frame_benchmarking::Benchmark<Block> for Runtime {
+        fn dispatch_benchmark(
+            pallet: Vec<u8>,
+            benchmark: Vec<u8>,
+            lowest_range_values: Vec<u32>,
+            highest_range_values: Vec<u32>,
+            steps: Vec<u32>,
+            repeat: u32,
+        ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
+            /*
+             * TODO: remember to benchhmark every pallet
+             */
+            use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
+            use frame_system_benchmarking::Module as SystemBench;
+            impl frame_system_benchmarking::Trait for Runtime {}
+
+            use crate::WorkingTeam;
+
+            let whitelist: Vec<Vec<u8>> = vec![
+                // Block Number
+                // frame_system::Number::<Runtime>::hashed_key().to_vec(),
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec(),
+                // Total Issuance
+                hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec(),
+                // Execution Phase
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec(),
+                // Event Count
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec(),
+                // System Events
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec(),
+                // Caller 0 Account
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da946c154ffd9992e395af90b5b13cc6f295c77033fce8a9045824a6690bbf99c6db269502f0a8d1d2a008542d5690a0749").to_vec(),
+                // Treasury Account
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec(),
+            ];
+
+            let mut batches = Vec::<BenchmarkBatch>::new();
+            let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat, &whitelist);
+
+            add_benchmark!(params, batches, b"system", SystemBench::<Runtime>);
+            add_benchmark!(params, batches, b"working-team", WorkingTeam);
+
+            if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
+            Ok(batches)
         }
     }
 }

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -218,8 +218,6 @@ impl_runtime_apis! {
             use frame_system_benchmarking::Module as SystemBench;
             impl frame_system_benchmarking::Trait for Runtime {}
 
-            use crate::WorkingTeam;
-
             let whitelist: Vec<Vec<u8>> = vec![
                 // Block Number
                 hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec(),
@@ -241,7 +239,6 @@ impl_runtime_apis! {
             let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat, &whitelist);
 
             add_benchmark!(params, batches, b"system", SystemBench::<Runtime>);
-            add_benchmark!(params, batches, b"working-team", WorkingTeam);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
             Ok(batches)

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -213,9 +213,6 @@ impl_runtime_apis! {
             steps: Vec<u32>,
             repeat: u32,
         ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
-            /*
-             * TODO: remember to benchhmark every pallet
-             */
             use sp_std::vec;
             use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
             use frame_system_benchmarking::Module as SystemBench;

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -8,6 +8,7 @@ use sp_core::crypto::KeyTypeId;
 use sp_core::OpaqueMetadata;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, NumberFor};
 use sp_runtime::{generic, ApplyExtrinsicResult};
+#[cfg(feature = "runtime-benchmarks")]
 use sp_std::vec;
 use sp_std::vec::Vec;
 


### PR DESCRIPTION
Pull Request to track progress in #1534 
---

We need to benchmark `working_team` to implement the weights for each extrinsic(and `on_initialize`)

In order to test the benchmark, I added a dummy implementation of `working_team::Trait` for the `Runtime` we are using.

**Note**: It's useless to calculate the weights in the reference hardware until the acual impl for the `Runtime` is done. (Benchmarking only make sense in the context of a given `Runtime`)

To complete the PR I need to do the following:

- [x] Add benchmarking to the Runtime(when the feature is enabled)
- [x] Add dummy `working_team::Trait` impl for `Runtime`
- [x] Add benchmark function for each branch of each extrinsic and `on_initialize`
  - [x] `leave_role`
  - [x] `set_budget`
  - [x] `add_opening`
  - [x] `update_reward_account`
  - [x] `set_status_text`
  - [x] `update_reward_amount`
  - [x] `spend_from_budget`
  - [x] `decrease_stake`
  - [x] `increase_stake`
  - [x] `terminate_role`
  - [x] `slash_stake`
  - [x] `withdraw_application`
  - [x] `cancel_opening`
  - [x] `update_role_account`
  - [x] `fill_opening`
  - [x] `apply_on_opening`
  - [x]  `on_initialize`
- [x] Add code to run verifications with the tests
- [x] Implement the verify function for each benchmark function
- [x] Whitelist appropiate keys
- [ ] Write the weight function for each extrinsic (**Note**:  in substrate current version this is done automatically by the CLI) 
- [ ] Run the code in [reference hardware](https://substrate.dev/docs/en/knowledgebase/learn-substrate/weight) (**Blocked until `working_team::Trait` is implemented**)
- [ ] Add weights in the extrinsics(and `on_initialize`)
