### PR TITLE
Content directory schemas - fix isCensored unique contraint bug

### DIFF
--- a/content-directory-schemas/inputs/schemas/ChannelSchema.json
+++ b/content-directory-schemas/inputs/schemas/ChannelSchema.json
@@ -36,7 +36,6 @@
       "name": "isCensored",
       "description": "Channel censorship status set by the Curator.",
       "required": false,
-      "unique": true,
       "property_type": { "Single": "Bool" },
       "locking_policy": { "is_locked_from_controller": true }
     },

--- a/content-directory-schemas/inputs/schemas/VideoSchema.json
+++ b/content-directory-schemas/inputs/schemas/VideoSchema.json
@@ -92,7 +92,6 @@
       "name": "isCensored",
       "description": "Video censorship status set by the Curator.",
       "required": false,
-      "unique": true,
       "property_type": { "Single": "Bool" },
       "locking_policy": { "is_locked_from_controller": true }
     }


### PR DESCRIPTION
Remove `unique` constraint from `isCensored` field (relic of `CurationStatus` beeing a separate entity before)