### PR TITLE
stick with rust v1.46.0 for successful build

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,8 +19,12 @@ rustup component add rustfmt clippy
 rustup install nightly-2020-05-23 --force
 rustup target add wasm32-unknown-unknown --toolchain nightly-2020-05-23
 
-# Ensure the stable toolchain is still the default
-rustup default stable
+# Latest clippy linter which comes with 1.47.0 fails on some subtrate modules
+# Also note combination of newer versions of toolchain with the above nightly
+# toolchain to build wasm seems to fail.
+# So we need to stick with an older version until we update substrate
+rustup install 1.46.0
+rustup default 1.46.0
 
 # TODO: Install additional tools...
 


### PR DESCRIPTION
It seems latest version of rust v1.47.0 is causing a problem when combined with nightly-2020-05-23.
Additionally latest version of clippy also causes some warnings (which we treat as errors) in substrate pallet crates.
So the recommended fix for in https://github.com/Joystream/joystream/issues/495 only really works for building node and runtime but breaks clippy.

So I think the safest fix for now is to stick with rust v1.46.0 and nightly-2020-05-23 for WASM build.

I updated the `setup.sh` to install v1.46.0 rather than the latest which gets installed by the "getsubstrate.io" bootstrap script.