### PR TITLE
Drop RewardPolicy from working group

### DIFF
--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -429,7 +429,7 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(
         let add_opening_parameters = AddOpeningParameters {
             description: b"some text".to_vec(),
             stake_policy: None,
-            reward_policy: None,
+            reward_per_block: None,
             working_group,
         };
 

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -7,7 +7,7 @@ use sp_std::vec::Vec;
 
 use common::working_group::WorkingGroup;
 
-use working_group::{Penalty, RewardPolicy, StakePolicy};
+use working_group::{Penalty, StakePolicy};
 
 /// Encodes proposal using its details information.
 pub trait ProposalEncoder<T: crate::Trait> {
@@ -146,8 +146,8 @@ pub struct AddOpeningParameters<BlockNumber, Balance> {
     /// Stake policy for the opening.
     pub stake_policy: Option<StakePolicy<BlockNumber, Balance>>,
 
-    /// Reward policy for the opening.
-    pub reward_policy: Option<RewardPolicy<Balance>>,
+    /// Reward per block for the opening.
+    pub reward_per_block: Option<Balance>,
 
     /// Defines working group with the open position.
     pub working_group: WorkingGroup,

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -54,9 +54,7 @@ fn add_opening_helper<T: Trait<I>, I: Instance>(
         vec![],
         *job_opening_type,
         staking_policy,
-        Some(RewardPolicy {
-            reward_per_block: One::one(),
-        }),
+        Some(One::one()),
     )
     .unwrap();
 
@@ -870,10 +868,6 @@ benchmarks_instance! {
             leaving_unstaking_period: T::BlockNumber::max_value(),
         };
 
-        let reward_policy = RewardPolicy {
-            reward_per_block: BalanceOf::<T>::max_value(),
-        };
-
         let description = vec![0u8; i.try_into().unwrap()];
 
     }: _(
@@ -881,7 +875,7 @@ benchmarks_instance! {
             description,
             OpeningType::Regular,
             Some(stake_policy),
-            Some(reward_policy)
+            Some(BalanceOf::<T>::max_value())
         )
     verify {
         assert!(OpeningById::<T, I>::contains_key(1));

--- a/runtime-modules/working-group/src/checks.rs
+++ b/runtime-modules/working-group/src/checks.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ApplicationId, BalanceOf, Instance, Opening, OpeningId, OpeningType, RewardPolicy, StakePolicy,
-    Trait, Worker, WorkerId,
+    ApplicationId, BalanceOf, Instance, Opening, OpeningId, OpeningType, StakePolicy, Trait,
+    Worker, WorkerId,
 };
 
 use super::Error;
@@ -205,13 +205,13 @@ pub(crate) fn ensure_valid_stake_policy<T: Trait<I>, I: Instance>(
     Ok(())
 }
 
-// Check opening: verifies reward policy for the opening.
-pub(crate) fn ensure_valid_reward_policy<T: Trait<I>, I: Instance>(
-    reward_policy: &Option<RewardPolicy<BalanceOf<T>>>,
+// Check opening: verifies reward per block for the opening.
+pub(crate) fn ensure_valid_reward_per_block<T: Trait<I>, I: Instance>(
+    reward_per_block: &Option<BalanceOf<T>>,
 ) -> Result<(), DispatchError> {
-    if let Some(reward_policy) = reward_policy {
+    if let Some(reward_per_block) = reward_per_block {
         ensure!(
-            reward_policy.reward_per_block != Zero::zero(),
+            *reward_per_block != Zero::zero(),
             Error::<T, I>::CannotRewardWithZero
         )
     }

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -50,7 +50,7 @@ use sp_std::vec::Vec;
 pub use errors::Error;
 pub use types::{
     Application, ApplicationId, ApplyOnOpeningParameters, BalanceOf, Opening, OpeningId,
-    OpeningType, Penalty, RewardPolicy, StakeParameters, StakePolicy, Worker, WorkerId,
+    OpeningType, Penalty, StakeParameters, StakePolicy, Worker, WorkerId,
 };
 use types::{ApplicationInfo, WorkerInfo};
 
@@ -328,13 +328,13 @@ decl_module! {
             description: Vec<u8>,
             opening_type: OpeningType,
             stake_policy: Option<StakePolicy<T::BlockNumber, BalanceOf<T>>>,
-            reward_policy: Option<RewardPolicy<BalanceOf<T>>>
+            reward_per_block: Option<BalanceOf<T>>
         ){
             checks::ensure_origin_for_opening_type::<T, I>(origin, opening_type)?;
 
             checks::ensure_valid_stake_policy::<T, I>(&stake_policy)?;
 
-            checks::ensure_valid_reward_policy::<T, I>(&reward_policy)?;
+            checks::ensure_valid_reward_per_block::<T, I>(&reward_per_block)?;
 
             //
             // == MUTATION SAFE ==
@@ -348,7 +348,7 @@ decl_module! {
                 created: Self::current_block(),
                 description_hash: hashed_description.as_ref().to_vec(),
                 stake_policy,
-                reward_policy,
+                reward_per_block,
             };
 
             let new_opening_id = NextOpeningId::<I>::get();
@@ -1112,7 +1112,7 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
                 .stake_policy
                 .as_ref()
                 .map_or(Zero::zero(), |sp| sp.leaving_unstaking_period),
-            opening.reward_policy.as_ref().map(|rp| rp.reward_per_block),
+            opening.reward_per_block,
             Self::current_block(),
         );
 

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -10,7 +10,7 @@ use super::mock::{Balances, LockId, System, Test, TestEvent, TestWorkingGroup};
 use crate::types::StakeParameters;
 use crate::{
     Application, ApplyOnOpeningParameters, DefaultInstance, Opening, OpeningType, Penalty,
-    RawEvent, RewardPolicy, StakePolicy, Worker,
+    RawEvent, StakePolicy, Worker,
 };
 
 pub struct EventFixture;
@@ -40,7 +40,7 @@ pub struct AddOpeningFixture {
     opening_type: OpeningType,
     starting_block: u64,
     stake_policy: Option<StakePolicy<u64, u64>>,
-    reward_policy: Option<RewardPolicy<u64>>,
+    reward_per_block: Option<u64>,
 }
 
 impl Default for AddOpeningFixture {
@@ -51,7 +51,7 @@ impl Default for AddOpeningFixture {
             opening_type: OpeningType::Regular,
             starting_block: 0,
             stake_policy: None,
-            reward_policy: None,
+            reward_per_block: None,
         }
     }
 }
@@ -78,7 +78,7 @@ impl AddOpeningFixture {
                 description_hash: expected_hash.as_ref().to_vec(),
                 opening_type: self.opening_type,
                 stake_policy: self.stake_policy.clone(),
-                reward_policy: self.reward_policy.clone(),
+                reward_per_block: self.reward_per_block.clone(),
             };
 
             assert_eq!(actual_opening, expected_opening);
@@ -94,7 +94,7 @@ impl AddOpeningFixture {
             self.description.clone(),
             self.opening_type,
             self.stake_policy.clone(),
-            self.reward_policy.clone(),
+            self.reward_per_block.clone(),
         )?;
 
         Ok(saved_opening_next_id)
@@ -125,9 +125,9 @@ impl AddOpeningFixture {
         }
     }
 
-    pub fn with_reward_policy(self, reward_policy: Option<RewardPolicy<u64>>) -> Self {
+    pub fn with_reward_per_block(self, reward_per_block: Option<u64>) -> Self {
         Self {
-            reward_policy,
+            reward_per_block,
             ..self
         }
     }
@@ -239,7 +239,7 @@ pub struct FillOpeningFixture {
     reward_account_id: u64,
     staking_account_id: Option<u64>,
     stake_policy: Option<StakePolicy<u64, u64>>,
-    reward_policy: Option<RewardPolicy<u64>>,
+    reward_per_block: Option<u64>,
     created_at: u64,
 }
 
@@ -255,7 +255,7 @@ impl FillOpeningFixture {
             reward_account_id: 1,
             staking_account_id: None,
             stake_policy: None,
-            reward_policy: None,
+            reward_per_block: None,
             created_at: 0,
         }
     }
@@ -282,9 +282,9 @@ impl FillOpeningFixture {
         }
     }
 
-    pub fn with_reward_policy(self, reward_policy: Option<RewardPolicy<u64>>) -> Self {
+    pub fn with_reward_per_block(self, reward_per_block: Option<u64>) -> Self {
         Self {
-            reward_policy,
+            reward_per_block,
             ..self
         }
     }
@@ -330,7 +330,7 @@ impl FillOpeningFixture {
                     .stake_policy
                     .as_ref()
                     .map_or(0, |sp| sp.leaving_unstaking_period),
-                reward_per_block: self.reward_policy.as_ref().map(|rp| rp.reward_per_block),
+                reward_per_block: self.reward_per_block,
                 missed_reward: None,
                 created_at: self.created_at,
             };
@@ -355,7 +355,7 @@ impl FillOpeningFixture {
 pub struct HireLeadFixture {
     setup_environment: bool,
     stake_policy: Option<StakePolicy<u64, u64>>,
-    reward_policy: Option<RewardPolicy<u64>>,
+    reward_per_block: Option<u64>,
 }
 
 impl Default for HireLeadFixture {
@@ -363,7 +363,7 @@ impl Default for HireLeadFixture {
         Self {
             setup_environment: true,
             stake_policy: None,
-            reward_policy: None,
+            reward_per_block: None,
         }
     }
 }
@@ -382,9 +382,9 @@ impl HireLeadFixture {
         }
     }
 
-    pub fn with_reward_policy(self, reward_policy: Option<RewardPolicy<u64>>) -> Self {
+    pub fn with_reward_per_block(self, reward_per_block: Option<u64>) -> Self {
         Self {
-            reward_policy,
+            reward_per_block,
             ..self
         }
     }
@@ -394,7 +394,7 @@ impl HireLeadFixture {
             .with_setup_environment(self.setup_environment)
             .with_opening_type(OpeningType::Leader)
             .with_stake_policy(self.stake_policy)
-            .with_reward_policy(self.reward_policy)
+            .with_reward_per_block(self.reward_per_block)
             .add_application(b"leader".to_vec())
             .execute()
             .unwrap()
@@ -405,7 +405,7 @@ impl HireLeadFixture {
             .with_setup_environment(self.setup_environment)
             .with_opening_type(OpeningType::Leader)
             .with_stake_policy(self.stake_policy)
-            .with_reward_policy(self.reward_policy)
+            .with_reward_per_block(self.reward_per_block)
             .add_application(b"leader".to_vec())
             .expect(Err(error))
             .execute();
@@ -415,7 +415,7 @@ impl HireLeadFixture {
 pub struct HireRegularWorkerFixture {
     setup_environment: bool,
     stake_policy: Option<StakePolicy<u64, u64>>,
-    reward_policy: Option<RewardPolicy<u64>>,
+    reward_per_block: Option<u64>,
 }
 
 impl Default for HireRegularWorkerFixture {
@@ -423,7 +423,7 @@ impl Default for HireRegularWorkerFixture {
         Self {
             setup_environment: true,
             stake_policy: None,
-            reward_policy: None,
+            reward_per_block: None,
         }
     }
 }
@@ -435,9 +435,9 @@ impl HireRegularWorkerFixture {
         }
     }
 
-    pub fn with_reward_policy(self, reward_policy: Option<RewardPolicy<u64>>) -> Self {
+    pub fn with_reward_per_block(self, reward_per_block: Option<u64>) -> Self {
         Self {
-            reward_policy,
+            reward_per_block,
             ..self
         }
     }
@@ -447,7 +447,7 @@ impl HireRegularWorkerFixture {
             .with_setup_environment(self.setup_environment)
             .with_opening_type(OpeningType::Regular)
             .with_stake_policy(self.stake_policy)
-            .with_reward_policy(self.reward_policy)
+            .with_reward_per_block(self.reward_per_block)
             .add_application(b"worker".to_vec())
             .execute()
             .unwrap()

--- a/runtime-modules/working-group/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-group/src/tests/hiring_workflow.rs
@@ -6,7 +6,7 @@ use crate::tests::fixtures::{
 };
 use crate::tests::mock::TestWorkingGroup;
 use crate::types::StakeParameters;
-use crate::{OpeningType, RewardPolicy, StakePolicy};
+use crate::{OpeningType, StakePolicy};
 
 #[derive(Clone)]
 struct HiringWorkflowApplication {
@@ -20,7 +20,7 @@ pub struct HiringWorkflow {
     opening_type: OpeningType,
     expected_result: DispatchResult,
     stake_policy: Option<StakePolicy<u64, u64>>,
-    reward_policy: Option<RewardPolicy<u64>>,
+    reward_per_block: Option<u64>,
     applications: Vec<HiringWorkflowApplication>,
     setup_environment: bool,
 }
@@ -31,7 +31,7 @@ impl Default for HiringWorkflow {
             opening_type: OpeningType::Regular,
             expected_result: Ok(()),
             stake_policy: None,
-            reward_policy: None,
+            reward_per_block: None,
             applications: Vec::new(),
             setup_environment: true,
         }
@@ -46,9 +46,9 @@ impl HiringWorkflow {
         }
     }
 
-    pub fn with_reward_policy(self, reward_policy: Option<RewardPolicy<u64>>) -> Self {
+    pub fn with_reward_per_block(self, reward_per_block: Option<u64>) -> Self {
         Self {
-            reward_policy,
+            reward_per_block,
             ..self
         }
     }
@@ -151,7 +151,7 @@ impl HiringWorkflow {
         // create the opening
         let add_worker_opening_fixture = AddOpeningFixture::default()
             .with_stake_policy(self.stake_policy.clone())
-            .with_reward_policy(self.reward_policy.clone())
+            .with_reward_per_block(self.reward_per_block.clone())
             .with_opening_type(self.opening_type)
             .with_origin(origin.clone());
 

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -17,9 +17,7 @@ use crate::tests::mock::{
     STAKING_ACCOUNT_ID_FOR_ZERO_STAKE,
 };
 use crate::types::StakeParameters;
-use crate::{
-    DefaultInstance, Error, OpeningType, Penalty, RawEvent, RewardPolicy, StakePolicy, Worker,
-};
+use crate::{DefaultInstance, Error, OpeningType, Penalty, RawEvent, StakePolicy, Worker};
 use fixtures::{
     increase_total_balance_issuance_using_account_id, AddOpeningFixture, ApplyOnOpeningFixture,
     EventFixture, FillOpeningFixture, HireLeadFixture, HireRegularWorkerFixture,
@@ -45,9 +43,7 @@ fn add_opening_succeeded() {
                 stake_amount: 10,
                 leaving_unstaking_period: 100,
             }))
-            .with_reward_policy(Some(RewardPolicy {
-                reward_per_block: 10,
-            }));
+            .with_reward_per_block(Some(10));
 
         let opening_id = add_opening_fixture.call_and_assert(Ok(()));
 
@@ -87,10 +83,7 @@ fn add_opening_fails_with_zero_reward() {
     build_test_externalities().execute_with(|| {
         HireLeadFixture::default().hire_lead();
 
-        let add_opening_fixture =
-            AddOpeningFixture::default().with_reward_policy(Some(RewardPolicy {
-                reward_per_block: 0,
-            }));
+        let add_opening_fixture = AddOpeningFixture::default().with_reward_per_block(Some(0));
 
         add_opening_fixture.call_and_assert(Err(
             Error::<Test, DefaultInstance>::CannotRewardWithZero.into(),
@@ -214,13 +207,11 @@ fn fill_opening_succeeded() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let reward_policy = Some(RewardPolicy {
-            reward_per_block: 10,
-        });
+        let reward_per_block = 10;
 
         let add_opening_fixture = AddOpeningFixture::default()
             .with_starting_block(starting_block)
-            .with_reward_policy(reward_policy.clone());
+            .with_reward_per_block(Some(reward_per_block.clone()));
 
         let opening_id = add_opening_fixture.call().unwrap();
 
@@ -230,7 +221,7 @@ fn fill_opening_succeeded() {
 
         let fill_opening_fixture =
             FillOpeningFixture::default_for_ids(opening_id, vec![application_id])
-                .with_reward_policy(reward_policy)
+                .with_reward_per_block(Some(reward_per_block))
                 .with_created_at(starting_block);
 
         let worker_id = fill_opening_fixture.call_and_assert(Ok(()));
@@ -536,10 +527,9 @@ fn leave_worker_role_succeeds_with_paying_missed_reward() {
     build_test_externalities().execute_with(|| {
         let account_id = 1;
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         let worker_id = HireRegularWorkerFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire();
         let block_number = 4;
 
@@ -564,10 +554,9 @@ fn leave_worker_role_succeeds_with_partial_payment_of_missed_reward() {
     build_test_externalities().execute_with(|| {
         let account_id = 1;
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         let worker_id = HireRegularWorkerFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire();
         let block_number = 4;
 
@@ -694,10 +683,9 @@ fn terminate_worker_role_succeeds_with_paying_missed_reward() {
     build_test_externalities().execute_with(|| {
         let account_id = 1;
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         let worker_id = HireRegularWorkerFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire();
         let block_number = 4;
 
@@ -1937,10 +1925,9 @@ fn increase_worker_stake_fails_with_leaving_worker() {
 fn rewards_payments_are_successful() {
     build_test_externalities().execute_with(|| {
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         let worker_id = HireRegularWorkerFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire();
 
         let worker = TestWorkingGroup::worker_by_id(worker_id);
@@ -1965,10 +1952,9 @@ fn rewards_payments_are_successful() {
 fn rewards_payments_with_no_budget() {
     build_test_externalities().execute_with(|| {
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         let worker_id = HireRegularWorkerFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire();
 
         let worker = TestWorkingGroup::worker_by_id(worker_id);
@@ -1995,10 +1981,9 @@ fn rewards_payments_with_no_budget() {
 fn rewards_payments_with_insufficient_budget_and_restored_budget() {
     build_test_externalities().execute_with(|| {
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         let worker_id = HireRegularWorkerFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire();
 
         let worker = TestWorkingGroup::worker_by_id(worker_id);
@@ -2045,11 +2030,10 @@ fn rewards_payments_with_starting_block() {
         run_to_block(starting_block);
 
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
         let reward_period: u64 = RewardPeriod::get().into();
 
         let worker_id = HireRegularWorkerFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire();
 
         let worker = TestWorkingGroup::worker_by_id(worker_id);
@@ -2107,10 +2091,9 @@ fn update_reward_account_succeeds() {
         run_to_block(1);
 
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         let worker_id = HireRegularWorkerFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire();
 
         let new_reward_account = 22;
@@ -2130,10 +2113,9 @@ fn update_reward_account_succeeds() {
 fn update_reward_account_succeeds_for_leader() {
     build_test_externalities().execute_with(|| {
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         let worker_id = HireLeadFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire_lead();
 
         let new_reward_account = 22;
@@ -2158,10 +2140,9 @@ fn update_reward_account_fails_with_invalid_origin() {
 fn update_reward_account_fails_with_invalid_origin_signed_account() {
     build_test_externalities().execute_with(|| {
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         let worker_id = HireLeadFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire_lead();
 
         let invalid_role_account = 23333;
@@ -2180,10 +2161,9 @@ fn update_reward_account_fails_with_invalid_origin_signed_account() {
 fn update_reward_account_fails_with_invalid_worker_id() {
     build_test_externalities().execute_with(|| {
         let reward_per_block = 10;
-        let reward_policy = Some(RewardPolicy { reward_per_block });
 
         HireRegularWorkerFixture::default()
-            .with_reward_policy(reward_policy)
+            .with_reward_per_block(Some(reward_per_block))
             .hire();
 
         let invalid_worker_id = 11;
@@ -2224,16 +2204,16 @@ fn update_reward_amount_succeeds() {
 
         let worker_id = HireRegularWorkerFixture::default().hire();
 
-        let reward_per_block = Some(120);
+        let reward_per_block = 120;
 
         let update_amount_fixture = UpdateRewardAmountFixture::default_for_worker_id(worker_id)
-            .with_reward_per_block(reward_per_block);
+            .with_reward_per_block(Some(reward_per_block));
 
         update_amount_fixture.call_and_assert(Ok(()));
 
         EventFixture::assert_last_crate_event(RawEvent::WorkerRewardAmountUpdated(
             worker_id,
-            reward_per_block,
+            Some(reward_per_block),
         ));
     });
 }
@@ -2242,9 +2222,7 @@ fn update_reward_amount_succeeds() {
 fn update_reward_amount_succeeds_for_leader() {
     build_test_externalities().execute_with(|| {
         let worker_id = HireLeadFixture::default()
-            .with_reward_policy(Some(RewardPolicy {
-                reward_per_block: 1000,
-            }))
+            .with_reward_per_block(Some(1000))
             .hire_lead();
 
         let update_amount_fixture = UpdateRewardAmountFixture::default_for_worker_id(worker_id)

--- a/runtime-modules/working-group/src/types.rs
+++ b/runtime-modules/working-group/src/types.rs
@@ -70,8 +70,8 @@ pub struct Opening<BlockNumber: Ord, Balance> {
     /// Stake policy for the job opening.
     pub stake_policy: Option<StakePolicy<BlockNumber, Balance>>,
 
-    /// Reward policy for the job opening.
-    pub reward_policy: Option<RewardPolicy<Balance>>,
+    /// Reward per block for the job opening.
+    pub reward_per_block: Option<Balance>,
 }
 
 /// Defines type of the opening: regular working group fellow or group leader.
@@ -195,14 +195,6 @@ impl<AccountId: Clone, MemberId: Clone, BlockNumber, Balance>
     pub fn is_leaving(&self) -> bool {
         self.started_leaving_at.is_some()
     }
-}
-
-/// Reward policy for the job opening.
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Debug, Clone, Default, PartialEq, Eq)]
-pub struct RewardPolicy<Balance> {
-    /// Reward per block for the worker.
-    pub reward_per_block: Balance,
 }
 
 /// Stake policy for the job opening.

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -121,7 +121,7 @@ where
             add_opening_params.description,
             OpeningType::Leader,
             add_opening_params.stake_policy,
-            add_opening_params.reward_policy,
+            add_opening_params.reward_per_block,
         )
     }
 

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -80,7 +80,7 @@ fn add_opening(
             ProposalDetails::AddWorkingGroupLeaderOpening(AddOpeningParameters {
                 description: Vec::new(),
                 stake_policy: stake_policy.clone(),
-                reward_policy: None,
+                reward_per_block: None,
                 working_group,
             }),
         )


### PR DESCRIPTION
# Tackling #1843

This PR drops `RewardPolicy` struct and use `Balance` instead to represent the `reward_per_block` in `Opening`