### PR TITLE
prevent cleanup() in run-tests.sh from failing

### DIFF
--- a/query-node/run-tests.sh
+++ b/query-node/run-tests.sh
@@ -7,10 +7,8 @@ cd $SCRIPT_PATH
 function cleanup() {
     # Show tail end of logs for the processor and indexer containers to
     # see any possible errors
-    echo "## Processor Logs ##"
-    docker logs query-node_processor_1 --tail 50
-    echo "## Indexer Logs ##"
-    docker logs query-node_indexer_1 --tail 50
+    (echo "## Processor Logs ##" && docker logs query-node_processor_1 --tail 50) || :
+    (echo "## Indexer Logs ##" && docker logs query-node_indexer_1 --tail 50) || :
     docker-compose down -v
 }
 


### PR DESCRIPTION
on exit the test runner for the query-node may actually fail if the indexer or processor containers are not running and the docker-compose down statement is not reached, which causes issues when restarting the tests.

Small fix to ensure this is handled gracefully.