### PR TITLE
Query node featured videos

### DIFF
--- a/query-node/mappings/content-directory/content-dir-consts.ts
+++ b/query-node/mappings/content-directory/content-dir-consts.ts
@@ -14,6 +14,7 @@ export enum ContentDirectoryKnownClasses {
   VIDEO = 'Video',
   VIDEOMEDIA = 'VideoMedia',
   VIDEOMEDIAENCODING = 'VideoMediaEncoding',
+  FEATUREDVIDEOS = 'FeaturedVideo',
 }
 
 // Predefined content-directory classes, classId may change after the runtime seeding
@@ -30,6 +31,7 @@ export const contentDirectoryClassNamesWithId: { classId: number; name: string }
   { name: ContentDirectoryKnownClasses.VIDEO, classId: 10 },
   { name: ContentDirectoryKnownClasses.VIDEOMEDIA, classId: 11 },
   { name: ContentDirectoryKnownClasses.VIDEOMEDIAENCODING, classId: 12 },
+  { name: ContentDirectoryKnownClasses.FEATUREDVIDEOS, classId: 13 },
 ]
 
 export const categoryPropertyNamesWithId: IPropertyWithId = {
@@ -113,4 +115,8 @@ export const videoPropertyNamesWithId: IPropertyWithId = {
   12: { name: 'isExplicit', type: 'boolean', required: true },
   13: { name: 'license', type: 'number', required: true },
   14: { name: 'isCurated', type: 'boolean', required: true },
+}
+
+export const featuredVideoPropertyNamesWithId: IPropertyWithId = {
+  0: { name: 'video', type: 'number', required: true },
 }

--- a/query-node/mappings/content-directory/entity/create.ts
+++ b/query-node/mappings/content-directory/entity/create.ts
@@ -403,18 +403,19 @@ async function createFeaturedVideo(
   nextEntityIdBeforeTransaction: number
 ): Promise<void> {
   const featuredVideo = new FeaturedVideo()
-  featuredVideo.id = id
+
   featuredVideo.video = await getOrCreate.video(
     { db, block, id },
     classEntityMap,
     p.video!,
     nextEntityIdBeforeTransaction
   )
+
+  featuredVideo.id = id
   featuredVideo.version = block
-
   featuredVideo.video.isFeatured = true
-  await db.save<Video>(featuredVideo.video)
 
+  await db.save<Video>(featuredVideo.video)
   await db.save<FeaturedVideo>(featuredVideo)
 }
 

--- a/query-node/mappings/content-directory/entity/create.ts
+++ b/query-node/mappings/content-directory/entity/create.ts
@@ -13,6 +13,7 @@ import { VideoMediaEncoding } from '../../../generated/graphql-server/src/module
 import { ClassEntity } from '../../../generated/graphql-server/src/modules/class-entity/class-entity.model'
 import { LicenseEntity } from '../../../generated/graphql-server/src/modules/license-entity/license-entity.model'
 import { MediaLocationEntity } from '../../../generated/graphql-server/src/modules/media-location-entity/media-location-entity.model'
+import { FeaturedVideo } from '../../../generated/graphql-server/src/modules/featured-video/featured-video.model'
 
 import { contentDirectoryClassNamesWithId } from '../content-dir-consts'
 import {
@@ -22,6 +23,7 @@ import {
   ICreateEntityOperation,
   IDBBlockId,
   IEntity,
+  IFeaturedVideo,
   IHttpMediaLocation,
   IJoystreamMediaLocation,
   IKnownLicense,
@@ -244,6 +246,7 @@ async function createVideo(
   video.skippableIntroDuration = p.skippableIntroDuration
   video.thumbnailUrl = p.thumbnailUrl
   video.version = block
+  video.isFeatured = false
 
   const { language, license, category, channel, media } = p
   if (language !== undefined) {
@@ -393,6 +396,28 @@ async function createMediaLocation(
   return location
 }
 
+async function createFeaturedVideo(
+  { db, block, id }: IDBBlockId,
+  classEntityMap: ClassEntityMap,
+  p: IFeaturedVideo,
+  nextEntityIdBeforeTransaction: number
+): Promise<void> {
+  const featuredVideo = new FeaturedVideo()
+  featuredVideo.id = id
+  featuredVideo.video = await getOrCreate.video(
+    { db, block, id },
+    classEntityMap,
+    p.video!,
+    nextEntityIdBeforeTransaction
+  )
+  featuredVideo.version = block
+
+  featuredVideo.video.isFeatured = true
+  await db.save<Video>(featuredVideo.video)
+
+  await db.save<FeaturedVideo>(featuredVideo)
+}
+
 async function getClassName(
   db: DB,
   entity: IEntity,
@@ -434,4 +459,5 @@ export {
   createMediaLocation,
   createBlockOrGetFromDatabase,
   getClassName,
+  createFeaturedVideo,
 }

--- a/query-node/mappings/content-directory/entity/index.ts
+++ b/query-node/mappings/content-directory/entity/index.ts
@@ -16,6 +16,7 @@ import {
   updateVideoMediaEncodingEntityPropertyValues,
   updateLicenseEntityPropertyValues,
   updateMediaLocationEntityPropertyValues,
+  updateFeaturedVideoEntityPropertyValues,
 } from './update'
 import {
   removeCategory,
@@ -30,6 +31,7 @@ import {
   removeVideoMediaEncoding,
   removeLicense,
   removeMediaLocation,
+  removeFeaturedVideo,
 } from './remove'
 import {
   createCategory,
@@ -43,6 +45,7 @@ import {
   createLanguage,
   createVideoMediaEncoding,
   createBlockOrGetFromDatabase,
+  createFeaturedVideo,
 } from './create'
 import {
   categoryPropertyNamesWithId,
@@ -56,6 +59,7 @@ import {
   videoPropertyNamesWithId,
   contentDirectoryClassNamesWithId,
   ContentDirectoryKnownClasses,
+  featuredVideoPropertyNamesWithId,
 } from '../content-dir-consts'
 
 import {
@@ -74,6 +78,7 @@ import {
   IEntity,
   ILicense,
   IMediaLocation,
+  IFeaturedVideo,
 } from '../../types'
 import { getOrCreate } from '../get-or-create'
 
@@ -168,6 +173,14 @@ async function contentDirectory_EntitySchemaSupportAdded(db: DB, event: Substrat
         decode.setProperties<IVideoMediaEncoding>(event, videoMediaEncodingPropertyNamesWithId)
       )
       break
+    case ContentDirectoryKnownClasses.FEATUREDVIDEOS:
+      await createFeaturedVideo(
+        arg,
+        new Map<string, IEntity[]>(),
+        decode.setProperties<IFeaturedVideo>(event, featuredVideoPropertyNamesWithId),
+        0
+      )
+      break
 
     default:
       throw new Error(`Unknown class name: ${cls.name}`)
@@ -239,6 +252,10 @@ async function contentDirectory_EntityRemoved(db: DB, event: SubstrateEvent): Pr
 
     case ContentDirectoryKnownClasses.MEDIALOCATION:
       await removeMediaLocation(db, where)
+      break
+
+    case ContentDirectoryKnownClasses.FEATUREDVIDEOS:
+      await removeFeaturedVideo(db, where)
       break
 
     default:
@@ -375,6 +392,15 @@ async function contentDirectory_EntityPropertyValuesUpdated(db: DB, event: Subst
         db,
         where,
         decode.setProperties<IMediaLocation>(event, videoMediaEncodingPropertyNamesWithId),
+        0
+      )
+      break
+
+    case ContentDirectoryKnownClasses.FEATUREDVIDEOS:
+      await updateFeaturedVideoEntityPropertyValues(
+        db,
+        where,
+        decode.setProperties<IFeaturedVideo>(event, featuredVideoPropertyNamesWithId),
         0
       )
       break

--- a/query-node/mappings/content-directory/entity/remove.ts
+++ b/query-node/mappings/content-directory/entity/remove.ts
@@ -136,7 +136,7 @@ async function removeVideoMediaEncoding(db: DB, where: IWhereCond): Promise<void
 }
 
 async function removeFeaturedVideo(db: DB, where: IWhereCond): Promise<void> {
-  const record = await db.get(FeaturedVideo, where)
+  const record = await db.get(FeaturedVideo, { ...where, relations: ['video'] })
   if (!record) throw Error(`FeaturedVideo not found. id: ${where.where.id}`)
 
   record.video.isFeatured = false

--- a/query-node/mappings/content-directory/entity/remove.ts
+++ b/query-node/mappings/content-directory/entity/remove.ts
@@ -1,3 +1,5 @@
+import Debug from 'debug'
+
 import { DB } from '../../../generated/indexer'
 import { Channel } from '../../../generated/graphql-server/src/modules/channel/channel.model'
 import { Category } from '../../../generated/graphql-server/src/modules/category/category.model'
@@ -11,8 +13,11 @@ import { Language } from '../../../generated/graphql-server/src/modules/language
 import { VideoMediaEncoding } from '../../../generated/graphql-server/src/modules/video-media-encoding/video-media-encoding.model'
 import { LicenseEntity } from '../../../generated/graphql-server/src/modules/license-entity/license-entity.model'
 import { MediaLocationEntity } from '../../../generated/graphql-server/src/modules/media-location-entity/media-location-entity.model'
+import { FeaturedVideo } from '../../../generated/graphql-server/src/modules/featured-video/featured-video.model'
 
 import { IWhereCond } from '../../types'
+
+const debug = Debug('mappings:remove-entity')
 
 async function removeChannel(db: DB, where: IWhereCond): Promise<void> {
   const record = await db.get(Channel, where)
@@ -20,6 +25,7 @@ async function removeChannel(db: DB, where: IWhereCond): Promise<void> {
   if (record.videos) record.videos.map(async (v) => await removeVideo(db, { where: { id: v.id } }))
   await db.remove<Channel>(record)
 }
+
 async function removeCategory(db: DB, where: IWhereCond): Promise<void> {
   const record = await db.get(Category, where)
   if (record === undefined) throw Error(`Category not found`)
@@ -129,6 +135,17 @@ async function removeVideoMediaEncoding(db: DB, where: IWhereCond): Promise<void
   await db.remove<VideoMediaEncoding>(record)
 }
 
+async function removeFeaturedVideo(db: DB, where: IWhereCond): Promise<void> {
+  const record = await db.get(FeaturedVideo, where)
+  if (!record) throw Error(`FeaturedVideo not found. id: ${where.where.id}`)
+
+  record.video.isFeatured = false
+  record.video.featured = undefined
+
+  await db.save<Video>(record.video)
+  await db.remove<FeaturedVideo>(record)
+}
+
 export {
   removeCategory,
   removeChannel,
@@ -142,4 +159,5 @@ export {
   removeVideoMediaEncoding,
   removeMediaLocation,
   removeLicense,
+  removeFeaturedVideo,
 }

--- a/query-node/mappings/content-directory/entity/update.ts
+++ b/query-node/mappings/content-directory/entity/update.ts
@@ -290,13 +290,17 @@ async function updateFeaturedVideoEntityPropertyValues(
   props: IFeaturedVideo,
   entityIdBeforeTransaction: number
 ): Promise<void> {
-  const record = await db.get(FeaturedVideo, where)
+  const record = await db.get(FeaturedVideo, { ...where, relations: ['video'] })
   if (record === undefined) throw Error(`FeaturedVideo entity not found: ${where.where.id}`)
 
   if (props.video) {
     const id = getEntityIdFromReferencedField(props.video, entityIdBeforeTransaction)
     const video = await db.get(Video, { where: { id } })
     if (!video) throw Error(`Video entity not found: ${id}`)
+
+    // Update old video isFeatured to false
+    record.video.isFeatured = false
+    await db.save<Video>(record.video)
 
     video.isFeatured = true
     record.video = video

--- a/query-node/mappings/content-directory/entity/update.ts
+++ b/query-node/mappings/content-directory/entity/update.ts
@@ -11,10 +11,12 @@ import { LicenseEntity } from '../../../generated/graphql-server/src/modules/lic
 import { MediaLocationEntity } from '../../../generated/graphql-server/src/modules/media-location-entity/media-location-entity.model'
 import { HttpMediaLocationEntity } from '../../../generated/graphql-server/src/modules/http-media-location-entity/http-media-location-entity.model'
 import { JoystreamMediaLocationEntity } from '../../../generated/graphql-server/src/modules/joystream-media-location-entity/joystream-media-location-entity.model'
+import { FeaturedVideo } from '../../../generated/graphql-server/src/modules/featured-video/featured-video.model'
 
 import {
   ICategory,
   IChannel,
+  IFeaturedVideo,
   IHttpMediaLocation,
   IJoystreamMediaLocation,
   IKnownLicense,
@@ -282,6 +284,28 @@ async function updateVideoMediaEncodingEntityPropertyValues(
   await db.save<VideoMediaEncoding>(record)
 }
 
+async function updateFeaturedVideoEntityPropertyValues(
+  db: DB,
+  where: IWhereCond,
+  props: IFeaturedVideo,
+  entityIdBeforeTransaction: number
+): Promise<void> {
+  const record = await db.get(FeaturedVideo, where)
+  if (record === undefined) throw Error(`FeaturedVideo entity not found: ${where.where.id}`)
+
+  if (props.video) {
+    const id = getEntityIdFromReferencedField(props.video, entityIdBeforeTransaction)
+    const video = await db.get(Video, { where: { id } })
+    if (!video) throw Error(`Video entity not found: ${id}`)
+
+    video.isFeatured = true
+    record.video = video
+
+    await db.save<Video>(video)
+    await db.save<FeaturedVideo>(record)
+  }
+}
+
 export {
   updateCategoryEntityPropertyValues,
   updateChannelEntityPropertyValues,
@@ -295,4 +319,5 @@ export {
   updateVideoMediaEncodingEntityPropertyValues,
   updateLicenseEntityPropertyValues,
   updateMediaLocationEntityPropertyValues,
+  updateFeaturedVideoEntityPropertyValues,
 }

--- a/query-node/mappings/content-directory/transaction.ts
+++ b/query-node/mappings/content-directory/transaction.ts
@@ -12,6 +12,7 @@ import {
   ICreateEntityOperation,
   IDBBlockId,
   IEntity,
+  IFeaturedVideo,
   IHttpMediaLocation,
   IJoystreamMediaLocation,
   IKnownLicense,
@@ -38,6 +39,7 @@ import {
   ContentDirectoryKnownClasses,
   licensePropertyNamesWithId,
   mediaLocationPropertyNamesWithId,
+  featuredVideoPropertyNamesWithId,
 } from './content-dir-consts'
 import {
   updateCategoryEntityPropertyValues,
@@ -52,6 +54,7 @@ import {
   updateVideoMediaEncodingEntityPropertyValues,
   updateLicenseEntityPropertyValues,
   updateMediaLocationEntityPropertyValues,
+  updateFeaturedVideoEntityPropertyValues,
 } from './entity/update'
 
 import {
@@ -69,6 +72,7 @@ import {
   createLicense,
   createMediaLocation,
   createBlockOrGetFromDatabase,
+  createFeaturedVideo,
 } from './entity/create'
 import { getOrCreate } from './get-or-create'
 
@@ -256,6 +260,15 @@ async function batchAddSchemaSupportToEntity(
           )
           break
 
+        case ContentDirectoryKnownClasses.FEATUREDVIDEOS:
+          await createFeaturedVideo(
+            arg,
+            classEntityMap,
+            decode.setEntityPropertyValues<IFeaturedVideo>(properties, featuredVideoPropertyNamesWithId),
+            nextEntityIdBeforeTransaction
+          )
+          break
+
         default:
           console.log(`Unknown class name: ${className}`)
           break
@@ -381,6 +394,14 @@ async function batchUpdatePropertyValue(db: DB, createEntityOperations: ICreateE
           db,
           where,
           decode.setEntityPropertyValues<IMediaLocation>(properties, mediaLocationPropertyNamesWithId),
+          entityIdBeforeTransaction
+        )
+        break
+      case ContentDirectoryKnownClasses.FEATUREDVIDEOS:
+        await updateFeaturedVideoEntityPropertyValues(
+          db,
+          where,
+          decode.setEntityPropertyValues<IFeaturedVideo>(properties, featuredVideoPropertyNamesWithId),
           entityIdBeforeTransaction
         )
         break

--- a/query-node/mappings/types.ts
+++ b/query-node/mappings/types.ts
@@ -197,3 +197,7 @@ export interface IDBBlockId {
 }
 
 export type ClassEntityMap = Map<string, IEntity[]>
+
+export interface IFeaturedVideo {
+  video?: IReference
+}

--- a/query-node/schema.graphql
+++ b/query-node/schema.graphql
@@ -293,6 +293,11 @@ type Video @entity {
   license: License!
 
   happenedIn: Block!
+
+  "Is video featured or not"
+  isFeatured: Boolean!
+
+  featured: FeaturedVideo @derivedFrom(field: "video")
 }
 
 type JoystreamMediaLocation @variant {
@@ -330,3 +335,11 @@ type UserDefinedLicense @variant {
 union MediaLocation = HttpMediaLocation | JoystreamMediaLocation
 
 union License = KnownLicense | UserDefinedLicense
+
+type FeaturedVideo @entity {
+  "Runtime entity identifier (EntityId)"
+  id: ID!
+
+  "Reference to a video"
+  video: Video!
+}


### PR DESCRIPTION
This PR introduces `FeaturedVideo` entity and adds `isFeatured` field to `Video` entity. There are two ways of querying featured videos:

```graphql
## 1 - Query featured videos by isFeatured ##
query {
  videos(where: { isFeatured_eq: true }) {
    id
    title
  }
}

## 2 - Query featured videos from FeaturedVideos entities ##
query {
  featuredVideos {
    video {
      id
      title
    }
  }
}

```