### PR TITLE
Query node mappings - isCurated default value

### DIFF
--- a/query-node/mappings/content-directory/entity/create.ts
+++ b/query-node/mappings/content-directory/entity/create.ts
@@ -216,8 +216,7 @@ async function createVideo(
   video.description = p.description
   video.duration = p.duration
   video.hasMarketing = p.hasMarketing
-  // TODO: needs to be handled correctly, from runtime CurationStatus is coming
-  video.isCurated = p.isCurated || true
+  video.isCurated = p.isCurated || false
   video.isExplicit = p.isExplicit
   video.isPublic = p.isPublic
   video.publishedBeforeJoystream = p.publishedBeforeJoystream

--- a/query-node/mappings/content-directory/entity/create.ts
+++ b/query-node/mappings/content-directory/entity/create.ts
@@ -61,7 +61,7 @@ async function createChannel(
   channel.id = id
   channel.title = p.title
   channel.description = p.description
-  channel.isCurated = p.isCurated
+  channel.isCurated = !!p.isCurated
   channel.isPublic = p.isPublic
   channel.coverPhotoUrl = p.coverPhotoUrl
   channel.avatarPhotoUrl = p.avatarPhotoUrl
@@ -216,7 +216,7 @@ async function createVideo(
   video.description = p.description
   video.duration = p.duration
   video.hasMarketing = p.hasMarketing
-  video.isCurated = p.isCurated
+  video.isCurated = !!p.isCurated
   video.isExplicit = p.isExplicit
   video.isPublic = p.isPublic
   video.publishedBeforeJoystream = p.publishedBeforeJoystream

--- a/query-node/mappings/content-directory/entity/create.ts
+++ b/query-node/mappings/content-directory/entity/create.ts
@@ -61,7 +61,7 @@ async function createChannel(
   channel.id = id
   channel.title = p.title
   channel.description = p.description
-  channel.isCurated = p.isCurated || false
+  channel.isCurated = p.isCurated
   channel.isPublic = p.isPublic
   channel.coverPhotoUrl = p.coverPhotoUrl
   channel.avatarPhotoUrl = p.avatarPhotoUrl
@@ -216,7 +216,7 @@ async function createVideo(
   video.description = p.description
   video.duration = p.duration
   video.hasMarketing = p.hasMarketing
-  video.isCurated = p.isCurated || false
+  video.isCurated = p.isCurated
   video.isExplicit = p.isExplicit
   video.isPublic = p.isPublic
   video.publishedBeforeJoystream = p.publishedBeforeJoystream

--- a/query-node/mappings/types.ts
+++ b/query-node/mappings/types.ts
@@ -45,7 +45,7 @@ export interface IChannel {
   coverPhotoUrl: string
   avatarPhotoUrl: string
   isPublic: boolean
-  isCurated: boolean
+  isCurated?: boolean
   language?: IReference
 }
 
@@ -107,7 +107,7 @@ export interface IVideo {
   hasMarketing?: boolean
   publishedBeforeJoystream?: number
   isPublic: boolean
-  isCurated: boolean
+  isCurated?: boolean
   isExplicit: boolean
   license?: IReference
 }


### PR DESCRIPTION
Fix the issue with `video.isCurated` defaulting to `true` when falsy in the query node mappings (making it impossible to set it to `false`)