### PR TITLE
Remove storage fields from the membership pallet.

### DIFF
--- a/runtime-modules/membership/src/tests/fixtures.rs
+++ b/runtime-modules/membership/src/tests/fixtures.rs
@@ -4,6 +4,7 @@ use frame_support::dispatch::DispatchResult;
 use frame_support::traits::{OnFinalize, OnInitialize};
 use frame_support::StorageMap;
 use frame_system::{EventRecord, Phase, RawOrigin};
+use sp_runtime::traits::Hash;
 
 // Recommendation from Parity on testing on_finalize
 // https://substrate.dev/docs/en/next/development/module/tests
@@ -53,23 +54,34 @@ pub fn assert_dispatch_error_message(result: DispatchResult, expected_result: Di
 pub struct TestUserInfo {
     pub name: Option<Vec<u8>>,
     pub handle: Option<Vec<u8>>,
+    pub handle_hash: Option<Vec<u8>>,
     pub avatar_uri: Option<Vec<u8>>,
     pub about: Option<Vec<u8>>,
 }
 
 pub fn get_alice_info() -> TestUserInfo {
+    let handle = b"alice".to_vec();
+    let hashed = <Test as frame_system::Trait>::Hashing::hash(&handle);
+    let hash = hashed.as_ref().to_vec();
+
     TestUserInfo {
         name: Some(b"Alice".to_vec()),
-        handle: Some(b"alice".to_vec()),
+        handle: Some(handle),
+        handle_hash: Some(hash),
         avatar_uri: Some(b"http://avatar-url.com/alice".to_vec()),
         about: Some(b"my name is alice".to_vec()),
     }
 }
 
 pub fn get_bob_info() -> TestUserInfo {
+    let handle = b"bobby".to_vec();
+    let hashed = <Test as frame_system::Trait>::Hashing::hash(&handle);
+    let hash = hashed.as_ref().to_vec();
+
     TestUserInfo {
         name: Some(b"Bob".to_vec()),
-        handle: Some(b"bobby".to_vec()),
+        handle: Some(handle),
+        handle_hash: Some(hash),
         avatar_uri: Some(b"http://avatar-url.com/bob".to_vec()),
         about: Some(b"my name is bob".to_vec()),
     }
@@ -195,13 +207,6 @@ impl BuyMembershipFixture {
     pub fn with_referrer_id(self, referrer_id: u64) -> Self {
         Self {
             referrer_id: Some(referrer_id),
-            ..self
-        }
-    }
-
-    pub fn with_name(self, name: Vec<u8>) -> Self {
-        Self {
-            name: Some(name),
             ..self
         }
     }
@@ -365,20 +370,6 @@ impl InviteMembershipFixture {
 
     pub fn with_member_id(self, member_id: u64) -> Self {
         Self { member_id, ..self }
-    }
-
-    pub fn with_name(self, name: Vec<u8>) -> Self {
-        Self {
-            name: Some(name),
-            ..self
-        }
-    }
-
-    pub fn with_avatar(self, avatar_uri: Vec<u8>) -> Self {
-        Self {
-            avatar_uri: Some(avatar_uri),
-            ..self
-        }
     }
 
     pub fn with_handle(self, handle: Vec<u8>) -> Self {

--- a/runtime-modules/proposals/discussion/src/benchmarking.rs
+++ b/runtime-modules/proposals/discussion/src/benchmarking.rs
@@ -9,7 +9,6 @@ use frame_system::EventRecord;
 use frame_system::Module as System;
 use frame_system::RawOrigin;
 use membership::Module as Membership;
-use sp_std::cmp::min;
 use sp_std::convert::TryInto;
 use sp_std::prelude::*;
 
@@ -22,11 +21,11 @@ fn get_byte(num: u32, byte_number: u8) -> u8 {
 // Method to generate a distintic valid handle
 // for a membership. For each index.
 fn handle_from_id<T: membership::Trait>(id: u32) -> Vec<u8> {
-    let min_handle_length = Membership::<T>::min_handle_length();
+    let min_handle_length = 1;
 
     let mut handle = vec![];
 
-    for i in 0..min(Membership::<T>::max_handle_length().try_into().unwrap(), 4) {
+    for i in 0..4 {
         handle.push(get_byte(id, i));
     }
 

--- a/runtime-modules/proposals/engine/src/benchmarking.rs
+++ b/runtime-modules/proposals/engine/src/benchmarking.rs
@@ -11,7 +11,7 @@ use frame_system::RawOrigin;
 use governance::council::Module as Council;
 use membership::Module as Membership;
 use sp_runtime::traits::{Bounded, One};
-use sp_std::cmp::{max, min};
+use sp_std::cmp::max;
 use sp_std::prelude::*;
 
 const SEED: u32 = 0;
@@ -23,11 +23,11 @@ fn get_byte(num: u32, byte_number: u8) -> u8 {
 // Method to generate a distintic valid handle
 // for a membership. For each index.
 fn handle_from_id<T: membership::Trait>(id: u32) -> Vec<u8> {
-    let min_handle_length = Membership::<T>::min_handle_length();
+    let min_handle_length = 1;
 
     let mut handle = vec![];
 
-    for i in 0..min(Membership::<T>::max_handle_length().try_into().unwrap(), 4) {
+    for i in 0..4 {
         handle.push(get_byte(id, i));
     }
 

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -195,7 +195,20 @@ fn member_funded_account<T: Trait<I> + membership::Trait, I: Instance>(
 
     let _ = Balances::<T>::make_free_balance_be(&account_id, BalanceOf::<T>::max_value());
 
-    (account_id, T::MemberId::from(id.try_into().unwrap()))
+    let member_id = T::MemberId::from(id.try_into().unwrap());
+    Membership::<T>::add_staking_account_candidate(
+        RawOrigin::Signed(account_id.clone()).into(),
+        member_id.clone(),
+        account_id.clone(),
+    )
+    .unwrap();
+    Membership::<T>::confirm_staking_account(
+        RawOrigin::Signed(account_id.clone()).into(),
+        member_id.clone(),
+    )
+    .unwrap();
+
+    (account_id, member_id)
 }
 
 fn force_missed_reward<T: Trait<I>, I: Instance>() {

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -157,11 +157,11 @@ fn add_and_apply_opening<T: Trait<I>, I: Instance>(
 // Method to generate a distintic valid handle
 // for a membership. For each index.
 fn handle_from_id<T: membership::Trait>(id: u32) -> Vec<u8> {
-    let min_handle_length = Membership::<T>::min_handle_length();
+    let min_handle_length = 1;
 
     let mut handle = vec![];
 
-    for i in 0..min(Membership::<T>::max_handle_length().try_into().unwrap(), 4) {
+    for i in 0..4 {
         handle.push(get_byte(id, i));
     }
 

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -199,12 +199,12 @@ fn member_funded_account<T: Trait<I> + membership::Trait, I: Instance>(
     Membership::<T>::add_staking_account_candidate(
         RawOrigin::Signed(account_id.clone()).into(),
         member_id.clone(),
-        account_id.clone(),
     )
     .unwrap();
     Membership::<T>::confirm_staking_account(
         RawOrigin::Signed(account_id.clone()).into(),
         member_id.clone(),
+        account_id.clone(),
     )
     .unwrap();
 


### PR DESCRIPTION
#### Changes
- remove name, about, avatar_uri from the storage
- change handle to the handle hash
- remove obsolete length constraints

[Main issue](https://github.com/Joystream/joystream/issues/1927)