### PR TITLE
Working group weight annotations

### DIFF
--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -222,6 +222,7 @@ parameter_types! {
     pub const LockId2: [u8; 8] = [2; 8];
 }
 
+pub struct WorkingGroupWeightInfo;
 impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
     type Event = ();
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
@@ -229,6 +230,79 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
+    type WeightInfo = WorkingGroupWeightInfo;
+}
+
+impl working_group::WeightInfo for WorkingGroupWeightInfo {
+    fn on_initialize_leaving(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_with_missing_reward(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_with_missing_reward_cant_pay(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_without_missing_reward(_: u32) -> Weight {
+        0
+    }
+    fn apply_on_opening(_: u32) -> Weight {
+        0
+    }
+    fn fill_opening_lead() -> Weight {
+        0
+    }
+    fn fill_opening_worker(_: u32) -> Weight {
+        0
+    }
+    fn update_role_account() -> Weight {
+        0
+    }
+    fn cancel_opening() -> Weight {
+        0
+    }
+    fn withdraw_application() -> Weight {
+        0
+    }
+    fn slash_stake() -> Weight {
+        0
+    }
+    fn terminate_role_worker() -> Weight {
+        0
+    }
+    fn terminate_role_lead() -> Weight {
+        0
+    }
+    fn increase_stake() -> Weight {
+        0
+    }
+    fn decrease_stake() -> Weight {
+        0
+    }
+    fn spend_from_budget() -> Weight {
+        0
+    }
+    fn update_reward_amount() -> Weight {
+        0
+    }
+    fn set_status_text(_: u32) -> Weight {
+        0
+    }
+    fn update_reward_account() -> Weight {
+        0
+    }
+    fn set_budget() -> Weight {
+        0
+    }
+    fn add_opening(_: u32) -> Weight {
+        0
+    }
+    fn leave_role_immediatly() -> Weight {
+        0
+    }
+    fn leave_role_later() -> Weight {
+        0
+    }
 }
 
 impl working_group::Trait<StorageWorkingGroupInstance> for Test {
@@ -238,6 +312,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
+    type WeightInfo = WorkingGroupWeightInfo;
 }
 
 impl recurring_rewards::Trait for Test {

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -270,7 +270,7 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn terminate_role_worker(_: u32) -> Weight {
         0
     }
-    fn terminate_role_lead() -> Weight {
+    fn terminate_role_lead(_: u32) -> Weight {
         0
     }
     fn increase_stake() -> Weight {

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -264,10 +264,10 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn withdraw_application() -> Weight {
         0
     }
-    fn slash_stake() -> Weight {
+    fn slash_stake(_: u32) -> Weight {
         0
     }
-    fn terminate_role_worker() -> Weight {
+    fn terminate_role_worker(_: u32) -> Weight {
         0
     }
     fn terminate_role_lead() -> Weight {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -2,6 +2,7 @@
 
 pub use crate::*;
 
+use frame_support::weights::Weight;
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 use sp_core::H256;
 use sp_runtime::{
@@ -139,6 +140,7 @@ parameter_types! {
     pub const LockId1: [u8; 8] = [1; 8];
 }
 
+pub struct WorkingGroupWeightInfo;
 impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type Event = MetaEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
@@ -146,6 +148,79 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
+    type WeightInfo = WorkingGroupWeightInfo;
+}
+
+impl working_group::WeightInfo for WorkingGroupWeightInfo {
+    fn on_initialize_leaving(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_with_missing_reward(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_with_missing_reward_cant_pay(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_without_missing_reward(_: u32) -> Weight {
+        0
+    }
+    fn apply_on_opening(_: u32) -> Weight {
+        0
+    }
+    fn fill_opening_lead() -> Weight {
+        0
+    }
+    fn fill_opening_worker(_: u32) -> Weight {
+        0
+    }
+    fn update_role_account() -> Weight {
+        0
+    }
+    fn cancel_opening() -> Weight {
+        0
+    }
+    fn withdraw_application() -> Weight {
+        0
+    }
+    fn slash_stake() -> Weight {
+        0
+    }
+    fn terminate_role_worker() -> Weight {
+        0
+    }
+    fn terminate_role_lead() -> Weight {
+        0
+    }
+    fn increase_stake() -> Weight {
+        0
+    }
+    fn decrease_stake() -> Weight {
+        0
+    }
+    fn spend_from_budget() -> Weight {
+        0
+    }
+    fn update_reward_amount() -> Weight {
+        0
+    }
+    fn set_status_text(_: u32) -> Weight {
+        0
+    }
+    fn update_reward_account() -> Weight {
+        0
+    }
+    fn set_budget() -> Weight {
+        0
+    }
+    fn add_opening(_: u32) -> Weight {
+        0
+    }
+    fn leave_role_immediatly() -> Weight {
+        0
+    }
+    fn leave_role_later() -> Weight {
+        0
+    }
 }
 
 impl common::origin::ActorOriginValidator<Origin, u64, u64> for () {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -182,10 +182,10 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn withdraw_application() -> Weight {
         0
     }
-    fn slash_stake() -> Weight {
+    fn slash_stake(_: u32) -> Weight {
         0
     }
-    fn terminate_role_worker() -> Weight {
+    fn terminate_role_worker(_: u32) -> Weight {
         0
     }
     fn terminate_role_lead() -> Weight {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -188,7 +188,7 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn terminate_role_worker(_: u32) -> Weight {
         0
     }
-    fn terminate_role_lead() -> Weight {
+    fn terminate_role_lead(_: u32) -> Weight {
         0
     }
     fn increase_stake() -> Weight {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -2,6 +2,7 @@
 
 use frame_support::storage::StorageMap;
 use frame_support::traits::{LockIdentifier, OnFinalize, OnInitialize};
+use frame_support::weights::Weight;
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 use sp_core::H256;
 use sp_runtime::{
@@ -155,6 +156,7 @@ parameter_types! {
     pub const LockId: LockIdentifier = [2; 8];
 }
 
+pub struct WorkingGroupWeightInfo;
 impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type Event = MetaEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
@@ -162,6 +164,79 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
+    type WeightInfo = WorkingGroupWeightInfo;
+}
+
+impl working_group::WeightInfo for WorkingGroupWeightInfo {
+    fn on_initialize_leaving(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_with_missing_reward(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_with_missing_reward_cant_pay(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_without_missing_reward(_: u32) -> Weight {
+        0
+    }
+    fn apply_on_opening(_: u32) -> Weight {
+        0
+    }
+    fn fill_opening_lead() -> Weight {
+        0
+    }
+    fn fill_opening_worker(_: u32) -> Weight {
+        0
+    }
+    fn update_role_account() -> Weight {
+        0
+    }
+    fn cancel_opening() -> Weight {
+        0
+    }
+    fn withdraw_application() -> Weight {
+        0
+    }
+    fn slash_stake() -> Weight {
+        0
+    }
+    fn terminate_role_worker() -> Weight {
+        0
+    }
+    fn terminate_role_lead() -> Weight {
+        0
+    }
+    fn increase_stake() -> Weight {
+        0
+    }
+    fn decrease_stake() -> Weight {
+        0
+    }
+    fn spend_from_budget() -> Weight {
+        0
+    }
+    fn update_reward_amount() -> Weight {
+        0
+    }
+    fn set_status_text(_: u32) -> Weight {
+        0
+    }
+    fn update_reward_account() -> Weight {
+        0
+    }
+    fn set_budget() -> Weight {
+        0
+    }
+    fn add_opening(_: u32) -> Weight {
+        0
+    }
+    fn leave_role_immediatly() -> Weight {
+        0
+    }
+    fn leave_role_later() -> Weight {
+        0
+    }
 }
 
 impl common::origin::ActorOriginValidator<Origin, u64, u64> for () {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -198,10 +198,10 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn withdraw_application() -> Weight {
         0
     }
-    fn slash_stake() -> Weight {
+    fn slash_stake(_: u32) -> Weight {
         0
     }
-    fn terminate_role_worker() -> Weight {
+    fn terminate_role_worker(_: u32) -> Weight {
         0
     }
     fn terminate_role_lead() -> Weight {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -204,7 +204,7 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn terminate_role_worker(_: u32) -> Weight {
         0
     }
-    fn terminate_role_lead() -> Weight {
+    fn terminate_role_lead(_: u32) -> Weight {
         0
     }
     fn increase_stake() -> Weight {

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -577,7 +577,7 @@ benchmarks_instance! {
     }
 
     fill_opening_worker {
-        let i in 2 .. T::MaxWorkerNumberLimit::get();
+        let i in 1 .. T::MaxWorkerNumberLimit::get() - 1;
         let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(
             StakingRole::WithoutStakes,
             OpeningType::Leader,
@@ -587,7 +587,7 @@ benchmarks_instance! {
 
         let (opening_id, successful_application_ids, _) =
             add_opening_and_apply_with_multiple_ids::<T, I>(
-                &(1..i).collect(),
+                &(1..i+1).collect(),
                 &T::Origin::from(RawOrigin::Signed(lead_id.clone())),
                 &StakingRole::WithoutStakes,
                 &OpeningType::Regular

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -9,10 +9,10 @@ use frame_system::RawOrigin;
 use sp_runtime::traits::Bounded;
 use sp_std::cmp::min;
 use sp_std::prelude::*;
-use system as frame_system;
 
 use crate::types::StakeParameters;
 use crate::Module as WorkingGroup;
+use balances::Module as Balances;
 use membership::Module as Membership;
 
 const SEED: u32 = 0;
@@ -40,7 +40,7 @@ fn add_opening_helper<T: Trait<I>, I: Instance>(
     add_opening_origin: &T::Origin,
     staking_role: &StakingRole,
     job_opening_type: &OpeningType,
-) -> T::OpeningId {
+) -> OpeningId {
     let staking_policy = match staking_role {
         StakingRole::WithStakes => Some(StakePolicy {
             stake_amount: One::one(),
@@ -60,7 +60,7 @@ fn add_opening_helper<T: Trait<I>, I: Instance>(
     )
     .unwrap();
 
-    let opening_id = T::OpeningId::from(id.try_into().unwrap());
+    let opening_id = id.into();
 
     assert!(
         OpeningById::<T, I>::contains_key(opening_id),
@@ -75,15 +75,12 @@ fn apply_on_opening_helper<T: Trait<I>, I: Instance>(
     staking_role: &StakingRole,
     applicant_id: &T::AccountId,
     member_id: &T::MemberId,
-    opening_id: &T::OpeningId,
-) -> T::ApplicationId {
+    opening_id: &OpeningId,
+) -> ApplicationId {
     let stake_parameters = match staking_role {
         StakingRole::WithStakes => Some(StakeParameters {
             // Due to mock implementation of StakingHandler we can't go over 1000
-            stake: min(
-                BalanceOfCurrency::<T>::max_value(),
-                BalanceOfCurrency::<T>::from(1000),
-            ),
+            stake: min(BalanceOf::<T>::max_value(), BalanceOf::<T>::from(1000)),
             staking_account_id: applicant_id.clone(),
         }),
         StakingRole::WithoutStakes => None,
@@ -91,7 +88,7 @@ fn apply_on_opening_helper<T: Trait<I>, I: Instance>(
 
     WorkingGroup::<T, _>::apply_on_opening(
         RawOrigin::Signed(applicant_id.clone()).into(),
-        ApplyOnOpeningParameters::<T, I> {
+        ApplyOnOpeningParameters::<T> {
             member_id: *member_id,
             opening_id: *opening_id,
             role_account_id: applicant_id.clone(),
@@ -102,7 +99,7 @@ fn apply_on_opening_helper<T: Trait<I>, I: Instance>(
     )
     .unwrap();
 
-    let application_id = T::ApplicationId::from(id.try_into().unwrap());
+    let application_id = id.into();
 
     assert!(
         ApplicationById::<T, I>::contains_key(application_id),
@@ -117,7 +114,7 @@ fn add_opening_and_apply_with_multiple_ids<T: Trait<I>, I: Instance>(
     add_opening_origin: &T::Origin,
     staking_role: &StakingRole,
     job_opening_type: &OpeningType,
-) -> (T::OpeningId, BTreeSet<T::ApplicationId>, Vec<T::AccountId>) {
+) -> (OpeningId, BTreeSet<ApplicationId>, Vec<T::AccountId>) {
     let opening_id =
         add_opening_helper::<T, I>(1, add_opening_origin, &staking_role, job_opening_type);
 
@@ -125,7 +122,8 @@ fn add_opening_and_apply_with_multiple_ids<T: Trait<I>, I: Instance>(
 
     let mut account_ids = Vec::new();
     for id in ids.iter() {
-        let (applicant_account_id, applicant_member_id) = member_funded_account::<T>("member", *id);
+        let (applicant_account_id, applicant_member_id) =
+            member_funded_account::<T, I>("member", *id);
         let application_id = apply_on_opening_helper::<T, I>(
             *id,
             &staking_role,
@@ -148,7 +146,7 @@ fn add_and_apply_opening<T: Trait<I>, I: Instance>(
     applicant_id: &T::AccountId,
     member_id: &T::MemberId,
     job_opening_type: &OpeningType,
-) -> (T::OpeningId, T::ApplicationId) {
+) -> (OpeningId, ApplicationId) {
     let opening_id =
         add_opening_helper::<T, I>(id, add_opening_origin, staking_role, job_opening_type);
 
@@ -176,17 +174,14 @@ fn handle_from_id<T: membership::Trait>(id: u32) -> Vec<u8> {
     handle
 }
 
-fn member_funded_account<T: membership::Trait>(
+fn member_funded_account<T: Trait<I>, I: Instance>(
     name: &'static str,
     id: u32,
 ) -> (T::AccountId, T::MemberId) {
     let account_id = account::<T::AccountId>(name, id, SEED);
     let handle = handle_from_id::<T>(id);
 
-    let _ = <T as common::currency::GovernanceCurrency>::Currency::make_free_balance_be(
-        &account_id,
-        BalanceOfCurrency::<T>::max_value(),
-    );
+    let _ = Balances::<T>::make_free_balance_be(&account_id, BalanceOf::<T>::max_value());
 
     let authority_account = account::<T::AccountId>(name, 0, SEED);
 
@@ -227,7 +222,7 @@ where
         OpeningType::Regular => RawOrigin::Signed(lead_id.clone().unwrap()),
     };
 
-    let (caller_id, member_id) = member_funded_account::<T>("member", id);
+    let (caller_id, member_id) = member_funded_account::<T, I>("member", id);
 
     let (opening_id, application_id) = add_and_apply_opening::<T, I>(
         id,
@@ -238,7 +233,7 @@ where
         &job_opening_type,
     );
 
-    let mut successful_application_ids = BTreeSet::<T::ApplicationId>::new();
+    let mut successful_application_ids = BTreeSet::<ApplicationId>::new();
     successful_application_ids.insert(application_id);
     WorkingGroup::<T, _>::fill_opening(
         add_worker_origin.clone().into(),
@@ -262,7 +257,7 @@ benchmarks_instance! {
     _ { }
 
     on_initialize_leaving {
-        let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let i in 2 .. T::MaxWorkerNumberLimit::get();
 
         let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(
             StakingRole::WithStakes,
@@ -279,7 +274,7 @@ benchmarks_instance! {
                 &OpeningType::Regular
             );
 
-        WorkingGroup::<T, _>::fill_opening(
+        WorkingGroup::<T, I>::fill_opening(
             RawOrigin::Signed(lead_id.clone()).into(),
             opening_id,
             successful_application_ids.clone()
@@ -321,22 +316,22 @@ benchmarks_instance! {
         System::<T>::set_block_number(curr_block_number);
         WorkingGroup::<T, _>::set_budget(
             RawOrigin::Root.into(),
-            BalanceOfCurrency::<T>::max_value()
+            BalanceOf::<T>::max_value()
         ).unwrap();
 
-        assert_eq!(WorkingGroup::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
+        assert_eq!(WorkingGroup::<T, _>::budget(), BalanceOf::<T>::max_value());
     }: { WorkingGroup::<T, _>::on_initialize(curr_block_number) }
     verify {
         WorkerById::<T, I>::iter().for_each(|(worker_id, _)| {
             assert!(!WorkerById::<T, I>::contains_key(worker_id), "Worker hasn't left");
         });
 
-        let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
+        let reward_per_worker = BalanceOf::<T>::from(T::RewardPeriod::get());
 
         assert_eq!(
             WorkingGroup::<T, I>::budget(),
-            BalanceOfCurrency::<T>::max_value()
-                .saturating_sub(BalanceOfCurrency::<T>::from(i) * reward_per_worker)
+            BalanceOf::<T>::max_value()
+                .saturating_sub(BalanceOf::<T>::from(i) * reward_per_worker)
                 .saturating_sub(reward_per_worker),
             "Budget wasn't correctly updated, probably not all workers rewarded"
         );
@@ -344,7 +339,7 @@ benchmarks_instance! {
 
 
     on_initialize_rewarding_with_missing_reward {
-        let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let i in 2 .. T::MaxWorkerNumberLimit::get();
 
         let (lead_id, _) = insert_a_worker::<T, I>(
             StakingRole::WithStakes,
@@ -382,23 +377,23 @@ benchmarks_instance! {
         // Sets budget so that we can pay it
         WorkingGroup::<T, _>::set_budget(
             RawOrigin::Root.into(),
-            BalanceOfCurrency::<T>::max_value()
+            BalanceOf::<T>::max_value()
         ).unwrap();
 
-        assert_eq!(WorkingGroup::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
+        assert_eq!(WorkingGroup::<T, _>::budget(), BalanceOf::<T>::max_value());
     }: { WorkingGroup::<T, _>::on_initialize(curr_block_number) }
     verify {
-        let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
+        let reward_per_worker = BalanceOf::<T>::from(T::RewardPeriod::get());
 
         let reward_for_workers =
-            BalanceOfCurrency::<T>::from(i) * reward_per_worker * BalanceOfCurrency::<T>::from(2);
+            BalanceOf::<T>::from(i) * reward_per_worker * BalanceOf::<T>::from(2);
 
         assert_eq!(
             WorkingGroup::<T, _>::budget(),
             // When creating a worker using `insert_a_worker` it gives the lead a number of block
             // equating to reward period as missed reward(and the reward value is 1) therefore the
             // additional discount of balance
-            BalanceOfCurrency::<T>::max_value()
+            BalanceOf::<T>::max_value()
                 .saturating_sub(reward_for_workers)
                 .saturating_sub(reward_per_worker),
             "Budget wasn't correctly updated, probably not all workers rewarded"
@@ -406,7 +401,7 @@ benchmarks_instance! {
     }
 
     on_initialize_rewarding_with_missing_reward_cant_pay {
-        let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let i in 2 .. T::MaxWorkerNumberLimit::get();
 
         let (lead_id, _) = insert_a_worker::<T, I>(
             StakingRole::WithStakes,
@@ -450,14 +445,14 @@ benchmarks_instance! {
             let missed_reward = worker.missed_reward.expect("There should be some missed reward");
 
             assert!(
-                missed_reward >= BalanceOfCurrency::<T>::from(T::RewardPeriod::get()),
+                missed_reward >= BalanceOf::<T>::from(T::RewardPeriod::get()),
                 "At least one worker wasn't rewarded"
             );
         });
     }
 
     on_initialize_rewarding_without_missing_reward {
-        let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let i in 2 .. T::MaxWorkerNumberLimit::get();
 
         let (lead_id, _) = insert_a_worker::<T, I>(
             StakingRole::WithStakes,
@@ -491,20 +486,20 @@ benchmarks_instance! {
 
         // Sets budget so that we can pay it
         WorkingGroup::<T, _>::set_budget(
-            RawOrigin::Root.into(), BalanceOfCurrency::<T>::max_value()
+            RawOrigin::Root.into(), BalanceOf::<T>::max_value()
         ).unwrap();
-        assert_eq!(WorkingGroup::<T, _>::budget(), BalanceOfCurrency::<T>::max_value());
+        assert_eq!(WorkingGroup::<T, _>::budget(), BalanceOf::<T>::max_value());
 
     }: { WorkingGroup::<T, _>::on_initialize(curr_block_number) }
     verify {
-        let reward_per_worker = BalanceOfCurrency::<T>::from(T::RewardPeriod::get());
-        let workers_total_reward = BalanceOfCurrency::<T>::from(i) * reward_per_worker;
+        let reward_per_worker = BalanceOf::<T>::from(T::RewardPeriod::get());
+        let workers_total_reward = BalanceOf::<T>::from(i) * reward_per_worker;
         assert_eq!(
             WorkingGroup::<T, _>::budget(),
             // When creating a worker using `insert_a_worker` it gives the lead a number of block
             // equating to reward period as missed reward(and the reward value is 1) therefore the
             // additional discount of balance
-            BalanceOfCurrency::<T>::max_value()
+            BalanceOf::<T>::max_value()
                 .saturating_sub(workers_total_reward)
                 .saturating_sub(reward_per_worker),
             "Budget wasn't correctly updated, probably not all workers rewarded"
@@ -514,7 +509,7 @@ benchmarks_instance! {
     apply_on_opening {
         let i in 1 .. MAX_BYTES;
 
-        let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0);
+        let (lead_account_id, lead_member_id) = member_funded_account::<T, I>("lead", 0);
         let opening_id = add_opening_helper::<T, I>(
             0,
             &T::Origin::from(RawOrigin::Root),
@@ -522,7 +517,7 @@ benchmarks_instance! {
             &OpeningType::Leader
         );
 
-        let apply_on_opening_params = ApplyOnOpeningParameters::<T, I> {
+        let apply_on_opening_params = ApplyOnOpeningParameters::<T> {
             member_id: lead_member_id,
             opening_id: opening_id.clone(),
             role_account_id: lead_account_id.clone(),
@@ -541,7 +536,7 @@ benchmarks_instance! {
     }: _ (RawOrigin::Signed(lead_account_id.clone()), apply_on_opening_params)
     verify {
         assert!(
-            ApplicationById::<T, I>::contains_key(T::ApplicationId::from(0)),
+            ApplicationById::<T, I>::contains_key(0),
             "Application not found"
         );
 
@@ -549,9 +544,7 @@ benchmarks_instance! {
     }
 
     fill_opening_lead {
-        let i in 0 .. 1;
-
-        let (lead_account_id, lead_member_id) = member_funded_account::<T>("lead", 0);
+        let (lead_account_id, lead_member_id) = member_funded_account::<T, I>("lead", 0);
         let (opening_id, application_id) = add_and_apply_opening::<T, I>(
             0,
             &RawOrigin::Root.into(),
@@ -561,7 +554,7 @@ benchmarks_instance! {
             &OpeningType::Leader
         );
 
-        let mut successful_application_ids: BTreeSet<T::ApplicationId> = BTreeSet::new();
+        let mut successful_application_ids: BTreeSet<ApplicationId> = BTreeSet::new();
         successful_application_ids.insert(application_id);
     }: fill_opening(RawOrigin::Root, opening_id, successful_application_ids)
     verify {
@@ -584,7 +577,7 @@ benchmarks_instance! {
     }
 
     fill_opening_worker {
-        let i in 1 .. T::MaxWorkerNumberLimit::get();
+        let i in 2 .. T::MaxWorkerNumberLimit::get();
         let (lead_id, lead_worker_id) = insert_a_worker::<T, I>(
             StakingRole::WithoutStakes,
             OpeningType::Leader,
@@ -623,7 +616,6 @@ benchmarks_instance! {
     }
 
     update_role_account{
-        let i in 0 .. 1;
         let (lead_id, lead_worker_id) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, OpeningType::Leader, 0, None);
         let new_account_id = account::<T::AccountId>("new_lead_account", 1, SEED);
@@ -641,8 +633,6 @@ benchmarks_instance! {
     }
 
     cancel_opening {
-        let i in 0 .. 1;
-
         let (lead_id, _) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, OpeningType::Leader, 0, None);
         let opening_id = add_opening_helper::<T, I>(
@@ -659,9 +649,8 @@ benchmarks_instance! {
     }
 
     withdraw_application {
-        let i in 0 .. 1;
 
-        let (caller_id, member_id) = member_funded_account::<T>("lead", 0);
+        let (caller_id, member_id) = member_funded_account::<T, I>("lead", 0);
         let (_, application_id) = add_and_apply_opening::<T, I>(0,
             &RawOrigin::Root.into(),
             &StakingRole::WithStakes,
@@ -711,7 +700,7 @@ benchmarks_instance! {
             Some(lead_id.clone())
         );
         // To be able to pay unpaid reward
-        let current_budget = BalanceOfCurrency::<T>::max_value();
+        let current_budget = BalanceOf::<T>::max_value();
         WorkingGroup::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
         let penalty = Penalty {
             slashing_text: vec![0u8; i.try_into().unwrap()],
@@ -728,7 +717,7 @@ benchmarks_instance! {
 
         let (_, lead_worker_id) =
             insert_a_worker::<T, I>(StakingRole::WithStakes, OpeningType::Leader, 0, None);
-        let current_budget = BalanceOfCurrency::<T>::max_value();
+        let current_budget = BalanceOf::<T>::max_value();
         // To be able to pay unpaid reward
         WorkingGroup::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
         let penalty = Penalty {
@@ -744,8 +733,6 @@ benchmarks_instance! {
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     increase_stake {
-        let i in 0 .. 1;
-
         let (lead_id, _) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, OpeningType::Leader, 0, None);
         let (caller_id, worker_id) = insert_a_worker::<T, I>(
@@ -767,8 +754,6 @@ benchmarks_instance! {
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     decrease_stake {
-        let i in 0 .. 1;
-
         let (lead_id, _) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, OpeningType::Leader, 0, None);
         let (_, worker_id) = insert_a_worker::<T, I>(
@@ -786,8 +771,6 @@ benchmarks_instance! {
     }
 
     spend_from_budget {
-        let i in 0 .. 1;
-
         let (lead_id, _) = insert_a_worker::<T, I>(
             StakingRole::WithoutStakes,
             OpeningType::Leader,
@@ -795,7 +778,7 @@ benchmarks_instance! {
             None
         );
 
-        let current_budget = BalanceOfCurrency::<T>::max_value();
+        let current_budget = BalanceOf::<T>::max_value();
         WorkingGroup::<T, _>::set_budget(RawOrigin::Root.into(), current_budget).unwrap();
     }: _ (RawOrigin::Signed(lead_id.clone()), lead_id.clone(), current_budget, None)
     verify {
@@ -806,8 +789,6 @@ benchmarks_instance! {
     // Regular worker is the worst case scenario since the checks
     // require access to the storage whilist that's not the case with a lead opening
     update_reward_amount {
-        let i in 0 .. 1;
-
         let (lead_id, _) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, OpeningType::Leader, 0, None);
         let (_, worker_id) = insert_a_worker::<T, I>(
@@ -817,7 +798,7 @@ benchmarks_instance! {
             Some(lead_id.clone())
         );
 
-        let new_reward = Some(BalanceOfCurrency::<T>::max_value());
+        let new_reward = Some(BalanceOf::<T>::max_value());
     }: _ (RawOrigin::Signed(lead_id.clone()), worker_id, new_reward)
     verify {
         assert_eq!(
@@ -852,8 +833,6 @@ benchmarks_instance! {
     }
 
     update_reward_account {
-        let i in 0 .. 1;
-
         let (caller_id, worker_id) =
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, OpeningType::Leader, 0, None);
         let new_id = account::<T::AccountId>("new_id", 1, 0);
@@ -870,9 +849,7 @@ benchmarks_instance! {
     }
 
     set_budget {
-        let i in 0 .. 1;
-
-        let new_budget = BalanceOfCurrency::<T>::max_value();
+        let new_budget = BalanceOf::<T>::max_value();
 
     }: _(RawOrigin::Root, new_budget)
     verify {
@@ -889,12 +866,12 @@ benchmarks_instance! {
             insert_a_worker::<T, I>(StakingRole::WithoutStakes, OpeningType::Leader, 0, None);
 
         let stake_policy = StakePolicy {
-            stake_amount: BalanceOfCurrency::<T>::max_value(),
+            stake_amount: BalanceOf::<T>::max_value(),
             leaving_unstaking_period: T::BlockNumber::max_value(),
         };
 
         let reward_policy = RewardPolicy {
-            reward_per_block: BalanceOfCurrency::<T>::max_value(),
+            reward_per_block: BalanceOf::<T>::max_value(),
         };
 
         let description = vec![0u8; i.try_into().unwrap()];
@@ -907,13 +884,12 @@ benchmarks_instance! {
             Some(reward_policy)
         )
     verify {
-        assert!(OpeningById::<T, I>::contains_key(T::OpeningId::from(1)));
-        assert_last_event::<T, I>(RawEvent::OpeningAdded(T::OpeningId::from(1)).into());
+        assert!(OpeningById::<T, I>::contains_key(1));
+        assert_last_event::<T, I>(RawEvent::OpeningAdded(1).into());
     }
 
     // This is always worse than leave_role_immediatly
     leave_role_immediatly {
-        let i in 0 .. 1;
         // Worst case scenario there is a lead(this requires **always** more steps)
         // could separate into new branch to tighten weight
         // Also, workers without stake can leave immediatly
@@ -923,7 +899,7 @@ benchmarks_instance! {
         // To be able to pay unpaid reward
         WorkingGroup::<T, _>::set_budget(
             RawOrigin::Root.into(),
-            BalanceOfCurrency::<T>::max_value()
+            BalanceOf::<T>::max_value()
         ).unwrap();
 
     }: leave_role(RawOrigin::Signed(caller_id), lead_worker_id)
@@ -936,8 +912,6 @@ benchmarks_instance! {
     // but since it's so obviously a different branch I think it's a good idea
     // to leave this branch and use tha max between these 2
     leave_role_later {
-        let i in 0 .. 1;
-
         // Workers with stake can't leave immediatly
         let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(
             StakingRole::WithStakes,

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -278,6 +278,14 @@ decl_module! {
         /// Exports const -  max simultaneous active worker number.
         const MaxWorkerNumberLimit: u32 = T::MaxWorkerNumberLimit::get();
 
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (W)` where:
+        /// - `W` is the number of workers currently present in the `working_group`
+        /// - DB:
+        ///    - O(W)
+        /// # </weight>
         fn on_initialize() -> Weight {
             let leaving_workers = Self::get_workers_with_finished_unstaking_period();
             let mut biggest_number_of_processed_workers = leaving_workers.len();
@@ -303,6 +311,15 @@ decl_module! {
 
         /// Add a job opening for a regular worker/lead role.
         /// Require signed leader origin or the root (to add opening for the leader position).
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (D)` where:
+        /// - `D` is the length of `description`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::add_opening(description.len().saturated_into())]
         pub fn add_opening(
             origin,
@@ -343,6 +360,15 @@ decl_module! {
         }
 
         /// Apply on a worker opening.
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (D)` where:
+        /// - `D` is the length of `p.description`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::apply_on_opening(p.description.len().saturated_into())]
         pub fn apply_on_opening(origin, p : ApplyOnOpeningParameters<T>) {
             // Ensure the origin of a member with given id.
@@ -406,6 +432,14 @@ decl_module! {
 
         /// Fill opening for the regular/lead position.
         /// Require signed leader origin or the root (to fill opening for the leader position).
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (A)` where:
+        /// - `A` is the length of `successful_application_ids`
+        /// - DB:
+        ///    - O(A)
+        /// # </weight>
         #[weight =
             WeightInfoWorkingGroup::<T, I>::fill_opening_worker(successful_application_ids.len().saturated_into())
             .max(WeightInfoWorkingGroup::<T, I>::fill_opening_lead())
@@ -458,6 +492,14 @@ decl_module! {
         }
 
         /// Update the associated role account of the active regular worker/lead.
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::update_role_account()]
         pub fn update_role_account(
             origin,
@@ -487,6 +529,13 @@ decl_module! {
         }
 
         /// Leave the role by the active worker.
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::leave_role_immediatly()
             .max(WeightInfoWorkingGroup::<T, I>::leave_role_later())]
         pub fn leave_role(
@@ -514,6 +563,13 @@ decl_module! {
 
         /// Terminate the active worker by the lead.
         /// Requires signed leader origin or the root (to terminate the leader role).
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::terminate_role_lead()
                 .max(WeightInfoWorkingGroup::<T, I>::terminate_role_worker())]
         pub fn terminate_role(
@@ -558,6 +614,13 @@ decl_module! {
         /// Slashes the regular worker stake, demands a leader origin. No limits, no actions on zero stake.
         /// If slashing balance greater than the existing stake - stake is slashed to zero.
         /// Requires signed leader origin or the root (to slash the leader stake).
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::slash_stake()]
         pub fn slash_stake(origin, worker_id: WorkerId<T>, penalty: Penalty<BalanceOf<T>>) {
             // Ensure lead is set or it is the council slashing the leader.
@@ -590,6 +653,14 @@ decl_module! {
         /// worker staking_account_id. Can be decreased to zero, no actions on zero stake.
         /// Accepts the stake amount to decrease.
         /// Requires signed leader origin or the root (to decrease the leader stake).
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::decrease_stake()]
         pub fn decrease_stake(origin, worker_id: WorkerId<T>, stake_balance_delta: BalanceOf<T>) {
             // Ensure lead is set or it is the council decreasing the leader's stake.
@@ -641,6 +712,14 @@ decl_module! {
 
         /// Increases the regular worker/lead stake, demands a worker origin.
         /// Locks tokens from the worker staking_account_id equal to new stake. No limits on the stake.
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::increase_stake()]
         pub fn increase_stake(origin, worker_id: WorkerId<T>, stake_balance_delta: BalanceOf<T>) {
             // Checks worker origin and worker existence.
@@ -684,6 +763,14 @@ decl_module! {
         }
 
         /// Withdraw the worker application. Can be done by the worker only.
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::withdraw_application()]
         pub fn withdraw_application(
             origin,
@@ -717,6 +804,14 @@ decl_module! {
 
         /// Cancel an opening for the regular worker/lead position.
         /// Require signed leader origin or the root (to cancel opening for the leader position).
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::cancel_opening()]
         pub fn cancel_opening(
             origin,
@@ -740,6 +835,14 @@ decl_module! {
 
         /// Sets a new budget for the working group.
         /// Requires root origin.
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::set_budget()]
         pub fn set_budget(
             origin,
@@ -759,6 +862,14 @@ decl_module! {
         }
 
         /// Update the reward account associated with a set reward relationship for the active worker.
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::update_reward_account()]
         pub fn update_reward_account(
             origin,
@@ -786,6 +897,14 @@ decl_module! {
 
         /// Update the reward per block for the active worker.
         /// Require signed leader origin or the root (to update leader's reward amount).
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::update_reward_amount()]
         pub fn update_reward_amount(
             origin,
@@ -813,6 +932,16 @@ decl_module! {
 
         /// Sets a new status text for the working group.
         /// Requires root origin.
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (S)` where:
+        /// - `S` is the length of the contents of `status_text` when it is not none
+        ///
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::set_status_text(
             if let Some(status_text) = status_text {
                 status_text.len().saturated_into()
@@ -848,6 +977,14 @@ decl_module! {
 
         /// Transfers specified amount to any account.
         /// Requires leader origin.
+        ///
+        /// # <weight>
+        ///
+        /// ## Weight
+        /// `O (1)`
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = WeightInfoWorkingGroup::<T, I>::spend_from_budget()]
         pub fn spend_from_budget(
             origin,

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -29,7 +29,8 @@
 // Do not delete! Cannot be uncommented by default, because of Parity decl_module! issue.
 //#![warn(missing_docs)]
 
-mod benchmarking;
+pub mod benchmarking;
+
 mod checks;
 mod errors;
 #[cfg(test)]

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -76,7 +76,7 @@ pub trait WeightInfo {
     fn withdraw_application() -> Weight;
     fn slash_stake(i: u32) -> Weight;
     fn terminate_role_worker(i: u32) -> Weight;
-    fn terminate_role_lead() -> Weight; // Parameter not used so it's discarded
+    fn terminate_role_lead(i: u32) -> Weight;
     fn increase_stake() -> Weight;
     fn decrease_stake() -> Weight;
     fn spend_from_budget() -> Weight;
@@ -571,7 +571,10 @@ decl_module! {
         /// - DB:
         ///    - O(1) doesn't depend on the state or parameters
         /// # </weight>
-        #[weight = WeightInfoWorkingGroup::<T, I>::terminate_role_lead()
+        #[weight = WeightInfoWorkingGroup::<T, I>::terminate_role_lead(
+                    penalty.as_ref().map(|penalty| penalty.slashing_text.len().saturated_into())
+                    .unwrap_or_else(|| 0)
+                )
                 .max(WeightInfoWorkingGroup::<T, I>::terminate_role_worker(
                         penalty.as_ref().map(|penalty| penalty.slashing_text.len().saturated_into())
                             .unwrap_or_else(|| 0)

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -155,10 +155,10 @@ impl crate::WeightInfo for () {
     fn withdraw_application() -> Weight {
         0
     }
-    fn slash_stake() -> Weight {
+    fn slash_stake(_: u32) -> Weight {
         0
     }
-    fn terminate_role_worker() -> Weight {
+    fn terminate_role_worker(_: u32) -> Weight {
         0
     }
     fn terminate_role_lead() -> Weight {

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -161,7 +161,7 @@ impl crate::WeightInfo for () {
     fn terminate_role_worker(_: u32) -> Weight {
         0
     }
-    fn terminate_role_lead() -> Weight {
+    fn terminate_role_lead(_: u32) -> Weight {
         0
     }
     fn increase_stake() -> Weight {

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -1,4 +1,5 @@
 use frame_support::traits::{OnFinalize, OnInitialize};
+use frame_support::weights::Weight;
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 use frame_system;
 use sp_core::H256;
@@ -120,6 +121,79 @@ impl Trait for Test {
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = RewardPeriod;
+    type WeightInfo = ();
+}
+
+impl crate::WeightInfo for () {
+    fn on_initialize_leaving(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_with_missing_reward(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_with_missing_reward_cant_pay(_: u32) -> Weight {
+        0
+    }
+    fn on_initialize_rewarding_without_missing_reward(_: u32) -> Weight {
+        0
+    }
+    fn apply_on_opening(_: u32) -> Weight {
+        0
+    }
+    fn fill_opening_lead() -> Weight {
+        0
+    }
+    fn fill_opening_worker(_: u32) -> Weight {
+        0
+    }
+    fn update_role_account() -> Weight {
+        0
+    }
+    fn cancel_opening() -> Weight {
+        0
+    }
+    fn withdraw_application() -> Weight {
+        0
+    }
+    fn slash_stake() -> Weight {
+        0
+    }
+    fn terminate_role_worker() -> Weight {
+        0
+    }
+    fn terminate_role_lead() -> Weight {
+        0
+    }
+    fn increase_stake() -> Weight {
+        0
+    }
+    fn decrease_stake() -> Weight {
+        0
+    }
+    fn spend_from_budget() -> Weight {
+        0
+    }
+    fn update_reward_amount() -> Weight {
+        0
+    }
+    fn set_status_text(_: u32) -> Weight {
+        0
+    }
+    fn update_reward_account() -> Weight {
+        0
+    }
+    fn set_budget() -> Weight {
+        0
+    }
+    fn add_opening(_: u32) -> Weight {
+        0
+    }
+    fn leave_role_immediatly() -> Weight {
+        0
+    }
+    fn leave_role_later() -> Weight {
+        0
+    }
 }
 
 pub const ACTOR_ORIGIN_ERROR: &'static str = "Invalid membership";

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -159,21 +159,22 @@ std = [
 ]
 runtime-benchmarks = [
     "frame-system/runtime-benchmarks",
-	"frame-support/runtime-benchmarks",
-	"sp-runtime/runtime-benchmarks",
-	"pallet-balances/runtime-benchmarks",
-	"pallet-im-online/runtime-benchmarks",
-	"pallet-staking/runtime-benchmarks",
-	"pallet-timestamp/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+    "pallet-balances/runtime-benchmarks",
+    "pallet-im-online/runtime-benchmarks",
+    "pallet-staking/runtime-benchmarks",
+    "pallet-timestamp/runtime-benchmarks",
     "frame-benchmarking",
     "frame-system-benchmarking",
     "pallet-offences-benchmarking",
-	"pallet-session-benchmarking",
+    "pallet-session-benchmarking",
     "pallet-utility/runtime-benchmarks",
     "proposals-discussion/runtime-benchmarks",
     "proposals-engine/runtime-benchmarks",
     "pallet_constitution/runtime-benchmarks",
-    "hex-literal"
+    "working-group/runtime-benchmarks",
+    "hex-literal",
 ]
 
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -634,6 +634,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Runtime {
     type MemberOriginValidator = MembershipOriginValidator<Self>;
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = ForumWorkingGroupRewardPeriod;
+    type WeightInfo = weights::working_group::WeightInfo;
 }
 
 impl working_group::Trait<StorageWorkingGroupInstance> for Runtime {
@@ -643,6 +644,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Runtime {
     type MemberOriginValidator = MembershipOriginValidator<Self>;
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = StorageWorkingGroupRewardPeriod;
+    type WeightInfo = weights::working_group::WeightInfo;
 }
 
 impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Runtime {
@@ -652,6 +654,7 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Runtime {
     type MemberOriginValidator = MembershipOriginValidator<Self>;
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = ContentWorkingGroupRewardPeriod;
+    type WeightInfo = weights::working_group::WeightInfo;
 }
 
 impl service_discovery::Trait for Runtime {

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -262,7 +262,7 @@ impl_runtime_apis! {
             use crate::ProposalsDiscussion;
             use crate::ProposalsEngine;
             use crate::Constitution;
-            use crate::ForumWorkingGroup;
+            use crate::ContentDirectoryWorkingGroup;
 
             let whitelist: Vec<TrackedStorageKey> = vec![
                 // Block Number
@@ -288,7 +288,7 @@ impl_runtime_apis! {
             add_benchmark!(params, batches, proposals_discussion, ProposalsDiscussion);
             add_benchmark!(params, batches, proposals_engine, ProposalsEngine);
             add_benchmark!(params, batches, pallet_constitution, Constitution);
-            add_benchmark!(params, batches, working_group, ForumWorkingGroup);
+            add_benchmark!(params, batches, working_group, ContentDirectoryWorkingGroup);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
             Ok(batches)

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -262,6 +262,7 @@ impl_runtime_apis! {
             use crate::ProposalsDiscussion;
             use crate::ProposalsEngine;
             use crate::Constitution;
+            use crate::ForumWorkingGroup;
 
             let whitelist: Vec<TrackedStorageKey> = vec![
                 // Block Number
@@ -287,6 +288,7 @@ impl_runtime_apis! {
             add_benchmark!(params, batches, proposals_discussion, ProposalsDiscussion);
             add_benchmark!(params, batches, proposals_engine, ProposalsEngine);
             add_benchmark!(params, batches, pallet_constitution, Constitution);
+            add_benchmark!(params, batches, working_group, ForumWorkingGroup);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
             Ok(batches)

--- a/runtime/src/weights/mod.rs
+++ b/runtime/src/weights/mod.rs
@@ -26,3 +26,4 @@ pub mod pallet_utility;
 pub mod pallet_constitution;
 pub mod proposals_discussion;
 pub mod proposals_engine;
+pub mod working_group;

--- a/runtime/src/weights/working_group.rs
+++ b/runtime/src/weights/working_group.rs
@@ -1,0 +1,142 @@
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+
+pub struct WeightInfo;
+impl working_group::WeightInfo for WeightInfo {
+    fn on_initialize_leaving(i: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((613_524_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
+    }
+    fn on_initialize_rewarding_with_missing_reward(i: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((612_352_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().reads((2 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+    }
+    fn on_initialize_rewarding_with_missing_reward_cant_pay(i: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((378_633_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+    }
+    fn on_initialize_rewarding_without_missing_reward(i: u32) -> Weight {
+        (168_498_000 as Weight)
+            .saturating_add((339_619_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().reads((2 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn apply_on_opening(i: u32) -> Weight {
+        (603_703_000 as Weight)
+            .saturating_add((1_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+    fn fill_opening_lead() -> Weight {
+        (521_141_000 as Weight)
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(6 as Weight))
+    }
+    fn fill_opening_worker(i: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((339_256_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+            .saturating_add(DbWeight::get().writes((2 as Weight).saturating_mul(i as Weight)))
+    }
+    fn update_role_account() -> Weight {
+        (408_130_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn cancel_opening() -> Weight {
+        (280_562_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn withdraw_application() -> Weight {
+        (407_575_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
+    // WARNING! Some components were not used: ["i"]
+    fn slash_stake() -> Weight {
+        (911_451_000 as Weight)
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    // WARNING! Some components were not used: ["i"]
+    fn terminate_role_worker() -> Weight {
+        (1_373_099_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
+    }
+    // WARNING! Some components were not used: ["i"]
+    fn terminate_role_lead() -> Weight {
+        (1_271_775_000 as Weight)
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(6 as Weight))
+    }
+    fn increase_stake() -> Weight {
+        (725_110_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn decrease_stake() -> Weight {
+        (835_788_000 as Weight)
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn spend_from_budget() -> Weight {
+        (305_871_000 as Weight)
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn update_reward_amount() -> Weight {
+        (419_462_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn set_status_text(i: u32) -> Weight {
+        (253_519_000 as Weight)
+            .saturating_add((66_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn update_reward_account() -> Weight {
+        (302_517_000 as Weight)
+            .saturating_add(DbWeight::get().reads(1 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn set_budget() -> Weight {
+        (77_498_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn add_opening(i: u32) -> Weight {
+        (278_869_000 as Weight)
+            .saturating_add((1_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn leave_role_immediatly() -> Weight {
+        (511_210_000 as Weight)
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+    fn leave_role_later() -> Weight {
+        (322_685_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+}

--- a/runtime/src/weights/working_group.rs
+++ b/runtime/src/weights/working_group.rs
@@ -9,7 +9,7 @@ pub struct WeightInfo;
 impl working_group::WeightInfo for WeightInfo {
     fn on_initialize_leaving(i: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((613_524_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((661_028_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
@@ -17,125 +17,125 @@ impl working_group::WeightInfo for WeightInfo {
     }
     fn on_initialize_rewarding_with_missing_reward(i: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((612_352_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((470_374_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((2 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn on_initialize_rewarding_with_missing_reward_cant_pay(i: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((378_633_000 as Weight).saturating_mul(i as Weight))
+        (90_637_000 as Weight)
+            .saturating_add((326_660_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn on_initialize_rewarding_without_missing_reward(i: u32) -> Weight {
-        (168_498_000 as Weight)
-            .saturating_add((339_619_000 as Weight).saturating_mul(i as Weight))
+        (168_436_000 as Weight)
+            .saturating_add((297_407_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((2 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn apply_on_opening(i: u32) -> Weight {
-        (603_703_000 as Weight)
-            .saturating_add((1_000 as Weight).saturating_mul(i as Weight))
+        (549_364_000 as Weight)
+            .saturating_add((2_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn fill_opening_lead() -> Weight {
-        (521_141_000 as Weight)
+        (507_605_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
     }
     fn fill_opening_worker(i: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((339_256_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
+        (215_972_000 as Weight)
+            .saturating_add((295_997_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((2 as Weight).saturating_mul(i as Weight)))
     }
     fn update_role_account() -> Weight {
-        (408_130_000 as Weight)
+        (366_128_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn cancel_opening() -> Weight {
-        (280_562_000 as Weight)
+        (267_071_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn withdraw_application() -> Weight {
-        (407_575_000 as Weight)
+        (372_243_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
-    // WARNING! Some components were not used: ["i"]
-    fn slash_stake() -> Weight {
-        (911_451_000 as Weight)
+    fn slash_stake(i: u32) -> Weight {
+        (751_074_000 as Weight)
+            .saturating_add((1_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
-    // WARNING! Some components were not used: ["i"]
-    fn terminate_role_worker() -> Weight {
-        (1_373_099_000 as Weight)
+    fn terminate_role_worker(i: u32) -> Weight {
+        (1_208_516_000 as Weight)
+            .saturating_add((1_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     // WARNING! Some components were not used: ["i"]
     fn terminate_role_lead() -> Weight {
-        (1_271_775_000 as Weight)
+        (1_158_631_000 as Weight)
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
     }
     fn increase_stake() -> Weight {
-        (725_110_000 as Weight)
+        (712_005_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn decrease_stake() -> Weight {
-        (835_788_000 as Weight)
+        (800_137_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn spend_from_budget() -> Weight {
-        (305_871_000 as Weight)
+        (285_147_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_reward_amount() -> Weight {
-        (419_462_000 as Weight)
+        (390_432_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_status_text(i: u32) -> Weight {
-        (253_519_000 as Weight)
-            .saturating_add((66_000 as Weight).saturating_mul(i as Weight))
+        (222_153_000 as Weight)
+            .saturating_add((60_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_reward_account() -> Weight {
-        (302_517_000 as Weight)
+        (282_438_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_budget() -> Weight {
-        (77_498_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        (74_429_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn add_opening(i: u32) -> Weight {
-        (278_869_000 as Weight)
-            .saturating_add((1_000 as Weight).saturating_mul(i as Weight))
+        (263_062_000 as Weight)
+            .saturating_add((2_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn leave_role_immediatly() -> Weight {
-        (511_210_000 as Weight)
+        (483_595_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn leave_role_later() -> Weight {
-        (322_685_000 as Weight)
+        (315_015_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }

--- a/runtime/src/weights/working_group.rs
+++ b/runtime/src/weights/working_group.rs
@@ -9,133 +9,133 @@ pub struct WeightInfo;
 impl working_group::WeightInfo for WeightInfo {
     fn on_initialize_leaving(i: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((661_028_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((744_041_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn on_initialize_rewarding_with_missing_reward(i: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((470_374_000 as Weight).saturating_mul(i as Weight))
+        (2_692_227_000 as Weight)
+            .saturating_add((490_219_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((2 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn on_initialize_rewarding_with_missing_reward_cant_pay(i: u32) -> Weight {
-        (90_637_000 as Weight)
-            .saturating_add((326_660_000 as Weight).saturating_mul(i as Weight))
+        (106_702_000 as Weight)
+            .saturating_add((382_691_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn on_initialize_rewarding_without_missing_reward(i: u32) -> Weight {
-        (168_436_000 as Weight)
-            .saturating_add((297_407_000 as Weight).saturating_mul(i as Weight))
+        (946_654_000 as Weight)
+            .saturating_add((326_825_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((2 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn apply_on_opening(i: u32) -> Weight {
-        (549_364_000 as Weight)
+        (583_905_000 as Weight)
             .saturating_add((2_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn fill_opening_lead() -> Weight {
-        (507_605_000 as Weight)
+        (517_943_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
     }
     fn fill_opening_worker(i: u32) -> Weight {
-        (215_972_000 as Weight)
-            .saturating_add((295_997_000 as Weight).saturating_mul(i as Weight))
+        (0 as Weight)
+            .saturating_add((337_560_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((2 as Weight).saturating_mul(i as Weight)))
     }
     fn update_role_account() -> Weight {
-        (366_128_000 as Weight)
+        (405_699_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn cancel_opening() -> Weight {
-        (267_071_000 as Weight)
+        (284_090_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn withdraw_application() -> Weight {
-        (372_243_000 as Weight)
+        (412_772_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn slash_stake(i: u32) -> Weight {
-        (751_074_000 as Weight)
-            .saturating_add((1_000 as Weight).saturating_mul(i as Weight))
+        (827_597_000 as Weight)
+            .saturating_add((4_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn terminate_role_worker(i: u32) -> Weight {
-        (1_208_516_000 as Weight)
-            .saturating_add((1_000 as Weight).saturating_mul(i as Weight))
+        (1_268_966_000 as Weight)
+            .saturating_add((14_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
-    // WARNING! Some components were not used: ["i"]
-    fn terminate_role_lead() -> Weight {
-        (1_158_631_000 as Weight)
+    fn terminate_role_lead(i: u32) -> Weight {
+        (1_266_771_000 as Weight)
+            .saturating_add((5_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
     }
     fn increase_stake() -> Weight {
-        (712_005_000 as Weight)
+        (783_675_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn decrease_stake() -> Weight {
-        (800_137_000 as Weight)
+        (895_623_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn spend_from_budget() -> Weight {
-        (285_147_000 as Weight)
+        (307_455_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_reward_amount() -> Weight {
-        (390_432_000 as Weight)
+        (420_916_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_status_text(i: u32) -> Weight {
-        (222_153_000 as Weight)
-            .saturating_add((60_000 as Weight).saturating_mul(i as Weight))
+        (238_830_000 as Weight)
+            .saturating_add((68_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_reward_account() -> Weight {
-        (282_438_000 as Weight)
+        (313_123_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_budget() -> Weight {
-        (74_429_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        (81_417_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn add_opening(i: u32) -> Weight {
-        (263_062_000 as Weight)
+        (290_743_000 as Weight)
             .saturating_add((2_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn leave_role_immediatly() -> Weight {
-        (483_595_000 as Weight)
+        (544_861_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn leave_role_later() -> Weight {
-        (315_015_000 as Weight)
+        (341_012_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }

--- a/scripts/generate-weights.sh
+++ b/scripts/generate-weights.sh
@@ -16,3 +16,8 @@ echo "Benchmarking pallet_constitution..."
 ./target/release/joystream-node benchmark --pallet=pallet_constitution --extrinsic=* --chain=dev --steps=50 --repeat=20 --execution=wasm --output=. > /dev/null
 mv pallet_constitution.rs runtime/src/weights/
 echo "pallet_constitution benchmarked"
+
+echo "Benchmarking working_group..."
+./target/release/joystream-node benchmark --pallet=working_group --extrinsic=* --chain=dev --steps=50 --repeat=20 --execution=wasm --output=. > /dev/null
+mv working_group.rs runtime/src/weights/
+echo "working_group benchmarked"


### PR DESCRIPTION
This PR includes:

* Fix `working_group` benchmark in Olympia
* Add `working_group` pallet to benchmark
  * **Note:** I used `ForumWorkingGroup` but for what I've seen which instance we should use to benchmark is arbitrary
* Add weight annotations for `working_group` pallet