### PR TITLE
Council spending budget2

### DIFF
--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -208,8 +208,7 @@ pub trait Trait: system::Trait {
 /// Trait with functions that MUST be called by the runtime with values received from the referendum module.
 pub trait ReferendumConnection<T: Trait> {
     /// Process referendum results. This function MUST be called in runtime's implementation of referendum's `process_results()`.
-    fn recieve_referendum_results(winners: &[OptionResult<VotePowerOf<T>>])
-        -> Result<(), Error<T>>;
+    fn recieve_referendum_results(winners: &[OptionResult<VotePowerOf<T>>]);
 
     /// Process referendum results. This function MUST be called in runtime's implementation of referendum's `can_release_voting_stake()`.
     fn can_release_vote_stake() -> Result<(), Error<T>>;
@@ -543,17 +542,13 @@ impl<T: Trait> Module<T> {
 
 impl<T: Trait> ReferendumConnection<T> for Module<T> {
     /// Process candidates' results recieved from the referendum.
-    fn recieve_referendum_results(
-        winners: &[OptionResult<VotePowerOf<T>>],
-    ) -> Result<(), Error<T>> {
+    fn recieve_referendum_results(winners: &[OptionResult<VotePowerOf<T>>]) {
         //
         // == MUTATION SAFE ==
         //
 
         // conclude election
         Self::end_election_period(winners);
-
-        Ok(())
     }
 
     /// Check that it is a proper time to release stake.

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -269,7 +269,7 @@ decl_storage! {
         pub Budget get(fn budget): Balance<T>;
 
         /// The next block in which the budget will be increased.
-        pub NextBudgetRefill get(fn next_budget_refill): T::BlockNumber;
+        pub NextRewardPayments get(fn next_reward_payments): T::BlockNumber;
     }
 }
 
@@ -396,7 +396,11 @@ decl_module! {
 
         // No origin so this is a priviledged call
         fn on_finalize(now: T::BlockNumber) {
+            // council stage progress
             Self::try_progress_stage(now);
+
+            // budget reward payment
+            Self::try_reward_payments(now);
         }
 
         /////////////////// Election-related ///////////////////////////////////
@@ -528,9 +532,12 @@ impl<T: Trait> Module<T> {
             }
             _ => (),
         }
+    }
 
-        // budget reward progress
-        if now == NextBudgetRefill::<T>::get() {
+    /// Checkout elected council members reward payments.
+    fn try_reward_payments(now: T::BlockNumber) {
+        // council members rewards
+        if now == NextRewardPayments::<T>::get() {
             Self::pay_elected_member_rewards(now);
         }
     }
@@ -921,7 +928,7 @@ impl<T: Trait> Mutations<T> {
 
         // plan next rewards payment
         let next_reward_block = now + T::ElectedMemberRewardPeriod::get();
-        NextBudgetRefill::<T>::put(next_reward_block);
+        NextRewardPayments::<T>::put(next_reward_block);
     }
 }
 

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -308,10 +308,7 @@ decl_event! {
         CandidacyNoteSet(MembershipId, Vec<u8>),
 
         /// The whole reward was paid to the council member.
-        RewardPayment(MembershipId, AccountId),
-
-        /// The reward was paid to the council member only partially.
-        RewardPartialPayment(MembershipId, AccountId),
+        RewardPayment(MembershipId, AccountId, Balance, Balance),
 
         /// Budget balance was changed by the root.
         BudgetBalanceSet(Balance),
@@ -655,19 +652,12 @@ impl<T: Trait> Module<T> {
             new_balance -= available_balance;
 
             // emit event
-            if missing_balance > 0.into() {
-                // reward has been paid only partially
-                Self::deposit_event(RawEvent::RewardPartialPayment(
-                    council_member.membership_id,
-                    council_member.staking_account_id.clone(),
-                ));
-            } else {
-                // whole reward has been paid
-                Self::deposit_event(RawEvent::RewardPayment(
-                    council_member.membership_id,
-                    council_member.staking_account_id.clone(),
-                ));
-            }
+            Self::deposit_event(RawEvent::RewardPayment(
+                council_member.membership_id,
+                council_member.staking_account_id.clone(),
+                available_balance,
+                missing_balance,
+            ));
         }
 
         // update state

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -303,9 +303,6 @@ decl_event! {
         /// The whole reward was paid to the council member.
         RewardPayment(MembershipId, AccountId, Balance, Balance),
 
-        /// No reward was paid to the elected member because the whole accumulated reward was already paid out.
-        NoUnpaidReward(MembershipId, AccountId),
-
         /// Budget balance was changed by the root.
         BudgetBalanceSet(Balance),
     }
@@ -623,9 +620,11 @@ impl<T: Trait> Module<T> {
                     Calculations::<T>::get_current_reward(&council_member, reward_per_block, now);
 
                 if unpaid_reward == 0.into() {
-                    Self::deposit_event(RawEvent::NoUnpaidReward(
+                    Self::deposit_event(RawEvent::RewardPayment(
                         council_member.membership_id,
                         council_member.staking_account_id.clone(),
+                        0.into(),
+                        0.into(),
                     ));
                     return balance;
                 }

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -739,6 +739,8 @@ impl<T: Trait> Calculations<T> {
         reward_per_block: Balance<T>,
         now: T::BlockNumber,
     ) -> Balance<T> {
+        // calculate currently unpaid reward for elected council member
+        // previously_unpaid_reward + (current_block_number - last_payment_block_number) * reward_per_block
         council_member.unpaid_reward.saturating_add(
             now.saturating_sub(council_member.last_payment_block)
                 .saturated_into()

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -58,6 +58,8 @@ parameter_types! {
     pub const ElectedMemberLockId: LockIdentifier = *b"council2";
     pub const ElectedMemberRewardPerBlock: u64 = 100;
     pub const ElectedMemberRewardPeriod: u64 = 10;
+    pub const BudgetRefillAmount: u64 = 1000;
+    pub const BudgetRefillPeriod: u64 = 1000; // intentionally high number that prevents side-effecting tests other than  budget refill tests
 }
 
 impl Trait for Runtime {
@@ -77,6 +79,9 @@ impl Trait for Runtime {
 
     type ElectedMemberRewardPerBlock = ElectedMemberRewardPerBlock;
     type ElectedMemberRewardPeriod = ElectedMemberRewardPeriod;
+
+    type BudgetRefillAmount = BudgetRefillAmount;
+    type BudgetRefillPeriod = BudgetRefillPeriod;
 
     fn is_council_member_account(
         membership_id: &Self::MembershipId,
@@ -343,6 +348,8 @@ pub struct CouncilSettings<T: Trait> {
     pub idle_stage_duration: T::BlockNumber,
     pub election_duration: T::BlockNumber,
     pub cycle_duration: T::BlockNumber,
+    pub budget_refill_amount: Balance<T>,
+    pub budget_refill_period: T::BlockNumber,
 }
 
 impl<T: Trait> CouncilSettings<T>
@@ -378,6 +385,9 @@ where
                 + announcing_stage_duration
                 + voting_stage_duration
                 + idle_stage_duration,
+
+            budget_refill_amount: <T as Trait>::BudgetRefillAmount::get(),
+            budget_refill_period: <T as Trait>::BudgetRefillPeriod::get(),
         }
     }
 }

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -489,6 +489,7 @@ where
         let origin = OriginType::Signed(account_id.into());
         let candidate = CandidateOf::<T> {
             staking_account_id: account_id.into(),
+            reward_account_id: account_id.into(),
             cycle_id: AnnouncementPeriodNr::get(),
             stake,
             note_hash: None,
@@ -698,7 +699,8 @@ where
             Module::<T>::announce_candidacy(
                 InstanceMockUtils::<T>::mock_origin(origin),
                 member_id,
-                member_id.into(),
+                member_id.into(), // use member id as staking account
+                member_id.into(), // use member id as reward account
                 stake
             ),
             expected_result,

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -190,7 +190,7 @@ impl referendum::Trait<ReferendumInstance> for RuntimeReferendum {
 
     type MinimumStake = MinimumVotingStake;
 
-    fn caclulate_vote_power(
+    fn calculate_vote_power(
         account_id: &<Self as system::Trait>::AccountId,
         stake: &BalanceReferendum<Self, ReferendumInstance>,
     ) -> Self::VotePower {

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -223,8 +223,7 @@ impl referendum::Trait<ReferendumInstance> for RuntimeReferendum {
             .collect();
         <Module<Runtime> as ReferendumConnection<Runtime>>::recieve_referendum_results(
             tmp_winners.as_slice(),
-        )
-        .unwrap();
+        );
 
         INTERMEDIATE_RESULTS.with(|value| value.replace(BTreeMap::new()));
     }

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -84,10 +84,6 @@ impl Trait for Runtime {
     ) -> bool {
         membership_id == account_id
     }
-
-    fn blocks_to_balance(block_number: &Self::BlockNumber) -> Balance<Self> {
-        (*block_number).into()
-    }
 }
 
 /////////////////// Module implementation //////////////////////////////////////

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -306,9 +306,27 @@ fn council_two_consecutive_rounds() {
             .collect();
 
         let expected_final_council_members: Vec<CouncilMemberOf<Runtime>> = vec![
-            (candidates[3].candidate.clone(), candidates[3].membership_id).into(),
-            (candidates[0].candidate.clone(), candidates[0].membership_id).into(),
-            (candidates[1].candidate.clone(), candidates[1].membership_id).into(),
+            (
+                candidates[3].candidate.clone(),
+                candidates[3].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[0].candidate.clone(),
+                candidates[0].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[1].candidate.clone(),
+                candidates[1].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
         ];
 
         // generate voter for each 6 voters and give: 4 votes for option D, 3 votes for option A, and 2 vote for option B, and 1 for option C
@@ -352,9 +370,27 @@ fn council_two_consecutive_rounds() {
             .collect();
 
         let expected_final_council_members2: Vec<CouncilMemberOf<Runtime>> = vec![
-            (candidates[3].candidate.clone(), candidates[3].membership_id).into(),
-            (candidates[1].candidate.clone(), candidates[1].membership_id).into(),
-            (candidates[2].candidate.clone(), candidates[2].membership_id).into(),
+            (
+                candidates[3].candidate.clone(),
+                candidates[3].membership_id,
+                council_settings.cycle_duration + council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[1].candidate.clone(),
+                candidates[1].membership_id,
+                council_settings.cycle_duration + council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[2].candidate.clone(),
+                candidates[2].membership_id,
+                council_settings.cycle_duration + council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
         ];
 
         let params2 = CouncilCycleParams {
@@ -462,9 +498,27 @@ fn council_candidate_stake_can_be_unlocked() {
             .collect();
 
         let expected_final_council_members: Vec<CouncilMemberOf<Runtime>> = vec![
-            (candidates[3].candidate.clone(), candidates[3].membership_id).into(),
-            (candidates[0].candidate.clone(), candidates[0].membership_id).into(),
-            (candidates[1].candidate.clone(), candidates[1].membership_id).into(),
+            (
+                candidates[3].candidate.clone(),
+                candidates[3].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[0].candidate.clone(),
+                candidates[0].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[1].candidate.clone(),
+                candidates[1].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
         ];
 
         // generate voter for each 6 voters and give: 4 votes for option D, 3 votes for option A, and 2 vote for option B, and 1 for option C
@@ -550,9 +604,27 @@ fn council_candidate_stake_automaticly_converted() {
             .collect();
 
         let expected_final_council_members: Vec<CouncilMemberOf<Runtime>> = vec![
-            (candidates[3].candidate.clone(), candidates[3].membership_id).into(),
-            (candidates[0].candidate.clone(), candidates[0].membership_id).into(),
-            (candidates[1].candidate.clone(), candidates[1].membership_id).into(),
+            (
+                candidates[3].candidate.clone(),
+                candidates[3].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[0].candidate.clone(),
+                candidates[0].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[1].candidate.clone(),
+                candidates[1].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
         ];
 
         // generate voter for each 6 voters and give: 4 votes for option D, 3 votes for option A, and 2 vote for option B, and 1 for option C
@@ -622,9 +694,27 @@ fn council_member_stake_is_locked() {
             .collect();
 
         let expected_final_council_members: Vec<CouncilMemberOf<Runtime>> = vec![
-            (candidates[3].candidate.clone(), candidates[3].membership_id).into(),
-            (candidates[0].candidate.clone(), candidates[0].membership_id).into(),
-            (candidates[1].candidate.clone(), candidates[1].membership_id).into(),
+            (
+                candidates[3].candidate.clone(),
+                candidates[3].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[0].candidate.clone(),
+                candidates[0].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[1].candidate.clone(),
+                candidates[1].membership_id,
+                council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
         ];
 
         // generate voter for each 6 voters and give: 4 votes for option D, 3 votes for option A, and 2 vote for option B, and 1 for option C
@@ -700,9 +790,27 @@ fn council_member_stake_automaticly_unlocked() {
             .collect();
 
         let expected_final_council_members2: Vec<CouncilMemberOf<Runtime>> = vec![
-            (candidates[3].candidate.clone(), candidates[3].membership_id).into(),
-            (candidates[1].candidate.clone(), candidates[1].membership_id).into(),
-            (candidates[2].candidate.clone(), candidates[2].membership_id).into(),
+            (
+                candidates[3].candidate.clone(),
+                candidates[3].membership_id,
+                council_settings.cycle_duration + council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[1].candidate.clone(),
+                candidates[1].membership_id,
+                council_settings.cycle_duration + council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
+            (
+                candidates[2].candidate.clone(),
+                candidates[2].membership_id,
+                council_settings.cycle_duration + council_settings.election_duration - 1,
+                0,
+            )
+                .into(),
         ];
 
         let params2 = CouncilCycleParams {

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -999,6 +999,34 @@ fn council_budget_can_be_set() {
     })
 }
 
+/// Test that budget balance can be set from external source.
+#[test]
+fn council_budget_refill_can_be_planned() {
+    let config = default_genesis_config();
+
+    build_test_externalities(config).execute_with(|| {
+        let origin = OriginType::Root;
+        let next_refill = 1000;
+
+        Mocks::plan_budget_refill(origin.clone(), next_refill, Ok(()));
+
+        // forward to one block before refill
+        MockUtils::increase_block_number(next_refill - 1);
+
+        // check no refill happened yet
+        Mocks::check_budget_refill(0, next_refill);
+
+        // forward to after block refill
+        MockUtils::increase_block_number(1);
+
+        // check budget was increased
+        Mocks::check_budget_refill(
+            <Runtime as Trait>::BudgetRefillAmount::get(),
+            next_refill + <Runtime as Trait>::BudgetRefillPeriod::get(),
+        );
+    })
+}
+
 /// Test that rewards for council members are paid.
 #[test]
 fn council_rewards_are_paid() {

--- a/runtime-modules/referendum/src/lib.rs
+++ b/runtime-modules/referendum/src/lib.rs
@@ -183,7 +183,7 @@ pub trait Trait<I: Instance>: system::Trait {
     type MinimumStake: Get<Balance<Self, I>>;
 
     /// Calculate the vote's power for user and his stake.
-    fn caclulate_vote_power(
+    fn calculate_vote_power(
         account_id: &<Self as system::Trait>::AccountId,
         stake: &Balance<Self, I>,
     ) -> <Self as Trait<I>>::VotePower;
@@ -553,7 +553,7 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
         cast_vote: CastVoteOf<T, I>,
     ) -> Result<(), Error<T, I>> {
         // prepare new values
-        let vote_power = T::caclulate_vote_power(&account_id, &cast_vote.stake);
+        let vote_power = T::calculate_vote_power(&account_id, &cast_vote.stake);
         let option_result = OptionResult {
             option_id: *option_id,
             vote_power,

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -556,9 +556,10 @@ impl InstanceMocks<Runtime, Instance0> {
     ) -> () {
         // check method returns expected result
         assert_eq!(
-            Module::<Runtime, Instance0>::release_stake(
-                InstanceMockUtils::<Runtime, Instance0>::mock_origin(origin),
-            ),
+            Module::<Runtime, Instance0>::release_voting_stake(InstanceMockUtils::<
+                Runtime,
+                Instance0,
+            >::mock_origin(origin),),
             expected_result,
         );
 

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -79,7 +79,7 @@ impl Trait<Instance0> for Runtime {
 
     type MinimumStake = MinimumStake;
 
-    fn caclulate_vote_power(
+    fn calculate_vote_power(
         account_id: &<Self as system::Trait>::AccountId,
         stake: &Balance<Self, Instance0>,
     ) -> <Self as Trait<Instance0>>::VotePower {


### PR DESCRIPTION
This PR adds elected member rewards budget to the council (part of #1487). A minor typo and compile bugs are also included.

Budget balance can be set from an external source and will be periodically paid to currently elected council members. In case reward(s) can't be paid in full, the remaining amount(s) will be remembered and paid next time. Any unpaid and at the moment, unpayable rewards will be discarded when the new council is established.