### PR TITLE
Add invites to membership module.

### DIFF
--- a/runtime-modules/common/src/working_group.rs
+++ b/runtime-modules/common/src/working_group.rs
@@ -21,7 +21,10 @@ pub enum WorkingGroup {
 
 /// Working group interface to use in the in the pallets with working groups.
 pub trait WorkingGroupIntegration<T: crate::Trait> {
+    /// Validate origin for the worker
     fn ensure_worker_origin(origin: T::Origin, worker_id: &T::ActorId) -> DispatchResult;
+
+    fn get_leader_member_id() -> Option<T::MemberId>;
 
     // TODO: Implement or remove during the Forum refactoring to this interface
     // /// Defines whether the member is the leader of the working group.

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -26,6 +26,7 @@ parameter_types! {
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
     pub const MembershipFee: u64 = 100;
+    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 impl frame_system::Trait for Test {
@@ -80,6 +81,7 @@ impl membership::Trait for Test {
     type Event = ();
     type MembershipFee = MembershipFee;
     type WorkingGroup = ();
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -26,6 +26,7 @@ parameter_types! {
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
     pub const DefaultMembershipPrice: u64 = 100;
+    pub const DefaultInitialInvitationBalance: u64 = 100;
 }
 
 impl frame_system::Trait for Test {
@@ -80,6 +81,7 @@ impl membership::Trait for Test {
     type Event = ();
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
+    type DefaultInitialInvitationBalance = ();
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -91,6 +91,10 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
     ) -> DispatchResult {
         unimplemented!();
     }
+
+    fn get_leader_member_id() -> Option<<Test as common::Trait>::MemberId> {
+        unimplemented!();
+    }
 }
 
 impl minting::Trait for Test {

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -26,7 +26,6 @@ parameter_types! {
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
     pub const DefaultMembershipPrice: u64 = 100;
-    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 impl frame_system::Trait for Test {
@@ -81,7 +80,6 @@ impl membership::Trait for Test {
     type Event = ();
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/governance/src/mock.rs
+++ b/runtime-modules/governance/src/mock.rs
@@ -25,7 +25,7 @@ parameter_types! {
     pub const MaximumBlockLength: u32 = 2 * 1024;
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
-    pub const MembershipFee: u64 = 100;
+    pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
@@ -79,7 +79,7 @@ impl common::Trait for Test {
 }
 impl membership::Trait for Test {
     type Event = ();
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -69,6 +69,9 @@ pub trait Trait:
 
     /// Working group pallet integration.
     type WorkingGroup: common::working_group::WorkingGroupIntegration<Self>;
+
+    /// Defines the default invite count for members.
+    type DefaultMemberInvitesCount: Get<u32>;
 }
 
 // Default user info constraints
@@ -110,6 +113,9 @@ pub struct MembershipObject<AccountId> {
     /// An indicator that reflects whether the implied real world identity in the profile
     /// corresponds to the true actor behind the membership.
     pub verified: bool,
+
+    /// Defines how many invitations this member has
+    pub invites: u32,
 }
 
 // Contains valid or default user details
@@ -625,6 +631,7 @@ impl<T: Trait> Module<T> {
             root_account: root_account.clone(),
             controller_account: controller_account.clone(),
             verified: false,
+            invites: T::DefaultMemberInvitesCount::get(),
         };
 
         <MemberIdsByRootAccountId<T>>::mutate(root_account, |ids| {

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -182,9 +182,6 @@ pub struct InviteMembershipParameters<AccountId, MemberId> {
 decl_error! {
     /// Membership module predefined errors
     pub enum Error for Module<T: Trait> {
-        /// New members not allowed.
-        NewMembersNotAllowed,
-
         /// Not enough balance to buy membership.
         NotEnoughBalanceToBuyMembership,
 
@@ -253,9 +250,6 @@ decl_storage! {
         /// Registered unique handles and their mapping to their owner.
         pub MemberIdByHandle get(fn handles) : map hasher(blake2_128_concat)
             Vec<u8> => T::MemberId;
-
-        /// Is the platform is accepting new members or not.
-        pub NewMembershipsAllowed get(fn new_memberships_allowed) : bool = true;
 
         /// Minimum allowed handle length.
         pub MinHandleLength get(fn min_handle_length) : u32 = DEFAULT_MIN_HANDLE_LENGTH;
@@ -341,9 +335,6 @@ decl_module! {
             params: BuyMembershipParameters<T::AccountId, T::MemberId>
         ) {
             let who = ensure_signed(origin)?;
-
-            // Make sure we are accepting new memberships.
-            ensure!(Self::new_memberships_allowed(), Error::<T>::NewMembersNotAllowed);
 
             let fee = Self::membership_price();
 
@@ -591,9 +582,6 @@ decl_module! {
 
             let mut inviting_membership = Self::ensure_membership(params.inviting_member_id)?;
             ensure!(inviting_membership.invites > Zero::zero(), Error::<T>::NotEnoughInvites);
-
-            // Make sure we are accepting new memberships.
-            ensure!(Self::new_memberships_allowed(), Error::<T>::NewMembersNotAllowed);
 
             // Verify user parameters.
             let user_info = Self::check_user_registration_info(

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -326,6 +326,7 @@ decl_event! {
         MembershipPriceUpdated(Balance),
         InitialInvitationBalanceUpdated(Balance),
         LeaderInvitationQuotaUpdated(u32),
+        InitialInvitationCountUpdated(u32),
     }
 }
 
@@ -533,10 +534,7 @@ decl_module! {
 
         /// Updates membership referral cut. Requires root origin.
         #[weight = 10_000_000] // TODO: adjust weight
-        pub fn set_referral_cut(
-            origin,
-            value: BalanceOf<T>
-        ) {
+        pub fn set_referral_cut(origin, value: BalanceOf<T>) {
             ensure_root(origin)?;
 
             //
@@ -628,10 +626,7 @@ decl_module! {
 
         /// Updates membership price. Requires root origin.
         #[weight = 10_000_000] // TODO: adjust weight
-        pub fn set_membership_price(
-            origin,
-            new_price: BalanceOf<T>
-        ) {
+        pub fn set_membership_price(origin, new_price: BalanceOf<T>) {
             ensure_root(origin)?;
 
             //
@@ -645,10 +640,7 @@ decl_module! {
 
         /// Updates leader invitation quota. Requires root origin.
         #[weight = 10_000_000] // TODO: adjust weight
-        pub fn set_leader_invitation_quota(
-            origin,
-            invitation_quota: u32
-        ) {
+        pub fn set_leader_invitation_quota(origin, invitation_quota: u32) {
             ensure_root(origin)?;
 
             let leader_member_id = T::WorkingGroup::get_leader_member_id();
@@ -672,13 +664,9 @@ decl_module! {
             }
         }
 
-
         /// Updates initial invitation balance for a invited member. Requires root origin.
         #[weight = 10_000_000] // TODO: adjust weight
-        pub fn set_initial_invitation_balance(
-            origin,
-            new_initial_balance: BalanceOf<T>
-        ) {
+        pub fn set_initial_invitation_balance(origin, new_initial_balance: BalanceOf<T>) {
             ensure_root(origin)?;
 
             //
@@ -688,6 +676,20 @@ decl_module! {
             <InitialInvitationBalance<T>>::put(new_initial_balance);
 
             Self::deposit_event(RawEvent::InitialInvitationBalanceUpdated(new_initial_balance));
+        }
+
+        /// Updates initial invitation count for a member. Requires root origin.
+        #[weight = 10_000_000] // TODO: adjust weight
+        pub fn set_initial_invitation_count(origin, new_invitation_count: u32) {
+            ensure_root(origin)?;
+
+            //
+            // == MUTATION SAFE ==
+            //
+
+            InitialInvitationCount::put(new_invitation_count);
+
+            Self::deposit_event(RawEvent::InitialInvitationCountUpdated(new_invitation_count));
         }
     }
 }

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -71,9 +71,6 @@ pub trait Trait:
 
     /// Working group pallet integration.
     type WorkingGroup: common::working_group::WorkingGroupIntegration<Self>;
-
-    /// Defines the default invite count for members.
-    type DefaultMemberInvitesCount: Get<u32>;
 }
 
 // Default user info constraints
@@ -82,7 +79,7 @@ const DEFAULT_MAX_HANDLE_LENGTH: u32 = 40;
 const DEFAULT_MAX_AVATAR_URI_LENGTH: u32 = 1024;
 const DEFAULT_MAX_ABOUT_TEXT_LENGTH: u32 = 2048;
 const DEFAULT_MAX_NAME_LENGTH: u32 = 200;
-const DEFAULT_MEMBER_INVITES_COUNT: u32 = 5;
+pub(crate) const DEFAULT_MEMBER_INVITES_COUNT: u32 = 5;
 
 /// Public membership profile alias.
 pub type Membership<T> = MembershipObject<<T as frame_system::Trait>::AccountId>;

--- a/runtime-modules/membership/src/tests/fixtures.rs
+++ b/runtime-modules/membership/src/tests/fixtures.rs
@@ -263,3 +263,56 @@ impl SetReferralCutFixture {
         Self { origin, ..self }
     }
 }
+
+pub struct TransferInvitesFixture {
+    pub origin: RawOrigin<u64>,
+    pub source_member_id: u64,
+    pub target_member_id: u64,
+    pub invites: u32,
+}
+
+impl Default for TransferInvitesFixture {
+    fn default() -> Self {
+        Self {
+            origin: RawOrigin::Signed(ALICE_ACCOUNT_ID),
+            source_member_id: 0,
+            target_member_id: 1,
+            invites: 3,
+        }
+    }
+}
+
+impl TransferInvitesFixture {
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let actual_result = Membership::transfer_invites(
+            self.origin.clone().into(),
+            self.source_member_id,
+            self.target_member_id,
+            self.invites,
+        );
+
+        assert_eq!(expected_result, actual_result);
+    }
+
+    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+        Self { origin, ..self }
+    }
+
+    pub fn with_source_member_id(self, source_member_id: u64) -> Self {
+        Self {
+            source_member_id,
+            ..self
+        }
+    }
+
+    pub fn with_target_member_id(self, target_member_id: u64) -> Self {
+        Self {
+            target_member_id,
+            ..self
+        }
+    }
+
+    pub fn with_invites_number(self, invites: u32) -> Self {
+        Self { invites, ..self }
+    }
+}

--- a/runtime-modules/membership/src/tests/fixtures.rs
+++ b/runtime-modules/membership/src/tests/fixtures.rs
@@ -407,3 +407,40 @@ impl InviteMembershipFixture {
         Self { origin, ..self }
     }
 }
+
+pub struct SetMembershipPriceFixture {
+    pub origin: RawOrigin<u64>,
+    pub price: u64,
+}
+
+pub const DEFAULT_MEMBERSHIP_PRICE: u64 = 100;
+
+impl Default for SetMembershipPriceFixture {
+    fn default() -> Self {
+        Self {
+            origin: RawOrigin::Root,
+            price: DEFAULT_MEMBERSHIP_PRICE,
+        }
+    }
+}
+
+impl SetMembershipPriceFixture {
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let actual_result =
+            Membership::set_membership_price(self.origin.clone().into(), self.price);
+
+        assert_eq!(expected_result, actual_result);
+
+        if actual_result.is_ok() {
+            assert_eq!(Membership::membership_price(), self.price);
+        }
+    }
+
+    pub fn with_price(self, price: u64) -> Self {
+        Self { price, ..self }
+    }
+
+    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+        Self { origin, ..self }
+    }
+}

--- a/runtime-modules/membership/src/tests/fixtures.rs
+++ b/runtime-modules/membership/src/tests/fixtures.rs
@@ -477,3 +477,41 @@ impl SetLeaderInvitationQuotaFixture {
         Self { origin, ..self }
     }
 }
+
+pub struct SetInitialInvitationBalanceFixture {
+    pub origin: RawOrigin<u64>,
+    pub new_initial_balance: u64,
+}
+
+pub const DEFAULT_INITIAL_INVITATION_BALANCE: u64 = 200;
+
+impl Default for SetInitialInvitationBalanceFixture {
+    fn default() -> Self {
+        Self {
+            origin: RawOrigin::Root,
+            new_initial_balance: DEFAULT_INITIAL_INVITATION_BALANCE,
+        }
+    }
+}
+
+impl SetInitialInvitationBalanceFixture {
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let actual_result = Membership::set_initial_invitation_balance(
+            self.origin.clone().into(),
+            self.new_initial_balance,
+        );
+
+        assert_eq!(expected_result, actual_result);
+
+        if actual_result.is_ok() {
+            assert_eq!(
+                Membership::initial_invitation_balance(),
+                self.new_initial_balance
+            );
+        }
+    }
+
+    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+        Self { origin, ..self }
+    }
+}

--- a/runtime-modules/membership/src/tests/fixtures.rs
+++ b/runtime-modules/membership/src/tests/fixtures.rs
@@ -444,3 +444,36 @@ impl SetMembershipPriceFixture {
         Self { origin, ..self }
     }
 }
+
+pub struct SetLeaderInvitationQuotaFixture {
+    pub origin: RawOrigin<u64>,
+    pub quota: u32,
+}
+
+pub const DEFAULT_LEADER_INVITATION_QUOTA: u32 = 100;
+
+impl Default for SetLeaderInvitationQuotaFixture {
+    fn default() -> Self {
+        Self {
+            origin: RawOrigin::Root,
+            quota: DEFAULT_LEADER_INVITATION_QUOTA,
+        }
+    }
+}
+
+impl SetLeaderInvitationQuotaFixture {
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let actual_result =
+            Membership::set_leader_invitation_quota(self.origin.clone().into(), self.quota);
+
+        assert_eq!(expected_result, actual_result);
+
+        if actual_result.is_ok() {
+            assert_eq!(Membership::membership(ALICE_MEMBER_ID).invites, self.quota);
+        }
+    }
+
+    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+        Self { origin, ..self }
+    }
+}

--- a/runtime-modules/membership/src/tests/fixtures.rs
+++ b/runtime-modules/membership/src/tests/fixtures.rs
@@ -515,3 +515,41 @@ impl SetInitialInvitationBalanceFixture {
         Self { origin, ..self }
     }
 }
+
+pub struct SetInitialInvitationCountFixture {
+    pub origin: RawOrigin<u64>,
+    pub new_invitation_count: u32,
+}
+
+pub const DEFAULT_INITIAL_INVITATION_COUNT: u32 = 5;
+
+impl Default for SetInitialInvitationCountFixture {
+    fn default() -> Self {
+        Self {
+            origin: RawOrigin::Root,
+            new_invitation_count: DEFAULT_INITIAL_INVITATION_COUNT,
+        }
+    }
+}
+
+impl SetInitialInvitationCountFixture {
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let actual_result = Membership::set_initial_invitation_count(
+            self.origin.clone().into(),
+            self.new_invitation_count,
+        );
+
+        assert_eq!(expected_result, actual_result);
+
+        if actual_result.is_ok() {
+            assert_eq!(
+                Membership::initial_invitation_count(),
+                self.new_invitation_count
+            );
+        }
+    }
+
+    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+        Self { origin, ..self }
+    }
+}

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -102,6 +102,7 @@ impl common::Trait for Test {
 parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [9; 8];
+    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -222,6 +223,7 @@ impl Trait for Test {
     type Event = TestEvent;
     type MembershipFee = MembershipFee;
     type WorkingGroup = ();
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -103,7 +103,6 @@ impl common::Trait for Test {
 parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [9; 8];
-    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -224,7 +223,6 @@ impl Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -5,6 +5,7 @@ pub use crate::{GenesisConfig, Trait};
 pub use frame_support::traits::{Currency, LockIdentifier};
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 
+use crate::tests::fixtures::ALICE_MEMBER_ID;
 pub use frame_system;
 use frame_system::RawOrigin;
 use sp_core::H256;
@@ -243,6 +244,10 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
         } else {
             Err(DispatchError::BadOrigin)
         }
+    }
+
+    fn get_leader_member_id() -> Option<<Test as common::Trait>::MemberId> {
+        Some(ALICE_MEMBER_ID)
     }
 }
 

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -103,6 +103,7 @@ impl common::Trait for Test {
 parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [9; 8];
+    pub const DefaultInitialInvitationBalance: u64 = 100;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -223,6 +224,7 @@ impl Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
+    type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -81,7 +81,7 @@ impl pallet_timestamp::Trait for Test {
 
 parameter_types! {
     pub const ExistentialDeposit: u32 = 0;
-    pub const MembershipFee: u64 = 100;
+    pub const DefaultMembershipPrice: u64 = 100;
 }
 
 impl balances::Trait for Test {
@@ -221,7 +221,7 @@ impl common::origin::ActorOriginValidator<Origin, u64, u64> for () {
 
 impl Trait for Test {
     type Event = TestEvent;
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -76,21 +76,6 @@ fn buy_membership_fails_without_enough_balance_with_locked_balance() {
 }
 
 #[test]
-fn new_memberships_allowed_flag_works() {
-    build_test_externalities().execute_with(|| {
-        let initial_balance = DefaultMembershipPrice::get() + 1;
-        set_alice_free_balance(initial_balance);
-
-        crate::NewMembershipsAllowed::put(false);
-
-        assert_dispatch_error_message(
-            buy_default_membership_as_alice(),
-            Err(Error::<Test>::NewMembersNotAllowed.into()),
-        );
-    });
-}
-
-#[test]
 fn buy_membership_fails_with_non_unique_handle() {
     build_test_externalities().execute_with(|| {
         let initial_balance = DefaultMembershipPrice::get();
@@ -586,21 +571,6 @@ fn invite_member_fails_with_not_enough_invites() {
     build_test_externalities_with_initial_members(initial_members.to_vec()).execute_with(|| {
         InviteMembershipFixture::default()
             .call_and_assert(Err(Error::<Test>::NotEnoughInvites.into()));
-    });
-}
-
-#[test]
-fn invite_member_fails_with_not_allowed_membership() {
-    build_test_externalities().execute_with(|| {
-        let initial_balance = DefaultMembershipPrice::get();
-        set_alice_free_balance(initial_balance);
-
-        assert_ok!(buy_default_membership_as_alice());
-
-        crate::NewMembershipsAllowed::put(false);
-
-        InviteMembershipFixture::default()
-            .call_and_assert(Err(Error::<Test>::NewMembersNotAllowed.into()));
     });
 }
 

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -685,3 +685,36 @@ fn buy_membership_with_zero_membership_price_succeeds() {
         assert_eq!(Balances::usable_balance(&ALICE_ACCOUNT_ID), initial_balance);
     });
 }
+
+#[test]
+fn set_leader_invitation_quota_succeeds() {
+    let initial_members = [(ALICE_MEMBER_ID, ALICE_ACCOUNT_ID)];
+
+    build_test_externalities_with_initial_members(initial_members.to_vec()).execute_with(|| {
+        let starting_block = 1;
+        run_to_block(starting_block);
+
+        SetLeaderInvitationQuotaFixture::default().call_and_assert(Ok(()));
+
+        EventFixture::assert_last_crate_event(Event::<Test>::LeaderInvitationQuotaUpdated(
+            DEFAULT_LEADER_INVITATION_QUOTA,
+        ));
+    });
+}
+
+#[test]
+fn set_leader_invitation_quota_with_invalid_origin() {
+    build_test_externalities().execute_with(|| {
+        SetLeaderInvitationQuotaFixture::default()
+            .with_origin(RawOrigin::Signed(ALICE_ACCOUNT_ID))
+            .call_and_assert(Err(DispatchError::BadOrigin));
+    });
+}
+
+#[test]
+fn set_leader_invitation_quota_fails_with_not_found_leader_membership() {
+    build_test_externalities().execute_with(|| {
+        SetLeaderInvitationQuotaFixture::default()
+            .call_and_assert(Err(Error::<Test>::MemberProfileNotFound.into()));
+    });
+}

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -34,7 +34,7 @@ fn buy_membership_succeeds() {
         assert_eq!(Some(profile.handle), get_alice_info().handle);
         assert_eq!(Some(profile.avatar_uri), get_alice_info().avatar_uri);
         assert_eq!(Some(profile.about), get_alice_info().about);
-        assert_eq!(profile.invites, DefaultMemberInvitesCount::get());
+        assert_eq!(profile.invites, crate::DEFAULT_MEMBER_INVITES_COUNT);
 
         // controller account initially set to primary account
         assert_eq!(profile.controller_account, ALICE_ACCOUNT_ID);
@@ -437,7 +437,7 @@ fn transfer_invites_succeeds() {
         assert_eq!(alice.invites, tranfer_invites_fixture.invites);
         assert_eq!(
             bob.invites,
-            DefaultMemberInvitesCount::get() - tranfer_invites_fixture.invites
+            crate::DEFAULT_MEMBER_INVITES_COUNT - tranfer_invites_fixture.invites
         );
 
         EventFixture::assert_last_crate_event(Event::<Test>::InvitesTransferred(

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -741,3 +741,26 @@ fn set_initial_invitation_balance_fails_with_invalid_origin() {
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
 }
+
+#[test]
+fn set_initial_invitation_count_succeeds() {
+    build_test_externalities().execute_with(|| {
+        let starting_block = 1;
+        run_to_block(starting_block);
+
+        SetInitialInvitationCountFixture::default().call_and_assert(Ok(()));
+
+        EventFixture::assert_last_crate_event(Event::<Test>::InitialInvitationCountUpdated(
+            DEFAULT_INITIAL_INVITATION_COUNT,
+        ));
+    });
+}
+
+#[test]
+fn set_initial_invitation_count_fails_with_invalid_origin() {
+    build_test_externalities().execute_with(|| {
+        SetInitialInvitationCountFixture::default()
+            .with_origin(RawOrigin::Signed(ALICE_ACCOUNT_ID))
+            .call_and_assert(Err(DispatchError::BadOrigin));
+    });
+}

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -18,7 +18,7 @@ fn buy_membership_succeeds() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         let next_member_id = Membership::members_created();
@@ -50,7 +50,7 @@ fn buy_membership_succeeds() {
 #[test]
 fn buy_membership_fails_without_enough_balance() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get() - 1;
+        let initial_balance = DefaultMembershipPrice::get() - 1;
         set_alice_free_balance(initial_balance);
 
         assert_dispatch_error_message(
@@ -63,7 +63,7 @@ fn buy_membership_fails_without_enough_balance() {
 #[test]
 fn buy_membership_fails_without_enough_balance_with_locked_balance() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         let lock_id = LockIdentifier::default();
         Balances::set_lock(lock_id, &ALICE_ACCOUNT_ID, 1, WithdrawReasons::all());
         set_alice_free_balance(initial_balance);
@@ -78,7 +78,7 @@ fn buy_membership_fails_without_enough_balance_with_locked_balance() {
 #[test]
 fn new_memberships_allowed_flag_works() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get() + 1;
+        let initial_balance = DefaultMembershipPrice::get() + 1;
         set_alice_free_balance(initial_balance);
 
         crate::NewMembershipsAllowed::put(false);
@@ -93,7 +93,7 @@ fn new_memberships_allowed_flag_works() {
 #[test]
 fn buy_membership_fails_with_non_unique_handle() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         // alice's handle already taken
@@ -113,7 +113,7 @@ fn update_profile_succeeds() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         let next_member_id = Membership::members_created();
@@ -147,7 +147,7 @@ fn update_profile_succeeds() {
 #[test]
 fn update_profile_has_no_effect_on_empty_parameters() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         let next_member_id = Membership::members_created();
@@ -248,7 +248,7 @@ fn update_verification_status_succeeds() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         let next_member_id = Membership::members_created();
@@ -291,7 +291,7 @@ fn update_verification_status_fails_with_invalid_member_id() {
 #[test]
 fn update_verification_status_fails_with_invalid_worker_id() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         let next_member_id = Membership::members_created();
@@ -313,7 +313,7 @@ fn update_verification_status_fails_with_invalid_worker_id() {
 #[test]
 fn buy_membership_fails_with_invalid_name() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         let name: [u8; 500] = [1; 500];
@@ -327,7 +327,7 @@ fn buy_membership_fails_with_invalid_name() {
 #[test]
 fn buy_membership_fails_with_non_member_referrer_id() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         let invalid_member_id = 111;
@@ -360,7 +360,7 @@ fn buy_membership_with_referral_cut_succeeds() {
         assert_eq!(Balances::usable_balance(&ALICE_ACCOUNT_ID), referral_cut);
         assert_eq!(
             Balances::usable_balance(&BOB_ACCOUNT_ID),
-            initial_balance - MembershipFee::get()
+            initial_balance - DefaultMembershipPrice::get()
         );
     });
 }
@@ -369,7 +369,7 @@ fn buy_membership_with_referral_cut_succeeds() {
 fn referral_bonus_calculated_successfully() {
     build_test_externalities().execute_with(|| {
         // it should take minimum of the referral cut and membership fee
-        let membership_fee = MembershipFee::get();
+        let membership_fee = DefaultMembershipPrice::get();
         let diff = 10;
 
         let referral_cut = membership_fee.saturating_sub(diff);
@@ -511,7 +511,7 @@ fn invite_member_succeeds() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         assert_ok!(buy_default_membership_as_alice());
@@ -551,7 +551,7 @@ fn invite_member_fails_with_bad_origin() {
 #[test]
 fn invite_member_fails_with_invalid_member_id() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         assert_ok!(buy_default_membership_as_alice());
@@ -566,7 +566,7 @@ fn invite_member_fails_with_invalid_member_id() {
 #[test]
 fn invite_member_fails_with_not_controller_account() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         assert_ok!(buy_default_membership_as_alice());
@@ -592,7 +592,7 @@ fn invite_member_fails_with_not_enough_invites() {
 #[test]
 fn invite_member_fails_with_not_allowed_membership() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         assert_ok!(buy_default_membership_as_alice());
@@ -607,7 +607,7 @@ fn invite_member_fails_with_not_allowed_membership() {
 #[test]
 fn invite_member_fails_with_bad_user_information() {
     build_test_externalities().execute_with(|| {
-        let initial_balance = MembershipFee::get();
+        let initial_balance = DefaultMembershipPrice::get();
         set_alice_free_balance(initial_balance);
 
         assert_ok!(buy_default_membership_as_alice());
@@ -642,5 +642,46 @@ fn invite_member_fails_with_bad_user_information() {
         InviteMembershipFixture::default()
             .with_handle(handle)
             .call_and_assert(Err(Error::<Test>::HandleAlreadyRegistered.into()));
+    });
+}
+
+#[test]
+fn set_membership_price_succeeds() {
+    build_test_externalities().execute_with(|| {
+        let starting_block = 1;
+        run_to_block(starting_block);
+
+        SetMembershipPriceFixture::default().call_and_assert(Ok(()));
+
+        EventFixture::assert_last_crate_event(Event::<Test>::MembershipPriceUpdated(
+            DEFAULT_MEMBERSHIP_PRICE,
+        ));
+    });
+}
+
+#[test]
+fn set_membership_price_fails_with_invalid_origin() {
+    build_test_externalities().execute_with(|| {
+        SetMembershipPriceFixture::default()
+            .with_origin(RawOrigin::Signed(ALICE_ACCOUNT_ID))
+            .call_and_assert(Err(DispatchError::BadOrigin));
+    });
+}
+
+#[test]
+fn buy_membership_with_zero_membership_price_succeeds() {
+    build_test_externalities().execute_with(|| {
+        let initial_balance = 10000;
+        increase_total_balance_issuance_using_account_id(ALICE_ACCOUNT_ID, initial_balance);
+
+        // Set zero membership price
+        SetMembershipPriceFixture::default()
+            .with_price(0)
+            .call_and_assert(Ok(()));
+
+        // Try to buy membership.
+        BuyMembershipFixture::default().call_and_assert(Ok(()));
+
+        assert_eq!(Balances::usable_balance(&ALICE_ACCOUNT_ID), initial_balance);
     });
 }

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -718,3 +718,26 @@ fn set_leader_invitation_quota_fails_with_not_found_leader_membership() {
             .call_and_assert(Err(Error::<Test>::MemberProfileNotFound.into()));
     });
 }
+
+#[test]
+fn set_initial_invitation_balance_succeeds() {
+    build_test_externalities().execute_with(|| {
+        let starting_block = 1;
+        run_to_block(starting_block);
+
+        SetInitialInvitationBalanceFixture::default().call_and_assert(Ok(()));
+
+        EventFixture::assert_last_crate_event(Event::<Test>::InitialInvitationBalanceUpdated(
+            DEFAULT_INITIAL_INVITATION_BALANCE,
+        ));
+    });
+}
+
+#[test]
+fn set_initial_invitation_balance_fails_with_invalid_origin() {
+    build_test_externalities().execute_with(|| {
+        SetInitialInvitationBalanceFixture::default()
+            .with_origin(RawOrigin::Signed(ALICE_ACCOUNT_ID))
+            .call_and_assert(Err(DispatchError::BadOrigin));
+    });
+}

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -435,10 +435,7 @@ fn transfer_invites_succeeds() {
         let alice = Membership::membership(alice_member_id);
         let bob = Membership::membership(bob_member_id);
 
-        assert_eq!(
-            alice.invites,
-            DefaultMemberInvitesCount::get() + tranfer_invites_fixture.invites
-        );
+        assert_eq!(alice.invites, tranfer_invites_fixture.invites);
         assert_eq!(
             bob.invites,
             DefaultMemberInvitesCount::get() - tranfer_invites_fixture.invites

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -53,6 +53,7 @@ impl membership::Trait for Test {
     type Event = ();
     type MembershipFee = MembershipFee;
     type WorkingGroup = ();
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {
@@ -65,6 +66,7 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
 }
 
 parameter_types! {
+    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const MembershipFee: u64 = 100;
     pub const ExistentialDeposit: u32 = 0;
 }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -53,6 +53,7 @@ impl membership::Trait for Test {
     type Event = ();
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
+    type DefaultInitialInvitationBalance = ();
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {
@@ -71,6 +72,7 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
 parameter_types! {
     pub const DefaultMembershipPrice: u64 = 100;
     pub const ExistentialDeposit: u32 = 0;
+    pub const DefaultInitialInvitationBalance: u64 = 100;
 }
 
 impl balances::Trait for Test {

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -63,6 +63,10 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
     ) -> DispatchResult {
         unimplemented!();
     }
+
+    fn get_leader_member_id() -> Option<<Test as common::Trait>::MemberId> {
+        unimplemented!();
+    }
 }
 
 parameter_types! {

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -51,7 +51,7 @@ impl common::Trait for Test {
 
 impl membership::Trait for Test {
     type Event = ();
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
@@ -67,7 +67,7 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
 
 parameter_types! {
     pub const DefaultMemberInvitesCount: u32 = 5;
-    pub const MembershipFee: u64 = 100;
+    pub const DefaultMembershipPrice: u64 = 100;
     pub const ExistentialDeposit: u32 = 0;
 }
 

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -53,7 +53,6 @@ impl membership::Trait for Test {
     type Event = ();
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {
@@ -70,7 +69,6 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
 }
 
 parameter_types! {
-    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const DefaultMembershipPrice: u64 = 100;
     pub const ExistentialDeposit: u32 = 0;
 }

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -57,6 +57,7 @@ parameter_types! {
     pub const CreationFee: u32 = 0;
     pub const MaxWhiteListSize: u32 = 4;
     pub const MembershipFee: u64 = 100;
+    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 impl balances::Trait for Test {
@@ -82,6 +83,7 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type MembershipFee = MembershipFee;
     type WorkingGroup = ();
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -57,7 +57,6 @@ parameter_types! {
     pub const CreationFee: u32 = 0;
     pub const MaxWhiteListSize: u32 = 4;
     pub const DefaultMembershipPrice: u64 = 100;
-    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 impl balances::Trait for Test {
@@ -83,7 +82,6 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -93,6 +93,10 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
     ) -> DispatchResult {
         unimplemented!();
     }
+
+    fn get_leader_member_id() -> Option<<Test as common::Trait>::MemberId> {
+        unimplemented!();
+    }
 }
 
 impl crate::Trait for Test {

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -56,7 +56,7 @@ parameter_types! {
     pub const TransferFee: u32 = 0;
     pub const CreationFee: u32 = 0;
     pub const MaxWhiteListSize: u32 = 4;
-    pub const MembershipFee: u64 = 100;
+    pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
@@ -81,7 +81,7 @@ impl common::Trait for Test {
 
 impl membership::Trait for Test {
     type Event = TestEvent;
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -57,6 +57,7 @@ parameter_types! {
     pub const CreationFee: u32 = 0;
     pub const MaxWhiteListSize: u32 = 4;
     pub const DefaultMembershipPrice: u64 = 100;
+    pub const DefaultInitialInvitationBalance: u64 = 100;
 }
 
 impl balances::Trait for Test {
@@ -82,6 +83,7 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
+    type DefaultInitialInvitationBalance = ();
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -79,6 +79,7 @@ parameter_types! {
     pub const MaxActiveProposalLimit: u32 = 100;
     pub const LockId: LockIdentifier = [1; 8];
     pub const MembershipFee: u64 = 100;
+    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 impl common::Trait for Test {
@@ -90,6 +91,7 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type MembershipFee = MembershipFee;
     type WorkingGroup = ();
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -78,7 +78,7 @@ parameter_types! {
     pub const DescriptionMaxLength: u32 = 10000;
     pub const MaxActiveProposalLimit: u32 = 100;
     pub const LockId: LockIdentifier = [1; 8];
-    pub const MembershipFee: u64 = 100;
+    pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
@@ -89,7 +89,7 @@ impl common::Trait for Test {
 
 impl membership::Trait for Test {
     type Event = TestEvent;
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -79,6 +79,7 @@ parameter_types! {
     pub const MaxActiveProposalLimit: u32 = 100;
     pub const LockId: LockIdentifier = [1; 8];
     pub const DefaultMembershipPrice: u64 = 100;
+    pub const DefaultInitialInvitationBalance: u64 = 100;
 }
 
 impl common::Trait for Test {
@@ -90,6 +91,7 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
+    type DefaultInitialInvitationBalance = ();
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -101,6 +101,10 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
     ) -> DispatchResult {
         unimplemented!();
     }
+
+    fn get_leader_member_id() -> Option<<Test as common::Trait>::MemberId> {
+        unimplemented!();
+    }
 }
 
 impl crate::Trait for Test {

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -79,7 +79,6 @@ parameter_types! {
     pub const MaxActiveProposalLimit: u32 = 100;
     pub const LockId: LockIdentifier = [1; 8];
     pub const DefaultMembershipPrice: u64 = 100;
-    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 impl common::Trait for Test {
@@ -91,7 +90,6 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -50,6 +50,7 @@ parameter_types! {
     pub const MinimumPeriod: u64 = 5;
     pub const ExistentialDeposit: u32 = 0;
     pub const DefaultMembershipPrice: u64 = 100;
+    pub const DefaultInitialInvitationBalance: u64 = 100;
 }
 
 impl frame_system::Trait for Test {
@@ -98,6 +99,7 @@ impl membership::Trait for Test {
     type Event = MetaEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
+    type DefaultInitialInvitationBalance = ();
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -98,7 +98,6 @@ impl membership::Trait for Test {
     type Event = MetaEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {
@@ -135,7 +134,6 @@ impl recurringrewards::Trait for Test {
 }
 
 parameter_types! {
-    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId1: [u8; 8] = [1; 8];
 }

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -98,6 +98,7 @@ impl membership::Trait for Test {
     type Event = MetaEvent;
     type MembershipFee = MembershipFee;
     type WorkingGroup = ();
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {
@@ -130,6 +131,7 @@ impl recurringrewards::Trait for Test {
 }
 
 parameter_types! {
+    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId1: [u8; 8] = [1; 8];
 }

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -49,7 +49,7 @@ parameter_types! {
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
     pub const ExistentialDeposit: u32 = 0;
-    pub const MembershipFee: u64 = 100;
+    pub const DefaultMembershipPrice: u64 = 100;
 }
 
 impl frame_system::Trait for Test {
@@ -96,7 +96,7 @@ impl common::Trait for Test {
 
 impl membership::Trait for Test {
     type Event = MetaEvent;
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -108,6 +108,10 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
     ) -> DispatchResult {
         unimplemented!();
     }
+
+    fn get_leader_member_id() -> Option<<Test as common::Trait>::MemberId> {
+        unimplemented!();
+    }
 }
 
 impl common::currency::GovernanceCurrency for Test {

--- a/runtime-modules/staking-handler/src/mock.rs
+++ b/runtime-modules/staking-handler/src/mock.rs
@@ -76,7 +76,6 @@ impl membership::Trait for Test {
     type Event = ();
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {
@@ -104,7 +103,6 @@ pub type System = frame_system::Module<Test>;
 pub type TestStakingManager = crate::StakingManager<Test, LockId>;
 
 parameter_types! {
-    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const RewardPeriod: u32 = 2;
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const MinUnstakingPeriodLimit: u64 = 3;

--- a/runtime-modules/staking-handler/src/mock.rs
+++ b/runtime-modules/staking-handler/src/mock.rs
@@ -86,6 +86,10 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
     ) -> DispatchResult {
         unimplemented!();
     }
+
+    fn get_leader_member_id() -> Option<<Test as common::Trait>::MemberId> {
+        unimplemented!();
+    }
 }
 
 impl pallet_timestamp::Trait for Test {

--- a/runtime-modules/staking-handler/src/mock.rs
+++ b/runtime-modules/staking-handler/src/mock.rs
@@ -76,6 +76,7 @@ impl membership::Trait for Test {
     type Event = ();
     type MembershipFee = MembershipFee;
     type WorkingGroup = ();
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {
@@ -99,6 +100,7 @@ pub type System = frame_system::Module<Test>;
 pub type TestStakingManager = crate::StakingManager<Test, LockId>;
 
 parameter_types! {
+    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const RewardPeriod: u32 = 2;
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const MinUnstakingPeriodLimit: u64 = 3;

--- a/runtime-modules/staking-handler/src/mock.rs
+++ b/runtime-modules/staking-handler/src/mock.rs
@@ -22,7 +22,7 @@ parameter_types! {
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
     pub const ExistentialDeposit: u32 = 0;
-    pub const MembershipFee: u64 = 100;
+    pub const DefaultMembershipPrice: u64 = 100;
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 - remove when sorted.
@@ -74,7 +74,7 @@ impl common::Trait for Test {
 
 impl membership::Trait for Test {
     type Event = ();
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }

--- a/runtime-modules/staking-handler/src/mock.rs
+++ b/runtime-modules/staking-handler/src/mock.rs
@@ -23,6 +23,7 @@ parameter_types! {
     pub const MinimumPeriod: u64 = 5;
     pub const ExistentialDeposit: u32 = 0;
     pub const DefaultMembershipPrice: u64 = 100;
+    pub const DefaultInitialInvitationBalance: u64 = 100;
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 - remove when sorted.
@@ -76,6 +77,7 @@ impl membership::Trait for Test {
     type Event = ();
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
+    type DefaultInitialInvitationBalance = ();
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -156,7 +156,6 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [2; 8];
     pub const DefaultMembershipPrice: u64 = 100;
-    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -285,7 +284,6 @@ impl membership::Trait for Test {
     type Event = MetaEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -156,6 +156,7 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [2; 8];
     pub const DefaultMembershipPrice: u64 = 100;
+    pub const DefaultInitialInvitationBalance: u64 = 100;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -284,6 +285,7 @@ impl membership::Trait for Test {
     type Event = MetaEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
+    type DefaultInitialInvitationBalance = ();
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -155,7 +155,7 @@ impl GovernanceCurrency for Test {
 parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [2; 8];
-    pub const MembershipFee: u64 = 100;
+    pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
@@ -283,7 +283,7 @@ impl common::Trait for Test {
 
 impl membership::Trait for Test {
     type Event = MetaEvent;
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -156,6 +156,7 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [2; 8];
     pub const MembershipFee: u64 = 100;
+    pub const DefaultMemberInvitesCount: u32 = 5;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -284,6 +285,7 @@ impl membership::Trait for Test {
     type Event = MetaEvent;
     type MembershipFee = MembershipFee;
     type WorkingGroup = ();
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 impl common::working_group::WorkingGroupIntegration<Test> for () {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -295,6 +295,10 @@ impl common::working_group::WorkingGroupIntegration<Test> for () {
     ) -> DispatchResult {
         unimplemented!();
     }
+
+    fn get_leader_member_id() -> Option<<Test as common::Trait>::MemberId> {
+        unimplemented!();
+    }
 }
 
 impl minting::Trait for Test {

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -1337,4 +1337,11 @@ impl<T: Trait<I>, I: Instance> common::working_group::WorkingGroupIntegration<T>
     fn ensure_worker_origin(origin: T::Origin, worker_id: &WorkerId<T>) -> DispatchResult {
         checks::ensure_worker_signed::<T, I>(origin, worker_id).map(|_| ())
     }
+
+    fn get_leader_member_id() -> Option<T::MemberId> {
+        checks::ensure_lead_is_set::<T, I>()
+            .map(Self::worker_by_id)
+            .map(|worker| worker.member_id)
+            .ok()
+    }
 }

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -35,7 +35,7 @@ parameter_types! {
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
     pub const ExistentialDeposit: u32 = 0;
-    pub const MembershipFee: u64 = 0;
+    pub const DefaultMembershipPrice: u64 = 0;
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 - remove when sorted.
@@ -98,7 +98,7 @@ impl common::Trait for Test {
 
 impl membership::Trait for Test {
     type Event = TestEvent;
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = Module<Test>;
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -100,12 +100,14 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type MembershipFee = MembershipFee;
     type WorkingGroup = Module<Test>;
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 pub type Balances = balances::Module<Test>;
 pub type System = frame_system::Module<Test>;
 
 parameter_types! {
+    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const RewardPeriod: u32 = 2;
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const MinUnstakingPeriodLimit: u64 = 3;

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -36,6 +36,7 @@ parameter_types! {
     pub const MinimumPeriod: u64 = 5;
     pub const ExistentialDeposit: u32 = 0;
     pub const DefaultMembershipPrice: u64 = 0;
+    pub const DefaultInitialInvitationBalance: u64 = 100;
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 - remove when sorted.
@@ -100,6 +101,7 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = Module<Test>;
+    type DefaultInitialInvitationBalance = ();
 }
 
 pub type Balances = balances::Module<Test>;

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -100,14 +100,12 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = Module<Test>;
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 pub type Balances = balances::Module<Test>;
 pub type System = frame_system::Module<Test>;
 
 parameter_types! {
-    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const RewardPeriod: u32 = 2;
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const MinUnstakingPeriodLimit: u64 = 3;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -480,7 +480,7 @@ impl memo::Trait for Runtime {
 
 parameter_types! {
     pub const MaxObjectsPerInjection: u32 = 100;
-    pub const MembershipFee: Balance = 100;
+    pub const DefaultMembershipPrice: Balance = 100;
 }
 
 impl storage::data_object_type_registry::Trait for Runtime {
@@ -510,7 +510,7 @@ impl common::Trait for Runtime {
 
 impl membership::Trait for Runtime {
     type Event = Event;
-    type MembershipFee = MembershipFee;
+    type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = MembershipWorkingGroup;
     type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -512,11 +512,9 @@ impl membership::Trait for Runtime {
     type Event = Event;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = MembershipWorkingGroup;
-    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 parameter_types! {
-    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const MaxCategoryDepth: u64 = 5;
     pub const MaxSubcategories: u64 = 20;
     pub const MaxThreadsInCategory: u64 = 20;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -512,9 +512,11 @@ impl membership::Trait for Runtime {
     type Event = Event;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = MembershipWorkingGroup;
+    type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
 }
 
 parameter_types! {
+    pub const DefaultInitialInvitationBalance: Balance = 100;
     pub const MaxCategoryDepth: u64 = 5;
     pub const MaxSubcategories: u64 = 20;
     pub const MaxThreadsInCategory: u64 = 20;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -512,9 +512,11 @@ impl membership::Trait for Runtime {
     type Event = Event;
     type MembershipFee = MembershipFee;
     type WorkingGroup = MembershipWorkingGroup;
+    type DefaultMemberInvitesCount = DefaultMemberInvitesCount;
 }
 
 parameter_types! {
+    pub const DefaultMemberInvitesCount: u32 = 5;
     pub const MaxCategoryDepth: u64 = 5;
     pub const MaxSubcategories: u64 = 20;
     pub const MaxThreadsInCategory: u64 = 20;

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -31,7 +31,7 @@ pub(crate) fn initial_test_ext() -> sp_io::TestExternalities {
 pub(crate) fn insert_member(account_id: AccountId32) {
     increase_total_balance_issuance_using_account_id(
         account_id.clone(),
-        crate::MembershipFee::get(),
+        crate::DefaultMembershipPrice::get(),
     );
     let handle: &[u8] = account_id.as_ref();
 


### PR DESCRIPTION
### Changes

#### Added general extrinsics
- add invite_member
- transfer_invites

#### Added "council proposals support" extrinsics
- set_membership_price
- set_membership_lead_invitation_quota
- set_initial_invitation_balance
- set_initial_invitation_count

#### Other
- The initial balance for the invited member will be implemented [later](https://github.com/Joystream/joystream/issues/1932). 
- NewMembershipsAllowed flag was removed


[Related issue](https://github.com/Joystream/joystream/issues/1779)