### PR TITLE
forum_config: fix data_migration_done encoded representation

### DIFF
--- a/node/src/chain_spec/forum_config.rs
+++ b/node/src/chain_spec/forum_config.rs
@@ -108,7 +108,8 @@ pub fn empty(forum_sudo: AccountId) -> ForumConfig {
         threads: vec![],
         posts: vec![],
         category_by_moderator: vec![],
-        data_migration_done: String::new(),
+        // true
+        data_migration_done: String::from("0x01"),
     };
     create(forum_sudo, forum_data)
 }


### PR DESCRIPTION
This PR aims to fix `data_migration_done` encoded representation, setting it to "0x01" (true), when `empty(forum_sudo: AccountId)` funtion called.