### PR TITLE
Proposals update

### DIFF
--- a/runtime-modules/proposals/discussion/src/benchmarking.rs
+++ b/runtime-modules/proposals/discussion/src/benchmarking.rs
@@ -3,13 +3,12 @@ use super::*;
 use crate::Module as ProposalsDiscussion;
 use core::convert::TryInto;
 use frame_benchmarking::{account, benchmarks};
+use frame_system::EventRecord;
+use frame_system::Module as System;
+use frame_system::RawOrigin;
 use membership::Module as Membership;
 use sp_std::cmp::min;
 use sp_std::prelude::*;
-use system as frame_system;
-use system::EventRecord;
-use system::Module as System;
-use system::RawOrigin;
 
 const SEED: u32 = 0;
 

--- a/runtime-modules/proposals/engine/src/lib.rs
+++ b/runtime-modules/proposals/engine/src/lib.rs
@@ -126,6 +126,7 @@ use codec::Decode;
 use frame_support::dispatch::{DispatchError, DispatchResult, UnfilteredDispatchable};
 use frame_support::storage::IterableStorageMap;
 use frame_support::traits::Get;
+use frame_support::weights::Weight;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, ensure, Parameter, StorageDoubleMap,
 };
@@ -348,6 +349,14 @@ decl_module! {
         /// Exports const -  max simultaneous active proposals number.
         const MaxActiveProposalLimit: u32 = T::MaxActiveProposalLimit::get();
 
+        /// Block Initialization. Perform voting period check, vote result tally, approved proposals
+        /// grace period checks, and proposal execution.
+        fn on_initialize() -> Weight {
+            Self::process_proposals();
+
+            10_000_000 // TODO: adjust weight
+        }
+
         /// Vote extrinsic. Conditions:  origin must allow votes.
         #[weight = 10_000_000] // TODO: adjust weight
         pub fn vote(
@@ -415,11 +424,6 @@ decl_module! {
             Self::finalize_proposal(proposal_id, proposal, ProposalDecision::Vetoed);
         }
 
-        /// Block finalization. Perform voting period check, vote result tally, approved proposals
-        /// grace period checks, and proposal execution.
-        fn on_finalize(_n: T::BlockNumber) {
-            Self::process_proposals();
-        }
     }
 }
 

--- a/runtime-modules/proposals/engine/src/tests/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mod.rs
@@ -375,7 +375,7 @@ fn vote_fails_with_insufficient_rights() {
 fn proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
         let starting_block = 1;
-        run_to_block_and_finalize(starting_block);
+        run_to_block(starting_block);
 
         let parameters_fixture = ProposalParametersFixture::default();
         let dummy_proposal =
@@ -391,7 +391,7 @@ fn proposal_execution_succeeds() {
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
 
-        run_to_block_and_finalize(2);
+        run_to_block(2);
 
         EventFixture::assert_events(vec![
             RawEvent::ProposalCreated(1, proposal_id),
@@ -405,7 +405,7 @@ fn proposal_execution_succeeds() {
             ),
             RawEvent::ProposalStatusUpdated(
                 proposal_id,
-                ProposalStatus::PendingExecution(starting_block),
+                ProposalStatus::PendingExecution(starting_block + 1),
             ),
             RawEvent::ProposalExecuted(proposal_id, ExecutionStatus::Executed),
         ]);
@@ -420,7 +420,7 @@ fn proposal_execution_succeeds() {
 fn proposal_execution_failed() {
     initial_test_ext().execute_with(|| {
         let starting_block = 1;
-        run_to_block_and_finalize(starting_block);
+        run_to_block(starting_block);
 
         let parameters_fixture = ProposalParametersFixture::default();
 
@@ -441,7 +441,7 @@ fn proposal_execution_failed() {
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
 
-        run_to_block_and_finalize(2);
+        run_to_block(2);
 
         assert!(!<crate::Proposals<Test>>::contains_key(proposal_id));
 
@@ -457,7 +457,7 @@ fn proposal_execution_failed() {
             ),
             RawEvent::ProposalStatusUpdated(
                 proposal_id,
-                ProposalStatus::PendingExecution(starting_block),
+                ProposalStatus::PendingExecution(starting_block + 1),
             ),
             RawEvent::ProposalExecuted(
                 proposal_id,
@@ -472,7 +472,7 @@ fn voting_results_calculation_succeeds() {
     initial_test_ext().execute_with(|| {
         // to enable events
         let starting_block = 1;
-        run_to_block_and_finalize(starting_block);
+        run_to_block(starting_block);
 
         let parameters = ProposalParameters {
             voting_period: 3,
@@ -494,7 +494,7 @@ fn voting_results_calculation_succeeds() {
         vote_generator.vote_and_assert_ok(VoteKind::Abstain);
 
         let block_number = 3;
-        run_to_block_and_finalize(block_number);
+        run_to_block(block_number);
 
         EventFixture::assert_events(vec![
             RawEvent::ProposalCreated(1, proposal_id),
@@ -508,7 +508,7 @@ fn voting_results_calculation_succeeds() {
             ),
             RawEvent::ProposalStatusUpdated(
                 proposal_id,
-                ProposalStatus::PendingExecution(starting_block),
+                ProposalStatus::PendingExecution(starting_block + 1),
             ),
             RawEvent::ProposalExecuted(proposal_id, ExecutionStatus::Executed),
         ]);
@@ -877,8 +877,7 @@ fn proposal_execution_postponed_because_of_grace_period() {
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
 
-        run_to_block_and_finalize(1);
-        run_to_block_and_finalize(2);
+        run_to_block(3);
 
         let proposal = <crate::Proposals<Test>>::get(proposal_id);
 
@@ -888,7 +887,7 @@ fn proposal_execution_postponed_because_of_grace_period() {
                 parameters: parameters_fixture.params(),
                 proposer_id: 1,
                 activated_at: 0,
-                status: ProposalStatus::approved(ApprovedProposalDecision::PendingExecution, 0),
+                status: ProposalStatus::approved(ApprovedProposalDecision::PendingExecution, 1),
                 voting_results: VotingResults {
                     abstentions: 0,
                     approvals: 4,
@@ -907,7 +906,7 @@ fn proposal_execution_postponed_because_of_grace_period() {
 fn proposal_execution_vetoed_successfully_during_the_grace_period() {
     initial_test_ext().execute_with(|| {
         let starting_block = 1;
-        run_to_block_and_finalize(starting_block);
+        run_to_block(starting_block);
 
         let parameters_fixture = ProposalParametersFixture::default().with_grace_period(3);
         let dummy_proposal =
@@ -921,8 +920,7 @@ fn proposal_execution_vetoed_successfully_during_the_grace_period() {
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
 
-        run_to_block_and_finalize(1);
-        run_to_block_and_finalize(2);
+        run_to_block(3);
 
         let pre_veto_proposal = <crate::Proposals<Test>>::get(proposal_id);
 
@@ -934,7 +932,7 @@ fn proposal_execution_vetoed_successfully_during_the_grace_period() {
                 activated_at: starting_block,
                 status: ProposalStatus::approved(
                     ApprovedProposalDecision::PendingExecution,
-                    starting_block
+                    starting_block + 1
                 ),
                 voting_results: VotingResults {
                     abstentions: 0,
@@ -962,7 +960,7 @@ fn proposal_execution_vetoed_successfully_during_the_grace_period() {
 fn proposal_execution_succeeds_after_the_grace_period() {
     initial_test_ext().execute_with(|| {
         let starting_block = 1;
-        run_to_block_and_finalize(starting_block);
+        run_to_block(starting_block);
 
         let parameters_fixture = ProposalParametersFixture::default().with_grace_period(2);
         let dummy_proposal =
@@ -975,7 +973,7 @@ fn proposal_execution_succeeds_after_the_grace_period() {
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
 
-        run_to_block_and_finalize(1);
+        run_to_block(2);
 
         let proposal = <crate::Proposals<Test>>::get(proposal_id);
 
@@ -985,7 +983,7 @@ fn proposal_execution_succeeds_after_the_grace_period() {
             activated_at: starting_block,
             status: ProposalStatus::approved(
                 ApprovedProposalDecision::PendingExecution,
-                starting_block,
+                starting_block + 1,
             ),
             voting_results: VotingResults {
                 abstentions: 0,
@@ -1000,8 +998,8 @@ fn proposal_execution_succeeds_after_the_grace_period() {
 
         assert_eq!(proposal, expected_proposal);
 
-        let finalization_block = 3;
-        run_to_block_and_finalize(finalization_block);
+        let finalization_block = 4;
+        run_to_block(finalization_block);
 
         EventFixture::assert_last_crate_event(RawEvent::ProposalExecuted(
             proposal_id,
@@ -1535,7 +1533,7 @@ fn proposal_execution_with_exact_execution_works() {
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
 
         // Proposal exists after the grace period
-        run_to_block_and_finalize(5);
+        run_to_block(5);
 
         let proposal = <crate::Proposals<Test>>::get(proposal_id);
 
@@ -1545,7 +1543,7 @@ fn proposal_execution_with_exact_execution_works() {
                 parameters: parameters_fixture.params(),
                 proposer_id: 1,
                 activated_at: 0,
-                status: ProposalStatus::approved(ApprovedProposalDecision::PendingExecution, 0),
+                status: ProposalStatus::approved(ApprovedProposalDecision::PendingExecution, 1),
                 voting_results: VotingResults {
                     abstentions: 0,
                     approvals: 4,
@@ -1559,7 +1557,7 @@ fn proposal_execution_with_exact_execution_works() {
         );
 
         // Exact execution block time.
-        run_to_block_and_finalize(exact_block);
+        run_to_block(exact_block);
 
         EventFixture::assert_last_crate_event(RawEvent::ProposalExecuted(
             proposal_id,
@@ -1719,7 +1717,7 @@ fn proposal_with_pending_constitutionality_reactivation_succeeds() {
 fn proposal_with_pending_constitutionality_execution_succeeds() {
     initial_test_ext().execute_with(|| {
         let starting_block = 1;
-        run_to_block_and_finalize(1);
+        run_to_block(starting_block);
 
         let account_id = 1;
         let total_balance = 1000;
@@ -1749,7 +1747,7 @@ fn proposal_with_pending_constitutionality_execution_succeeds() {
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
 
-        run_to_block_and_finalize(2);
+        run_to_block(2);
 
         // first chain of event from the creation to the approval
         EventFixture::assert_global_events(vec![
@@ -1780,7 +1778,7 @@ fn proposal_with_pending_constitutionality_execution_succeeds() {
                 activated_at: starting_block,
                 status: ProposalStatus::approved(
                     ApprovedProposalDecision::PendingConstitutionality,
-                    starting_block
+                    starting_block + 1
                 ),
                 voting_results: VotingResults {
                     abstentions: 0,
@@ -1800,7 +1798,7 @@ fn proposal_with_pending_constitutionality_execution_succeeds() {
         );
 
         let reactivation_block = 5;
-        run_to_block_and_finalize(reactivation_block);
+        run_to_block(reactivation_block);
 
         ProposalsEngine::reactivate_pending_constitutionality_proposals();
 
@@ -1822,8 +1820,8 @@ fn proposal_with_pending_constitutionality_execution_succeeds() {
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
         vote_generator.vote_and_assert_ok(VoteKind::Approve);
 
-        let next_block_after_approval = 6;
-        run_to_block_and_finalize(next_block_after_approval);
+        let next_block_after_approval = 7;
+        run_to_block(next_block_after_approval);
 
         // internal active proposal counter check
         assert_eq!(<ActiveProposalCount>::get(), 0);
@@ -1863,7 +1861,7 @@ fn proposal_with_pending_constitutionality_execution_succeeds() {
             )),
             TestEvent::engine(RawEvent::ProposalStatusUpdated(
                 proposal_id,
-                ProposalStatus::PendingExecution(reactivation_block),
+                ProposalStatus::PendingExecution(reactivation_block + 1),
             )),
             // execution
             TestEvent::engine(RawEvent::ProposalExecuted(

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -258,45 +258,40 @@ impl_runtime_apis! {
      #[cfg(feature = "runtime-benchmarks")]
     impl frame_benchmarking::Benchmark<Block> for Runtime {
         fn dispatch_benchmark(
-            pallet: Vec<u8>,
-            benchmark: Vec<u8>,
-            lowest_range_values: Vec<u32>,
-            highest_range_values: Vec<u32>,
-            steps: Vec<u32>,
-            repeat: u32,
+            config: frame_benchmarking::BenchmarkConfig
         ) -> Result<Vec<frame_benchmarking::BenchmarkBatch>, sp_runtime::RuntimeString> {
             /*
              * TODO: remember to benchhmark every pallet
              */
             use sp_std::vec;
-            use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark};
+            use frame_benchmarking::{Benchmarking, BenchmarkBatch, add_benchmark, TrackedStorageKey};
             use frame_system_benchmarking::Module as SystemBench;
             impl frame_system_benchmarking::Trait for Runtime {}
 
             use crate::ProposalsDiscussion;
 
-            let whitelist: Vec<Vec<u8>> = vec![
+            let whitelist: Vec<TrackedStorageKey> = vec![
                 // Block Number
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec(),
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac").to_vec().into(),
                 // Total Issuance
-                hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec(),
+                hex_literal::hex!("c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80").to_vec().into(),
                 // Execution Phase
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec(),
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7ff553b5a9862a516939d82b3d3d8661a").to_vec().into(),
                 // Event Count
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec(),
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850").to_vec().into(),
                 // System Events
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec(),
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7").to_vec().into(),
                 // Caller 0 Account
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da946c154ffd9992e395af90b5b13cc6f295c77033fce8a9045824a6690bbf99c6db269502f0a8d1d2a008542d5690a0749").to_vec(),
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da946c154ffd9992e395af90b5b13cc6f295c77033fce8a9045824a6690bbf99c6db269502f0a8d1d2a008542d5690a0749").to_vec().into(),
                 // Treasury Account
-                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec(),
+                hex_literal::hex!("26aa394eea5630e07c48ae0c9558cef7b99d880ec681799c0cf30e8886371da95ecffd7b6c0f78751baa9d281e0bfa3a6d6f646c70792f74727372790000000000000000000000000000000000000000").to_vec().into(),
             ];
 
             let mut batches = Vec::<BenchmarkBatch>::new();
-            let params = (&pallet, &benchmark, &lowest_range_values, &highest_range_values, &steps, repeat, &whitelist);
+            let params = (&config, &whitelist);
 
-            add_benchmark!(params, batches, b"system", SystemBench::<Runtime>);
-            add_benchmark!(params, batches, b"proposals-discussion", ProposalsDiscussion);
+            add_benchmark!(params, batches, system, SystemBench::<Runtime>);
+            add_benchmark!(params, batches, proposals_discussion, ProposalsDiscussion);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
             Ok(batches)

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -431,7 +431,7 @@ fn run_create_begin_review_working_group_leader_applications_proposal_execution_
             hiring_opening.stage,
             hiring::OpeningStage::Active {
                 stage: hiring::ActiveOpeningStage::AcceptingApplications {
-                    started_accepting_applicants_at_block: 0
+                    started_accepting_applicants_at_block: 1
                 },
                 applications_added: BTreeSet::new(),
                 active_application_count: 0,
@@ -449,8 +449,8 @@ fn run_create_begin_review_working_group_leader_applications_proposal_execution_
             hiring_opening.stage,
             hiring::OpeningStage::Active {
                 stage: hiring::ActiveOpeningStage::ReviewPeriod {
-                    started_accepting_applicants_at_block: 0,
-                    started_review_period_at_block: grace_period + 2,
+                    started_accepting_applicants_at_block: 1,
+                    started_review_period_at_block: grace_period + 3,
                 },
                 applications_added: BTreeSet::new(),
                 active_application_count: 0,


### PR DESCRIPTION
# PR to track #1751 

In this PR we refactored `proposal/engine` to execute the logic for proposal execution in `on_initialize` instead of `on_finalize` as it's recommended.

Furthermore, we take into account the weight for each executed proposal in the weight calculation for `on_initialize`

* Move `process_proposals` to `on_initialze`
* Update tests accordingly
* Add `GetDispatchInfo` as a required trait for `DispatchableCallCode`
* Use the weight info to calculate the executed proposal weights in `on_initialize`