### PR TITLE
DRY proposal creation

### DIFF
--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -74,14 +74,12 @@ pub use crate::proposal_types::{
     AddOpeningParameters, FillOpeningParameters, TerminateRoleParameters,
 };
 use common::origin::ActorOriginValidator;
-use common::working_group::WorkingGroup;
 use common::MemberId;
 pub use proposal_types::{ProposalDetails, ProposalDetailsOf, ProposalEncoder};
 use proposals_discussion::ThreadMode;
 use proposals_engine::{
     BalanceOf, ProposalCreationParameters, ProposalObserver, ProposalParameters,
 };
-use working_group::Penalty;
 
 // 'Set working group budget capacity' proposal limit
 const WORKING_GROUP_BUDGET_CAPACITY_MAX_VALUE: u32 = 5_000_000;
@@ -90,31 +88,21 @@ const MAX_SPENDING_PROPOSAL_VALUE: u32 = 5_000_000_u32;
 // Max validator count for the 'set validator count' proposal
 const MAX_VALIDATOR_COUNT: u32 = 100;
 
-// Data container struct to fix linter warning 'too many arguments for the function' for the
-// create_proposal() function.
-struct CreateProposalParameters<T: Trait> {
-    pub origin: T::Origin,
-    pub member_id: MemberId<T>,
-    pub title: Vec<u8>,
-    pub description: Vec<u8>,
-    pub staking_account_id: Option<T::AccountId>,
-    pub proposal_code: Vec<u8>,
-    pub proposal_parameters: ProposalParameters<T::BlockNumber, BalanceOf<T>>,
-    pub proposal_details: ProposalDetailsOf<T>,
-    pub exact_execution_block: Option<T::BlockNumber>,
-}
-
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Debug, Default, Clone, PartialEq, Eq)]
-pub struct GeneralProposalParams<MemberId, AccountId> {
+pub struct GeneralProposalParams<MemberId, AccountId, BlockNumber> {
     pub member_id: MemberId,
     pub title: Vec<u8>,
     pub description: Vec<u8>,
     pub staking_account_id: Option<AccountId>,
+    pub exact_execution_block: Option<BlockNumber>,
 }
 
-pub type GeneralProposalParameters<T> =
-    GeneralProposalParams<MemberId<T>, <T as frame_system::Trait>::AccountId>;
+pub type GeneralProposalParameters<T> = GeneralProposalParams<
+    MemberId<T>,
+    <T as frame_system::Trait>::AccountId,
+    <T as frame_system::Trait>::BlockNumber,
+>;
 
 /// 'Proposals codex' substrate module Trait
 pub trait Trait:
@@ -324,360 +312,57 @@ decl_module! {
         const AmendConstitutionProposalParameters: ProposalParameters<T::BlockNumber, BalanceOf<T>>
             = T::AmendConstitutionProposalParameters::get();
 
-
-        /// Create 'Text (signal)' proposal type.
+        /// Create a proposal, the type of proposal depends on the `proposal_details` variant
         #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_text_proposal(
+        pub fn create_proposal(
             origin,
             general_proposal_parameters: GeneralProposalParameters<T>,
-            text: Vec<u8>,
-            exact_execution_block: Option<T::BlockNumber>,
+            proposal_details: ProposalDetailsOf<T>,
         ) {
-            ensure!(!text.is_empty(), Error::<T>::TextProposalIsEmpty);
+            Self::ensure_details_checks(&proposal_details)?;
 
-            let proposal_details = ProposalDetails::Text(text);
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
+            let proposal_parameters = Self::get_proposal_parameters(&proposal_details);
+            let proposal_code = T::ProposalEncoder::encode_proposal(proposal_details.clone());
+
+            let account_id =
+                T::MembershipOriginValidator::ensure_actor_origin(
+                    origin,
+                    general_proposal_parameters.member_id
+                )?;
+
+            <proposals_engine::Module<T>>::ensure_create_proposal_parameters_are_valid(
+                &proposal_parameters,
+                &general_proposal_parameters.title,
+                &general_proposal_parameters.description,
+                general_proposal_parameters.staking_account_id.clone(),
+                general_proposal_parameters.exact_execution_block,
+            )?;
+
+            let initial_thread_mode = ThreadMode::Open;
+            <proposals_discussion::Module<T>>::ensure_can_create_thread(&initial_thread_mode)?;
+
+            let discussion_thread_id = <proposals_discussion::Module<T>>::create_thread(
+                general_proposal_parameters.member_id,
+                initial_thread_mode,
+            )?;
+
+            let proposal_creation_params = ProposalCreationParameters {
+                account_id,
+                proposer_id: general_proposal_parameters.member_id,
+                proposal_parameters,
                 title: general_proposal_parameters.title,
                 description: general_proposal_parameters.description,
                 staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::TextProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block
+                encoded_dispatchable_call_code: proposal_code,
+                exact_execution_block: general_proposal_parameters.exact_execution_block,
             };
 
-            Self::create_proposal(params)?;
+            let proposal_id =
+                <proposals_engine::Module<T>>::create_proposal(proposal_creation_params)?;
+
+            <ThreadIdByProposalId<T>>::insert(proposal_id, discussion_thread_id);
+            <ProposalDetailsByProposalId<T>>::insert(proposal_id, proposal_details);
         }
-
-        /// Create 'Runtime upgrade' proposal type. Runtime upgrade can be initiated only by
-        /// members from the hardcoded list `RuntimeUpgradeProposalAllowedProposers`
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_runtime_upgrade_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            wasm: Vec<u8>,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            ensure!(!wasm.is_empty(), Error::<T>::RuntimeProposalIsEmpty);
-
-            let proposal_details = ProposalDetails::RuntimeUpgrade(wasm);
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::RuntimeUpgradeProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'Spending' proposal type.
-        /// This proposal uses `spend_from_council_mint()` extrinsic from the `governance::council`  module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_spending_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            balance: BalanceOfMint<T>,
-            destination: T::AccountId,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            ensure!(balance != BalanceOfMint::<T>::zero(), Error::<T>::InvalidSpendingProposalBalance);
-            ensure!(
-                balance <= <BalanceOfMint<T>>::from(MAX_SPENDING_PROPOSAL_VALUE),
-                Error::<T>::InvalidSpendingProposalBalance
-            );
-
-            let proposal_details = ProposalDetails::Spending(balance, destination);
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::SpendingProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'Evict storage provider' proposal type.
-        /// This proposal uses `set_validator_count()` extrinsic from the Substrate `staking`  module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_set_validator_count_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            new_validator_count: u32,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            ensure!(
-                new_validator_count >= <staking::Module<T>>::minimum_validator_count(),
-                Error::<T>::InvalidValidatorCount
-            );
-
-            ensure!(
-                new_validator_count <= MAX_VALIDATOR_COUNT,
-                Error::<T>::InvalidValidatorCount
-            );
-
-            let proposal_details = ProposalDetails::SetValidatorCount(new_validator_count);
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::SetValidatorCountProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'Add working group leader opening' proposal type.
-        /// This proposal uses `add_opening()` extrinsic from the Joystream `working group` module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_add_working_group_leader_opening_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            add_opening_parameters: AddOpeningParameters<T::BlockNumber, BalanceOfGovernanceCurrency<T>>,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            let proposal_details = ProposalDetails::AddWorkingGroupLeaderOpening(add_opening_parameters);
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters. title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::AddWorkingGroupOpeningProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'Fill working group leader opening' proposal type.
-        /// This proposal uses `fill_opening()` extrinsic from the Joystream `working group` module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_fill_working_group_leader_opening_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            fill_opening_parameters: FillOpeningParameters,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            let proposal_details = ProposalDetails::FillWorkingGroupLeaderOpening(fill_opening_parameters);
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::FillWorkingGroupOpeningProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'Set working group budget capacity' proposal type.
-        /// This proposal uses `set_mint_capacity()` extrinsic from the `working-group`  module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_set_working_group_budget_capacity_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            mint_balance: BalanceOfMint<T>,
-            working_group: WorkingGroup,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            ensure!(
-                mint_balance <= <BalanceOfMint<T>>::from(WORKING_GROUP_BUDGET_CAPACITY_MAX_VALUE),
-                Error::<T>::InvalidWorkingGroupBudgetCapacity
-            );
-
-            let proposal_details = ProposalDetails::SetWorkingGroupBudgetCapacity(mint_balance, working_group);
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::SetWorkingGroupBudgetCapacityProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'decrease working group leader stake' proposal type.
-        /// This proposal uses `decrease_stake()` extrinsic from the `working-group`  module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_decrease_working_group_leader_stake_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            worker_id: working_group::WorkerId<T>,
-            decreasing_stake: BalanceOf<T>,
-            working_group: WorkingGroup,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            ensure!(decreasing_stake != Zero::zero(), Error::<T>::DecreasingStakeIsZero);
-
-            let proposal_details = ProposalDetails::DecreaseWorkingGroupLeaderStake(
-                worker_id,
-                decreasing_stake,
-                working_group
-            );
-
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::DecreaseWorkingGroupLeaderStakeProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'slash working group leader stake' proposal type.
-        /// This proposal uses `slash_stake()` extrinsic from the `working-group`  module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_slash_working_group_leader_stake_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            worker_id: working_group::WorkerId<T>,
-            penalty: Penalty<BalanceOf<T>>,
-            working_group: WorkingGroup,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            ensure!(penalty.slashing_amount != Zero::zero(), Error::<T>::SlashingStakeIsZero);
-
-            let proposal_details = ProposalDetails::SlashWorkingGroupLeaderStake(
-                worker_id,
-                penalty,
-                working_group
-            );
-
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::SlashWorkingGroupLeaderStakeProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'set working group leader reward' proposal type.
-        /// This proposal uses `update_reward_amount()` extrinsic from the `working-group`  module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_set_working_group_leader_reward_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            worker_id: working_group::WorkerId<T>,
-            reward_amount: Option<BalanceOfMint<T>>,
-            working_group: WorkingGroup,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            let proposal_details = ProposalDetails::SetWorkingGroupLeaderReward(
-                worker_id,
-                reward_amount,
-                working_group
-            );
-
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::SetWorkingGroupLeaderRewardProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'terminate working group leader role' proposal type.
-        /// This proposal uses `terminate_role()` extrinsic from the `working-group`  module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_terminate_working_group_leader_role_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            terminate_role_parameters: TerminateRoleParameters<working_group::WorkerId<T>, BalanceOf<T>>,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            let proposal_details = ProposalDetails::TerminateWorkingGroupLeaderRole(terminate_role_parameters);
-
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::TerminateWorkingGroupLeaderRoleProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
-        /// Create 'amend constitution' proposal type.
-        /// This proposal uses `amend_constitution()` extrinsic from the `constitution`  module.
-        #[weight = 10_000_000] // TODO: adjust weight
-        pub fn create_amend_constitution_proposal(
-            origin,
-            general_proposal_parameters: GeneralProposalParameters<T>,
-            constitution_text: Vec<u8>,
-            exact_execution_block: Option<T::BlockNumber>,
-        ) {
-            let proposal_details = ProposalDetails::AmendConstitution(constitution_text);
-
-            let params = CreateProposalParameters{
-                origin,
-                member_id: general_proposal_parameters.member_id,
-                title: general_proposal_parameters.title,
-                description: general_proposal_parameters.description,
-                staking_account_id: general_proposal_parameters.staking_account_id,
-                proposal_details: proposal_details.clone(),
-                proposal_parameters: T::AmendConstitutionProposalParameters::get(),
-                proposal_code: T::ProposalEncoder::encode_proposal(proposal_details),
-                exact_execution_block,
-            };
-
-            Self::create_proposal(params)?;
-        }
-
 
 // *************** Extrinsic to execute
 
@@ -714,44 +399,111 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
-    // Generic template proposal builder
-    fn create_proposal(params: CreateProposalParameters<T>) -> DispatchResult {
-        let account_id =
-            T::MembershipOriginValidator::ensure_actor_origin(params.origin, params.member_id)?;
+    // Ensure that the proposal details respects all the checks
+    fn ensure_details_checks(details: &ProposalDetailsOf<T>) -> DispatchResult {
+        match details {
+            ProposalDetails::Text(ref text) => {
+                ensure!(!text.is_empty(), Error::<T>::TextProposalIsEmpty);
+            }
+            ProposalDetails::RuntimeUpgrade(ref wasm) => {
+                ensure!(!wasm.is_empty(), Error::<T>::RuntimeProposalIsEmpty);
+            }
+            ProposalDetails::Spending(ref balance, _) => {
+                ensure!(
+                    *balance != BalanceOfMint::<T>::zero(),
+                    Error::<T>::InvalidSpendingProposalBalance
+                );
+                ensure!(
+                    *balance <= <BalanceOfMint<T>>::from(MAX_SPENDING_PROPOSAL_VALUE),
+                    Error::<T>::InvalidSpendingProposalBalance
+                );
+            }
+            ProposalDetails::SetValidatorCount(ref new_validator_count) => {
+                ensure!(
+                    *new_validator_count >= <staking::Module<T>>::minimum_validator_count(),
+                    Error::<T>::InvalidValidatorCount
+                );
 
-        <proposals_engine::Module<T>>::ensure_create_proposal_parameters_are_valid(
-            &params.proposal_parameters,
-            &params.title,
-            &params.description,
-            params.staking_account_id.clone(),
-            params.exact_execution_block,
-        )?;
-
-        let initial_thread_mode = ThreadMode::Open;
-        <proposals_discussion::Module<T>>::ensure_can_create_thread(&initial_thread_mode)?;
-
-        let discussion_thread_id = <proposals_discussion::Module<T>>::create_thread(
-            params.member_id,
-            initial_thread_mode,
-        )?;
-
-        let proposal_creation_params = ProposalCreationParameters {
-            account_id,
-            proposer_id: params.member_id,
-            proposal_parameters: params.proposal_parameters,
-            title: params.title,
-            description: params.description,
-            staking_account_id: params.staking_account_id,
-            encoded_dispatchable_call_code: params.proposal_code,
-            exact_execution_block: params.exact_execution_block,
-        };
-
-        let proposal_id = <proposals_engine::Module<T>>::create_proposal(proposal_creation_params)?;
-
-        <ThreadIdByProposalId<T>>::insert(proposal_id, discussion_thread_id);
-        <ProposalDetailsByProposalId<T>>::insert(proposal_id, params.proposal_details);
+                ensure!(
+                    *new_validator_count <= MAX_VALIDATOR_COUNT,
+                    Error::<T>::InvalidValidatorCount
+                );
+            }
+            ProposalDetails::AddWorkingGroupLeaderOpening(_) => {
+                // Note: No checks for this proposal for now
+            }
+            ProposalDetails::FillWorkingGroupLeaderOpening(_) => {
+                // Note: No checks for this proposal for now
+            }
+            ProposalDetails::SetWorkingGroupBudgetCapacity(ref mint_balance, _) => {
+                ensure!(
+                    *mint_balance
+                        <= <BalanceOfMint<T>>::from(WORKING_GROUP_BUDGET_CAPACITY_MAX_VALUE),
+                    Error::<T>::InvalidWorkingGroupBudgetCapacity
+                );
+            }
+            ProposalDetails::DecreaseWorkingGroupLeaderStake(_, ref decreasing_stake, _) => {
+                ensure!(
+                    *decreasing_stake != Zero::zero(),
+                    Error::<T>::DecreasingStakeIsZero
+                );
+            }
+            ProposalDetails::SlashWorkingGroupLeaderStake(_, ref penalty, _) => {
+                ensure!(
+                    penalty.slashing_amount != Zero::zero(),
+                    Error::<T>::SlashingStakeIsZero
+                );
+            }
+            ProposalDetails::SetWorkingGroupLeaderReward(_, _, _) => {
+                // Note: No checks for this proposal for now
+            }
+            ProposalDetails::TerminateWorkingGroupLeaderRole(_) => {
+                // Note: No checks for this proposal for now
+            }
+            ProposalDetails::AmendConstitution(_) => {
+                // Note: No checks for this proposal for now
+            }
+        }
 
         Ok(())
+    }
+
+    // Returns the proposal parameters according to ProposalDetials
+    fn get_proposal_parameters(
+        details: &ProposalDetailsOf<T>,
+    ) -> ProposalParameters<T::BlockNumber, BalanceOf<T>> {
+        match details {
+            ProposalDetailsOf::<T>::Text(_) => T::TextProposalParameters::get(),
+            ProposalDetailsOf::<T>::RuntimeUpgrade(_) => T::RuntimeUpgradeProposalParameters::get(),
+            ProposalDetailsOf::<T>::Spending(_, _) => T::SpendingProposalParameters::get(),
+            ProposalDetailsOf::<T>::SetValidatorCount(_) => {
+                T::SetValidatorCountProposalParameters::get()
+            }
+            ProposalDetailsOf::<T>::AddWorkingGroupLeaderOpening(_) => {
+                T::AddWorkingGroupOpeningProposalParameters::get()
+            }
+            ProposalDetailsOf::<T>::FillWorkingGroupLeaderOpening(_) => {
+                T::FillWorkingGroupOpeningProposalParameters::get()
+            }
+            ProposalDetailsOf::<T>::SetWorkingGroupBudgetCapacity(_, _) => {
+                T::SetWorkingGroupBudgetCapacityProposalParameters::get()
+            }
+            ProposalDetailsOf::<T>::DecreaseWorkingGroupLeaderStake(_, _, _) => {
+                T::DecreaseWorkingGroupLeaderStakeProposalParameters::get()
+            }
+            ProposalDetailsOf::<T>::SlashWorkingGroupLeaderStake(_, _, _) => {
+                T::SlashWorkingGroupLeaderStakeProposalParameters::get()
+            }
+            ProposalDetailsOf::<T>::SetWorkingGroupLeaderReward(_, _, _) => {
+                T::SetWorkingGroupLeaderRewardProposalParameters::get()
+            }
+            ProposalDetailsOf::<T>::TerminateWorkingGroupLeaderRole(_) => {
+                T::TerminateWorkingGroupLeaderRoleProposalParameters::get()
+            }
+            ProposalDetailsOf::<T>::AmendConstitution(_) => {
+                T::AmendConstitutionProposalParameters::get()
+            }
+        }
     }
 }
 

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -7,6 +7,7 @@ use frame_system::RawOrigin;
 
 use common::working_group::WorkingGroup;
 use proposals_engine::ProposalParameters;
+use working_group::Penalty;
 
 use crate::*;
 use crate::{Error, ProposalDetails};
@@ -97,6 +98,7 @@ fn create_text_proposal_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -104,35 +106,35 @@ fn create_text_proposal_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
+
+        let text_proposal_details = ProposalDetails::Text(b"text".to_vec());
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_text_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    b"text".to_vec(),
-                    None,
+                    text_proposal_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_text_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    b"text".to_vec(),
-                    None,
+                    text_proposal_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_text_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    b"text".to_vec(),
-                    None,
+                    text_proposal_details.clone(),
                 )
             },
             proposal_parameters: <Test as crate::Trait>::TextProposalParameters::get(),
-            proposal_details: ProposalDetails::Text(b"text".to_vec()),
+            proposal_details: text_proposal_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -146,14 +148,14 @@ fn create_text_proposal_codex_call_fails_without_text() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         assert_eq!(
-            ProposalCodex::create_text_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),
                 general_proposal_parameters.clone(),
-                Vec::new(),
-                None,
+                ProposalDetails::Text(Vec::new()),
             ),
             Err(Error::<Test>::TextProposalIsEmpty.into())
         );
@@ -170,6 +172,7 @@ fn create_runtime_upgrade_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -177,35 +180,35 @@ fn create_runtime_upgrade_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
+
+        let proposal_details_upgrade = ProposalDetails::RuntimeUpgrade(b"wasm".to_vec());
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_runtime_upgrade_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    b"wasm".to_vec(),
-                    None,
+                    proposal_details_upgrade.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_runtime_upgrade_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    b"wasm".to_vec(),
-                    None,
+                    proposal_details_upgrade.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_runtime_upgrade_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    b"wasm".to_vec(),
-                    None,
+                    proposal_details_upgrade.clone(),
                 )
             },
             proposal_parameters: <Test as crate::Trait>::RuntimeUpgradeProposalParameters::get(),
-            proposal_details: ProposalDetails::RuntimeUpgrade(b"wasm".to_vec()),
+            proposal_details: proposal_details_upgrade.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -219,14 +222,14 @@ fn create_upgrade_runtime_proposal_codex_call_fails_with_empty_wasm() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         assert_eq!(
-            ProposalCodex::create_runtime_upgrade_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),
                 general_proposal_parameters.clone(),
-                Vec::new(),
-                None,
+                ProposalDetails::RuntimeUpgrade(Vec::new()),
             ),
             Err(Error::<Test>::RuntimeProposalIsEmpty.into())
         );
@@ -243,6 +246,7 @@ fn create_spending_proposal_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -250,38 +254,36 @@ fn create_spending_proposal_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
+
+        let spending_proposal_details = ProposalDetails::Spending(20, 10);
+        let spending_proposal_details_succesful = ProposalDetails::Spending(100, 2);
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_spending_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    20,
-                    10,
-                    None,
+                    spending_proposal_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_spending_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    20,
-                    10,
-                    None,
+                    spending_proposal_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_spending_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    100,
-                    2,
-                    None,
+                    spending_proposal_details_succesful.clone(),
                 )
             },
             proposal_parameters: <Test as crate::Trait>::SpendingProposalParameters::get(),
-            proposal_details: ProposalDetails::Spending(100, 2),
+            proposal_details: spending_proposal_details_succesful.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -297,26 +299,23 @@ fn create_spending_proposal_call_fails_with_incorrect_balance() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
 
         assert_eq!(
-            ProposalCodex::create_spending_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),
                 general_proposal_parameters.clone(),
-                0,
-                2,
-                None,
+                ProposalDetails::Spending(0, 2),
             ),
             Err(Error::<Test>::InvalidSpendingProposalBalance.into())
         );
 
         assert_eq!(
-            ProposalCodex::create_spending_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),
                 general_proposal_parameters.clone(),
-                5000001,
-                2,
-                None,
+                ProposalDetails::Spending(5000001, 2),
             ),
             Err(Error::<Test>::InvalidSpendingProposalBalance.into())
         );
@@ -333,6 +332,7 @@ fn create_set_validator_count_proposal_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -340,35 +340,35 @@ fn create_set_validator_count_proposal_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
+
+        let validator_count_details = ProposalDetails::SetValidatorCount(4);
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_set_validator_count_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    4,
-                    None,
+                    validator_count_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_set_validator_count_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    4,
-                    None,
+                    validator_count_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_set_validator_count_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    4,
-                    None,
+                    validator_count_details.clone(),
                 )
             },
             proposal_parameters: <Test as crate::Trait>::SetValidatorCountProposalParameters::get(),
-            proposal_details: ProposalDetails::SetValidatorCount(4),
+            proposal_details: validator_count_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -384,14 +384,14 @@ fn create_set_validator_count_proposal_failed_with_invalid_validator_count() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(<BalanceOf<Test>>::from(100_000_u32)),
+            exact_execution_block: None,
         };
 
         assert_eq!(
-            ProposalCodex::create_set_validator_count_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),
                 general_proposal_parameters.clone(),
-                3,
-                None,
+                ProposalDetails::SetValidatorCount(3),
             ),
             Err(Error::<Test>::InvalidValidatorCount.into())
         );
@@ -415,6 +415,7 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -422,6 +423,7 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
 
         let add_opening_parameters = AddOpeningParameters {
@@ -431,38 +433,36 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(
             working_group,
         };
 
+        let add_leader_details =
+            ProposalDetails::AddWorkingGroupLeaderOpening(add_opening_parameters);
+
         increase_total_balance_issuance_using_account_id(1, 500000);
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_add_working_group_leader_opening_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    add_opening_parameters.clone(),
-                    None,
+                    add_leader_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_add_working_group_leader_opening_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    add_opening_parameters.clone(),
-                    None,
+                    add_leader_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_add_working_group_leader_opening_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    add_opening_parameters.clone(),
-                    None,
+                    add_leader_details.clone(),
                 )
             },
             proposal_parameters:
                 <Test as crate::Trait>::AddWorkingGroupOpeningProposalParameters::get(),
-            proposal_details: ProposalDetails::AddWorkingGroupLeaderOpening(
-                add_opening_parameters.clone(),
-            ),
+            proposal_details: add_leader_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -487,6 +487,7 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -494,6 +495,7 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
 
         let fill_opening_parameters = FillOpeningParameters {
@@ -502,38 +504,36 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
             working_group,
         };
 
+        let fill_opening_details =
+            ProposalDetails::FillWorkingGroupLeaderOpening(fill_opening_parameters);
+
         increase_total_balance_issuance_using_account_id(1, 500000);
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_fill_working_group_leader_opening_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    fill_opening_parameters.clone(),
-                    None,
+                    fill_opening_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_fill_working_group_leader_opening_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    fill_opening_parameters.clone(),
-                    None,
+                    fill_opening_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_fill_working_group_leader_opening_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    fill_opening_parameters.clone(),
-                    None,
+                    fill_opening_details.clone(),
                 )
             },
             proposal_parameters:
                 <Test as crate::Trait>::FillWorkingGroupOpeningProposalParameters::get(),
-            proposal_details: ProposalDetails::FillWorkingGroupLeaderOpening(
-                fill_opening_parameters.clone(),
-            ),
+            proposal_details: fill_opening_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -558,15 +558,17 @@ fn run_create_working_group_mint_capacity_proposal_fails_with_invalid_parameters
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
 
         assert_eq!(
-            ProposalCodex::create_set_working_group_budget_capacity_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),
                 general_proposal_parameters.clone(),
-                (crate::WORKING_GROUP_BUDGET_CAPACITY_MAX_VALUE + 1) as u64,
-                working_group,
-                None,
+                ProposalDetails::SetWorkingGroupBudgetCapacity(
+                    (crate::WORKING_GROUP_BUDGET_CAPACITY_MAX_VALUE + 1) as u64,
+                    working_group,
+                ),
             ),
             Err(Error::<Test>::InvalidWorkingGroupBudgetCapacity.into())
         );
@@ -592,6 +594,7 @@ fn run_create_set_working_group_mint_capacity_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -599,39 +602,39 @@ fn run_create_set_working_group_mint_capacity_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
+
+        let budget_capacity_details =
+            ProposalDetails::SetWorkingGroupBudgetCapacity(0, working_group);
+        let budget_capacity_details_success =
+            ProposalDetails::SetWorkingGroupBudgetCapacity(0, working_group);
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_set_working_group_budget_capacity_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    0,
-                    working_group,
-                    None,
+                    budget_capacity_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_set_working_group_budget_capacity_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    0,
-                    working_group,
-                    None,
+                    budget_capacity_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_set_working_group_budget_capacity_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    10,
-                    working_group,
-                    None,
+                    budget_capacity_details_success.clone(),
                 )
             },
             proposal_parameters:
                 <Test as crate::Trait>::SetWorkingGroupBudgetCapacityProposalParameters::get(),
-            proposal_details: ProposalDetails::SetWorkingGroupBudgetCapacity(10, working_group),
+            proposal_details: budget_capacity_details_success.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -656,6 +659,7 @@ fn run_create_decrease_working_group_leader_stake_proposal_common_checks_succeed
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -663,46 +667,40 @@ fn run_create_decrease_working_group_leader_stake_proposal_common_checks_succeed
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
+
+        let decrease_lead_stake_details =
+            ProposalDetails::DecreaseWorkingGroupLeaderStake(0, 10, working_group);
+
+        let decrease_lead_stake_details_success =
+            ProposalDetails::DecreaseWorkingGroupLeaderStake(10, 10, working_group);
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_decrease_working_group_leader_stake_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    0,
-                    10,
-                    working_group,
-                    None,
+                    decrease_lead_stake_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_decrease_working_group_leader_stake_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    0,
-                    10,
-                    working_group,
-                    None,
+                    decrease_lead_stake_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_decrease_working_group_leader_stake_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    10,
-                    10,
-                    working_group,
-                    None,
+                    decrease_lead_stake_details_success.clone(),
                 )
             },
             proposal_parameters:
                 <Test as crate::Trait>::DecreaseWorkingGroupLeaderStakeProposalParameters::get(),
-            proposal_details: ProposalDetails::DecreaseWorkingGroupLeaderStake(
-                10,
-                10,
-                working_group,
-            ),
+            proposal_details: decrease_lead_stake_details_success.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -727,6 +725,7 @@ fn run_create_slash_working_group_leader_stake_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -734,58 +733,52 @@ fn run_create_slash_working_group_leader_stake_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
+
+        let slash_lead_details = ProposalDetails::SlashWorkingGroupLeaderStake(
+            0,
+            Penalty {
+                slashing_amount: 10,
+                slashing_text: Vec::new(),
+            },
+            working_group,
+        );
+
+        let slash_lead_details_success = ProposalDetails::SlashWorkingGroupLeaderStake(
+            10,
+            Penalty {
+                slashing_amount: 10,
+                slashing_text: Vec::new(),
+            },
+            working_group,
+        );
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_slash_working_group_leader_stake_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    0,
-                    Penalty {
-                        slashing_amount: 10,
-                        slashing_text: Vec::new(),
-                    },
-                    working_group,
-                    None,
+                    slash_lead_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_slash_working_group_leader_stake_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    0,
-                    Penalty {
-                        slashing_amount: 10,
-                        slashing_text: Vec::new(),
-                    },
-                    working_group,
-                    None,
+                    slash_lead_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_slash_working_group_leader_stake_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    10,
-                    Penalty {
-                        slashing_amount: 10,
-                        slashing_text: Vec::new(),
-                    },
-                    working_group,
-                    None,
+                    slash_lead_details_success.clone(),
                 )
             },
             proposal_parameters:
                 <Test as crate::Trait>::SlashWorkingGroupLeaderStakeProposalParameters::get(),
-            proposal_details: ProposalDetails::SlashWorkingGroupLeaderStake(
-                10,
-                Penalty {
-                    slashing_amount: 10,
-                    slashing_text: Vec::new(),
-                },
-                working_group,
-            ),
+            proposal_details: slash_lead_details_success.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -808,6 +801,7 @@ fn run_slash_stake_with_zero_staking_balance_fails(working_group: WorkingGroup) 
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
 
         let lead_account_id = 20;
@@ -818,16 +812,17 @@ fn run_slash_stake_with_zero_staking_balance_fails(working_group: WorkingGroup) 
         .unwrap();
 
         assert_eq!(
-            ProposalCodex::create_slash_working_group_leader_stake_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),
                 general_proposal_parameters.clone(),
-                10,
-                Penalty {
-                    slashing_amount: 0,
-                    slashing_text: Vec::new()
-                },
-                working_group,
-                None,
+                ProposalDetails::SlashWorkingGroupLeaderStake(
+                    10,
+                    Penalty {
+                        slashing_amount: 0,
+                        slashing_text: Vec::new()
+                    },
+                    working_group,
+                )
             ),
             Err(Error::<Test>::SlashingStakeIsZero.into())
         );
@@ -851,6 +846,7 @@ fn run_decrease_stake_with_zero_staking_balance_fails(working_group: WorkingGrou
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
 
         let lead_account_id = 20;
@@ -861,13 +857,10 @@ fn run_decrease_stake_with_zero_staking_balance_fails(working_group: WorkingGrou
         .unwrap();
 
         assert_eq!(
-            ProposalCodex::create_decrease_working_group_leader_stake_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),
-                general_proposal_parameters.clone(),
-                10,
-                0,
-                working_group,
-                None,
+                general_proposal_parameters,
+                ProposalDetails::DecreaseWorkingGroupLeaderStake(10, 0, working_group,)
             ),
             Err(Error::<Test>::DecreasingStakeIsZero.into())
         );
@@ -891,6 +884,7 @@ fn run_create_set_working_group_leader_reward_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -898,46 +892,39 @@ fn run_create_set_working_group_leader_reward_proposal_common_checks_succeed(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
 
+        let set_lead_reward_details =
+            ProposalDetails::SetWorkingGroupLeaderReward(0, Some(10), working_group);
+
+        let set_lead_reward_details_success =
+            ProposalDetails::SetWorkingGroupLeaderReward(10, Some(10), working_group);
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_set_working_group_leader_reward_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    0,
-                    Some(10),
-                    working_group,
-                    None,
+                    set_lead_reward_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_set_working_group_leader_reward_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    0,
-                    Some(10),
-                    working_group,
-                    None,
+                    set_lead_reward_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_set_working_group_leader_reward_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    10,
-                    Some(10),
-                    working_group,
-                    None,
+                    set_lead_reward_details_success.clone(),
                 )
             },
             proposal_parameters:
                 <Test as crate::Trait>::SlashWorkingGroupLeaderStakeProposalParameters::get(),
-            proposal_details: ProposalDetails::SetWorkingGroupLeaderReward(
-                10,
-                Some(10),
-                working_group,
-            ),
+            proposal_details: set_lead_reward_details_success.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -962,6 +949,7 @@ fn run_create_terminate_working_group_leader_role_proposal_common_checks_succeed
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -969,6 +957,7 @@ fn run_create_terminate_working_group_leader_role_proposal_common_checks_succeed
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
 
         let terminate_role_parameters = TerminateRoleParameters {
@@ -977,36 +966,34 @@ fn run_create_terminate_working_group_leader_role_proposal_common_checks_succeed
             working_group,
         };
 
+        let terminate_lead_details =
+            ProposalDetails::TerminateWorkingGroupLeaderRole(terminate_role_parameters);
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_terminate_working_group_leader_role_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    terminate_role_parameters.clone(),
-                    None,
+                    terminate_lead_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_terminate_working_group_leader_role_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    terminate_role_parameters.clone(),
-                    None,
+                    terminate_lead_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_terminate_working_group_leader_role_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    terminate_role_parameters.clone(),
-                    None,
+                    terminate_lead_details.clone(),
                 )
             },
             proposal_parameters:
                 <Test as crate::Trait>::TerminateWorkingGroupLeaderRoleProposalParameters::get(),
-            proposal_details: ProposalDetails::TerminateWorkingGroupLeaderRole(
-                terminate_role_parameters.clone(),
-            ),
+            proposal_details: terminate_lead_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1022,6 +1009,7 @@ fn create_amend_constitution_proposal_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: None,
+            exact_execution_block: None,
         };
 
         let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
@@ -1029,35 +1017,36 @@ fn create_amend_constitution_proposal_common_checks_succeed() {
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(1),
+            exact_execution_block: None,
         };
+
+        let amend_constitution_details =
+            ProposalDetails::AmendConstitution(b"constitution text".to_vec());
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
-                ProposalCodex::create_amend_constitution_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::None.into(),
                     general_proposal_parameters_no_staking.clone(),
-                    b"constitution text".to_vec(),
-                    None,
+                    amend_constitution_details.clone(),
                 )
             },
             empty_stake_call: || {
-                ProposalCodex::create_amend_constitution_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_no_staking.clone(),
-                    b"constitution text".to_vec(),
-                    None,
+                    amend_constitution_details.clone(),
                 )
             },
             successful_call: || {
-                ProposalCodex::create_amend_constitution_proposal(
+                ProposalCodex::create_proposal(
                     RawOrigin::Signed(1).into(),
                     general_proposal_parameters_with_staking.clone(),
-                    b"constitution text".to_vec(),
-                    None,
+                    amend_constitution_details.clone(),
                 )
             },
             proposal_parameters: <Test as crate::Trait>::AmendConstitutionProposalParameters::get(),
-            proposal_details: ProposalDetails::AmendConstitution(b"constitution text".to_vec()),
+            proposal_details: amend_constitution_details.clone(),
         };
         proposal_fixture.check_all();
     });

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -92,14 +92,25 @@ fn create_text_proposal_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance(500000);
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_text_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     b"text".to_vec(),
                     None,
                 )
@@ -107,10 +118,7 @@ fn create_text_proposal_common_checks_succeed() {
             empty_stake_call: || {
                 ProposalCodex::create_text_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     b"text".to_vec(),
                     None,
                 )
@@ -118,10 +126,7 @@ fn create_text_proposal_common_checks_succeed() {
             successful_call: || {
                 ProposalCodex::create_text_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     b"text".to_vec(),
                     None,
                 )
@@ -136,13 +141,17 @@ fn create_text_proposal_common_checks_succeed() {
 #[test]
 fn create_text_proposal_codex_call_fails_without_text() {
     initial_test_ext().execute_with(|| {
+        let general_proposal_parameters = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
         assert_eq!(
             ProposalCodex::create_text_proposal(
                 RawOrigin::Signed(1).into(),
-                1,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                None,
+                general_proposal_parameters.clone(),
                 Vec::new(),
                 None,
             ),
@@ -156,14 +165,25 @@ fn create_runtime_upgrade_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance_using_account_id(1, 5000000);
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_runtime_upgrade_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     b"wasm".to_vec(),
                     None,
                 )
@@ -171,10 +191,7 @@ fn create_runtime_upgrade_common_checks_succeed() {
             empty_stake_call: || {
                 ProposalCodex::create_runtime_upgrade_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     b"wasm".to_vec(),
                     None,
                 )
@@ -182,10 +199,7 @@ fn create_runtime_upgrade_common_checks_succeed() {
             successful_call: || {
                 ProposalCodex::create_runtime_upgrade_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     b"wasm".to_vec(),
                     None,
                 )
@@ -200,13 +214,17 @@ fn create_runtime_upgrade_common_checks_succeed() {
 #[test]
 fn create_upgrade_runtime_proposal_codex_call_fails_with_empty_wasm() {
     initial_test_ext().execute_with(|| {
+        let general_proposal_parameters = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
         assert_eq!(
             ProposalCodex::create_runtime_upgrade_proposal(
                 RawOrigin::Signed(1).into(),
-                1,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                None,
+                general_proposal_parameters.clone(),
                 Vec::new(),
                 None,
             ),
@@ -220,14 +238,25 @@ fn create_spending_proposal_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance(500000);
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_spending_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     20,
                     10,
                     None,
@@ -236,10 +265,7 @@ fn create_spending_proposal_common_checks_succeed() {
             empty_stake_call: || {
                 ProposalCodex::create_spending_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     20,
                     10,
                     None,
@@ -248,10 +274,7 @@ fn create_spending_proposal_common_checks_succeed() {
             successful_call: || {
                 ProposalCodex::create_spending_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     100,
                     2,
                     None,
@@ -269,13 +292,17 @@ fn create_spending_proposal_call_fails_with_incorrect_balance() {
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance_using_account_id(500000, 1);
 
+        let general_proposal_parameters = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         assert_eq!(
             ProposalCodex::create_spending_proposal(
                 RawOrigin::Signed(1).into(),
-                1,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(1),
+                general_proposal_parameters.clone(),
                 0,
                 2,
                 None,
@@ -286,10 +313,7 @@ fn create_spending_proposal_call_fails_with_incorrect_balance() {
         assert_eq!(
             ProposalCodex::create_spending_proposal(
                 RawOrigin::Signed(1).into(),
-                1,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(1),
+                general_proposal_parameters.clone(),
                 5000001,
                 2,
                 None,
@@ -304,14 +328,25 @@ fn create_set_validator_count_proposal_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance_using_account_id(1, 500000);
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_set_validator_count_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     4,
                     None,
                 )
@@ -319,10 +354,7 @@ fn create_set_validator_count_proposal_common_checks_succeed() {
             empty_stake_call: || {
                 ProposalCodex::create_set_validator_count_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     4,
                     None,
                 )
@@ -330,10 +362,7 @@ fn create_set_validator_count_proposal_common_checks_succeed() {
             successful_call: || {
                 ProposalCodex::create_set_validator_count_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     4,
                     None,
                 )
@@ -350,13 +379,17 @@ fn create_set_validator_count_proposal_failed_with_invalid_validator_count() {
     initial_test_ext().execute_with(|| {
         staking::MinimumValidatorCount::put(10);
 
+        let general_proposal_parameters = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(<BalanceOf<Test>>::from(100_000_u32)),
+        };
+
         assert_eq!(
             ProposalCodex::create_set_validator_count_proposal(
                 RawOrigin::Signed(1).into(),
-                1,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(<BalanceOf<Test>>::from(100_000_u32)),
+                general_proposal_parameters.clone(),
                 3,
                 None,
             ),
@@ -377,6 +410,20 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(
     working_group: WorkingGroup,
 ) {
     initial_test_ext().execute_with(|| {
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let add_opening_parameters = AddOpeningParameters {
             description: b"some text".to_vec(),
             stake_policy: None,
@@ -390,10 +437,7 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(
             insufficient_rights_call: || {
                 ProposalCodex::create_add_working_group_leader_opening_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     add_opening_parameters.clone(),
                     None,
                 )
@@ -401,10 +445,7 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(
             empty_stake_call: || {
                 ProposalCodex::create_add_working_group_leader_opening_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     add_opening_parameters.clone(),
                     None,
                 )
@@ -412,10 +453,7 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(
             successful_call: || {
                 ProposalCodex::create_add_working_group_leader_opening_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     add_opening_parameters.clone(),
                     None,
                 )
@@ -444,6 +482,20 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
     initial_test_ext().execute_with(|| {
         let opening_id = 1; // random opening id.
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let fill_opening_parameters = FillOpeningParameters {
             opening_id,
             successful_application_id: 1,
@@ -456,10 +508,7 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
             insufficient_rights_call: || {
                 ProposalCodex::create_fill_working_group_leader_opening_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     fill_opening_parameters.clone(),
                     None,
                 )
@@ -467,10 +516,7 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
             empty_stake_call: || {
                 ProposalCodex::create_fill_working_group_leader_opening_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     fill_opening_parameters.clone(),
                     None,
                 )
@@ -478,10 +524,7 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
             successful_call: || {
                 ProposalCodex::create_fill_working_group_leader_opening_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     fill_opening_parameters.clone(),
                     None,
                 )
@@ -510,13 +553,17 @@ fn run_create_working_group_mint_capacity_proposal_fails_with_invalid_parameters
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance_using_account_id(1, 500000);
 
+        let general_proposal_parameters = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         assert_eq!(
             ProposalCodex::create_set_working_group_budget_capacity_proposal(
                 RawOrigin::Signed(1).into(),
-                1,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(1),
+                general_proposal_parameters.clone(),
                 (crate::WORKING_GROUP_BUDGET_CAPACITY_MAX_VALUE + 1) as u64,
                 working_group,
                 None,
@@ -540,14 +587,25 @@ fn run_create_set_working_group_mint_capacity_proposal_common_checks_succeed(
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance(500000);
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_set_working_group_budget_capacity_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     0,
                     working_group,
                     None,
@@ -556,10 +614,7 @@ fn run_create_set_working_group_mint_capacity_proposal_common_checks_succeed(
             empty_stake_call: || {
                 ProposalCodex::create_set_working_group_budget_capacity_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     0,
                     working_group,
                     None,
@@ -568,10 +623,7 @@ fn run_create_set_working_group_mint_capacity_proposal_common_checks_succeed(
             successful_call: || {
                 ProposalCodex::create_set_working_group_budget_capacity_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     10,
                     working_group,
                     None,
@@ -599,14 +651,25 @@ fn run_create_decrease_working_group_leader_stake_proposal_common_checks_succeed
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance(500000);
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_decrease_working_group_leader_stake_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     0,
                     10,
                     working_group,
@@ -616,10 +679,7 @@ fn run_create_decrease_working_group_leader_stake_proposal_common_checks_succeed
             empty_stake_call: || {
                 ProposalCodex::create_decrease_working_group_leader_stake_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     0,
                     10,
                     working_group,
@@ -629,10 +689,7 @@ fn run_create_decrease_working_group_leader_stake_proposal_common_checks_succeed
             successful_call: || {
                 ProposalCodex::create_decrease_working_group_leader_stake_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     10,
                     10,
                     working_group,
@@ -665,14 +722,25 @@ fn run_create_slash_working_group_leader_stake_proposal_common_checks_succeed(
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance(500000);
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_slash_working_group_leader_stake_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     0,
                     Penalty {
                         slashing_amount: 10,
@@ -685,10 +753,7 @@ fn run_create_slash_working_group_leader_stake_proposal_common_checks_succeed(
             empty_stake_call: || {
                 ProposalCodex::create_slash_working_group_leader_stake_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     0,
                     Penalty {
                         slashing_amount: 10,
@@ -701,10 +766,7 @@ fn run_create_slash_working_group_leader_stake_proposal_common_checks_succeed(
             successful_call: || {
                 ProposalCodex::create_slash_working_group_leader_stake_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     10,
                     Penalty {
                         slashing_amount: 10,
@@ -741,6 +803,13 @@ fn run_slash_stake_with_zero_staking_balance_fails(working_group: WorkingGroup) 
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance_using_account_id(1, 500000);
 
+        let general_proposal_parameters = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let lead_account_id = 20;
         <governance::council::Module<Test>>::set_council(
             RawOrigin::Root.into(),
@@ -751,10 +820,7 @@ fn run_slash_stake_with_zero_staking_balance_fails(working_group: WorkingGroup) 
         assert_eq!(
             ProposalCodex::create_slash_working_group_leader_stake_proposal(
                 RawOrigin::Signed(1).into(),
-                1,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(1),
+                general_proposal_parameters.clone(),
                 10,
                 Penalty {
                     slashing_amount: 0,
@@ -780,6 +846,13 @@ fn run_decrease_stake_with_zero_staking_balance_fails(working_group: WorkingGrou
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance_using_account_id(1, 500000);
 
+        let general_proposal_parameters = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let lead_account_id = 20;
         <governance::council::Module<Test>>::set_council(
             RawOrigin::Root.into(),
@@ -790,10 +863,7 @@ fn run_decrease_stake_with_zero_staking_balance_fails(working_group: WorkingGrou
         assert_eq!(
             ProposalCodex::create_decrease_working_group_leader_stake_proposal(
                 RawOrigin::Signed(1).into(),
-                1,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(1),
+                general_proposal_parameters.clone(),
                 10,
                 0,
                 working_group,
@@ -816,14 +886,25 @@ fn run_create_set_working_group_leader_reward_proposal_common_checks_succeed(
     working_group: WorkingGroup,
 ) {
     initial_test_ext().execute_with(|| {
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_set_working_group_leader_reward_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     0,
                     Some(10),
                     working_group,
@@ -833,10 +914,7 @@ fn run_create_set_working_group_leader_reward_proposal_common_checks_succeed(
             empty_stake_call: || {
                 ProposalCodex::create_set_working_group_leader_reward_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     0,
                     Some(10),
                     working_group,
@@ -846,10 +924,7 @@ fn run_create_set_working_group_leader_reward_proposal_common_checks_succeed(
             successful_call: || {
                 ProposalCodex::create_set_working_group_leader_reward_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     10,
                     Some(10),
                     working_group,
@@ -882,6 +957,20 @@ fn run_create_terminate_working_group_leader_role_proposal_common_checks_succeed
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance(500000);
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let terminate_role_parameters = TerminateRoleParameters {
             worker_id: 10,
             penalty: None,
@@ -892,10 +981,7 @@ fn run_create_terminate_working_group_leader_role_proposal_common_checks_succeed
             insufficient_rights_call: || {
                 ProposalCodex::create_terminate_working_group_leader_role_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     terminate_role_parameters.clone(),
                     None,
                 )
@@ -903,10 +989,7 @@ fn run_create_terminate_working_group_leader_role_proposal_common_checks_succeed
             empty_stake_call: || {
                 ProposalCodex::create_terminate_working_group_leader_role_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     terminate_role_parameters.clone(),
                     None,
                 )
@@ -914,10 +997,7 @@ fn run_create_terminate_working_group_leader_role_proposal_common_checks_succeed
             successful_call: || {
                 ProposalCodex::create_terminate_working_group_leader_role_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     terminate_role_parameters.clone(),
                     None,
                 )
@@ -937,14 +1017,25 @@ fn create_amend_constitution_proposal_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance_using_account_id(1, 1_500_000);
 
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+        };
+
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_amend_constitution_proposal(
                     RawOrigin::None.into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     b"constitution text".to_vec(),
                     None,
                 )
@@ -952,10 +1043,7 @@ fn create_amend_constitution_proposal_common_checks_succeed() {
             empty_stake_call: || {
                 ProposalCodex::create_amend_constitution_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    None,
+                    general_proposal_parameters_no_staking.clone(),
                     b"constitution text".to_vec(),
                     None,
                 )
@@ -963,10 +1051,7 @@ fn create_amend_constitution_proposal_common_checks_succeed() {
             successful_call: || {
                 ProposalCodex::create_amend_constitution_proposal(
                     RawOrigin::Signed(1).into(),
-                    1,
-                    b"title".to_vec(),
-                    b"body".to_vec(),
-                    Some(1),
+                    general_proposal_parameters_with_staking.clone(),
                     b"constitution text".to_vec(),
                     None,
                 )

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -88,6 +88,26 @@ impl<MintedBalance, CurrencyBalance, BlockNumber, AccountId, StakeBalance, Worke
     }
 }
 
+/// Proposal parameters common to all proposals
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Debug, Default, Clone, PartialEq, Eq)]
+pub struct GeneralProposalParams<MemberId, AccountId, BlockNumber> {
+    /// Member ID of proposer
+    pub member_id: MemberId,
+
+    /// Title of the proposal
+    pub title: Vec<u8>,
+
+    /// Proposal description
+    pub description: Vec<u8>,
+
+    /// Staking Account Id for proposer, must have one for proposal to work
+    pub staking_account_id: Option<AccountId>,
+
+    /// Intended execution block for the proposal
+    pub exact_execution_block: Option<BlockNumber>,
+}
+
 /// Parameters for the 'terminate the leader position' proposal.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -7,6 +7,8 @@ mod working_group_proposals;
 use crate::{BlockNumber, ProposalCancellationFee, Runtime};
 use codec::Encode;
 use governance::election_params::ElectionParameters;
+use membership;
+use proposals_codex::GeneralProposalParameters;
 use proposals_engine::{
     ApprovedProposalDecision, BalanceOf, Proposal, ProposalCreationParameters, ProposalParameters,
     ProposalStatus, VoteKind, VotersParameters, VotingResults,
@@ -503,12 +505,16 @@ fn text_proposal_execution_succeeds() {
         let account_id: [u8; 32] = [member_id; 32];
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+            };
+
             ProposalCodex::create_text_proposal(
                 RawOrigin::Signed(account_id.into()).into(),
-                member_id as u64,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(account_id.into()),
+                general_proposal_parameters,
                 b"text".to_vec(),
                 None,
             )
@@ -531,12 +537,16 @@ fn spending_proposal_execution_succeeds() {
         assert!(Council::set_council_mint_capacity(RawOrigin::Root.into(), new_balance).is_ok());
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+            };
+
             ProposalCodex::create_spending_proposal(
                 RawOrigin::Signed(account_id.clone().into()).into(),
-                member_id as u64,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(account_id.into()),
+                general_proposal_parameters,
                 new_balance,
                 target_account_id.clone().into(),
                 None,
@@ -565,12 +575,16 @@ fn set_validator_count_proposal_execution_succeeds() {
         assert_eq!(<pallet_staking::ValidatorCount>::get(), 0);
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+            };
+
             ProposalCodex::create_set_validator_count_proposal(
                 RawOrigin::Signed(account_id.clone().into()).into(),
-                member_id as u64,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(account_id.into()),
+                general_proposal_parameters,
                 new_validator_count,
                 None,
             )
@@ -590,12 +604,16 @@ fn amend_constitution_proposal_execution_succeeds() {
         let account_id: [u8; 32] = [member_id; 32];
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+            };
+
             ProposalCodex::create_amend_constitution_proposal(
                 RawOrigin::Signed(account_id.into()).into(),
-                member_id as u64,
-                b"title".to_vec(),
-                b"body".to_vec(),
-                Some(account_id.into()),
+                general_proposal_parameters,
                 b"Constitution text".to_vec(),
                 None,
             )

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -8,7 +8,7 @@ use crate::{BlockNumber, ProposalCancellationFee, Runtime};
 use codec::Encode;
 use governance::election_params::ElectionParameters;
 use membership;
-use proposals_codex::GeneralProposalParameters;
+use proposals_codex::{GeneralProposalParameters, ProposalDetails};
 use proposals_engine::{
     ApprovedProposalDecision, BalanceOf, Proposal, ProposalCreationParameters, ProposalParameters,
     ProposalStatus, VoteKind, VotersParameters, VotingResults,
@@ -510,13 +510,13 @@ fn text_proposal_execution_succeeds() {
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
                 staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
             };
 
-            ProposalCodex::create_text_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(account_id.into()).into(),
                 general_proposal_parameters,
-                b"text".to_vec(),
-                None,
+                ProposalDetails::Text(b"text".to_vec()),
             )
         })
         .with_member_id(member_id as u64);
@@ -542,14 +542,13 @@ fn spending_proposal_execution_succeeds() {
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
                 staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
             };
 
-            ProposalCodex::create_spending_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(account_id.clone().into()).into(),
                 general_proposal_parameters,
-                new_balance,
-                target_account_id.clone().into(),
-                None,
+                ProposalDetails::Spending(new_balance, target_account_id.clone().into()),
             )
         })
         .with_member_id(member_id as u64);
@@ -580,13 +579,13 @@ fn set_validator_count_proposal_execution_succeeds() {
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
                 staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
             };
 
-            ProposalCodex::create_set_validator_count_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(account_id.clone().into()).into(),
                 general_proposal_parameters,
-                new_validator_count,
-                None,
+                ProposalDetails::SetValidatorCount(new_validator_count),
             )
         });
         codex_extrinsic_test_fixture.call_extrinsic_and_assert();
@@ -609,13 +608,13 @@ fn amend_constitution_proposal_execution_succeeds() {
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
                 staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
             };
 
-            ProposalCodex::create_amend_constitution_proposal(
+            ProposalCodex::create_proposal(
                 RawOrigin::Signed(account_id.into()).into(),
                 general_proposal_parameters,
-                b"Constitution text".to_vec(),
-                None,
+                ProposalDetails::AmendConstitution(b"Constitution text".to_vec()),
             )
         })
         .with_member_id(member_id as u64);

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -7,7 +7,6 @@ mod working_group_proposals;
 use crate::{BlockNumber, ProposalCancellationFee, Runtime};
 use codec::Encode;
 use governance::election_params::ElectionParameters;
-use membership;
 use proposals_codex::{GeneralProposalParameters, ProposalDetails};
 use proposals_engine::{
     ApprovedProposalDecision, BalanceOf, Proposal, ProposalCreationParameters, ProposalParameters,

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -71,18 +71,18 @@ fn add_opening(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(account_id.into()),
+            exact_execution_block: None,
         };
 
-        ProposalCodex::create_add_working_group_leader_opening_proposal(
+        ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            AddOpeningParameters {
+            ProposalDetails::AddWorkingGroupLeaderOpening(AddOpeningParameters {
                 description: Vec::new(),
                 stake_policy: stake_policy.clone(),
                 reward_policy: None,
                 working_group,
-            },
-            None,
+            }),
         )
     })
     .with_expected_proposal_id(expected_proposal_id)
@@ -110,17 +110,19 @@ fn fill_opening(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(account_id.into()),
+            exact_execution_block: None,
         };
 
-        ProposalCodex::create_fill_working_group_leader_opening_proposal(
+        ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            proposals_codex::FillOpeningParameters {
-                opening_id,
-                successful_application_id,
-                working_group,
-            },
-            None,
+            ProposalDetails::FillWorkingGroupLeaderOpening(
+                proposals_codex::FillOpeningParameters {
+                    opening_id,
+                    successful_application_id,
+                    working_group,
+                },
+            ),
         )
     })
     .disable_setup_enviroment()
@@ -147,15 +149,17 @@ fn decrease_stake(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(account_id.into()),
+            exact_execution_block: None,
         };
 
-        ProposalCodex::create_decrease_working_group_leader_stake_proposal(
+        ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            leader_worker_id,
-            stake_amount,
-            working_group,
-            None,
+            ProposalDetails::DecreaseWorkingGroupLeaderStake(
+                leader_worker_id,
+                stake_amount,
+                working_group,
+            ),
         )
     })
     .disable_setup_enviroment()
@@ -182,18 +186,20 @@ fn slash_stake(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(account_id.into()),
+            exact_execution_block: None,
         };
 
-        ProposalCodex::create_slash_working_group_leader_stake_proposal(
+        ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            leader_worker_id,
-            Penalty {
-                slashing_amount: stake_amount,
-                slashing_text: Vec::new(),
-            },
-            working_group,
-            None,
+            ProposalDetails::SlashWorkingGroupLeaderStake(
+                leader_worker_id,
+                Penalty {
+                    slashing_amount: stake_amount,
+                    slashing_text: Vec::new(),
+                },
+                working_group,
+            ),
         )
     })
     .disable_setup_enviroment()
@@ -220,15 +226,17 @@ fn set_reward(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(account_id.into()),
+            exact_execution_block: None,
         };
 
-        ProposalCodex::create_set_working_group_leader_reward_proposal(
+        ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            leader_worker_id,
-            Some(reward_amount),
-            working_group,
-            None,
+            ProposalDetails::SetWorkingGroupLeaderReward(
+                leader_worker_id,
+                Some(reward_amount),
+                working_group,
+            ),
         )
     })
     .disable_setup_enviroment()
@@ -258,14 +266,13 @@ fn set_mint_capacity<
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(account_id.into()),
+            exact_execution_block: None,
         };
 
-        ProposalCodex::create_set_working_group_budget_capacity_proposal(
+        ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            mint_capacity,
-            working_group,
-            None,
+            ProposalDetails::SetWorkingGroupBudgetCapacity(mint_capacity, working_group),
         )
     })
     .with_setup_enviroment(setup_environment)
@@ -292,17 +299,19 @@ fn terminate_role(
             title: b"title".to_vec(),
             description: b"body".to_vec(),
             staking_account_id: Some(account_id.into()),
+            exact_execution_block: None,
         };
 
-        ProposalCodex::create_terminate_working_group_leader_role_proposal(
+        ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            proposals_codex::TerminateRoleParameters {
-                worker_id: leader_worker_id,
-                penalty: penalty.clone(),
-                working_group,
-            },
-            None,
+            ProposalDetails::TerminateWorkingGroupLeaderRole(
+                proposals_codex::TerminateRoleParameters {
+                    worker_id: leader_worker_id,
+                    penalty: penalty.clone(),
+                    working_group,
+                },
+            ),
         )
     })
     .disable_setup_enviroment()

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -66,12 +66,16 @@ fn add_opening(
     };
 
     let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+        let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+            member_id: member_id.into(),
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(account_id.into()),
+        };
+
         ProposalCodex::create_add_working_group_leader_opening_proposal(
             RawOrigin::Signed(account_id.into()).into(),
-            member_id as u64,
-            b"title".to_vec(),
-            b"body".to_vec(),
-            Some(account_id.into()),
+            general_proposal_parameters,
             AddOpeningParameters {
                 description: Vec::new(),
                 stake_policy: stake_policy.clone(),
@@ -101,12 +105,16 @@ fn fill_opening(
     let run_to_block = sequence_number * 2;
 
     let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+        let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+            member_id: member_id.into(),
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(account_id.into()),
+        };
+
         ProposalCodex::create_fill_working_group_leader_opening_proposal(
             RawOrigin::Signed(account_id.into()).into(),
-            member_id,
-            b"title".to_vec(),
-            b"body".to_vec(),
-            Some(account_id.into()),
+            general_proposal_parameters,
             proposals_codex::FillOpeningParameters {
                 opening_id,
                 successful_application_id,
@@ -134,12 +142,16 @@ fn decrease_stake(
     let run_to_block = sequence_number * 2;
 
     let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+        let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+            member_id: member_id.into(),
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(account_id.into()),
+        };
+
         ProposalCodex::create_decrease_working_group_leader_stake_proposal(
             RawOrigin::Signed(account_id.into()).into(),
-            member_id,
-            b"title".to_vec(),
-            b"body".to_vec(),
-            Some(account_id.into()),
+            general_proposal_parameters,
             leader_worker_id,
             stake_amount,
             working_group,
@@ -165,12 +177,16 @@ fn slash_stake(
     let run_to_block = sequence_number * 2;
 
     let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+        let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+            member_id: member_id.into(),
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(account_id.into()),
+        };
+
         ProposalCodex::create_slash_working_group_leader_stake_proposal(
             RawOrigin::Signed(account_id.into()).into(),
-            member_id,
-            b"title".to_vec(),
-            b"body".to_vec(),
-            Some(account_id.into()),
+            general_proposal_parameters,
             leader_worker_id,
             Penalty {
                 slashing_amount: stake_amount,
@@ -199,12 +215,16 @@ fn set_reward(
     let run_to_block = sequence_number * 2;
 
     let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+        let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+            member_id: member_id.into(),
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(account_id.into()),
+        };
+
         ProposalCodex::create_set_working_group_leader_reward_proposal(
             RawOrigin::Signed(account_id.into()).into(),
-            member_id as u64,
-            b"title".to_vec(),
-            b"body".to_vec(),
-            Some(account_id.into()),
+            general_proposal_parameters,
             leader_worker_id,
             Some(reward_amount),
             working_group,
@@ -233,12 +253,16 @@ fn set_mint_capacity<
     let run_to_block = sequence_number * 2;
 
     let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+        let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+            member_id: member_id.into(),
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(account_id.into()),
+        };
+
         ProposalCodex::create_set_working_group_budget_capacity_proposal(
             RawOrigin::Signed(account_id.into()).into(),
-            member_id,
-            b"title".to_vec(),
-            b"body".to_vec(),
-            Some(account_id.into()),
+            general_proposal_parameters,
             mint_capacity,
             working_group,
             None,
@@ -263,12 +287,16 @@ fn terminate_role(
     let run_to_block = sequence_number * 2;
 
     let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+        let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+            member_id: member_id.into(),
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(account_id.into()),
+        };
+
         ProposalCodex::create_terminate_working_group_leader_role_proposal(
             RawOrigin::Signed(account_id.into()).into(),
-            member_id,
-            b"title".to_vec(),
-            b"body".to_vec(),
-            Some(account_id.into()),
+            general_proposal_parameters,
             proposals_codex::TerminateRoleParameters {
                 worker_id: leader_worker_id,
                 penalty: penalty.clone(),


### PR DESCRIPTION
# Addressing #1841 

This PR change `create_*_proposals` the following ways:
* Unify repeated parameters into `GeneralProposalParameters`
* Unify all extrinsics into `create_proposal`
  * Make use of already existing `ProposalDetals` to distinguish between specific proposals and pass specific parameters
    * **Note**: The issue originally suggested creating a new enum for these parameters, I took advantage of the already existing enum, let me know if it's preferable to do it the other way
  * Inline the old `create_proposal` function into the extrinsic
* Update tests to adapt to these changes