### PR TITLE
Add migration for the content working group.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "7.6.0"
+version = "7.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '3.4.0'
+version = '3.4.1'
 default-run = "joystream-node"
 
 [[bin]]

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -316,14 +316,14 @@ pub fn testnet_genesis(
         }),
         working_group_Instance2: Some(StorageWorkingGroupConfig {
             phantom: Default::default(),
-            storage_working_group_mint_capacity: 0,
+            working_group_mint_capacity: 0,
             opening_human_readable_text_constraint: default_text_constraint,
             worker_application_human_readable_text_constraint: default_text_constraint,
             worker_exit_rationale_text_constraint: default_text_constraint,
         }),
         working_group_Instance3: Some(ContentDirectoryWorkingGroupConfig {
             phantom: Default::default(),
-            storage_working_group_mint_capacity: 0,
+            working_group_mint_capacity: 0,
             opening_human_readable_text_constraint: default_text_constraint,
             worker_application_human_readable_text_constraint: default_text_constraint,
             worker_exit_rationale_text_constraint: default_text_constraint,

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -328,7 +328,7 @@ decl_storage! {
     }
         add_extra_genesis {
         config(phantom): sp_std::marker::PhantomData<I>;
-        config(storage_working_group_mint_capacity): minting::BalanceOf<T>;
+        config(working_group_mint_capacity): minting::BalanceOf<T>;
         config(opening_human_readable_text_constraint): InputValidationLengthConstraint;
         config(worker_application_human_readable_text_constraint): InputValidationLengthConstraint;
         config(worker_exit_rationale_text_constraint): InputValidationLengthConstraint;
@@ -337,7 +337,7 @@ decl_storage! {
                 config.opening_human_readable_text_constraint,
                 config.worker_application_human_readable_text_constraint,
                 config.worker_exit_rationale_text_constraint,
-                config.storage_working_group_mint_capacity)
+                config.working_group_mint_capacity)
         });
     }
 }
@@ -1483,8 +1483,8 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
         Ok(())
     }
 
-    // Initialize working group constraints and mint.
-    pub(crate) fn initialize_working_group(
+    /// Initialize working group constraints and mint.
+    pub fn initialize_working_group(
         opening_human_readable_text_constraint: InputValidationLengthConstraint,
         worker_application_human_readable_text_constraint: InputValidationLengthConstraint,
         worker_exit_rationale_text_constraint: InputValidationLengthConstraint,

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -156,7 +156,7 @@ pub fn build_test_externalities() -> sp_io::TestExternalities {
 
     crate::GenesisConfig::<Test, TestWorkingGroupInstance> {
         phantom: Default::default(),
-        storage_working_group_mint_capacity: WORKING_GROUP_MINT_CAPACITY,
+        working_group_mint_capacity: WORKING_GROUP_MINT_CAPACITY,
         opening_human_readable_text_constraint: InputValidationLengthConstraint::new(
             WORKING_GROUP_CONSTRAINT_MIN,
             WORKING_GROUP_CONSTRAINT_DIFF,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '7.6.0'
+version = '7.7.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -75,7 +75,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 7,
-    spec_version: 6,
+    spec_version: 7,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
We need to initialize the content working group parameters on runtime upgrade. Before this PR it was initialized on genesis only.

The original issue could be found [here](https://github.com/Joystream/joystream/pull/1544#issuecomment-710686042). 

On manual testing with pioneer be aware of [system.set_code weight limits](https://github.com/paritytech/substrate/issues/6117). It is possible to test it manually using codex extrinsics (the simplest is `execute_runtime_upgrade_proposal`).