### PR TITLE
Modify message for a proposal’s decoding.

### DIFF
--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -64,7 +64,6 @@ use frame_support::{decl_error, decl_module, decl_storage, ensure, print};
 use frame_system::ensure_root;
 use sp_arithmetic::traits::Zero;
 use sp_std::clone::Clone;
-use sp_std::str::from_utf8;
 use sp_std::vec::Vec;
 
 pub use crate::types::{

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -354,18 +354,16 @@ decl_module! {
 
 // *************** Extrinsic to execute
 
-        /// Text proposal extrinsic. Should be used as callable object to pass to the `engine` module.
+        /// Text proposal extrinsic.
+        /// Should be used as callable object to pass to the `engine` module.
         #[weight = 10_000_000] // TODO: adjust weight
         pub fn execute_text_proposal(
             origin,
             text: Vec<u8>,
         ) {
             ensure_root(origin)?;
-            print("Text proposal: ");
-            let text_string_result = from_utf8(text.as_slice());
-            if let Ok(text_string) = text_string_result{
-                print(text_string);
-            }
+
+            // Text proposal stub: no code implied.
         }
 
         /// Runtime upgrade proposal extrinsic.

--- a/runtime-modules/proposals/engine/src/lib.rs
+++ b/runtime-modules/proposals/engine/src/lib.rs
@@ -772,7 +772,7 @@ impl<T: Trait> Module<T> {
                     ExecutionStatus::Executed
                 }
             }
-            Err(error) => ExecutionStatus::failed_execution(error.what()),
+            Err(_) => ExecutionStatus::failed_execution("Decoding error"),
         };
 
         Self::deposit_event(RawEvent::ProposalExecuted(proposal_id, execution_status));


### PR DESCRIPTION
### Problem
The text proposal execution had failed on the testnet. Text proposal execution doesn't contain any logic except printing to console.
https://testnet.joystream.org/#/proposals/80

### Investigation
I confirmed that the text proposal could not be executed as well as runtime upgrade and working group proposals after the runtime upgrade. Council and election proposals work well after the runtime upgrade.

#### Facts
1. Council and election pallets have last changes committed before the alexandria release.

2. Text proposals and runtime upgrade belong to the codex pallet. Codex and working group pallets were changed during the babylon preparation.

3. Codex and working group proposals don't work after the runtime upgrade.

4. Council (spending) and election (set_election_parameters) proposals work after the runtime upgrade.

#### My theory
Proposals engine cannot deserialize extrinsic from the old code into new code.
I proved it by changing the error message for decoding the extrinsic (decode function from the Substrate returns an empty error).

#### Solution
I will change the error message for the Olympia release, but we should cancel manually affected proposals before the next runtime upgrade.

### Changes
- changed non-working Substrate decoding error message to the "Decoding error" 
- removed printing to the console in the text proposal and placed the comment instead