### PR TITLE
Integration tests refactoring

### DIFF
--- a/query-node/package.json
+++ b/query-node/package.json
@@ -18,7 +18,8 @@
 		"db:indexer:migrate": "(cd ./generated/indexer && yarn db:migrate)",
 		"codegen:indexer": "yarn hydra-cli codegen --no-install --no-graphql && cp indexer-tsconfig.json generated/indexer/tsconfig.json",
 		"codegen:server": "yarn hydra-cli codegen --no-install --no-indexer",
-		"cd-classes": "ts-node scripts/get-class-id-and-name.ts"
+		"cd-classes": "ts-node scripts/get-class-id-and-name.ts",
+		"integration-tests": "./run-tests.sh"
 	},
 	"author": "",
 	"license": "ISC",

--- a/query-node/run-tests.sh
+++ b/query-node/run-tests.sh
@@ -29,9 +29,6 @@ function cleanup() {
 
 trap cleanup EXIT
 
-# We expect docker image to be started by test runner
-export WS_PROVIDER_ENDPOINT_URI=ws://joystream-node:9944/
-
 # Bring up db
 docker-compose up -d db
 
@@ -40,8 +37,10 @@ yarn workspace query-node-root db:migrate
 
 docker-compose up -d graphql-server
 
+# Start the joystream-node before the indexer
+docker-compose up -d joystream-node
+
 # Starting up processor will bring up all services it depends on
 docker-compose up -d processor
 
-# Run tests
-ATTACH_TO_NETWORK=joystream_default ../tests/network-tests/run-tests.sh content-directory
+time yarn workspace network-tests run-test-scenario content-directory

--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,10 @@ fi
 # Volta nodejs, npm, yarn tools manager
 curl https://get.volta.sh | bash
 
-volta install node@12
-volta install yarn
-volta install npx
+# After installing volta the .profile and .bash_profile are updated
+# to add it to the PATH, so we start new shell to use it
+env bash -c "volta install node@12"
+env bash -c "volta install yarn"
+env bash -c "volta install npx"
+
+echo "Open a new terminal to start using newly installed tools"

--- a/tests/network-tests/package.json
+++ b/tests/network-tests/package.json
@@ -4,8 +4,9 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "build": "tsc --noEmit",
-    "run-tests": "./run-tests.sh",
-    "test-run": "node -r ts-node/register --unhandled-rejections=strict",
+    "test": "./start-test-chain.sh && ./run-tests.sh",
+    "run-test-scenario": "./run-test-scenario.sh",
+    "node-ts-strict": "node -r ts-node/register --unhandled-rejections=strict",
     "lint": "eslint . --quiet --ext .ts",
     "checks": "tsc --noEmit --pretty && prettier ./ --check && yarn lint",
     "format": "prettier ./ --write "

--- a/tests/network-tests/package.json
+++ b/tests/network-tests/package.json
@@ -4,7 +4,7 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "build": "tsc --noEmit",
-    "test": "./start-test-chain.sh && ./run-tests.sh",
+    "test": "./run-tests.sh",
     "run-test-scenario": "./run-test-scenario.sh",
     "node-ts-strict": "node -r ts-node/register --unhandled-rejections=strict",
     "lint": "eslint . --quiet --ext .ts",

--- a/tests/network-tests/run-storage-node-tests.sh
+++ b/tests/network-tests/run-storage-node-tests.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-# SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
-# cd $SCRIPT_PATH
+SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+cd $SCRIPT_PATH
+
+set -a
+. ../../.env
+set +a
 
 function cleanup() {
     # Show tail end of logs for the processor and indexer containers to
@@ -13,15 +17,6 @@ function cleanup() {
 }
 
 trap cleanup EXIT
-
-export WS_PROVIDER_ENDPOINT_URI=ws://joystream-node:9944/
-
-# Only run codegen if no generated files found
-[ ! -d "query-node/generated/" ] && yarn workspace query-node-root build
-
-# Make sure typeorm is available.. it get removed again when yarn is run again
-# typeorm commandline is used by db:migrate step below.
-ln -s ../../../../../node_modules/typeorm/cli.js query-node/generated/graphql-server/node_modules/.bin/typeorm || :
 
 # clean start
 docker-compose down -v
@@ -52,4 +47,4 @@ yes | yarn joystream-cli media:uploadVideo ./tests/network-tests/assets/joystrea
   --input ./tests/network-tests/assets/TestVideo.json \
   --confirm 
 
-time DEBUG=* yarn workspace network-tests test-run src/scenarios/storage-node.ts
+time DEBUG=* yarn workspace network-tests run-test-scenario storage-node

--- a/tests/network-tests/run-storage-node-tests.sh
+++ b/tests/network-tests/run-storage-node-tests.sh
@@ -37,7 +37,7 @@ docker-compose up -d processor
 yarn workspace @joystream/cd-schemas initialize:dev
 
 # Fixes Error: No active storage providers available
-sleep 1m 
+sleep 3m
 
 echo "Creating channel..."
 yarn joystream-cli media:createChannel \

--- a/tests/network-tests/run-storage-node-tests.sh
+++ b/tests/network-tests/run-storage-node-tests.sh
@@ -41,11 +41,11 @@ sleep 1m
 
 echo "Creating channel..."
 yarn joystream-cli media:createChannel \
-  --input ./tests/network-tests/assets/TestChannel.json --confirm
+  --input ./assets/TestChannel.json --confirm
 
 echo "Uploading video..."
-yes | yarn joystream-cli media:uploadVideo ./tests/network-tests/assets/joystream.MOV \
-  --input ./tests/network-tests/assets/TestVideo.json \
+yes | yarn joystream-cli media:uploadVideo ./assets/joystream.MOV \
+  --input ./assets/TestVideo.json \
   --confirm 
 
 time DEBUG=* yarn workspace network-tests run-test-scenario storage-node

--- a/tests/network-tests/run-storage-node-tests.sh
+++ b/tests/network-tests/run-storage-node-tests.sh
@@ -27,6 +27,7 @@ docker-compose up -d joystream-node
 DEBUG=joystream:storage-cli:dev yarn storage-cli dev-init
 docker-compose up -d colossus
 
+# Query node is expected to have been already built
 docker-compose up -d db
 yarn workspace query-node-root db:migrate
 docker-compose up -d graphql-server

--- a/tests/network-tests/run-test-scenario.sh
+++ b/tests/network-tests/run-test-scenario.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+cd $SCRIPT_PATH
+
+# pass the scenario name without .ts extension
+SCENARIO=$1
+# fallback to full.ts scenario if not specified
+SCENARIO=${SCENARIO:=full}
+
+# Execute the tests
+time DEBUG=* yarn workspace network-tests node-ts-strict src/scenarios/${SCENARIO}.ts

--- a/tests/network-tests/run-tests.sh
+++ b/tests/network-tests/run-tests.sh
@@ -102,3 +102,7 @@ fi
 # Display runtime version
 yarn workspace api-scripts tsnode-strict src/status.ts | grep Runtime
 
+echo "Waiting for chain to startup..."
+sleep 5s
+
+./run-test-scenario.sh $1

--- a/tests/network-tests/src/flows/storageNode/getContentFromStorageNode.ts
+++ b/tests/network-tests/src/flows/storageNode/getContentFromStorageNode.ts
@@ -9,8 +9,8 @@ import { Utils } from '../../utils'
 export default async function getContentFromStorageNode(api: QueryNodeApi): Promise<void> {
   const videoTitle = 'Storage node test'
 
-  // Temporary solution (wait 1 minute)
-  await Utils.wait(60000)
+  // Temporary solution (wait 2 minutes)
+  await Utils.wait(120000)
 
   // Query video by title with where expression
   const videoWhereQueryResult = await api.performWhereQueryByVideoTitle(videoTitle)

--- a/tests/network-tests/start-test-chain.sh
+++ b/tests/network-tests/start-test-chain.sh
@@ -102,10 +102,3 @@ fi
 # Display runtime version
 yarn workspace api-scripts tsnode-strict src/status.ts | grep Runtime
 
-# pass the scenario name without .ts extension
-SCENARIO=$1
-# fallback to full.ts scenario if not specified
-SCENARIO=${SCENARIO:=full}
-
-# Execute the tests
-time DEBUG=* yarn workspace network-tests test-run src/scenarios/${SCENARIO}.ts

--- a/tests/network-tests/tsconfig.json
+++ b/tests/network-tests/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "paths": {
       "@polkadot/types/augment": ["../../types/augment-codec/augment-types.ts"],
-      // "@polkadot/api/augment": [ "../../types/augment-codec/augment-api.ts"]
+      "@polkadot/api/augment": [ "../../types/augment-codec/augment-api.ts"]
     }
   }
 }


### PR DESCRIPTION
Some basic preparation for larger refactoring of the testing framework:

Enabling `"@polkadot/api/augment": [ "../../types/augment-codec/augment-api.ts"]` in tsconfig and fixing issues found as a result. Simplification mostly.

Some small fixes for running test scripts.