### PR TITLE
Forum v2: Fix overflow risk in update_category_membership_of_moderator extrinsic

### DIFF
--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -372,6 +372,7 @@ decl_event!(
     pub enum Event<T>
     where
         <T as Trait>::CategoryId,
+        <T as Trait>::ModeratorId,
         <T as Trait>::ThreadId,
         <T as Trait>::PostId,
         <T as Trait>::ForumUserId,
@@ -424,6 +425,9 @@ decl_event!(
 
         /// Sticky thread updated for category
         CategoryStickyThreadUpdate(CategoryId, Vec<ThreadId>),
+
+        /// An moderator ability to moderate a category and its subcategories updated
+        CategoryMembershipOfModeratorUpdated(ModeratorId, CategoryId, bool),
     }
 );
 
@@ -459,6 +463,9 @@ decl_module! {
 
                 <CategoryById<T>>::mutate(category_id, |category| category.num_direct_moderators -= 1);
             }
+
+            // Generate event
+            Self::deposit_event(RawEvent::CategoryMembershipOfModeratorUpdated(moderator_id, category_id, new_value));
 
             Ok(())
         }

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -514,6 +514,15 @@ pub fn update_category_membership_of_moderator_mock(
             <CategoryByModerator<Runtime>>::contains_key(category_id, moderator_id),
             new_value
         );
+
+        assert_eq!(
+            System::events().last().unwrap().event,
+            TestEvent::forum_mod(RawEvent::CategoryMembershipOfModeratorUpdated(
+                moderator_id,
+                category_id,
+                new_value
+            ))
+        );
     };
     category_id
 }

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -74,6 +74,30 @@ fn update_category_membership_of_moderator_category() {
 }
 
 #[test]
+// test an attempt to slash category_membership_of_moderator when provided moderator is not given category moderator.
+fn update_category_membership_category_moderator_does_not_exist() {
+    let forum_lead = FORUM_LEAD_ORIGIN_ID;
+    let origin = OriginType::Signed(forum_lead);
+    with_test_externalities(|| {
+        let moderator_id = forum_lead;
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
+        update_category_membership_of_moderator_mock(
+            origin.clone(),
+            moderator_id,
+            category_id,
+            false,
+            Err(Error::<Runtime>::CategoryModeratorDoesNotExist.into()),
+        );
+    });
+}
+
+#[test]
 // test case for check if origin is forum lead
 fn create_category_origin() {
     let origins = vec![FORUM_LEAD_ORIGIN, NOT_FORUM_LEAD_ORIGIN];


### PR DESCRIPTION
This PR aims to:
1. Fix overflow risk in update_category_membership_of_moderator extrinsic
1. Add missing event to  `update_category_membership_of_moderator` extrinsic
1. Adjusting related test coverage

Closes  https://github.com/Joystream/joystream/issues/1862
https://github.com/Joystream/joystream/issues/1865