### PR TITLE
Drop obsolete membership code.

### DIFF
--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -281,10 +281,7 @@ pub fn testnet_genesis(
                 min_voting_stake: 100,
             },
         }),
-        membership: Some(MembersConfig {
-            default_paid_membership_fee: 100u128,
-            members,
-        }),
+        membership: Some(MembersConfig { members }),
         forum: Some(forum_config),
         data_object_type_registry: Some(DataObjectTypeRegistryConfig {
             first_data_object_type_id: 1,

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -25,6 +25,7 @@ parameter_types! {
     pub const MaximumBlockLength: u32 = 2 * 1024;
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
+    pub const MembershipFee: u64 = 100;
 }
 
 impl frame_system::Trait for Test {
@@ -74,8 +75,8 @@ impl election::Trait for Test {
 impl membership::Trait for Test {
     type Event = ();
     type MemberId = u64;
-    type PaidTermId = u32;
     type ActorId = u32;
+    type MembershipFee = MembershipFee;
 }
 impl minting::Trait for Test {
     type Currency = Balances;

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -115,7 +115,6 @@ pub fn initial_test_ext() -> sp_io::TestExternalities {
         .unwrap();
 
     let members_config_builder = membership::genesis::GenesisConfigBuilder::<Test>::default()
-        .default_paid_membership_fee(0)
         .members(vec![
             // member_id, account_id
             (0, 1),

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -74,7 +74,6 @@ impl election::Trait for Test {
 impl membership::Trait for Test {
     type Event = ();
     type MemberId = u64;
-    type SubscriptionId = u32;
     type PaidTermId = u32;
     type ActorId = u32;
 }

--- a/runtime-modules/membership/src/genesis.rs
+++ b/runtime-modules/membership/src/genesis.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "std")]
 
+use crate::BalanceOf;
 use crate::{GenesisConfig, Trait};
-use common::currency::BalanceOf;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/runtime-modules/membership/src/genesis.rs
+++ b/runtime-modules/membership/src/genesis.rs
@@ -67,7 +67,6 @@ impl<T: Trait> GenesisConfigBuilder<T> {
     /// Construct GenesisConfig for mocked testing purposes only
     pub fn build(&self) -> GenesisConfig<T> {
         GenesisConfig::<T> {
-            default_paid_membership_fee: self.default_paid_membership_fee,
             members: self.generate_mock_members(),
         }
     }

--- a/runtime-modules/membership/src/genesis.rs
+++ b/runtime-modules/membership/src/genesis.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "std")]
 
-use crate::BalanceOf;
 use crate::{GenesisConfig, Trait};
 use serde::{Deserialize, Serialize};
 
@@ -17,29 +16,16 @@ pub struct Member<MemberId, AccountId, Moment> {
 
 /// Builder fo membership module genesis configuration.
 pub struct GenesisConfigBuilder<T: Trait> {
-    default_paid_membership_fee: BalanceOf<T>,
     members: Vec<(T::MemberId, T::AccountId)>,
 }
 
 impl<T: Trait> Default for GenesisConfigBuilder<T> {
     fn default() -> Self {
-        Self {
-            default_paid_membership_fee: BalanceOf::<T>::default(), // Was 100, will this break any tests??
-            members: vec![],
-        }
+        Self { members: vec![] }
     }
 }
 
 impl<T: Trait> GenesisConfigBuilder<T> {
-    /// Assign default paid membeship fee
-    pub fn default_paid_membership_fee(
-        mut self,
-        default_paid_membership_fee: BalanceOf<T>,
-    ) -> Self {
-        self.default_paid_membership_fee = default_paid_membership_fee;
-        self
-    }
-
     /// Assign a collection of MemberId and AccountId pairs, used to derive mock member at genesis
     pub fn members(mut self, members: Vec<(T::MemberId, T::AccountId)>) -> Self {
         self.members = members;

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -46,15 +46,6 @@ pub trait Trait: frame_system::Trait + GovernanceCurrency + pallet_timestamp::Tr
         + MaybeSerialize
         + PartialEq;
 
-    type SubscriptionId: Parameter
-        + Member
-        + BaseArithmetic
-        + Codec
-        + Default
-        + Copy
-        + MaybeSerialize
-        + PartialEq;
-
     /// Describes the common type for the working group members (workers).
     type ActorId: Parameter
         + Member
@@ -83,13 +74,12 @@ pub type Membership<T> = MembershipObject<
     <T as frame_system::Trait>::BlockNumber,
     <T as pallet_timestamp::Trait>::Moment,
     <T as Trait>::PaidTermId,
-    <T as Trait>::SubscriptionId,
     <T as frame_system::Trait>::AccountId,
 >;
 
 #[derive(Encode, Decode, Default)]
 /// Stored information about a registered user
-pub struct MembershipObject<BlockNumber, Moment, PaidTermId, SubscriptionId, AccountId> {
+pub struct MembershipObject<BlockNumber, Moment, PaidTermId, AccountId> {
     /// The unique handle chosen by member
     pub handle: Vec<u8>,
 
@@ -107,12 +97,6 @@ pub struct MembershipObject<BlockNumber, Moment, PaidTermId, SubscriptionId, Acc
 
     /// How the member was registered
     pub entry: EntryMethod<PaidTermId, AccountId>,
-
-    /// Whether the member is suspended or not.
-    pub suspended: bool,
-
-    /// The type of subscription the member has purchased if any.
-    pub subscription: Option<SubscriptionId>,
 
     /// Member's root account id. Only the root account is permitted to set a new root account
     /// and update the controller account. Other modules may only allow certain actions if
@@ -595,8 +579,6 @@ impl<T: Trait> Module<T> {
             registered_at_block,
             registered_at_time,
             entry: entry_method,
-            suspended: false,
-            subscription: None,
             root_account: root_account.clone(),
             controller_account: controller_account.clone(),
         };

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -1,22 +1,17 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
-// Clippy linter requirement.
-// Disable it because of the substrate lib design
-// Example:  pub PaidMembershipTermsById get(paid_membership_terms_by_id) build(|config: &GenesisConfig<T>| {}
-#![allow(clippy::redundant_closure_call)]
 
 pub mod genesis;
 pub(crate) mod mock;
 mod tests;
 
 use codec::{Codec, Decode, Encode};
-use frame_support::traits::Currency;
+use frame_support::traits::{Currency, Get};
 use frame_support::{decl_event, decl_module, decl_storage, ensure, Parameter};
-use frame_system::{ensure_root, ensure_signed};
+use frame_system::ensure_signed;
 use sp_arithmetic::traits::{BaseArithmetic, One};
 use sp_runtime::traits::{MaybeSerialize, Member};
 use sp_std::borrow::ToOwned;
-use sp_std::vec;
 use sp_std::vec::Vec;
 
 use common::currency::{BalanceOf, GovernanceCurrency};
@@ -37,15 +32,6 @@ pub trait Trait: frame_system::Trait + GovernanceCurrency + pallet_timestamp::Tr
         + MaybeSerialize
         + PartialEq;
 
-    type PaidTermId: Parameter
-        + Member
-        + BaseArithmetic
-        + Codec
-        + Default
-        + Copy
-        + MaybeSerialize
-        + PartialEq;
-
     /// Describes the common type for the working group members (workers).
     type ActorId: Parameter
         + Member
@@ -56,12 +42,10 @@ pub trait Trait: frame_system::Trait + GovernanceCurrency + pallet_timestamp::Tr
         + MaybeSerialize
         + PartialEq
         + Ord;
+
+    /// Defines the default membership fee.
+    type MembershipFee: Get<BalanceOf<Self>>;
 }
-
-const FIRST_PAID_TERMS_ID: u8 = 1;
-
-// Default paid membership terms
-pub const DEFAULT_PAID_TERM_ID: u8 = 0;
 
 // Default user info constraints
 const DEFAULT_MIN_HANDLE_LENGTH: u32 = 5;
@@ -73,13 +57,12 @@ const DEFAULT_MAX_ABOUT_TEXT_LENGTH: u32 = 2048;
 pub type Membership<T> = MembershipObject<
     <T as frame_system::Trait>::BlockNumber,
     <T as pallet_timestamp::Trait>::Moment,
-    <T as Trait>::PaidTermId,
     <T as frame_system::Trait>::AccountId,
 >;
 
 #[derive(Encode, Decode, Default)]
 /// Stored information about a registered user
-pub struct MembershipObject<BlockNumber, Moment, PaidTermId, AccountId> {
+pub struct MembershipObject<BlockNumber, Moment, AccountId> {
     /// The unique handle chosen by member
     pub handle: Vec<u8>,
 
@@ -96,7 +79,7 @@ pub struct MembershipObject<BlockNumber, Moment, PaidTermId, AccountId> {
     pub registered_at_time: Moment,
 
     /// How the member was registered
-    pub entry: EntryMethod<PaidTermId, AccountId>,
+    pub entry: EntryMethod,
 
     /// Member's root account id. Only the root account is permitted to set a new root account
     /// and update the controller account. Other modules may only allow certain actions if
@@ -118,26 +101,17 @@ struct ValidatedUserInfo {
 }
 
 #[derive(Encode, Decode, Debug, PartialEq)]
-pub enum EntryMethod<PaidTermId, AccountId> {
-    Paid(PaidTermId),
-    Screening(AccountId),
+pub enum EntryMethod {
+    Paid,
     Genesis,
 }
 
 /// Must be default constructible because it indirectly is a value in a storage map.
 /// ***SHOULD NEVER ACTUALLY GET CALLED, IS REQUIRED TO DUE BAD STORAGE MODEL IN SUBSTRATE***
-impl<PaidTermId, AccountId> Default for EntryMethod<PaidTermId, AccountId> {
+impl Default for EntryMethod {
     fn default() -> Self {
         Self::Genesis
     }
-}
-
-#[derive(Encode, Decode, Eq, PartialEq, Default)]
-pub struct PaidMembershipTerms<Balance> {
-    /// Quantity of native tokens which must be provably burned
-    pub fee: Balance,
-    /// String of capped length describing human readable conditions which are being agreed upon
-    pub text: Vec<u8>,
 }
 
 decl_storage! {
@@ -162,33 +136,8 @@ decl_storage! {
         pub MemberIdByHandle get(fn handles) : map hasher(blake2_128_concat)
             Vec<u8> => T::MemberId;
 
-        /// Next paid membership terms id
-        pub NextPaidMembershipTermsId get(fn next_paid_membership_terms_id) :
-            T::PaidTermId = T::PaidTermId::from(FIRST_PAID_TERMS_ID);
-
-        /// Paid membership terms record
-        // Remember to add _genesis_phantom_data: std::marker::PhantomData{} to membership
-        // genesis config if not providing config() or extra_genesis
-        pub PaidMembershipTermsById get(fn paid_membership_terms_by_id) build(|config: &GenesisConfig<T>| {
-            // This method only gets called when initializing storage, and is
-            // compiled as native code. (Will be called when building `raw` chainspec)
-            // So it can't be relied upon to initialize storage for runtimes updates.
-            // Initialization for updated runtime is done in run_migration()
-            let terms = PaidMembershipTerms {
-                fee:  config.default_paid_membership_fee,
-                text: Vec::default(),
-            };
-            vec![(T::PaidTermId::from(DEFAULT_PAID_TERM_ID), terms)]
-        }) : map hasher(blake2_128_concat) T::PaidTermId => PaidMembershipTerms<BalanceOf<T>>;
-
-        /// Active Paid membership terms
-        pub ActivePaidMembershipTerms get(fn active_paid_membership_terms) :
-            Vec<T::PaidTermId> = vec![T::PaidTermId::from(DEFAULT_PAID_TERM_ID)];
-
         /// Is the platform is accepting new members or not
         pub NewMembershipsAllowed get(fn new_memberships_allowed) : bool = true;
-
-        pub ScreeningAuthority get(fn screening_authority) : T::AccountId;
 
         // User Input Validation parameters - do these really need to be state variables
         // I don't see a need to adjust these in future?
@@ -199,7 +148,6 @@ decl_storage! {
 
     }
     add_extra_genesis {
-        config(default_paid_membership_fee): BalanceOf<T>;
         config(members) : Vec<genesis::Member<T::MemberId, T::AccountId, T::Moment>>;
         build(|config: &GenesisConfig<T>| {
             for member in &config.members {
@@ -217,6 +165,8 @@ decl_storage! {
                     T::BlockNumber::from(1),
                     member.registered_at_time
                 ).expect("Importing Member Failed");
+
+
 
                 // ensure imported member id matches assigned id
                 assert_eq!(member_id, member.member_id, "Import Member Failed: MemberId Incorrect");
@@ -243,11 +193,13 @@ decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
         fn deposit_event() = default;
 
+        /// Exports const - membership fee.
+        const MembershipFee: BalanceOf<T> = T::MembershipFee::get();
+
         /// Non-members can buy membership
         #[weight = 10_000_000] // TODO: adjust weight
         pub fn buy_membership(
             origin,
-            paid_terms_id: T::PaidTermId,
             handle: Option<Vec<u8>>,
             avatar_uri: Option<Vec<u8>>,
             about: Option<Vec<u8>>
@@ -257,11 +209,10 @@ decl_module! {
             // make sure we are accepting new memberships
             ensure!(Self::new_memberships_allowed(), "new members not allowed");
 
-            // ensure paid_terms_id is active
-            let terms = Self::ensure_active_terms_id(paid_terms_id)?;
+            let fee = T::MembershipFee::get();
 
             // ensure enough free balance to cover terms fees
-            ensure!(T::Currency::can_slash(&who, terms.fee), "not enough balance to buy membership");
+            ensure!(T::Currency::can_slash(&who, fee), "not enough balance to buy membership");
 
             let user_info = Self::check_user_registration_info(handle, avatar_uri, about)?;
 
@@ -269,12 +220,12 @@ decl_module! {
                 &who,
                 &who,
                 &user_info,
-                EntryMethod::Paid(paid_terms_id),
+                EntryMethod::Paid,
                 <frame_system::Module<T>>::block_number(),
                 <pallet_timestamp::Module<T>>::now()
             )?;
 
-            let _ = T::Currency::slash(&who, terms.fee);
+            let _ = T::Currency::slash(&who, fee);
 
             Self::deposit_event(RawEvent::MemberRegistered(member_id, who));
         }
@@ -389,47 +340,6 @@ decl_module! {
                 Self::deposit_event(RawEvent::MemberSetRootAccount(member_id, new_root_account));
             }
         }
-
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn add_screened_member(
-            origin,
-            new_member_account: T::AccountId,
-            handle: Option<Vec<u8>>,
-            avatar_uri: Option<Vec<u8>>,
-            about: Option<Vec<u8>>
-        ) {
-            // ensure sender is screening authority
-            let sender = ensure_signed(origin)?;
-
-            if <ScreeningAuthority<T>>::exists() {
-                ensure!(sender == Self::screening_authority(), "not screener");
-            } else {
-                // no screening authority defined. Cannot accept this request
-                return Err("no screening authority defined".into());
-            }
-
-            // make sure we are accepting new memberships
-            ensure!(Self::new_memberships_allowed(), "new members not allowed");
-
-            let user_info = Self::check_user_registration_info(handle, avatar_uri, about)?;
-
-            let member_id = Self::insert_member(
-                &new_member_account,
-                &new_member_account,
-                &user_info,
-                EntryMethod::Screening(sender),
-                <frame_system::Module<T>>::block_number(),
-                <pallet_timestamp::Module<T>>::now()
-            )?;
-
-            Self::deposit_event(RawEvent::MemberRegistered(member_id, new_member_account));
-        }
-
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn set_screening_authority(origin, authority: T::AccountId) {
-            ensure_root(origin)?;
-            <ScreeningAuthority<T>>::put(authority);
-        }
     }
 }
 
@@ -486,22 +396,6 @@ impl<T: Trait> Module<T> {
     pub fn is_member_account(who: &T::AccountId) -> bool {
         <MemberIdsByRootAccountId<T>>::contains_key(who)
             || <MemberIdsByControllerAccountId<T>>::contains_key(who)
-    }
-
-    fn ensure_active_terms_id(
-        terms_id: T::PaidTermId,
-    ) -> Result<PaidMembershipTerms<BalanceOf<T>>, &'static str> {
-        let active_terms = Self::active_paid_membership_terms();
-        ensure!(
-            active_terms.iter().any(|&id| id == terms_id),
-            "paid terms id not active"
-        );
-
-        if <PaidMembershipTermsById<T>>::contains_key(terms_id) {
-            Ok(Self::paid_membership_terms_by_id(terms_id))
-        } else {
-            Err("paid membership term id does not exist")
-        }
     }
 
     #[allow(clippy::ptr_arg)] // cannot change to the "&[u8]" suggested by clippy
@@ -564,7 +458,7 @@ impl<T: Trait> Module<T> {
         root_account: &T::AccountId,
         controller_account: &T::AccountId,
         user_info: &ValidatedUserInfo,
-        entry_method: EntryMethod<T::PaidTermId, T::AccountId>,
+        entry_method: EntryMethod,
         registered_at_block: T::BlockNumber,
         registered_at_time: T::Moment,
     ) -> Result<T::MemberId, &'static str> {

--- a/runtime-modules/membership/src/mock.rs
+++ b/runtime-modules/membership/src/mock.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-pub use crate::{GenesisConfig, Trait, DEFAULT_PAID_TERM_ID};
+pub use crate::{GenesisConfig, Trait};
 
 pub use frame_support::traits::Currency;
 use frame_support::{impl_outer_origin, parameter_types};
@@ -66,6 +66,7 @@ impl pallet_timestamp::Trait for Test {
 
 parameter_types! {
     pub const ExistentialDeposit: u32 = 0;
+    pub const MembershipFee: u64 = 100;
 }
 
 impl balances::Trait for Test {
@@ -85,8 +86,8 @@ impl GovernanceCurrency for Test {
 impl Trait for Test {
     type Event = ();
     type MemberId = u64;
-    type PaidTermId = u32;
     type ActorId = u32;
+    type MembershipFee = MembershipFee;
 }
 
 pub struct TestExternalitiesBuilder<T: Trait> {

--- a/runtime-modules/membership/src/mock.rs
+++ b/runtime-modules/membership/src/mock.rs
@@ -86,7 +86,6 @@ impl Trait for Test {
     type Event = ();
     type MemberId = u64;
     type PaidTermId = u32;
-    type SubscriptionId = u32;
     type ActorId = u32;
 }
 

--- a/runtime-modules/membership/src/tests.rs
+++ b/runtime-modules/membership/src/tests.rs
@@ -73,11 +73,7 @@ fn buy_membership() {
     const SURPLUS_BALANCE: u64 = 500;
 
     TestExternalitiesBuilder::<Test>::default()
-        .set_membership_config(
-            genesis::GenesisConfigBuilder::default()
-                .default_paid_membership_fee(MembershipFee::get())
-                .build(),
-        )
+        .set_membership_config(genesis::GenesisConfigBuilder::default().build())
         .build()
         .execute_with(|| {
             let initial_balance = MembershipFee::get() + SURPLUS_BALANCE;
@@ -110,11 +106,7 @@ fn buy_membership() {
 #[test]
 fn buy_membership_fails_without_enough_balance() {
     TestExternalitiesBuilder::<Test>::default()
-        .set_membership_config(
-            genesis::GenesisConfigBuilder::default()
-                .default_paid_membership_fee(MembershipFee::get())
-                .build(),
-        )
+        .set_membership_config(genesis::GenesisConfigBuilder::default().build())
         .build()
         .execute_with(|| {
             let initial_balance = MembershipFee::get() - 1;
@@ -130,11 +122,7 @@ fn buy_membership_fails_without_enough_balance() {
 #[test]
 fn buy_membership_fails_without_enough_balance_with_locked_balance() {
     TestExternalitiesBuilder::<Test>::default()
-        .set_membership_config(
-            genesis::GenesisConfigBuilder::default()
-                .default_paid_membership_fee(MembershipFee::get())
-                .build(),
-        )
+        .set_membership_config(genesis::GenesisConfigBuilder::default().build())
         .build()
         .execute_with(|| {
             let initial_balance = MembershipFee::get();
@@ -152,11 +140,7 @@ fn buy_membership_fails_without_enough_balance_with_locked_balance() {
 #[test]
 fn new_memberships_allowed_flag() {
     TestExternalitiesBuilder::<Test>::default()
-        .set_membership_config(
-            genesis::GenesisConfigBuilder::default()
-                .default_paid_membership_fee(MembershipFee::get())
-                .build(),
-        )
+        .set_membership_config(genesis::GenesisConfigBuilder::default().build())
         .build()
         .execute_with(|| {
             let initial_balance = MembershipFee::get() + 1;
@@ -176,11 +160,7 @@ fn unique_handles() {
     const SURPLUS_BALANCE: u64 = 500;
 
     TestExternalitiesBuilder::<Test>::default()
-        .set_membership_config(
-            genesis::GenesisConfigBuilder::default()
-                .default_paid_membership_fee(MembershipFee::get())
-                .build(),
-        )
+        .set_membership_config(genesis::GenesisConfigBuilder::default().build())
         .build()
         .execute_with(|| {
             let initial_balance = MembershipFee::get() + SURPLUS_BALANCE;
@@ -202,11 +182,7 @@ fn update_profile() {
     const SURPLUS_BALANCE: u64 = 500;
 
     TestExternalitiesBuilder::<Test>::default()
-        .set_membership_config(
-            genesis::GenesisConfigBuilder::default()
-                .default_paid_membership_fee(MembershipFee::get())
-                .build(),
-        )
+        .set_membership_config(genesis::GenesisConfigBuilder::default().build())
         .build()
         .execute_with(|| {
             let initial_balance = MembershipFee::get() + SURPLUS_BALANCE;

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -49,7 +49,6 @@ impl membership::Trait for Test {
     type Event = ();
     type MemberId = u64;
     type PaidTermId = u64;
-    type SubscriptionId = u64;
     type ActorId = u64;
 }
 

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -48,11 +48,12 @@ impl common::currency::GovernanceCurrency for Test {
 impl membership::Trait for Test {
     type Event = ();
     type MemberId = u64;
-    type PaidTermId = u64;
     type ActorId = u64;
+    type MembershipFee = MembershipFee;
 }
 
 parameter_types! {
+    pub const MembershipFee: u64 = 100;
     pub const ExistentialDeposit: u32 = 0;
 }
 

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -77,7 +77,6 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type MemberId = u64;
     type PaidTermId = u64;
-    type SubscriptionId = u64;
     type ActorId = u64;
 }
 

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -57,6 +57,7 @@ parameter_types! {
     pub const TransferFee: u32 = 0;
     pub const CreationFee: u32 = 0;
     pub const MaxWhiteListSize: u32 = 4;
+    pub const MembershipFee: u64 = 100;
 }
 
 impl balances::Trait for Test {
@@ -76,8 +77,8 @@ impl common::currency::GovernanceCurrency for Test {
 impl membership::Trait for Test {
     type Event = TestEvent;
     type MemberId = u64;
-    type PaidTermId = u64;
     type ActorId = u64;
+    type MembershipFee = MembershipFee;
 }
 
 impl crate::Trait for Test {

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -84,7 +84,6 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type MemberId = u64;
     type PaidTermId = u64;
-    type SubscriptionId = u64;
     type ActorId = u64;
 }
 

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -78,13 +78,14 @@ parameter_types! {
     pub const DescriptionMaxLength: u32 = 10000;
     pub const MaxActiveProposalLimit: u32 = 100;
     pub const LockId: LockIdentifier = [1; 8];
+    pub const MembershipFee: u64 = 100;
 }
 
 impl membership::Trait for Test {
     type Event = TestEvent;
     type MemberId = u64;
-    type PaidTermId = u64;
     type ActorId = u64;
+    type MembershipFee = MembershipFee;
 }
 
 impl crate::Trait for Test {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -110,7 +110,6 @@ impl membership::Trait for Test {
     type Event = MetaEvent;
     type MemberId = u64;
     type PaidTermId = u64;
-    type SubscriptionId = u64;
     type ActorId = u64;
 }
 

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -52,6 +52,7 @@ parameter_types! {
     pub const MinimumPeriod: u64 = 5;
     pub const StakePoolId: [u8; 8] = *b"joystake";
     pub const ExistentialDeposit: u32 = 0;
+    pub const MembershipFee: u64 = 100;
 }
 
 impl frame_system::Trait for Test {
@@ -109,8 +110,8 @@ impl stake::Trait for Test {
 impl membership::Trait for Test {
     type Event = MetaEvent;
     type MemberId = u64;
-    type PaidTermId = u64;
     type ActorId = u64;
+    type MembershipFee = MembershipFee;
 }
 
 impl common::currency::GovernanceCurrency for Test {

--- a/runtime-modules/staking-handler/src/lib.rs
+++ b/runtime-modules/staking-handler/src/lib.rs
@@ -80,7 +80,7 @@ impl<
     }
 
     fn unlock(account_id: &T::AccountId) {
-        T::Currency::remove_lock(LockId::get(), &account_id);
+        <pallet_balances::Module<T>>::remove_lock(LockId::get(), &account_id);
     }
 
     fn slash(account_id: &T::AccountId, amount: Option<BalanceOf<T>>) -> BalanceOf<T> {

--- a/runtime-modules/staking-handler/src/mock.rs
+++ b/runtime-modules/staking-handler/src/mock.rs
@@ -23,6 +23,7 @@ parameter_types! {
     pub const MinimumPeriod: u64 = 5;
     pub const StakePoolId: [u8; 8] = *b"joystake";
     pub const ExistentialDeposit: u32 = 0;
+    pub const MembershipFee: u64 = 100;
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 - remove when sorted.
@@ -70,8 +71,8 @@ impl pallet_balances::Trait for Test {
 impl membership::Trait for Test {
     type Event = ();
     type MemberId = u64;
-    type PaidTermId = u64;
     type ActorId = u64;
+    type MembershipFee = MembershipFee;
 }
 
 impl common::currency::GovernanceCurrency for Test {

--- a/runtime-modules/staking-handler/src/mock.rs
+++ b/runtime-modules/staking-handler/src/mock.rs
@@ -71,7 +71,6 @@ impl membership::Trait for Test {
     type Event = ();
     type MemberId = u64;
     type PaidTermId = u64;
-    type SubscriptionId = u64;
     type ActorId = u64;
 }
 

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -153,6 +153,7 @@ impl GovernanceCurrency for Test {
 parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [2; 8];
+    pub const MembershipFee: u64 = 100;
 }
 
 impl working_group::Trait<StorageWorkingGroupInstance> for Test {
@@ -201,8 +202,8 @@ impl data_object_storage_registry::Trait for Test {
 impl membership::Trait for Test {
     type Event = MetaEvent;
     type MemberId = u64;
-    type PaidTermId = u32;
     type ActorId = u32;
+    type MembershipFee = MembershipFee;
 }
 
 impl stake::Trait for Test {
@@ -284,7 +285,6 @@ impl ExtBuilder {
         .unwrap();
 
         membership::GenesisConfig::<Test> {
-            default_paid_membership_fee: 0,
             members: vec![membership::genesis::Member {
                 member_id: 0,
                 root_account: 1,

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -201,7 +201,6 @@ impl data_object_storage_registry::Trait for Test {
 impl membership::Trait for Test {
     type Event = MetaEvent;
     type MemberId = u64;
-    type SubscriptionId = u32;
     type PaidTermId = u32;
     type ActorId = u32;
 }

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -232,15 +232,11 @@ impl ApplyOnOpeningFixture {
 }
 
 pub fn setup_members(count: u8) {
-    let authority_account_id = 1;
-    Membership::set_screening_authority(RawOrigin::Root.into(), authority_account_id).unwrap();
-
     for i in 0..count {
         let account_id: u64 = i as u64;
         let handle: [u8; 20] = [i; 20];
-        Membership::add_screened_member(
-            RawOrigin::Signed(authority_account_id).into(),
-            account_id,
+        Membership::buy_membership(
+            RawOrigin::Signed(account_id).into(),
             Some(handle.to_vec()),
             None,
             None,

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -39,6 +39,7 @@ parameter_types! {
     pub const MinimumPeriod: u64 = 5;
     pub const StakePoolId: [u8; 8] = *b"joystake";
     pub const ExistentialDeposit: u32 = 0;
+    pub const MembershipFee: u64 = 0;
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 - remove when sorted.
@@ -97,13 +98,13 @@ impl balances::Trait for Test {
 impl membership::Trait for Test {
     type Event = TestEvent;
     type MemberId = u64;
-    type PaidTermId = u64;
     type ActorId = u64;
+    type MembershipFee = MembershipFee;
 }
 
-pub type Membership = membership::Module<Test>;
 pub type Balances = balances::Module<Test>;
 pub type System = frame_system::Module<Test>;
+pub type Membership = membership::Module<Test>;
 
 parameter_types! {
     pub const RewardPeriod: u32 = 2;

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -98,7 +98,6 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type MemberId = u64;
     type PaidTermId = u64;
-    type SubscriptionId = u64;
     type ActorId = u64;
 }
 

--- a/runtime/src/integration/proposals/council_origin_validator.rs
+++ b/runtime/src/integration/proposals/council_origin_validator.rs
@@ -52,17 +52,9 @@ mod tests {
     use proposals_engine::VotersParameters;
     use sp_runtime::AccountId32;
 
+    use crate::tests::{initial_test_ext, insert_member};
+
     type Council = governance::council::Module<Runtime>;
-
-    fn initial_test_ext() -> sp_io::TestExternalities {
-        let t = frame_system::GenesisConfig::default()
-            .build_storage::<Runtime>()
-            .unwrap();
-
-        t.into()
-    }
-
-    type Membership = membership::Module<Runtime>;
 
     #[test]
     fn council_origin_validator_fails_with_unregistered_member() {
@@ -93,21 +85,7 @@ mod tests {
 
             let account_id = AccountId32::default();
             let origin = RawOrigin::Signed(account_id.clone());
-            let authority_account_id = AccountId32::default();
-            Membership::set_screening_authority(
-                RawOrigin::Root.into(),
-                authority_account_id.clone(),
-            )
-            .unwrap();
-
-            Membership::add_screened_member(
-                RawOrigin::Signed(authority_account_id).into(),
-                account_id.clone(),
-                Some(b"handle".to_vec()),
-                None,
-                None,
-            )
-            .unwrap();
+            insert_member(account_id.clone());
             let member_id = 0; // newly created member_id
 
             let validation_result =
@@ -123,21 +101,7 @@ mod tests {
             let account_id = AccountId32::default();
             let error =
                 "Membership validation failed: given account doesn't match with profile accounts";
-            let authority_account_id = AccountId32::default();
-            Membership::set_screening_authority(
-                RawOrigin::Root.into(),
-                authority_account_id.clone(),
-            )
-            .unwrap();
-
-            Membership::add_screened_member(
-                RawOrigin::Signed(authority_account_id).into(),
-                account_id.clone(),
-                Some(b"handle".to_vec()),
-                None,
-                None,
-            )
-            .unwrap();
+            insert_member(account_id);
             let member_id = 0; // newly created member_id
 
             let invalid_account_id: [u8; 32] = [2; 32];
@@ -156,21 +120,7 @@ mod tests {
             let account_id = AccountId32::default();
             let origin = RawOrigin::Signed(account_id.clone());
             let error = "Council validation failed: account id doesn't belong to a council member";
-            let authority_account_id = AccountId32::default();
-            Membership::set_screening_authority(
-                RawOrigin::Root.into(),
-                authority_account_id.clone(),
-            )
-            .unwrap();
-
-            Membership::add_screened_member(
-                RawOrigin::Signed(authority_account_id).into(),
-                account_id,
-                Some(b"handle".to_vec()),
-                None,
-                None,
-            )
-            .unwrap();
+            insert_member(account_id);
             let member_id = 0; // newly created member_id
 
             let validation_result =

--- a/runtime/src/integration/proposals/membership_origin_validator.rs
+++ b/runtime/src/integration/proposals/membership_origin_validator.rs
@@ -53,15 +53,7 @@ mod tests {
     use frame_system::RawOrigin;
     use sp_runtime::AccountId32;
 
-    type Membership = membership::Module<Runtime>;
-
-    fn initial_test_ext() -> sp_io::TestExternalities {
-        let t = frame_system::GenesisConfig::default()
-            .build_storage::<Runtime>()
-            .unwrap();
-
-        t.into()
-    }
+    use crate::tests::{initial_test_ext, insert_member};
 
     #[test]
     fn membership_origin_validator_fails_with_unregistered_member() {
@@ -82,21 +74,7 @@ mod tests {
         initial_test_ext().execute_with(|| {
             let account_id = AccountId32::default();
             let origin = RawOrigin::Signed(account_id.clone());
-            let authority_account_id = AccountId32::default();
-            Membership::set_screening_authority(
-                RawOrigin::Root.into(),
-                authority_account_id.clone(),
-            )
-            .unwrap();
-
-            Membership::add_screened_member(
-                RawOrigin::Signed(authority_account_id).into(),
-                account_id.clone(),
-                Some(b"handle".to_vec()),
-                None,
-                None,
-            )
-            .unwrap();
+            insert_member(account_id.clone());
             let member_id = 0; // newly created member_id
 
             let validation_result =
@@ -112,21 +90,8 @@ mod tests {
             let account_id = AccountId32::default();
             let error =
                 "Membership validation failed: given account doesn't match with profile accounts";
-            let authority_account_id = AccountId32::default();
-            Membership::set_screening_authority(
-                RawOrigin::Root.into(),
-                authority_account_id.clone(),
-            )
-            .unwrap();
 
-            Membership::add_screened_member(
-                RawOrigin::Signed(authority_account_id).into(),
-                account_id,
-                Some(b"handle".to_vec()),
-                None,
-                None,
-            )
-            .unwrap();
+            insert_member(account_id.clone());
             let member_id = 0; // newly created member_id
 
             let invalid_account_id: [u8; 32] = [2; 32];

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -497,6 +497,7 @@ impl memo::Trait for Runtime {
 
 parameter_types! {
     pub const MaxObjectsPerInjection: u32 = 100;
+    pub const MembershipFee: Balance = 100;
 }
 
 impl storage::data_object_type_registry::Trait for Runtime {
@@ -522,8 +523,8 @@ impl storage::data_object_storage_registry::Trait for Runtime {
 impl membership::Trait for Runtime {
     type Event = Event;
     type MemberId = MemberId;
-    type PaidTermId = u64;
     type ActorId = ActorId;
+    type MembershipFee = MembershipFee;
 }
 
 parameter_types! {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -242,7 +242,6 @@ parameter_types! {
     pub const ExistentialDeposit: u128 = 0;
     pub const TransferFee: u128 = 0;
     pub const CreationFee: u128 = 0;
-    pub const InitialMembersBalance: u32 = 2000;
     pub const MaxLocks: u32 = 50;
 }
 
@@ -524,13 +523,11 @@ impl membership::Trait for Runtime {
     type Event = Event;
     type MemberId = MemberId;
     type PaidTermId = u64;
-    type SubscriptionId = u64;
     type ActorId = ActorId;
 }
 
 parameter_types! {
     pub const MaxCategoryDepth: u64 = 5;
-
     pub const MaxSubcategories: u64 = 20;
     pub const MaxThreadsInCategory: u64 = 20;
     pub const MaxPostsInThread: u64 = 20;

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -5,11 +5,17 @@
 
 mod proposals_integration;
 mod storage_integration;
-use sp_runtime::BuildStorage;
+
+use crate::Runtime;
+use frame_support::traits::Currency;
+use frame_system::RawOrigin;
+use sp_runtime::{AccountId32, BuildStorage};
+
+type Membership = membership::Module<Runtime>;
 
 pub(crate) fn initial_test_ext() -> sp_io::TestExternalities {
     let mut t = frame_system::GenesisConfig::default()
-        .build_storage::<crate::Runtime>()
+        .build_storage::<Runtime>()
         .unwrap();
 
     // build the council config to initialize the mint
@@ -20,4 +26,31 @@ pub(crate) fn initial_test_ext() -> sp_io::TestExternalities {
     council_config.assimilate_storage(&mut t).unwrap();
 
     t.into()
+}
+
+pub(crate) fn insert_member(account_id: AccountId32) {
+    increase_total_balance_issuance_using_account_id(
+        account_id.clone(),
+        crate::MembershipFee::get(),
+    );
+    let handle: &[u8] = account_id.as_ref();
+    Membership::buy_membership(
+        RawOrigin::Signed(account_id.clone()).into(),
+        Some(handle.to_vec()),
+        None,
+        None,
+    )
+    .unwrap();
+}
+
+pub(crate) fn increase_total_balance_issuance_using_account_id(
+    account_id: AccountId32,
+    balance: u128,
+) {
+    type Balances = pallet_balances::Module<Runtime>;
+    let initial_balance = Balances::total_issuance();
+    {
+        let _ = <Runtime as stake::Trait>::Currency::deposit_creating(&account_id, balance);
+    }
+    assert_eq!(Balances::total_issuance(), initial_balance + balance);
 }


### PR DESCRIPTION
### Related issues
- [Drop speculative unused fields from membership](https://github.com/Joystream/joystream/issues/516)
- [Drop InitialMembersBalance membership module configuration](https://github.com/Joystream/joystream/issues/516)

Comments:
- buy_membership extrinsic was changed from `paid_term_id` to get membership price to `MembershipFee` trait constant
- `default_membership_fee` was removed from the genesis config.