### PR TITLE
Add membership working group.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,6 +3892,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "staking-handler",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "7.8.0"
+version = "8.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3736,13 +3736,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-common"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
+ "sp-arithmetic",
  "sp-runtime",
  "strum 0.19.5",
  "strum_macros 0.19.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4277,7 +4277,6 @@ dependencies = [
  "frame-system",
  "pallet-balances",
  "pallet-common",
- "pallet-membership",
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3884,6 +3884,7 @@ dependencies = [
  "pallet-balances",
  "pallet-common",
  "pallet-timestamp",
+ "pallet-working-group",
  "parity-scale-codec",
  "serde",
  "sp-arithmetic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "chain-spec-builder"
-version = "3.1.1"
+version = "4.0.0"
 dependencies = [
  "ansi_term 0.12.1",
  "enum-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/runtime-modules/common/Cargo.toml
+++ b/runtime-modules/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-common'
-version = '3.1.0'
+version = '4.0.0'
 authors = ['Joystream contributors']
 edition = '2018'
 
@@ -13,6 +13,8 @@ sp-runtime = { package = 'sp-runtime', default-features = false, git = 'https://
 frame-support = { package = 'frame-support', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 frame-system = { package = 'frame-system', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
+sp-arithmetic = { package = 'sp-arithmetic', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
+
 
 [features]
 default = ['std']
@@ -25,4 +27,5 @@ std = [
 	'frame-support/std',
 	'frame-system/std',
 	'pallet-timestamp/std',
+	'sp-arithmetic/std',
 ]

--- a/runtime-modules/common/src/lib.rs
+++ b/runtime-modules/common/src/lib.rs
@@ -6,9 +6,41 @@ pub mod currency;
 pub mod origin;
 pub mod working_group;
 
-use codec::{Decode, Encode};
+use codec::{Codec, Decode, Encode};
+use frame_support::Parameter;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
+use sp_arithmetic::traits::BaseArithmetic;
+use sp_runtime::traits::{MaybeSerialize, Member};
+
+/// Member id type alias
+pub type MemberId<T> = <T as Trait>::MemberId;
+
+/// Actor id type alias
+pub type ActorId<T> = <T as Trait>::ActorId;
+
+/// Generic trait for membership dependent pallets.
+pub trait Trait: frame_system::Trait {
+    /// Describes the common type for the members.
+    type MemberId: Parameter
+        + Member
+        + BaseArithmetic
+        + Codec
+        + Default
+        + Copy
+        + MaybeSerialize
+        + PartialEq;
+
+    /// Describes the common type for the working group members (workers).
+    type ActorId: Parameter
+        + Member
+        + BaseArithmetic
+        + Codec
+        + Default
+        + Copy
+        + MaybeSerialize
+        + PartialEq;
+}
 
 /// Defines time in both block number and substrate time abstraction.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/runtime-modules/common/src/working_group.rs
+++ b/runtime-modules/common/src/working_group.rs
@@ -12,6 +12,8 @@ pub enum WorkingGroup {
     Forum,
     /// Storage working group: working_group::Instance2.
     Storage,
-    /// Storage working group: working_group::Instance3.
+    /// Content directory working group: working_group::Instance3.
     Content,
+    /// Membership working group: working_group::Instance3.
+    Membership,
 }

--- a/runtime-modules/common/src/working_group.rs
+++ b/runtime-modules/common/src/working_group.rs
@@ -14,6 +14,15 @@ pub enum WorkingGroup {
     Storage,
     /// Content directory working group: working_group::Instance3.
     Content,
-    /// Membership working group: working_group::Instance3.
+    /// Membership working group: working_group::Instance4.
     Membership,
+}
+
+/// Working group interface to use in the in the pallets with working groups.
+pub trait Interface<T: crate::Trait> {
+    /// Defines whether the member is the worker of the working group.
+    fn is_working_group_member(member_id: &T::MemberId) -> bool;
+
+    /// Defines whether the member is the leader of the working group.
+    fn is_working_group_leader(member_id: &T::MemberId) -> bool;
 }

--- a/runtime-modules/common/src/working_group.rs
+++ b/runtime-modules/common/src/working_group.rs
@@ -19,7 +19,7 @@ pub enum WorkingGroup {
 }
 
 /// Working group interface to use in the in the pallets with working groups.
-pub trait Interface<T: crate::Trait> {
+pub trait WorkingGroupIntegration<T: crate::Trait> {
     /// Defines whether the member is the worker of the working group.
     fn is_working_group_member(member_id: &T::MemberId) -> bool;
 

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -72,10 +72,12 @@ impl election::Trait for Test {
 
     type CouncilElected = (Council,);
 }
+impl common::Trait for Test {
+    type MemberId = u64;
+    type ActorId = u64;
+}
 impl membership::Trait for Test {
     type Event = ();
-    type MemberId = u64;
-    type ActorId = u32;
     type MembershipFee = MembershipFee;
 }
 impl minting::Trait for Test {

--- a/runtime-modules/membership/Cargo.toml
+++ b/runtime-modules/membership/Cargo.toml
@@ -13,8 +13,9 @@ frame-system = { package = 'frame-system', default-features = false, git = 'http
 sp-arithmetic = { package = 'sp-arithmetic', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-runtime = { package = 'sp-runtime', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-common = { package = 'pallet-common', default-features = false, path = '../common'}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
+common = { package = 'pallet-common', default-features = false, path = '../common'}
+working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group'}
 
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
@@ -31,6 +32,7 @@ std = [
 	'sp-arithmetic/std',
 	'sp-runtime/std',
 	'pallet-timestamp/std',
-	'common/std',
 	'balances/std',
+	'common/std',
+	'working-group/std',
 ]

--- a/runtime-modules/membership/Cargo.toml
+++ b/runtime-modules/membership/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-membership'
-version = '3.1.0'
+version = '4.0.0'
 authors = ['Joystream contributors']
 edition = '2018'
 

--- a/runtime-modules/membership/Cargo.toml
+++ b/runtime-modules/membership/Cargo.toml
@@ -20,6 +20,7 @@ working-group = { package = 'pallet-working-group', default-features = false, pa
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
+staking-handler = { package = 'staking-handler', default-features = false, path = '../staking-handler'}
 
 [features]
 default = ['std']

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -5,40 +5,24 @@ pub mod genesis;
 pub(crate) mod mock;
 mod tests;
 
-use codec::{Codec, Decode, Encode};
+use codec::{Decode, Encode};
 use frame_support::traits::{Currency, Get};
-use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure, Parameter};
+use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure};
 use frame_system::ensure_signed;
-use sp_arithmetic::traits::{BaseArithmetic, One};
-use sp_runtime::traits::{MaybeSerialize, Member};
+use sp_arithmetic::traits::One;
 use sp_std::borrow::ToOwned;
 use sp_std::vec::Vec;
+
+// The storage working group instance alias.
+//pub type StorageWorkingGroupInstance = working_group::Instance2;
 
 // Balance type alias
 type BalanceOf<T> = <T as balances::Trait>::Balance;
 
-pub trait Trait: frame_system::Trait + balances::Trait + pallet_timestamp::Trait {
+pub trait Trait:
+    frame_system::Trait + balances::Trait + pallet_timestamp::Trait + common::Trait
+{
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
-
-    type MemberId: Parameter
-        + Member
-        + BaseArithmetic
-        + Codec
-        + Default
-        + Copy
-        + MaybeSerialize
-        + PartialEq;
-
-    /// Describes the common type for the working group members (workers).
-    type ActorId: Parameter
-        + Member
-        + BaseArithmetic
-        + Codec
-        + Default
-        + Copy
-        + MaybeSerialize
-        + PartialEq
-        + Ord;
 
     /// Defines the default membership fee.
     type MembershipFee: Get<BalanceOf<Self>>;
@@ -213,7 +197,7 @@ decl_storage! {
 decl_event! {
     pub enum Event<T> where
       <T as frame_system::Trait>::AccountId,
-      <T as Trait>::MemberId,
+      <T as common::Trait>::MemberId,
     {
         MemberRegistered(MemberId, AccountId),
         MemberUpdatedAboutText(MemberId),

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -20,11 +20,7 @@ pub type MembershipWorkingGroupInstance = working_group::Instance4;
 type BalanceOf<T> = <T as balances::Trait>::Balance;
 
 pub trait Trait:
-    frame_system::Trait
-    + balances::Trait
-    + pallet_timestamp::Trait
-    + common::Trait
-    + working_group::Trait<MembershipWorkingGroupInstance>
+    frame_system::Trait + balances::Trait + pallet_timestamp::Trait + common::Trait
 {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -13,14 +13,18 @@ use sp_arithmetic::traits::One;
 use sp_std::borrow::ToOwned;
 use sp_std::vec::Vec;
 
-// The storage working group instance alias.
-//pub type StorageWorkingGroupInstance = working_group::Instance2;
+// The membership working group instance alias.
+pub type MembershipWorkingGroupInstance = working_group::Instance4;
 
 // Balance type alias
 type BalanceOf<T> = <T as balances::Trait>::Balance;
 
 pub trait Trait:
-    frame_system::Trait + balances::Trait + pallet_timestamp::Trait + common::Trait
+    frame_system::Trait
+    + balances::Trait
+    + pallet_timestamp::Trait
+    + common::Trait
+    + working_group::Trait<MembershipWorkingGroupInstance>
 {
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 

--- a/runtime-modules/membership/src/mock.rs
+++ b/runtime-modules/membership/src/mock.rs
@@ -2,7 +2,7 @@
 
 pub use crate::{GenesisConfig, Trait};
 
-pub use frame_support::traits::Currency;
+pub use frame_support::traits::{Currency, LockIdentifier};
 use frame_support::{impl_outer_origin, parameter_types};
 pub use frame_system;
 use sp_core::H256;
@@ -82,6 +82,28 @@ impl balances::Trait for Test {
 impl common::Trait for Test {
     type MemberId = u64;
     type ActorId = u32;
+}
+
+parameter_types! {
+    pub const MaxWorkerNumberLimit: u32 = 3;
+    pub const LockId: LockIdentifier = [9; 8];
+}
+
+impl working_group::Trait<crate::MembershipWorkingGroupInstance> for Test {
+    type Event = ();
+    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
+    type StakingHandler = staking_handler::StakingManager<Self, LockId>;
+    type MemberOriginValidator = ();
+    type MinUnstakingPeriodLimit = ();
+    type RewardPeriod = ();
+}
+
+impl common::origin::ActorOriginValidator<Origin, u64, u64> for () {
+    fn ensure_actor_origin(origin: Origin, _: u64) -> Result<u64, &'static str> {
+        let account_id = frame_system::ensure_signed(origin)?;
+
+        Ok(account_id)
+    }
 }
 
 impl Trait for Test {

--- a/runtime-modules/membership/src/mock.rs
+++ b/runtime-modules/membership/src/mock.rs
@@ -79,14 +79,13 @@ impl balances::Trait for Test {
     type MaxLocks = ();
 }
 
-impl GovernanceCurrency for Test {
-    type Currency = balances::Module<Self>;
+impl common::Trait for Test {
+    type MemberId = u64;
+    type ActorId = u32;
 }
 
 impl Trait for Test {
     type Event = ();
-    type MemberId = u64;
-    type ActorId = u32;
     type MembershipFee = MembershipFee;
 }
 

--- a/runtime-modules/proposals/codex/Cargo.toml
+++ b/runtime-modules/proposals/codex/Cargo.toml
@@ -15,7 +15,6 @@ frame-system = { package = 'frame-system', default-features = false, git = 'http
 staking = { package = 'pallet-staking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-membership = { package = 'pallet-membership', default-features = false, path = '../../membership'}
 governance = { package = 'pallet-governance', default-features = false, path = '../../governance'}
 minting = { package = 'pallet-token-mint', default-features = false, path = '../../token-minting'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../../working-group'}
@@ -23,6 +22,7 @@ common = { package = 'pallet-common', default-features = false, path = '../../co
 proposals-engine = { package = 'pallet-proposals-engine', default-features = false, path = '../engine'}
 proposals-discussion = { package = 'pallet-proposals-discussion', default-features = false, path = '../discussion'}
 constitution = { package = 'pallet-constitution', default-features = false, path = '../../constitution'}
+membership = { package = 'pallet-membership', default-features = false, path = '../../membership'}
 
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
@@ -46,7 +46,6 @@ std = [
     'staking/std',
     'pallet-timestamp/std',
     'balances/std',
-    'membership/std',
     'governance/std',
     'minting/std',
     'working-group/std',

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -71,6 +71,7 @@ pub use crate::proposal_types::{
 };
 use common::origin::ActorOriginValidator;
 use common::working_group::WorkingGroup;
+use common::MemberId;
 pub use proposal_types::{ProposalDetails, ProposalDetailsOf, ProposalEncoder};
 use proposals_discussion::ThreadMode;
 use proposals_engine::{
@@ -104,7 +105,7 @@ pub trait Trait:
     frame_system::Trait
     + proposals_engine::Trait
     + proposals_discussion::Trait
-    + membership::Trait
+    + common::Trait
     + governance::election::Trait
     + staking::Trait
 {
@@ -190,8 +191,6 @@ pub type BalanceOfGovernanceCurrency<T> =
 /// Balance alias for token mint balance from `token mint` module. TODO: replace with BalanceOf
 pub type BalanceOfMint<T> =
     <<T as minting::Trait>::Currency as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
-
-type MemberId<T> = <T as membership::Trait>::MemberId;
 
 decl_error! {
     /// Codex module predefined errors

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -44,10 +44,13 @@ impl common::currency::GovernanceCurrency for Test {
     type Currency = balances::Module<Self>;
 }
 
-impl membership::Trait for Test {
-    type Event = ();
+impl common::Trait for Test {
     type MemberId = u64;
     type ActorId = u64;
+}
+
+impl membership::Trait for Test {
+    type Event = ();
     type MembershipFee = MembershipFee;
 }
 

--- a/runtime-modules/proposals/discussion/Cargo.toml
+++ b/runtime-modules/proposals/discussion/Cargo.toml
@@ -11,8 +11,11 @@ sp-std = { package = 'sp-std', default-features = false, git = 'https://github.c
 frame-support = { package = 'frame-support', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 frame-system = { package = 'frame-system', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 common = { package = 'pallet-common', default-features = false, path = '../../common'}
+
+# Benchmarking dependencies
 frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
+membership = { package = 'pallet-membership', default-features = false, path = '../../membership', optional = true}
 
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
@@ -26,7 +29,8 @@ membership = { package = 'pallet-membership', default-features = false, path = '
 default = ['std']
 runtime-benchmarks = [
     'frame-benchmarking',
-    'balances'
+    'balances',
+	'membership'
 ]
 std = [
 	'serde',

--- a/runtime-modules/proposals/discussion/Cargo.toml
+++ b/runtime-modules/proposals/discussion/Cargo.toml
@@ -10,7 +10,6 @@ codec = { package = 'parity-scale-codec', version = '1.3.4', default-features = 
 sp-std = { package = 'sp-std', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 frame-support = { package = 'frame-support', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 frame-system = { package = 'frame-system', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-membership = { package = 'pallet-membership', default-features = false, path = '../../membership'}
 common = { package = 'pallet-common', default-features = false, path = '../../common'}
 frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
@@ -21,6 +20,7 @@ sp-core = { package = 'sp-core', default-features = false, git = 'https://github
 sp-runtime = { package = 'sp-runtime', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
+membership = { package = 'pallet-membership', default-features = false, path = '../../membership'}
 
 [features]
 default = ['std']
@@ -34,6 +34,5 @@ std = [
 	'sp-std/std',
 	'frame-support/std',
 	'frame-system/std',
-    'membership/std',
     'common/std',
 ]

--- a/runtime-modules/proposals/discussion/src/benchmarking.rs
+++ b/runtime-modules/proposals/discussion/src/benchmarking.rs
@@ -45,7 +45,7 @@ fn assert_last_event<T: Trait>(generic_event: <T as Trait>::Event) {
     assert_eq!(event, &system_event);
 }
 
-fn member_account<T: membership::Trait + balances::Trait>(
+fn member_account<T: common::Trait + balances::Trait + membership::Trait>(
     name: &'static str,
     id: u32,
 ) -> (T::AccountId, T::MemberId) {
@@ -74,7 +74,7 @@ fn member_account<T: membership::Trait + balances::Trait>(
 const MAX_BYTES: u32 = 16384;
 
 benchmarks! {
-    where_clause { where T: balances::Trait }
+    where_clause { where T: balances::Trait, T: membership::Trait }
     _ { }
 
     add_post {

--- a/runtime-modules/proposals/discussion/src/lib.rs
+++ b/runtime-modules/proposals/discussion/src/lib.rs
@@ -61,11 +61,10 @@ use sp_std::clone::Clone;
 use sp_std::vec::Vec;
 
 use common::origin::ActorOriginValidator;
+use common::MemberId;
 use types::{DiscussionPost, DiscussionThread};
 
 pub use types::ThreadMode;
-
-type MemberId<T> = <T as membership::Trait>::MemberId;
 
 /// Proposals discussion WeightInfo.
 /// Note: This was auto generated through the benchmark CLI using the `--weight-trait` flag

--- a/runtime-modules/proposals/discussion/src/lib.rs
+++ b/runtime-modules/proposals/discussion/src/lib.rs
@@ -24,7 +24,7 @@
 //! use frame_system::ensure_root;
 //! use pallet_proposals_discussion::{self as discussions, ThreadMode};
 //!
-//! pub trait Trait: discussions::Trait + membership::Trait {}
+//! pub trait Trait: discussions::Trait + common::Trait {}
 //!
 //! decl_module! {
 //!     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
@@ -105,7 +105,7 @@ pub trait CouncilMembership<AccountId, MemberId> {
 }
 
 /// 'Proposal discussion' substrate module Trait
-pub trait Trait: frame_system::Trait + membership::Trait {
+pub trait Trait: frame_system::Trait + common::Trait {
     /// Discussion event type.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -73,10 +73,13 @@ impl common::currency::GovernanceCurrency for Test {
     type Currency = balances::Module<Self>;
 }
 
-impl membership::Trait for Test {
-    type Event = TestEvent;
+impl common::Trait for Test {
     type MemberId = u64;
     type ActorId = u64;
+}
+
+impl membership::Trait for Test {
+    type Event = TestEvent;
     type MembershipFee = MembershipFee;
 }
 

--- a/runtime-modules/proposals/engine/Cargo.toml
+++ b/runtime-modules/proposals/engine/Cargo.toml
@@ -14,7 +14,6 @@ pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git
 sp-arithmetic = { package = 'sp-arithmetic', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-runtime = { package = 'sp-runtime', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-membership = { package = 'pallet-membership', default-features = false, path = '../../membership'}
 common = { package = 'pallet-common', default-features = false, path = '../../common'}
 staking-handler = { package = 'staking-handler', default-features = false, path = '../../staking-handler'}
 
@@ -30,6 +29,7 @@ sp-core = { package = 'sp-core', default-features = false, git = 'https://github
 governance = { package = 'pallet-governance', default-features = false, path = '../../governance'}
 recurringrewards = { package = 'pallet-recurring-reward', default-features = false, path = '../../recurring-reward'}
 minting = { package = 'pallet-token-mint', default-features = false, path = '../../token-minting'}
+membership = { package = 'pallet-membership', default-features = false, path = '../../membership'}
 
 [features]
 default = ['std']
@@ -49,7 +49,6 @@ std = [
 	'sp-arithmetic/std',
 	'sp-runtime/std',
 	'balances/std',
-    'membership/std',
     'common/std',
     'staking-handler/std',
 ]

--- a/runtime-modules/proposals/engine/Cargo.toml
+++ b/runtime-modules/proposals/engine/Cargo.toml
@@ -22,6 +22,7 @@ frame-benchmarking = { package = 'frame-benchmarking', default-features = false,
 governance = { package = 'pallet-governance', default-features = false, path = '../../governance', optional = true}
 recurringrewards = { package = 'pallet-recurring-reward', default-features = false, path = '../../recurring-reward', optional = true}
 minting = { package = 'pallet-token-mint', default-features = false, path = '../../token-minting', optional = true}
+membership = { package = 'pallet-membership', default-features = false, path = '../../membership', optional = true}
 
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
@@ -38,6 +39,7 @@ runtime-benchmarks = [
     'governance',
     'recurringrewards',
     'minting',
+    'membership',
 ]
 std = [
 	'serde',

--- a/runtime-modules/proposals/engine/src/benchmarking.rs
+++ b/runtime-modules/proposals/engine/src/benchmarking.rs
@@ -64,7 +64,10 @@ fn assert_in_events<T: Trait>(generic_event: <T as Trait>::Event) {
     }));
 }
 
-fn member_funded_account<T: Trait>(name: &'static str, id: u32) -> (T::AccountId, T::MemberId) {
+fn member_funded_account<T: Trait + membership::Trait>(
+    name: &'static str,
+    id: u32,
+) -> (T::AccountId, T::MemberId) {
     let account_id = account::<T::AccountId>(name, id, SEED);
     let handle = handle_from_id::<T>(id);
 
@@ -84,7 +87,7 @@ fn member_funded_account<T: Trait>(name: &'static str, id: u32) -> (T::AccountId
     (account_id, T::MemberId::from(id.try_into().unwrap()))
 }
 
-fn create_proposal<T: Trait>(
+fn create_proposal<T: Trait + membership::Trait>(
     id: u32,
     proposal_number: u32,
     constitutionality: u32,
@@ -154,7 +157,9 @@ fn create_proposal<T: Trait>(
     (account_id, member_id, proposal_id)
 }
 
-fn create_multiple_finalized_proposals<T: Trait + governance::council::Trait>(
+fn create_multiple_finalized_proposals<
+    T: Trait + governance::council::Trait + membership::Trait,
+>(
     number_of_proposals: u32,
     constitutionality: u32,
     vote_kind: VoteKind,
@@ -203,7 +208,7 @@ const MAX_BYTES: u32 = 16384;
 benchmarks! {
     // Note: this is the syntax for this macro can't use "+"
     where_clause {
-        where T: governance::council::Trait
+        where T: governance::council::Trait, T: membership::Trait
     }
 
     _ { }

--- a/runtime-modules/proposals/engine/src/lib.rs
+++ b/runtime-modules/proposals/engine/src/lib.rs
@@ -59,7 +59,7 @@
 //! use codec::Encode;
 //! use pallet_proposals_engine::{self as engine, ProposalParameters, ProposalCreationParameters};
 //!
-//! pub trait Trait: engine::Trait + membership::Trait {}
+//! pub trait Trait: engine::Trait + common::Trait {}
 //!
 //! decl_module! {
 //!     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
@@ -157,7 +157,7 @@ type WeightInfoEngine<T> = <T as Trait>::WeightInfo;
 
 /// Proposals engine trait.
 pub trait Trait:
-    frame_system::Trait + pallet_timestamp::Trait + membership::Trait + balances::Trait
+    frame_system::Trait + pallet_timestamp::Trait + common::Trait + balances::Trait
 {
     /// Engine event type.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;

--- a/runtime-modules/proposals/engine/src/lib.rs
+++ b/runtime-modules/proposals/engine/src/lib.rs
@@ -109,7 +109,7 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use types::{MemberId, ProposalOf};
+use types::ProposalOf;
 
 pub use types::{
     ApprovedProposalDecision, BalanceOf, ExecutionStatus, Proposal, ProposalCodeDecoder,
@@ -137,6 +137,7 @@ use sp_arithmetic::traits::{SaturatedConversion, Saturating, Zero};
 use sp_std::vec::Vec;
 
 use common::origin::ActorOriginValidator;
+use common::MemberId;
 use staking_handler::StakingHandler;
 
 /// Proposals engine WeightInfo.

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -81,10 +81,13 @@ parameter_types! {
     pub const MembershipFee: u64 = 100;
 }
 
-impl membership::Trait for Test {
-    type Event = TestEvent;
+impl common::Trait for Test {
     type MemberId = u64;
     type ActorId = u64;
+}
+
+impl membership::Trait for Test {
+    type Event = TestEvent;
     type MembershipFee = MembershipFee;
 }
 

--- a/runtime-modules/proposals/engine/src/types/mod.rs
+++ b/runtime-modules/proposals/engine/src/types/mod.rs
@@ -13,6 +13,8 @@ use sp_std::cmp::PartialOrd;
 use sp_std::ops::Add;
 use sp_std::vec::Vec;
 
+use common::MemberId;
+
 mod proposal_statuses;
 
 pub use proposal_statuses::{
@@ -406,9 +408,6 @@ pub struct ProposalCreationParameters<BlockNumber, Balance, MemberId, AccountId>
     /// Should be greater than starting block + grace_period if set.
     pub exact_execution_block: Option<BlockNumber>,
 }
-
-// Type alias for member id.
-pub(crate) type MemberId<T> = <T as membership::Trait>::MemberId;
 
 /// Balance alias for `balances` module.
 pub type BalanceOf<T> = <T as balances::Trait>::Balance;

--- a/runtime-modules/service-discovery/Cargo.toml
+++ b/runtime-modules/service-discovery/Cargo.toml
@@ -19,11 +19,11 @@ sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 minting = { package = 'pallet-token-mint', default-features = false, path = '../token-minting'}
 recurringrewards = { package = 'pallet-recurring-reward', default-features = false, path = '../recurring-reward'}
 common = { package = 'pallet-common', default-features = false, path = '../common'}
 staking-handler = { package = 'staking-handler', default-features = false, path = '../staking-handler'}
+membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 
 [features]
 default = ['std']

--- a/runtime-modules/service-discovery/src/lib.rs
+++ b/runtime-modules/service-discovery/src/lib.rs
@@ -51,8 +51,8 @@ pub type IPNSIdentity = Vec<u8>;
 /// HTTP Url string to a discovery service endpoint
 pub type Url = Vec<u8>;
 
-// The storage working group instance alias.
-pub(crate) type StorageWorkingGroupInstance = working_group::Instance2;
+/// The storage working group instance alias.
+pub type StorageWorkingGroupInstance = working_group::Instance2;
 
 /// Storage provider is a worker from the  working_group module.
 pub type StorageProviderId<T> = working_group::WorkerId<T>;

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -10,9 +10,6 @@ use sp_runtime::{
     Perbill,
 };
 
-// The storage working group instance alias.
-pub type StorageWorkingGroupInstance = working_group::Instance2;
-
 mod working_group_mod {
     pub use super::StorageWorkingGroupInstance;
     pub use working_group::Event;

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -91,10 +91,13 @@ impl minting::Trait for Test {
     type MintId = u64;
 }
 
-impl membership::Trait for Test {
-    type Event = MetaEvent;
+impl common::Trait for Test {
     type MemberId = u64;
     type ActorId = u64;
+}
+
+impl membership::Trait for Test {
+    type Event = MetaEvent;
     type MembershipFee = MembershipFee;
 }
 

--- a/runtime-modules/staking-handler/Cargo.toml
+++ b/runtime-modules/staking-handler/Cargo.toml
@@ -17,7 +17,6 @@ sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 codec = { package = 'parity-scale-codec', version = '1.3.1', default-features = false, features = ['derive'] }
 sp-runtime = { package = 'sp-runtime', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-common = { package = 'pallet-common', default-features = false, path = '../common'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 

--- a/runtime-modules/staking-handler/Cargo.toml
+++ b/runtime-modules/staking-handler/Cargo.toml
@@ -11,6 +11,7 @@ frame-system = { package = 'frame-system', default-features = false, git = 'http
 sp-arithmetic = { package = 'sp-arithmetic', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 pallet-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
+common = { package = 'pallet-common', default-features = false, path = '../common'}
 
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
@@ -29,4 +30,5 @@ std = [
     'sp-arithmetic/std',
     'pallet-balances/std',
     'membership/std',
+    'common/std',
 ]

--- a/runtime-modules/staking-handler/Cargo.toml
+++ b/runtime-modules/staking-handler/Cargo.toml
@@ -10,7 +10,6 @@ frame-support = { package = 'frame-support', default-features = false, git = 'ht
 frame-system = { package = 'frame-system', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-arithmetic = { package = 'sp-arithmetic', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 pallet-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 common = { package = 'pallet-common', default-features = false, path = '../common'}
 
 [dev-dependencies]
@@ -20,6 +19,7 @@ codec = { package = 'parity-scale-codec', version = '1.3.1', default-features = 
 sp-runtime = { package = 'sp-runtime', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 common = { package = 'pallet-common', default-features = false, path = '../common'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
+membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 
 [features]
 default = ['std']
@@ -29,6 +29,5 @@ std = [
     'frame-system/std',
     'sp-arithmetic/std',
     'pallet-balances/std',
-    'membership/std',
     'common/std',
 ]

--- a/runtime-modules/staking-handler/src/lib.rs
+++ b/runtime-modules/staking-handler/src/lib.rs
@@ -56,7 +56,7 @@ pub trait StakingHandler<T: frame_system::Trait + common::Trait + pallet_balance
 
 /// Implementation of the StakingHandler.
 pub struct StakingManager<
-    T: frame_system::Trait + membership::Trait + pallet_balances::Trait,
+    T: frame_system::Trait + common::Trait + pallet_balances::Trait,
     LockId: Get<LockIdentifier>,
 > {
     trait_marker: PhantomData<T>,
@@ -64,7 +64,7 @@ pub struct StakingManager<
 }
 
 impl<
-        T: frame_system::Trait + membership::Trait + pallet_balances::Trait,
+        T: frame_system::Trait + common::Trait + pallet_balances::Trait,
         LockId: Get<LockIdentifier>,
     > StakingHandler<T> for StakingManager<T, LockId>
 {

--- a/runtime-modules/staking-handler/src/lib.rs
+++ b/runtime-modules/staking-handler/src/lib.rs
@@ -6,6 +6,7 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use common::MemberId;
 use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_support::traits::{Currency, Get, LockIdentifier, LockableCurrency, WithdrawReasons};
 use sp_arithmetic::traits::Zero;
@@ -16,16 +17,13 @@ mod mock;
 #[cfg(test)]
 mod test;
 
-/// Type alias for member id.
-pub type MemberId<T> = <T as membership::Trait>::MemberId;
-
 /// Balance alias for `balances` module.
 pub type BalanceOf<T> = <T as pallet_balances::Trait>::Balance;
 
 /// Defines abstract staking handler to manage user stakes for different activities
 /// like adding a proposal. Implementation should use built-in LockableCurrency
 /// and LockIdentifier to lock balance consistently with pallet_staking.
-pub trait StakingHandler<T: frame_system::Trait + membership::Trait + pallet_balances::Trait> {
+pub trait StakingHandler<T: frame_system::Trait + common::Trait + pallet_balances::Trait> {
     /// Locks the specified balance on the account using specific lock identifier.
     fn lock(account_id: &T::AccountId, amount: BalanceOf<T>);
 

--- a/runtime-modules/staking-handler/src/mock.rs
+++ b/runtime-modules/staking-handler/src/mock.rs
@@ -67,10 +67,13 @@ impl pallet_balances::Trait for Test {
     type MaxLocks = ();
 }
 
-impl membership::Trait for Test {
-    type Event = ();
+impl common::Trait for Test {
     type MemberId = u64;
     type ActorId = u64;
+}
+
+impl membership::Trait for Test {
+    type Event = ();
     type MembershipFee = MembershipFee;
 }
 

--- a/runtime-modules/staking-handler/src/mock.rs
+++ b/runtime-modules/staking-handler/src/mock.rs
@@ -77,10 +77,6 @@ impl membership::Trait for Test {
     type MembershipFee = MembershipFee;
 }
 
-impl common::currency::GovernanceCurrency for Test {
-    type Currency = Balances;
-}
-
 impl pallet_timestamp::Trait for Test {
     type Moment = u64;
     type OnTimestampSet = ();

--- a/runtime-modules/staking-handler/src/test.rs
+++ b/runtime-modules/staking-handler/src/test.rs
@@ -6,10 +6,7 @@ use frame_support::traits::Currency;
 pub(crate) fn increase_total_balance_issuance_using_account_id(account_id: u64, balance: u64) {
     let initial_balance = Balances::total_issuance();
     {
-        let _ = <Test as common::currency::GovernanceCurrency>::Currency::deposit_creating(
-            &account_id,
-            balance,
-        );
+        let _ = Balances::deposit_creating(&account_id, balance);
     }
     assert_eq!(Balances::total_issuance(), initial_balance + balance);
 }

--- a/runtime-modules/storage/Cargo.toml
+++ b/runtime-modules/storage/Cargo.toml
@@ -12,7 +12,6 @@ frame-support = { package = 'frame-support', default-features = false, git = 'ht
 frame-system = { package = 'frame-system', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-arithmetic = { package = 'sp-arithmetic', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-runtime = { package = 'sp-runtime', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group'}
 common = { package = 'pallet-common', default-features = false, path = '../common'}
@@ -24,6 +23,7 @@ balances = { package = 'pallet-balances', default-features = false, git = 'https
 minting = { package = 'pallet-token-mint', default-features = false, path = '../token-minting'}
 recurringrewards = { package = 'pallet-recurring-reward', default-features = false, path = '../recurring-reward'}
 staking-handler = { package = 'staking-handler', default-features = false, path = '../staking-handler'}
+membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 
 [features]
 default = ['std']
@@ -35,7 +35,6 @@ std = [
 	'frame-system/std',
 	'sp-arithmetic/std',
 	'sp-runtime/std',
-	'membership/std',
 	'pallet-timestamp/std',
 	'working-group/std',
 	'common/std',

--- a/runtime-modules/storage/src/data_directory.rs
+++ b/runtime-modules/storage/src/data_directory.rs
@@ -47,7 +47,7 @@ pub trait Trait:
     pallet_timestamp::Trait
     + frame_system::Trait
     + data_object_type_registry::Trait
-    + membership::Trait
+    + common::Trait
     + working_group::Trait<StorageWorkingGroupInstance>
 {
     /// _Data directory_ event type.

--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -7,11 +7,10 @@ pub mod data_object_type_registry;
 
 mod tests;
 
-// The storage working group instance alias.
-pub type StorageWorkingGroupInstance = working_group::Instance2;
+pub use common::MemberId;
 
-// Alias for the member id.
-pub(crate) type MemberId<T> = <T as membership::Trait>::MemberId;
+/// The storage working group instance alias.
+pub type StorageWorkingGroupInstance = working_group::Instance2;
 
 /// Storage provider is a worker from the working group module.
 pub type StorageProviderId<T> = working_group::WorkerId<T>;

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -198,10 +198,13 @@ impl data_object_storage_registry::Trait for Test {
     type ContentIdExists = MockContent;
 }
 
-impl membership::Trait for Test {
-    type Event = MetaEvent;
+impl common::Trait for Test {
     type MemberId = u64;
     type ActorId = u32;
+}
+
+impl membership::Trait for Test {
+    type Event = MetaEvent;
     type MembershipFee = MembershipFee;
 }
 

--- a/runtime-modules/working-group/Cargo.toml
+++ b/runtime-modules/working-group/Cargo.toml
@@ -13,7 +13,6 @@ frame-system = { package = 'frame-system', default-features = false, git = 'http
 sp-arithmetic = { package = 'sp-arithmetic', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-std = { package = 'sp-std', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 common = { package = 'pallet-common', default-features = false, path = '../common'}
-membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
 staking-handler = { package = 'staking-handler', default-features = false, path = '../staking-handler'}
@@ -22,6 +21,7 @@ staking-handler = { package = 'staking-handler', default-features = false, path 
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
+membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 
 [features]
 default = ['std']
@@ -35,7 +35,6 @@ std = [
 	'sp-arithmetic/std',
 	'sp-std/std',
 	'common/std',
-	'membership/std',
 	'balances/std',
 	'staking-handler/std',
 ]

--- a/runtime-modules/working-group/Cargo.toml
+++ b/runtime-modules/working-group/Cargo.toml
@@ -21,7 +21,6 @@ staking-handler = { package = 'staking-handler', default-features = false, path 
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 
 [features]
 default = ['std']

--- a/runtime-modules/working-group/src/checks.rs
+++ b/runtime-modules/working-group/src/checks.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ApplicationId, BalanceOf, Instance, MemberId, Opening, OpeningId, OpeningType, RewardPolicy,
-    StakePolicy, Trait, Worker, WorkerId,
+    ApplicationId, BalanceOf, Instance, Opening, OpeningId, OpeningType, RewardPolicy, StakePolicy,
+    Trait, Worker, WorkerId,
 };
 
 use super::Error;
@@ -146,17 +146,6 @@ pub fn ensure_worker_exists<T: Trait<I>, I: Instance>(
     let worker = <crate::WorkerById<T, I>>::get(worker_id);
 
     Ok(worker)
-}
-
-// Check worker: verifies that origin is signed and corresponds with the membership.
-pub(crate) fn ensure_origin_signed_by_member<T: Trait<I>, I: Instance>(
-    origin: T::Origin,
-    member_id: &MemberId<T>,
-) -> Result<(), Error<T, I>> {
-    membership::Module::<T>::ensure_member_controller_account_signed(origin, member_id)
-        .map_err(|_| Error::<T, I>::InvalidMemberOrigin)?;
-
-    Ok(())
 }
 
 /// Check worker: ensures the origin contains signed account that belongs to existing worker.

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -48,7 +48,7 @@ use sp_std::vec::Vec;
 
 pub use errors::Error;
 pub use types::{
-    Application, ApplicationId, ApplyOnOpeningParameters, BalanceOf, MemberId, Opening, OpeningId,
+    Application, ApplicationId, ApplyOnOpeningParameters, BalanceOf, Opening, OpeningId,
     OpeningType, Penalty, RewardPolicy, StakeParameters, StakePolicy, Worker, WorkerId,
 };
 use types::{ApplicationInfo, WorkerInfo};
@@ -56,11 +56,12 @@ use types::{ApplicationInfo, WorkerInfo};
 pub use checks::{ensure_origin_is_active_leader, ensure_worker_exists, ensure_worker_signed};
 
 use common::origin::ActorOriginValidator;
+use common::MemberId;
 use staking_handler::StakingHandler;
 
 /// The _Group_ main _Trait_
 pub trait Trait<I: Instance = DefaultInstance>:
-    frame_system::Trait + membership::Trait + balances::Trait
+    frame_system::Trait + balances::Trait + common::Trait
 {
     /// _Administration_ event type.
     type Event: From<Event<Self, I>> + Into<<Self as frame_system::Trait>::Event>;
@@ -423,8 +424,8 @@ decl_module! {
             // Ensuring worker actually exists
             let worker = checks::ensure_worker_exists::<T, I>(&worker_id)?;
 
-            // Ensure that origin is signed by member with given id.
-            checks::ensure_origin_signed_by_member::<T, I>(origin, &worker.member_id)?;
+            // Ensure the origin of a member with given id.
+            T::MemberOriginValidator::ensure_actor_origin(origin, worker.member_id)?;
 
             // Ensure the worker is active.
             ensure!(!worker.is_leaving(), Error::<T, I>::WorkerIsLeaving);

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -6,7 +6,7 @@ use sp_runtime::traits::Hash;
 use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
 
 use super::hiring_workflow::HiringWorkflow;
-use super::mock::{Balances, LockId, Membership, System, Test, TestEvent, TestWorkingGroup};
+use super::mock::{Balances, LockId, System, Test, TestEvent, TestWorkingGroup};
 use crate::types::StakeParameters;
 use crate::{
     Application, ApplyOnOpeningParameters, DefaultInstance, Opening, OpeningType, Penalty,
@@ -228,20 +228,6 @@ impl ApplyOnOpeningFixture {
         }
 
         saved_application_next_id
-    }
-}
-
-pub fn setup_members(count: u8) {
-    for i in 0..count {
-        let account_id: u64 = i as u64;
-        let handle: [u8; 20] = [i; 20];
-        Membership::buy_membership(
-            RawOrigin::Signed(account_id).into(),
-            Some(handle.to_vec()),
-            None,
-            None,
-        )
-        .unwrap();
     }
 }
 

--- a/runtime-modules/working-group/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-group/src/tests/hiring_workflow.rs
@@ -2,7 +2,7 @@ use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_system::RawOrigin;
 
 use crate::tests::fixtures::{
-    setup_members, AddOpeningFixture, ApplyOnOpeningFixture, FillOpeningFixture, HireLeadFixture,
+    AddOpeningFixture, ApplyOnOpeningFixture, FillOpeningFixture, HireLeadFixture,
 };
 use crate::tests::mock::TestWorkingGroup;
 use crate::types::StakeParameters;
@@ -118,7 +118,7 @@ impl HiringWorkflow {
         if matches!(self.opening_type, OpeningType::Regular) {
             HireLeadFixture::default().hire_lead();
         } else {
-            setup_members(6);
+            //         setup_members(6);
         }
     }
 

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -94,10 +94,13 @@ impl balances::Trait for Test {
     type MaxLocks = ();
 }
 
-impl membership::Trait for Test {
-    type Event = TestEvent;
+impl common::Trait for Test {
     type MemberId = u64;
     type ActorId = u64;
+}
+
+impl membership::Trait for Test {
+    type Event = TestEvent;
     type MembershipFee = MembershipFee;
 }
 

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -18,15 +18,10 @@ mod working_group {
     pub use crate::Event;
 }
 
-mod membership_mod {
-    pub use membership::Event;
-}
-
 impl_outer_event! {
     pub enum TestEvent for Test {
         balances<T>,
         crate DefaultInstance <T>,
-        membership_mod<T>,
         frame_system<T>,
     }
 }
@@ -99,14 +94,8 @@ impl common::Trait for Test {
     type ActorId = u64;
 }
 
-impl membership::Trait for Test {
-    type Event = TestEvent;
-    type MembershipFee = MembershipFee;
-}
-
 pub type Balances = balances::Module<Test>;
 pub type System = frame_system::Module<Test>;
-pub type Membership = membership::Module<Test>;
 
 parameter_types! {
     pub const RewardPeriod: u32 = 2;

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -21,10 +21,9 @@ use crate::{
     DefaultInstance, Error, OpeningType, Penalty, RawEvent, RewardPolicy, StakePolicy, Worker,
 };
 use fixtures::{
-    increase_total_balance_issuance_using_account_id, setup_members, AddOpeningFixture,
-    ApplyOnOpeningFixture, EventFixture, FillOpeningFixture, HireLeadFixture,
-    HireRegularWorkerFixture, LeaveWorkerRoleFixture, TerminateWorkerRoleFixture,
-    UpdateWorkerRoleAccountFixture,
+    increase_total_balance_issuance_using_account_id, AddOpeningFixture, ApplyOnOpeningFixture,
+    EventFixture, FillOpeningFixture, HireLeadFixture, HireRegularWorkerFixture,
+    LeaveWorkerRoleFixture, TerminateWorkerRoleFixture, UpdateWorkerRoleAccountFixture,
 };
 use frame_support::dispatch::DispatchError;
 use frame_support::StorageMap;
@@ -159,8 +158,6 @@ fn apply_on_opening_succeeded() {
 #[test]
 fn apply_on_opening_fails_with_invalid_opening_id() {
     build_test_externalities().execute_with(|| {
-        setup_members(2);
-
         let invalid_opening_id = 22;
 
         let apply_on_opening_fixture =

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -510,9 +510,7 @@ fn update_worker_role_account_fails_with_invalid_origin() {
             UpdateWorkerRoleAccountFixture::default_with_ids(worker_id, 1)
                 .with_origin(RawOrigin::None);
 
-        update_worker_account_fixture.call_and_assert(Err(
-            Error::<Test, DefaultInstance>::InvalidMemberOrigin.into(),
-        ));
+        update_worker_account_fixture.call_and_assert(Err(DispatchError::Other("Bad origin")));
     });
 }
 

--- a/runtime-modules/working-group/src/types.rs
+++ b/runtime-modules/working-group/src/types.rs
@@ -7,14 +7,13 @@ use sp_std::vec::Vec;
 use serde::{Deserialize, Serialize};
 use sp_std::marker::PhantomData;
 
+use common::{ActorId, MemberId};
+
 /// Working group job application type alias.
 pub type Application<T> = JobApplication<<T as frame_system::Trait>::AccountId, MemberId<T>>;
 
-/// Member identifier in membership::member module.
-pub type MemberId<T> = <T as membership::Trait>::MemberId;
-
 /// Type identifier for a worker role, which must be same as membership actor identifier.
-pub type WorkerId<T> = <T as membership::Trait>::ActorId;
+pub type WorkerId<T> = ActorId<T>;
 
 /// Type for an application id.
 pub type ApplicationId = u64;
@@ -30,12 +29,12 @@ pub(crate) struct ApplicationInfo<T: crate::Trait<I>, I: crate::Instance> {
 }
 
 // WorkerId - Worker - helper struct.
-pub(crate) struct WorkerInfo<T: membership::Trait + frame_system::Trait + balances::Trait> {
+pub(crate) struct WorkerInfo<T: common::Trait + frame_system::Trait + balances::Trait> {
     pub worker_id: WorkerId<T>,
     pub worker: Worker<T>,
 }
 
-impl<T: membership::Trait + frame_system::Trait + balances::Trait> From<(WorkerId<T>, Worker<T>)>
+impl<T: common::Trait + frame_system::Trait + balances::Trait> From<(WorkerId<T>, Worker<T>)>
     for WorkerInfo<T>
 {
     fn from((worker_id, worker): (WorkerId<T>, Worker<T>)) -> Self {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '7.8.0'
+version = '8.0.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/integration/proposals/council_origin_validator.rs
+++ b/runtime/src/integration/proposals/council_origin_validator.rs
@@ -3,9 +3,10 @@
 use sp_std::marker::PhantomData;
 
 use common::origin::ActorOriginValidator;
+use common::MemberId;
 use proposals_engine::VotersParameters;
 
-use super::{MemberId, MembershipOriginValidator};
+use super::MembershipOriginValidator;
 
 /// Handles work with the council.
 /// Provides implementations for ActorOriginValidator and VotersParameters.

--- a/runtime/src/integration/proposals/membership_origin_validator.rs
+++ b/runtime/src/integration/proposals/membership_origin_validator.rs
@@ -3,10 +3,8 @@
 use sp_std::marker::PhantomData;
 
 use common::origin::ActorOriginValidator;
+use common::MemberId;
 use frame_system::ensure_signed;
-
-/// Member of the Joystream organization
-pub type MemberId<T> = <T as membership::Trait>::MemberId;
 
 /// Default membership actor origin validator.
 pub struct MembershipOriginValidator<T> {

--- a/runtime/src/integration/proposals/mod.rs
+++ b/runtime/src/integration/proposals/mod.rs
@@ -7,5 +7,5 @@ mod proposal_encoder;
 
 pub use council_elected_handler::CouncilElectedHandler;
 pub use council_origin_validator::CouncilManager;
-pub use membership_origin_validator::{MemberId, MembershipOriginValidator};
+pub use membership_origin_validator::MembershipOriginValidator;
 pub use proposal_encoder::ExtrinsicProposalEncoder;

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -22,6 +22,7 @@ macro_rules! wrap_working_group_call {
             }
             WorkingGroup::Storage => Call::StorageWorkingGroup($working_group_instance_call),
             WorkingGroup::Forum => Call::ForumWorkingGroup($working_group_instance_call),
+            WorkingGroup::Membership => Call::MembershipWorkingGroup($working_group_instance_call),
         }
     }};
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -87,8 +87,8 @@ pub fn wasm_binary_unwrap() -> &'static [u8] {
 pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
-    authoring_version: 7,
-    spec_version: 8,
+    authoring_version: 8,
+    spec_version: 0,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -501,10 +501,13 @@ impl storage::data_object_storage_registry::Trait for Runtime {
     type ContentIdExists = DataDirectory;
 }
 
-impl membership::Trait for Runtime {
-    type Event = Event;
+impl common::Trait for Runtime {
     type MemberId = MemberId;
     type ActorId = ActorId;
+}
+
+impl membership::Trait for Runtime {
+    type Event = Event;
     type MembershipFee = MembershipFee;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -593,10 +593,13 @@ impl forum::Trait for Runtime {
 pub type ForumWorkingGroupInstance = working_group::Instance1;
 
 // The storage working group instance alias.
-pub type StorageWorkingGroupInstance = working_group::Instance2;
+pub type StorageWorkingGroupInstance = storage::StorageWorkingGroupInstance;
 
 // The content directory working group instance alias.
 pub type ContentDirectoryWorkingGroupInstance = working_group::Instance3;
+
+// The membership working group instance alias.
+pub type MembershipWorkingGroupInstance = membership::MembershipWorkingGroupInstance;
 
 parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 100;
@@ -604,9 +607,11 @@ parameter_types! {
     pub const ForumWorkingGroupRewardPeriod: u32 = 14400 + 10;
     pub const StorageWorkingGroupRewardPeriod: u32 = 14400 + 20;
     pub const ContentWorkingGroupRewardPeriod: u32 = 14400 + 30;
+    pub const MembershipRewardPeriod: u32 = 14400 + 40;
     pub const StorageWorkingGroupLockId: LockIdentifier = [6; 8];
     pub const ContentWorkingGroupLockId: LockIdentifier = [7; 8];
     pub const ForumGroupLockId: LockIdentifier = [8; 8];
+    pub const MembershipWorkingGroupLockId: LockIdentifier = [9; 8];
 }
 
 // Staking managers type aliases.
@@ -616,6 +621,8 @@ pub type ContentDirectoryWorkingGroupStakingManager =
     staking_handler::StakingManager<Runtime, ContentWorkingGroupLockId>;
 pub type StorageWorkingGroupStakingManager =
     staking_handler::StakingManager<Runtime, StorageWorkingGroupLockId>;
+pub type MembershipWorkingGroupStakingManager =
+    staking_handler::StakingManager<Runtime, MembershipWorkingGroupLockId>;
 
 impl working_group::Trait<ForumWorkingGroupInstance> for Runtime {
     type Event = Event;
@@ -642,6 +649,15 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Runtime {
     type MemberOriginValidator = MembershipOriginValidator<Self>;
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = ContentWorkingGroupRewardPeriod;
+}
+
+impl working_group::Trait<MembershipWorkingGroupInstance> for Runtime {
+    type Event = Event;
+    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
+    type StakingHandler = MembershipWorkingGroupStakingManager;
+    type MemberOriginValidator = MembershipOriginValidator<Self>;
+    type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
+    type RewardPeriod = MembershipRewardPeriod;
 }
 
 impl service_discovery::Trait for Runtime {
@@ -804,5 +820,6 @@ construct_runtime!(
         ForumWorkingGroup: working_group::<Instance1>::{Module, Call, Storage, Event<T>},
         StorageWorkingGroup: working_group::<Instance2>::{Module, Call, Storage, Event<T>},
         ContentDirectoryWorkingGroup: working_group::<Instance3>::{Module, Call, Storage, Event<T>},
+        MembershipWorkingGroup: working_group::<Instance4>::{Module, Call, Storage, Event<T>},
     }
 );

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -7,7 +7,6 @@ mod working_group_proposals;
 use crate::{BlockNumber, ProposalCancellationFee, Runtime};
 use codec::Encode;
 use governance::election_params::ElectionParameters;
-use membership;
 use proposals_engine::{
     ApprovedProposalDecision, BalanceOf, Proposal, ProposalCreationParameters, ProposalParameters,
     ProposalStatus, VoteKind, VotersParameters, VotingResults,

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -308,7 +308,7 @@ fn run_create_add_working_group_leader_opening_proposal_execution_succeeds<
 >(
     working_group: WorkingGroup,
 ) where
-    <T as membership::Trait>::MemberId: From<u64>,
+    <T as common::Trait>::MemberId: From<u64>,
 {
     initial_test_ext().execute_with(|| {
         let member_id: MemberId = 1;
@@ -365,8 +365,8 @@ fn run_create_fill_working_group_leader_opening_proposal_execution_succeeds<
     working_group: WorkingGroup,
 ) where
     <T as frame_system::Trait>::AccountId: From<[u8; 32]>,
-    <T as membership::Trait>::MemberId: From<u64>,
-    working_group::MemberId<T>: From<u64>,
+    <T as common::Trait>::MemberId: From<u64>,
+    common::MemberId<T>: From<u64>,
 {
     initial_test_ext().execute_with(|| {
         let member_id: u64 = 1;
@@ -440,15 +440,15 @@ fn create_decrease_group_leader_stake_proposal_execution_succeeds() {
 }
 
 fn run_create_decrease_group_leader_stake_proposal_execution_succeeds<
-    T: working_group::Trait<I> + frame_system::Trait + membership::Trait + pallet_balances::Trait,
+    T: working_group::Trait<I> + frame_system::Trait + common::Trait + pallet_balances::Trait,
     I: frame_support::traits::Instance,
     SM: staking_handler::StakingHandler<T>,
 >(
     working_group: WorkingGroup,
 ) where
     <T as frame_system::Trait>::AccountId: From<[u8; 32]>,
-    <T as membership::Trait>::MemberId: From<u64>,
-    <T as membership::Trait>::ActorId: Into<u64>,
+    <T as common::Trait>::MemberId: From<u64>,
+    <T as common::Trait>::ActorId: Into<u64>,
     <T as pallet_balances::Trait>::Balance: From<u128>,
 {
     initial_test_ext().execute_with(|| {
@@ -565,8 +565,8 @@ fn run_create_slash_group_leader_stake_proposal_execution_succeeds<
     working_group: WorkingGroup,
 ) where
     <T as frame_system::Trait>::AccountId: From<[u8; 32]>,
-    <T as membership::Trait>::MemberId: From<u64>,
-    <T as membership::Trait>::ActorId: Into<u64>,
+    <T as common::Trait>::MemberId: From<u64>,
+    <T as common::Trait>::ActorId: Into<u64>,
     <T as pallet_balances::Trait>::Balance: From<u128>,
 {
     initial_test_ext().execute_with(|| {
@@ -680,7 +680,7 @@ fn run_create_set_working_group_mint_capacity_proposal_execution_succeeds<
     working_group: WorkingGroup,
 ) where
     <T as frame_system::Trait>::AccountId: From<[u8; 32]>,
-    <T as membership::Trait>::MemberId: From<u64>,
+    <T as common::Trait>::MemberId: From<u64>,
     <T as minting::Trait>::MintId: From<u64>,
     working_group::BalanceOf<T>: From<u128>,
 {
@@ -732,8 +732,8 @@ fn run_create_set_group_leader_reward_proposal_execution_succeeds<
     working_group: WorkingGroup,
 ) where
     <T as frame_system::Trait>::AccountId: From<[u8; 32]>,
-    <T as membership::Trait>::MemberId: From<u64>,
-    <T as membership::Trait>::ActorId: Into<u64>,
+    <T as common::Trait>::MemberId: From<u64>,
+    <T as common::Trait>::ActorId: Into<u64>,
     <T as minting::Trait>::MintId: From<u64>,
     working_group::BalanceOf<T>: From<u128>,
 {
@@ -834,9 +834,9 @@ fn run_create_terminate_group_leader_role_proposal_execution_succeeds<
     working_group: WorkingGroup,
 ) where
     <T as frame_system::Trait>::AccountId: From<[u8; 32]>,
-    <T as membership::Trait>::MemberId: From<u64>,
-    working_group::MemberId<T>: From<u64>,
-    <T as membership::Trait>::ActorId: Into<u64>,
+    <T as common::Trait>::MemberId: From<u64>,
+    common::MemberId<T>: From<u64>,
+    <T as common::Trait>::ActorId: Into<u64>,
     <T as minting::Trait>::MintId: From<u64>,
     <T as pallet_balances::Trait>::Balance: From<u128>,
 {
@@ -953,8 +953,8 @@ fn run_create_terminate_group_leader_role_proposal_with_slashing_execution_succe
     working_group: WorkingGroup,
 ) where
     <T as frame_system::Trait>::AccountId: From<[u8; 32]>,
-    <T as membership::Trait>::MemberId: From<u64>,
-    <T as membership::Trait>::ActorId: Into<u64>,
+    <T as common::Trait>::MemberId: From<u64>,
+    <T as common::Trait>::ActorId: Into<u64>,
     <T as pallet_balances::Trait>::Balance: From<u128>,
 {
     initial_test_ext().execute_with(|| {

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -13,7 +13,8 @@ use crate::primitives::{ActorId, MemberId};
 use crate::{
     Balance, BlockNumber, ContentDirectoryWorkingGroup, ContentDirectoryWorkingGroupInstance,
     ContentDirectoryWorkingGroupStakingManager, ForumWorkingGroup, ForumWorkingGroupInstance,
-    ForumWorkingGroupStakingManager, StorageWorkingGroup, StorageWorkingGroupInstance,
+    ForumWorkingGroupStakingManager, MembershipWorkingGroup, MembershipWorkingGroupInstance,
+    MembershipWorkingGroupStakingManager, StorageWorkingGroup, StorageWorkingGroupInstance,
     StorageWorkingGroupStakingManager,
 };
 
@@ -51,6 +52,14 @@ fn add_opening(
             assert!(!<working_group::OpeningById<
                 Runtime,
                 ForumWorkingGroupInstance,
+            >>::contains_key(opening_id));
+            opening_id
+        }
+        WorkingGroup::Membership => {
+            let opening_id = MembershipWorkingGroup::next_opening_id();
+            assert!(!<working_group::OpeningById<
+                Runtime,
+                MembershipWorkingGroupInstance,
             >>::contains_key(opening_id));
             opening_id
         }
@@ -298,6 +307,12 @@ fn create_add_working_group_leader_opening_proposal_execution_succeeds() {
                     ForumWorkingGroupInstance,
                 >(group);
             }
+            WorkingGroup::Membership => {
+                run_create_add_working_group_leader_opening_proposal_execution_succeeds::<
+                    Runtime,
+                    MembershipWorkingGroupInstance,
+                >(group);
+            }
         }
     }
 }
@@ -352,6 +367,12 @@ fn create_fill_working_group_leader_opening_proposal_execution_succeeds() {
                 run_create_fill_working_group_leader_opening_proposal_execution_succeeds::<
                     Runtime,
                     ForumWorkingGroupInstance,
+                >(group);
+            }
+            WorkingGroup::Membership => {
+                run_create_fill_working_group_leader_opening_proposal_execution_succeeds::<
+                    Runtime,
+                    MembershipWorkingGroupInstance,
                 >(group);
             }
         }
@@ -433,6 +454,13 @@ fn create_decrease_group_leader_stake_proposal_execution_succeeds() {
                     Runtime,
                     ForumWorkingGroupInstance,
                     ForumWorkingGroupStakingManager,
+                >(group);
+            }
+            WorkingGroup::Membership => {
+                run_create_decrease_group_leader_stake_proposal_execution_succeeds::<
+                    Runtime,
+                    MembershipWorkingGroupInstance,
+                    MembershipWorkingGroupStakingManager,
                 >(group);
             }
         }
@@ -553,6 +581,13 @@ fn create_slash_group_leader_stake_proposal_execution_succeeds() {
                     ForumWorkingGroupStakingManager,
                 >(group)
             }
+            WorkingGroup::Membership => {
+                run_create_slash_group_leader_stake_proposal_execution_succeeds::<
+                    Runtime,
+                    MembershipWorkingGroupInstance,
+                    MembershipWorkingGroupStakingManager,
+                >(group)
+            }
         }
     }
 }
@@ -669,6 +704,12 @@ fn create_set_working_group_mint_capacity_proposal_execution_succeeds() {
                     ForumWorkingGroupInstance,
                 >(group);
             }
+            WorkingGroup::Membership => {
+                run_create_set_working_group_mint_capacity_proposal_execution_succeeds::<
+                    Runtime,
+                    MembershipWorkingGroupInstance,
+                >(group);
+            }
         }
     }
 }
@@ -719,6 +760,12 @@ fn create_set_group_leader_reward_proposal_execution_succeeds() {
                 run_create_set_working_group_mint_capacity_proposal_execution_succeeds::<
                     Runtime,
                     ForumWorkingGroupInstance,
+                >(group);
+            }
+            WorkingGroup::Membership => {
+                run_create_set_working_group_mint_capacity_proposal_execution_succeeds::<
+                    Runtime,
+                    MembershipWorkingGroupInstance,
                 >(group);
             }
         }
@@ -820,6 +867,13 @@ fn create_terminate_group_leader_role_proposal_execution_succeeds() {
                     Runtime,
                     ForumWorkingGroupInstance,
                     ForumWorkingGroupStakingManager,
+                >(group);
+            }
+            WorkingGroup::Membership => {
+                run_create_terminate_group_leader_role_proposal_execution_succeeds::<
+                    Runtime,
+                    MembershipWorkingGroupInstance,
+                    MembershipWorkingGroupStakingManager,
                 >(group);
             }
         }
@@ -939,6 +993,13 @@ fn create_terminate_group_leader_role_proposal_with_slashing_execution_succeeds(
                     Runtime,
                     ForumWorkingGroupInstance,
                     ForumWorkingGroupStakingManager,
+                >(group);
+            }
+            WorkingGroup::Membership => {
+                run_create_terminate_group_leader_role_proposal_with_slashing_execution_succeeds::<
+                    Runtime,
+                    MembershipWorkingGroupInstance,
+                    MembershipWorkingGroupStakingManager,
                 >(group);
             }
         }

--- a/utils/chain-spec-builder/Cargo.toml
+++ b/utils/chain-spec-builder/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'chain-spec-builder'
-version = '3.1.1'
+version = '4.0.0'
 
 [dependencies]
 enum-utils = "0.1.2"


### PR DESCRIPTION
### Changes
- membership working group was added with all dependencies
- membershp pallet error style was changed from the strings to the `decl_error` macro.
- runtime version was bumped
- chain-spec-builder version was bumped
- `MemberId` and `ActorId` were moved to the newly created `common::Trait` from the membership module in order to remove cyclic dependencies with the working group pallet. As a result, the dependency on the membership module is decreased among the runtime pallets.
- `working_group::Interface` trait prototype was added 

[Main PR issue](https://github.com/Joystream/joystream/issues/1781)

### Comments
- The usage of the working group is different in the pallets Storage, Content Directory, Forum (and Membership)
- `working_group::Interface` trait is the prototype for the [working-group interface unification](https://github.com/Joystream/joystream/issues/1884)