### PR TITLE
github workflows: replace deprecated set-env

### DIFF
--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -55,7 +55,7 @@ jobs:
             docker save --output joystream-node-docker-image.tar joystream/node
             gzip joystream-node-docker-image.tar
             cp joystream-node-docker-image.tar.gz ~/docker-images/
-            echo "NEW_BUILD=1" >> $GITHUB_ENV
+            echo "NEW_BUILD=true" >> $GITHUB_ENV
           fi
 
       - name: Save joystream/node image to Artifacts

--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -55,7 +55,7 @@ jobs:
             docker save --output joystream-node-docker-image.tar joystream/node
             gzip joystream-node-docker-image.tar
             cp joystream-node-docker-image.tar.gz ~/docker-images/
-            echo "::set-env name=NEW_BUILD::true"
+            echo "NEW_BUILD=1" >> $GITHUB_ENV
           fi
 
       - name: Save joystream/node image to Artifacts


### PR DESCRIPTION
Problem:
The workflow that builds joystream/node docker images and caches it and make it also available on docker-hub is failing, causing PRs to have to rebuild the image on every commit, which is taking too long.

The Issue is found in:
```
Error: Unable to process command '::set-env name=NEW_BUILD::true' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```
..as seen in build run: https://github.com/Joystream/joystream/actions/runs/394116932

**Cause**: `set-env` has been disabled for security reasons.
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

**Fix** use new recommended way:
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

