### PR TITLE
rocksdb fix - bump cc pacakge to v1.0.65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,9 +635,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92cc7b4cfeaa608da27ccbd00af8e1485761334821791ccf5ce88e9a2bb949e7"
+checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
 dependencies = [
  "jobserver",
 ]


### PR DESCRIPTION
Trying suggested fix from https://github.com/paritytech/substrate/issues/7593#issuecomment-733668743