### PR TITLE
Content Dir Schemas: initialize:dev script exit process on error

### DIFF
--- a/content-directory-schemas/scripts/devInitAliceLead.ts
+++ b/content-directory-schemas/scripts/devInitAliceLead.ts
@@ -85,4 +85,7 @@ async function main() {
 
 main()
   .then(() => process.exit())
-  .catch((e) => console.error(e))
+  .catch((e) => {
+    console.error(e)
+    process.exit(-1)
+  })

--- a/content-directory-schemas/scripts/initializeContentDir.ts
+++ b/content-directory-schemas/scripts/initializeContentDir.ts
@@ -59,4 +59,7 @@ async function main() {
 
 main()
   .then(() => process.exit())
-  .catch((e) => console.error(e))
+  .catch((e) => {
+    console.error(e)
+    process.exit(-1)
+  })


### PR DESCRIPTION
When script connects to newer runtime which isn't compatible, the script errors out but doesn't exit the process which makes the CI jobs runs for too long until they timeout:

```
$ yarn initialize:alice-as-lead && yarn initialize:content-dir
$ ts-node ./scripts/devInitAliceLead.ts
Initializing the api (ws://127.0.0.1:9944)...
2020-12-14 12:33:27        API/INIT: RPC methods not decorated: grandpa_proveFinality, grandpa_subscribeJustifications, grandpa_unsubscribeJustifications
2020-12-14 12:33:28        RPC-CORE: getMetadata(at?: BlockHash): Metadata:: createType(Metadata):: Unable to create Enum via index 12, in V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11
2020-12-14 12:33:28        API/INIT: Error: FATAL: Unable to initialize the API: createType(Metadata):: Unable to create Enum via index 12, in V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11
    at EventEmitter.value (/home/runner/work/joystream/joystream/node_modules/@polkadot/api/base/Init.js:77:25)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at runNextTicks (internal/process/task_queues.js:66:3)
    at processImmediate (internal/timers.js:434:9)
Error: FATAL: Unable to initialize the API: createType(Metadata):: Unable to create Enum via index 12, in V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11
    at EventEmitter.value (/home/runner/work/joystream/joystream/node_modules/@polkadot/api/base/Init.js:77:25)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at runNextTicks (internal/process/task_queues.js:66:3)
    at processImmediate (internal/timers.js:434:9)
Error: The operation was canceled.
```

![Screen Shot 2020-12-15 at 9 07 56 AM](https://user-images.githubusercontent.com/1621012/102182734-33e4a000-3ec6-11eb-8d6e-4e4a2253fd08.png)

I simply exit after catching the exception.