### PR TITLE
fix searchbar alignment

### DIFF
--- a/atlas/src/components/Navbar/Navbar.style.tsx
+++ b/atlas/src/components/Navbar/Navbar.style.tsx
@@ -36,6 +36,8 @@ export const SearchbarContainer = styled.div`
   justify-content: flex-end;
   align-items: center;
 
+  justify-self: end;
+
   width: 100%;
   max-width: 1156px;
 `


### PR DESCRIPTION
Before and after:

<img width="2196" alt="Screenshot 2020-11-10 at 6 27 23 PM" src="https://user-images.githubusercontent.com/12646744/98709368-96f08d80-2382-11eb-8069-4dbe6c84c05b.png">
<img width="2198" alt="Screenshot 2020-11-10 at 6 27 44 PM" src="https://user-images.githubusercontent.com/12646744/98709385-9b1cab00-2382-11eb-940b-0d8eb3267e10.png">
