### PR TITLE
travis: rust v1.46.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: rust
 # one is embedded in the binary)
 # cache: cargo
 
-rust: stable
+rust: 1.46.0
 
 # Skip Rust build in a pull request if no rust project files were modified
 before_install:


### PR DESCRIPTION
complements #1655 and updates travis CI check to also use rust v1.46.0 for native build and clippy