### PR TITLE
api-scripts: increase retry attempts on connect

### DIFF
--- a/utils/api-scripts/src/dev-set-runtime-code.ts
+++ b/utils/api-scripts/src/dev-set-runtime-code.ts
@@ -32,7 +32,7 @@ async function main() {
   const provider = new WsProvider('ws://127.0.0.1:9944')
 
   let api: ApiPromise
-  let retry = 3
+  let retry = 6
   while (true) {
     try {
       api = await ApiPromise.create({ provider, types })

--- a/utils/api-scripts/src/status.ts
+++ b/utils/api-scripts/src/status.ts
@@ -12,7 +12,7 @@ async function main() {
 
   // Create the API and wait until ready
   let api: ApiPromise
-  let retry = 3
+  let retry = 6
   while (true) {
     try {
       api = await ApiPromise.create({ provider, types })


### PR DESCRIPTION
These scripts are used by tests to wait for joystream-node to come up,
even after the process/service is up it may take some time to initialize
genesis state. Increasing the retry count will help when running on systems with limited resources.