### PR TITLE
content-directory: set initial ids to 1 on runtime upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "7.8.0"
+version = "7.9.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/runtime-modules/content-directory/src/lib.rs
+++ b/runtime-modules/content-directory/src/lib.rs
@@ -2864,6 +2864,14 @@ impl<T: Trait> Module<T> {
     }
 }
 
+impl<T: Trait> Module<T> {
+    pub fn set_initial_ids_to_one() {
+        <NextEntityId<T>>::put(T::EntityId::one());
+        <NextClassId<T>>::put(T::ClassId::one());
+        <NextCuratorGroupId<T>>::put(T::CuratorGroupId::one());
+    }
+}
+
 decl_event!(
     pub enum Event<T>
     where

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '7.8.0'
+version = '7.9.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -75,7 +75,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 7,
-    spec_version: 8,
+    spec_version: 9,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -13,8 +13,8 @@ use sp_std::vec::Vec;
 use crate::constants::PRIMARY_PROBABILITY;
 use crate::integration::content_directory::ContentDirectoryWorkingGroup;
 use crate::{
-    AccountId, AuthorityDiscoveryId, Balance, BlockNumber, EpochDuration, GrandpaAuthorityList,
-    GrandpaId, Hash, Index, RuntimeVersion, Signature, VERSION,
+    content_directory, AccountId, AuthorityDiscoveryId, Balance, BlockNumber, EpochDuration,
+    GrandpaAuthorityList, GrandpaId, Hash, Index, RuntimeVersion, Signature, VERSION,
 };
 use crate::{
     AllModules, AuthorityDiscovery, Babe, Call, Grandpa, Historical, InherentDataExt,
@@ -69,6 +69,10 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
             default_text_constraint,
             default_content_working_group_mint_capacity,
         );
+
+        // Next Id's are configured at genesis. Our applications are harcoded to expect initial
+        // values of the ids to start at 1
+        content_directory::Module::<Runtime>::set_initial_ids_to_one();
 
         10_000_000 // TODO: adjust weight
     }

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -70,8 +70,9 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
             default_content_working_group_mint_capacity,
         );
 
-        // Next Id's are configured at genesis. Our applications are harcoded to expect initial
-        // values of the ids to start at 1
+        // Next Id's are configured at genesis. Applications and tools are harcoded to expect initial
+        // values of the ids to start at 1. With a runtime upgrade the initial values will not be
+        // configured and get an initial default value of zero. This corrects this problem.
         content_directory::Module::<Runtime>::set_initial_ids_to_one();
 
         10_000_000 // TODO: adjust weight


### PR DESCRIPTION
Next Id's are configured at genesis. 
Our applications and tools are hardcoded to expect initial values of the ids to start at 1.
With a runtime upgrade the initial values will not be configured and get an initial default value of zero. 
This corrects this problem by setting them to `one` on runtime upgrade.