### PR TITLE
storage-node integration tests: retry on wait for ipfs registration

### DIFF
--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -214,6 +214,6 @@ jobs:
             if yarn storage-cli upload ./pioneer/packages/apps/public/images/default-thumbnail.png 1 0; then
               break
             else
-              echo "Upload test failed, will retry" && sleep ${WAIT_TIME}
+              echo "Upload test failed, will retry"
             fi
           done

--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -203,8 +203,14 @@ jobs:
         run: docker-compose --file docker-compose-with-storage.yml up -d
       - name: Add development storage node and initialize content directory
         run: DEBUG=* yarn storage-cli dev-init
-      - name: Wait for storage-node to publish identity
-        run: sleep 90
-        # Better would be poll `http://localhost:3001/discover/v0/1` until we get 200 Response
-      - name: Upload a file
-        run: DEBUG=joystream:* yarn storage-cli upload ./pioneer/packages/apps/public/images/default-thumbnail.png 1 0
+      - name: Try uploading
+        run: |
+          WAIT_TIME=90
+          export DEBUG=joystream:*
+          for i in {1..4}; do
+            [ "$i" == "4" ] && exit -1
+            echo "Waiting for ipfs name registration"
+            sleep ${WAIT_TIME}
+            yarn storage-cli upload ./pioneer/packages/apps/public/images/default-thumbnail.png 1 0 || 
+              (echo "Upload test failed, will retry" && sleep ${WAIT_TIME} && continue)
+          done

--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -211,6 +211,9 @@ jobs:
             [ "$i" == "4" ] && exit -1
             echo "Waiting for ipfs name registration"
             sleep ${WAIT_TIME}
-            (yarn storage-cli upload ./pioneer/packages/apps/public/images/default-thumbnail.png 1 0 && break) || \
-              (echo "Upload test failed, will retry" && sleep ${WAIT_TIME} && continue)
+            if yarn storage-cli upload ./pioneer/packages/apps/public/images/default-thumbnail.png 1 0; then
+              break
+            else
+              echo "Upload test failed, will retry" && sleep ${WAIT_TIME}
+            fi
           done

--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -211,6 +211,6 @@ jobs:
             [ "$i" == "4" ] && exit -1
             echo "Waiting for ipfs name registration"
             sleep ${WAIT_TIME}
-            yarn storage-cli upload ./pioneer/packages/apps/public/images/default-thumbnail.png 1 0 || 
+            (yarn storage-cli upload ./pioneer/packages/apps/public/images/default-thumbnail.png 1 0 && break) || \
               (echo "Upload test failed, will retry" && sleep ${WAIT_TIME} && continue)
           done

--- a/storage-node/packages/cli/src/cli.ts
+++ b/storage-node/packages/cli/src/cli.ts
@@ -104,7 +104,7 @@ const commands = {
 
 // Entry point.
 export async function main() {
-  const api = await RuntimeApi.create()
+  const api = await RuntimeApi.create({ retries: 3 })
 
   // Simple CLI commands
   const command = cli.input[0]

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -55,14 +55,20 @@ class RuntimeApi {
     options = options || {}
 
     const provider = new WsProvider(options.provider_url || 'ws://localhost:9944')
-
+    let attempts = 0
     // Create the API instrance
     while (true) {
+      attempts++
+
+      if (options.retries && attempts > options.retries) {
+        throw new Error('Timeout trying to connect to node')
+      }
+
       try {
         this.api = await ApiPromise.create({ provider, types: types })
         break
       } catch (err) {
-        debug('connecting to node failed, will retry..')
+        debug('Connecting to node failed, will retry..')
       }
       await sleep(5000)
     }


### PR DESCRIPTION
Allow multiple tries when testing upload in storage-node integration tests, because ipfs name registration sometimes takes more than allotted time.