### PR TITLE
Implement, test, and benchmark new proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,6 +3955,7 @@ dependencies = [
 name = "pallet-proposals-codex"
 version = "4.0.0"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",

--- a/node/src/chain_spec/council_config.rs
+++ b/node/src/chain_spec/council_config.rs
@@ -11,6 +11,7 @@ pub fn create_council_config() -> CouncilConfig {
         budget: 0,
         next_reward_payments: 0,
         next_budget_refill: <Runtime as CouncilTrait>::BudgetRefillPeriod::get(),
+        budget_increment: 1,
     }
 }
 

--- a/node/src/chain_spec/council_config.rs
+++ b/node/src/chain_spec/council_config.rs
@@ -12,6 +12,7 @@ pub fn create_council_config() -> CouncilConfig {
         next_reward_payments: 0,
         next_budget_refill: <Runtime as CouncilTrait>::BudgetRefillPeriod::get(),
         budget_increment: 1,
+        councilor_reward: 100,
     }
 }
 

--- a/runtime-modules/council/src/benchmarking.rs
+++ b/runtime-modules/council/src/benchmarking.rs
@@ -395,7 +395,7 @@ benchmarks! {
             .collect::<Vec<_>>();
     }: { Council::<T>::try_process_budget(target); }
     verify {
-        let reward_per_block: Balance<T> = T::ElectedMemberRewardPerBlock::get();
+        let reward_per_block: Balance<T> = Council::<T>::councilor_reward();
 
         let reward_per_councillor: Balance<T> =
             reward_period

--- a/runtime-modules/council/src/benchmarking.rs
+++ b/runtime-modules/council/src/benchmarking.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "runtime-benchmarks")]
 use super::*;
+use balances::Module as Balances;
 use frame_benchmarking::{account, benchmarks, Zero};
 use frame_support::traits::{Currency, OnFinalize, OnInitialize};
 use frame_system::EventRecord;
@@ -68,7 +69,7 @@ fn assert_in_events<T: Trait>(generic_event: <T as Trait>::Event) {
 }
 
 fn make_free_balance_be<T: Trait>(account_id: &T::AccountId, balance: Balance<T>) {
-    balances::Module::<T>::make_free_balance_be(&account_id, balance);
+    Balances::<T>::make_free_balance_be(&account_id, balance);
 }
 
 fn start_announcing_period<T: Trait>() {

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -2,10 +2,10 @@
 
 /////////////////// Configuration //////////////////////////////////////////////
 use crate::{
-    AnnouncementPeriodNr, Balance, Budget, CandidateOf, Candidates, CouncilMemberOf,
-    CouncilMembers, CouncilStage, CouncilStageAnnouncing, CouncilStageElection, CouncilStageUpdate,
-    CouncilStageUpdateOf, Error, GenesisConfig, Module, NextBudgetRefill, RawEvent,
-    ReferendumConnection, Stage, Trait, WeightInfo,
+    AnnouncementPeriodNr, Balance, Budget, BudgetIncrement, CandidateOf, Candidates,
+    CouncilMemberOf, CouncilMembers, CouncilStage, CouncilStageAnnouncing, CouncilStageElection,
+    CouncilStageUpdate, CouncilStageUpdateOf, Error, GenesisConfig, Module, NextBudgetRefill,
+    RawEvent, ReferendumConnection, Stage, Trait, WeightInfo,
 };
 
 use balances;
@@ -66,7 +66,6 @@ parameter_types! {
     pub const CouncilorLockId: LockIdentifier = *b"council2";
     pub const ElectedMemberRewardPerBlock: u64 = 100;
     pub const ElectedMemberRewardPeriod: u64 = 10;
-    pub const BudgetRefillAmount: u64 = 1000;
     // intentionally high number that prevents side-effecting tests other than  budget refill tests
     pub const BudgetRefillPeriod: u64 = 1000;
 }
@@ -95,7 +94,6 @@ impl Trait for Runtime {
 
     type StakingAccountValidator = ();
 
-    type BudgetRefillAmount = BudgetRefillAmount;
     type BudgetRefillPeriod = BudgetRefillPeriod;
 
     type WeightInfo = ();
@@ -488,7 +486,6 @@ pub struct CouncilSettings<T: Trait> {
     pub idle_stage_duration: T::BlockNumber,
     pub election_duration: T::BlockNumber,
     pub cycle_duration: T::BlockNumber,
-    pub budget_refill_amount: Balance<T>,
     pub budget_refill_period: T::BlockNumber,
 }
 
@@ -523,7 +520,6 @@ where
                 + voting_stage_duration
                 + idle_stage_duration,
 
-            budget_refill_amount: <T as Trait>::BudgetRefillAmount::get(),
             budget_refill_period: <T as Trait>::BudgetRefillPeriod::get(),
         }
     }
@@ -588,6 +584,7 @@ pub fn default_genesis_config() -> GenesisConfig<Runtime> {
         budget: 0,
         next_reward_payments: 0,
         next_budget_refill: <Runtime as Trait>::BudgetRefillPeriod::get(),
+        budget_increment: 1,
     }
 }
 
@@ -1100,6 +1097,36 @@ where
                 .unwrap()
                 .event,
             TestEvent::event_mod(RawEvent::BudgetRefillPlanned(next_refill.into())),
+        );
+    }
+
+    pub fn set_budget_increment(
+        origin: OriginType<T::AccountId>,
+        budget_increment: T::Balance,
+        expected_result: Result<(), ()>,
+    ) {
+        // check method returns expected result
+        assert_eq!(
+            Module::<T>::set_budget_increment(
+                InstanceMockUtils::<T>::mock_origin(origin),
+                budget_increment,
+            )
+            .is_ok(),
+            expected_result.is_ok(),
+        );
+
+        if expected_result.is_err() {
+            return;
+        }
+
+        assert_eq!(BudgetIncrement::<T>::get(), budget_increment,);
+
+        assert_eq!(
+            frame_system::Module::<Runtime>::events()
+                .last()
+                .unwrap()
+                .event,
+            TestEvent::event_mod(RawEvent::BudgetIncrementUpdated(budget_increment.into())),
         );
     }
 

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -1069,6 +1069,43 @@ where
         );
     }
 
+    pub fn funding_request(
+        origin: OriginType<T::AccountId>,
+        amount: Balance<T>,
+        reciever: T::AccountId,
+        expected_result: Result<(), Error<T>>,
+    ) {
+        let initial_budget = Module::<T>::budget();
+        // check method returns expected result
+        assert_eq!(
+            Module::<T>::funding_request(
+                InstanceMockUtils::<T>::mock_origin(origin),
+                amount,
+                reciever.clone(),
+            )
+            .is_ok(),
+            expected_result.is_ok(),
+        );
+
+        if expected_result.is_err() {
+            return;
+        }
+
+        assert_eq!(
+            frame_system::Module::<Runtime>::events()
+                .last()
+                .unwrap()
+                .event,
+            TestEvent::event_mod(RawEvent::RequestFunded(
+                reciever.clone().into(),
+                amount.into()
+            )),
+        );
+
+        assert_eq!(Module::<T>::budget(), initial_budget - amount);
+        assert_eq!(balances::Module::<T>::free_balance(reciever), amount);
+    }
+
     pub fn plan_budget_refill(
         origin: OriginType<T::AccountId>,
         next_refill: T::BlockNumber,

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1478,6 +1478,17 @@ fn council_origin_validator_fails_with_unregistered_member() {
 }
 
 #[test]
+fn test_funding_request_fails_insufficient_fundings() {
+    let config = default_genesis_config();
+
+    build_test_externalities(config).execute_with(|| {
+        let origin = OriginType::Root;
+        Mocks::set_budget(origin.clone(), 0, Ok(()));
+        Mocks::funding_request(origin, 1, 0, Err(Error::InsufficientFundsForFundingRequest));
+    });
+}
+
+#[test]
 fn council_origin_validator_succeeds() {
     let config = default_genesis_config();
 
@@ -1502,6 +1513,16 @@ fn council_origin_validator_succeeds() {
             Council::ensure_member_consulate(origin.into(), councilor1_member_id);
 
         assert!(validation_result.is_ok());
+    });
+}
+
+#[test]
+fn test_funding_request_fails_permission() {
+    let config = default_genesis_config();
+
+    build_test_externalities(config).execute_with(|| {
+        let origin = OriginType::Signed(0);
+        Mocks::funding_request(origin.into(), 1, 0, Err(Error::BadOrigin));
     });
 }
 
@@ -1585,5 +1606,19 @@ fn council_many_cycle_rewards() {
             num_blocks_elected * <Runtime as Trait>::ElectedMemberRewardPerBlock::get()
                 + num_iterations * auto_topup_amount
         );
+    });
+}
+
+#[test]
+fn test_funding_request_succeeds() {
+    let config = default_genesis_config();
+
+    build_test_externalities(config).execute_with(|| {
+        let origin = OriginType::Root;
+        let initial_budget = 100;
+        let funding_amount = 5;
+        let recieving_account = 0;
+        Mocks::set_budget(origin.clone(), initial_budget, Ok(()));
+        Mocks::funding_request(origin, funding_amount, recieving_account, Ok(()));
     });
 }

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1130,8 +1130,12 @@ fn council_budget_increment_can_be_upddated() {
 
         Mocks::set_budget_increment(origin.clone(), budget_increment, Ok(()));
 
+        let current_block = frame_system::Module::<Runtime>::block_number();
+
+        assert_eq!(current_block, 1);
+
         // forward to one block before refill
-        MockUtils::increase_block_number(next_refill - 1);
+        MockUtils::increase_block_number(next_refill - current_block - 1);
 
         // Check budget currently is 0
         Mocks::check_budget_refill(0, next_refill);
@@ -1159,8 +1163,12 @@ fn council_budget_increment_can_be_updated() {
 
         Mocks::set_budget_increment(origin.clone(), budget_increment, Ok(()));
 
+        let current_block = frame_system::Module::<Runtime>::block_number();
+
+        assert_eq!(current_block, 1);
+
         // forward to one block before refill
-        MockUtils::increase_block_number(next_refill - 1);
+        MockUtils::increase_block_number(next_refill - current_block - 1);
 
         // Check budget currently is 0
         Mocks::check_budget_refill(0, next_refill);
@@ -1235,15 +1243,12 @@ fn councilor_reward_can_be_set() {
 
         // calculate council member last reward block
         let last_payment_block = council_settings.cycle_duration
-            + (<Runtime as Trait>::ElectedMemberRewardPeriod::get()
-                - (council_settings.idle_stage_duration
-                    % <Runtime as Trait>::ElectedMemberRewardPeriod::get()))
-            - 1; // -1 because current block is not finalized yet
+            - (council_settings.idle_stage_duration
+                % <Runtime as Trait>::ElectedMemberRewardPeriod::get());
 
         let start_rewarding_block = council_settings.reveal_stage_duration
             + council_settings.announcing_stage_duration
-            + council_settings.voting_stage_duration
-            - 1;
+            + council_settings.voting_stage_duration;
 
         let councilor_initial_balance = council_settings.min_candidate_stake * TOPUP_MULTIPLIER;
         let current_council_balance =

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1603,8 +1603,7 @@ fn council_many_cycle_rewards() {
 
         assert_eq!(
             balances::Module::<Runtime>::total_balance(&council_members[0].staking_account_id),
-            num_blocks_elected * <Runtime as Trait>::ElectedMemberRewardPerBlock::get()
-                + num_iterations * auto_topup_amount
+            num_blocks_elected * Council::councilor_reward() + num_iterations * auto_topup_amount
         );
     });
 }

--- a/runtime-modules/proposals/codex/Cargo.toml
+++ b/runtime-modules/proposals/codex/Cargo.toml
@@ -23,6 +23,9 @@ constitution = { package = 'pallet-constitution', default-features = false, path
 membership = { package = 'pallet-membership', default-features = false, path = '../../membership'}
 council = { package = 'pallet-council', default-features = false, path = '../../council'}
 
+# Benchmarking dependencies
+frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
+
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
@@ -34,6 +37,7 @@ referendum = { package = 'pallet-referendum', default-features = false, path = '
 
 [features]
 default = ['std']
+runtime-benchmarks = ['frame-benchmarking']
 std = [
     'serde',
     'codec/std',

--- a/runtime-modules/proposals/codex/Cargo.toml
+++ b/runtime-modules/proposals/codex/Cargo.toml
@@ -21,6 +21,7 @@ proposals-engine = { package = 'pallet-proposals-engine', default-features = fal
 proposals-discussion = { package = 'pallet-proposals-discussion', default-features = false, path = '../discussion'}
 constitution = { package = 'pallet-constitution', default-features = false, path = '../../constitution'}
 membership = { package = 'pallet-membership', default-features = false, path = '../../membership'}
+council = { package = 'pallet-council', default-features = false, path = '../../council'}
 
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
@@ -30,7 +31,6 @@ pallet-staking-reward-curve = { package = 'pallet-staking-reward-curve', default
 strum = {version = "0.19", default-features = false}
 staking-handler = { package = 'pallet-staking-handler', default-features = false, path = '../../staking-handler'}
 referendum = { package = 'pallet-referendum', default-features = false, path = '../../referendum'}
-council = { package = 'pallet-council', default-features = false, path = '../../council'}
 
 [features]
 default = ['std']

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -18,8 +18,6 @@ use sp_std::prelude::*;
 const SEED: u32 = 0;
 const MAX_BYTES: u32 = 16384;
 
-use crate::call_wg;
-
 // Note: We use proposals_engine::Trait::Event here because crate::Trait
 // doesn't implement Event and we only use this function to assert events
 // from the proposals_engine pallet
@@ -177,13 +175,7 @@ fn create_proposal_verify<T: Trait>(
 fn set_wg_and_council_budget<T: Trait>(budget: u32, group: WorkingGroup) {
     Council::<T>::set_budget(RawOrigin::Root.into(), BalanceOf::<T>::from(budget)).unwrap();
 
-    call_wg!(
-        group<T>,
-        set_budget,
-        RawOrigin::Root.into(),
-        BalanceOf::<T>::from(budget)
-    )
-    .unwrap();
+    T::set_working_group_budget(group, BalanceOf::<T>::from(budget));
 
     assert_eq!(
         Council::<T>::budget(),
@@ -192,7 +184,7 @@ fn set_wg_and_council_budget<T: Trait>(budget: u32, group: WorkingGroup) {
     );
 
     assert_eq!(
-        call_wg!(group<T>, budget),
+        T::get_working_group_budget(group),
         BalanceOf::<T>::from(budget),
         "Working Group budget not updated"
     );
@@ -210,7 +202,7 @@ fn assert_new_budgets<T: Trait>(
     );
 
     assert_eq!(
-        call_wg!(group<T>, budget),
+        T::get_working_group_budget(group),
         BalanceOf::<T>::from(new_budget_working_group),
         "Working Group budget not updated"
     );

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -566,37 +566,6 @@ benchmarks! {
     verify {
         assert_new_budgets::<T>(101, 99, WorkingGroup::Membership);
     }
-
-    funding_request {
-        let council_budget = BalanceOf::<T>::from(100);
-        let transfer_balance = BalanceOf::<T>::from(60);
-        let recieving_account = account::<T::AccountId>("reciever", 0, SEED);
-        Council::<T>::set_budget(RawOrigin::Root.into(), council_budget).unwrap();
-        assert_eq!(
-            Council::<T>::budget(),
-            council_budget,
-            "Council budget not updated"
-        );
-
-        assert_eq!(
-            Balances::<T>::free_balance(&recieving_account),
-            Zero::zero(),
-            "Recieving account has funds",
-        );
-    }: _ (RawOrigin::Root, transfer_balance, recieving_account.clone())
-    verify {
-        assert_eq!(
-            Council::<T>::budget(),
-            council_budget - transfer_balance,
-            "Council didn't discount transference",
-        );
-
-        assert_eq!(
-            Balances::<T>::free_balance(recieving_account),
-            transfer_balance,
-            "Recieving account didn't recieve amount",
-        );
-    }
 }
 
 #[cfg(test)]

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -1,0 +1,560 @@
+#![cfg(feature = "runtime-benchmarks")]
+use super::*;
+use crate::Module as Codex;
+use balances::Module as Balances;
+use frame_benchmarking::{account, benchmarks};
+use frame_support::sp_runtime::traits::Bounded;
+use frame_support::traits::Currency;
+use frame_system::EventRecord;
+use frame_system::Module as System;
+use frame_system::RawOrigin;
+use membership::Module as Membership;
+use proposals_discussion::Module as Discussion;
+use proposals_engine::Module as Engine;
+use sp_runtime::traits::One;
+use sp_std::convert::TryInto;
+use sp_std::prelude::*;
+
+const SEED: u32 = 0;
+const MAX_BYTES: u32 = 16384;
+
+// Note: We use proposals_engine::Trait::Event here because crate::Trait
+// doesn't implement Event and we only use this function to assert events
+// from the proposals_engine pallet
+fn assert_last_event<T: Trait>(generic_event: <T as proposals_engine::Trait>::Event) {
+    let events = System::<T>::events();
+    let system_event: <T as frame_system::Trait>::Event = generic_event.into();
+    assert!(
+        events.len() > 0,
+        "If you are checking for last event there must be at least 1 event"
+    );
+    let EventRecord { event, .. } = &events[events.len() - 1];
+    assert_eq!(event, &system_event);
+}
+
+fn get_byte(num: u32, byte_number: u8) -> u8 {
+    ((num & (0xff << (8 * byte_number))) >> 8 * byte_number) as u8
+}
+
+// Method to generate a distintic valid handle
+// for a membership. For each index.
+fn handle_from_id(id: u32) -> Vec<u8> {
+    let mut handle = vec![];
+
+    for i in 0..4 {
+        handle.push(get_byte(id, i));
+    }
+
+    handle
+}
+
+fn member_funded_account<T: Trait + membership::Trait>(
+    name: &'static str,
+    id: u32,
+) -> (T::AccountId, T::MemberId) {
+    let account_id = account::<T::AccountId>(name, id, SEED);
+    let handle = handle_from_id(id);
+
+    // Give balance for buying membership
+    let _ = Balances::<T>::make_free_balance_be(&account_id, T::Balance::max_value());
+
+    let params = membership::BuyMembershipParameters {
+        root_account: account_id.clone(),
+        controller_account: account_id.clone(),
+        name: None,
+        handle: Some(handle),
+        avatar_uri: None,
+        about: None,
+        referrer_id: None,
+    };
+
+    Membership::<T>::buy_membership(RawOrigin::Signed(account_id.clone()).into(), params).unwrap();
+
+    let _ = Balances::<T>::make_free_balance_be(&account_id, T::Balance::max_value());
+
+    (account_id, T::MemberId::from(id.try_into().unwrap()))
+}
+
+fn create_proposal_parameters<T: Trait + membership::Trait>(
+    title_length: u32,
+    description_length: u32,
+) -> (T::AccountId, T::MemberId, GeneralProposalParameters<T>) {
+    let (account_id, member_id) = member_funded_account::<T>("account", 0);
+
+    let general_proposal_paramters = GeneralProposalParameters::<T> {
+        member_id,
+        title: vec![0u8; title_length.try_into().unwrap()],
+        description: vec![0u8; description_length.try_into().unwrap()],
+        staking_account_id: Some(account_id.clone()),
+        exact_execution_block: None,
+    };
+
+    (account_id, member_id, general_proposal_paramters)
+}
+
+fn create_proposal_verify<T: Trait>(
+    account_id: T::AccountId,
+    member_id: T::MemberId,
+    proposal_details: ProposalDetailsOf<T>,
+) {
+    assert_eq!(Discussion::<T>::thread_count(), 1, "No threads created");
+    let thread_id = T::ThreadId::from(1);
+    assert!(
+        proposals_discussion::ThreadById::<T>::contains_key(thread_id),
+        "No thread created"
+    );
+
+    let proposal_id = T::ProposalId::from(1);
+    assert!(
+        proposals_engine::Proposals::<T>::contains_key(proposal_id),
+        "Proposal not inserted in engine"
+    );
+
+    assert_eq!(
+        Engine::<T>::proposals(proposal_id),
+        proposals_engine::Proposal {
+            activated_at: System::<T>::block_number(),
+            parameters: Codex::<T>::get_proposal_parameters(&proposal_details),
+            proposer_id: member_id,
+            status: proposals_engine::ProposalStatus::Active,
+            voting_results: proposals_engine::VotingResults::default(),
+            exact_execution_block: None,
+            nr_of_council_confirmations: 0,
+            staking_account_id: Some(account_id)
+        },
+        "Proposal not correctly created"
+    );
+
+    assert!(
+        proposals_engine::DispatchableCallCode::<T>::contains_key(proposal_id),
+        "Dispatchable code not stored"
+    );
+
+    assert_eq!(
+        Engine::<T>::proposal_codes(proposal_id),
+        T::ProposalEncoder::encode_proposal(proposal_details.clone()),
+        "Stored proposal code doesn't match"
+    );
+
+    assert_eq!(
+        Engine::<T>::proposal_count(),
+        1,
+        "Proposal count not updated"
+    );
+    assert_eq!(
+        Engine::<T>::active_proposal_count(),
+        1,
+        "Active proposal count not updated"
+    );
+    assert_last_event::<T>(
+        proposals_engine::RawEvent::ProposalCreated(member_id, proposal_id).into(),
+    );
+
+    assert!(
+        ThreadIdByProposalId::<T>::contains_key(proposal_id),
+        "Proposal thread not stored"
+    );
+    assert_eq!(
+        Codex::<T>::thread_id_by_proposal_id(proposal_id),
+        thread_id,
+        "Proposal and thread ID doesn't match"
+    );
+
+    assert!(
+        ProposalDetailsByProposalId::<T>::contains_key(proposal_id),
+        "Proposal details not stored"
+    );
+
+    assert_eq!(
+        ProposalDetailsByProposalId::<T>::get(proposal_id),
+        proposal_details,
+        "Proposal details doesn't match"
+    );
+}
+
+benchmarks! {
+    where_clause { where T: membership::Trait }
+    _ {
+        let t in 1 .. T::TitleMaxLength::get() => ();
+        let d in 1 .. T::DescriptionMaxLength::get() => ();
+    }
+
+    // Note: No verify since there is no side effect to test
+    execute_signal_proposal {
+        let i in 1 .. MAX_BYTES;
+    }: _(RawOrigin::Root, vec![0u8; i.try_into().unwrap()])
+
+    create_proposal_signal {
+        let i in 1 .. MAX_BYTES;
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::Signal(vec![0u8; i.try_into().unwrap()]);
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_runtime_upgrade {
+        let i in 1 .. MAX_BYTES;
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::RuntimeUpgrade(vec![0u8; i.try_into().unwrap()]);
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_funding_request {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        council::Module::<T>::set_budget(RawOrigin::Root.into(), council::Balance::<T>::max_value()).unwrap();
+
+        let proposal_details = ProposalDetails::FundingRequest(
+                crate::BalanceOf::<T>::one(),
+                account::<T::AccountId>("reciever", 1, SEED)
+            );
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_set_max_validator_count {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::SetMaxValidatorCount(MAX_VALIDATOR_COUNT);
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_create_working_group_lead_opening {
+        let i in 1 .. MAX_BYTES;
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::CreateWorkingGroupLeadOpening(CreateOpeningParameters {
+            description: vec![0u8; i.try_into().unwrap()],
+            stake_policy: None,
+            reward_per_block: None,
+            group: WorkingGroup::Forum,
+        });
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_fill_working_group_lead_opening {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::FillWorkingGroupLeadOpening(FillOpeningParameters {
+            opening_id: working_group::OpeningId::zero(),
+            application_id: working_group::ApplicationId::zero(),
+            working_group: WorkingGroup::Forum,
+        });
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_update_working_group_budget {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::UpdateWorkingGroupBudget(
+            BalanceOf::<T>::one(),
+            WorkingGroup::Forum,
+            BalanceKind::Positive
+        );
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_decrease_working_group_lead_stake {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::DecreaseWorkingGroupLeadStake(
+            working_group::WorkerId::<T>::zero(),
+            BalanceOf::<T>::one(),
+            WorkingGroup::Forum,
+        );
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_slash_working_group_lead {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::SlashWorkingGroupLead(
+            working_group::WorkerId::<T>::zero(),
+            BalanceOf::<T>::one(),
+            WorkingGroup::Forum,
+        );
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_set_working_group_lead_reward {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::SetWorkingGroupLeadReward(
+            working_group::WorkerId::<T>::zero(),
+            None,
+            WorkingGroup::Forum,
+        );
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_terminate_working_group_lead {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::TerminateWorkingGroupLead(
+            TerminateRoleParameters {
+                worker_id: working_group::WorkerId::<T>::zero(),
+                slashing_amount: None,
+                group: WorkingGroup::Forum,
+            }
+        );
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_amend_constitution {
+        let i in 1 .. MAX_BYTES;
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::AmendConstitution(vec![0u8; i.try_into().unwrap()]);
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_cancel_working_group_lead_opening {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::CancelWorkingGroupLeadOpening(
+            working_group::OpeningId::zero(),
+            WorkingGroup::Forum);
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_set_membership_price {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::SetMembershipPrice(BalanceOf::<T>::one());
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_set_council_budget_increment {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::SetCouncilBudgetIncrement(BalanceOf::<T>::one());
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_set_councilor_reward {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::SetCouncilorReward(BalanceOf::<T>::one());
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+
+    create_proposal_set_initial_invitation_balance {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::SetInitialInvitationBalance(BalanceOf::<T>::one());
+    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    verify {
+        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{initial_test_ext, Test};
+    use frame_support::assert_ok;
+
+    #[test]
+    fn test_execute_signal_proposal() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_execute_signal_proposal::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_signal() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_signal::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_funding_request() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_funding_request::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_set_max_validator_count() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_set_max_validator_count::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_create_working_group_lead_opening() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_create_working_group_lead_opening::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_fill_working_group_lead_opening() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_fill_working_group_lead_opening::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_update_working_group_budget() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_update_working_group_budget::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_decrease_working_group_lead_stake() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_decrease_working_group_lead_stake::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_slash_working_group_lead() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_slash_working_group_lead::<
+                Test,
+            >());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_set_working_group_lead_reward() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_set_working_group_lead_reward::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_terminate_working_group_lead() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_terminate_working_group_lead::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_amend_constitution() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_amend_constitution::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_cancel_working_group_lead_opening() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_amend_constitution::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_set_membership_price() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_set_membership_price::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_set_council_budget_increment() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_set_council_budget_increment::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_set_councior_reward() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_set_councilor_reward::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_create_proposal_set_initial_invitation_balance() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_set_initial_invitation_balance::<Test>());
+        });
+    }
+}

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -324,7 +324,7 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::UpdateWorkingGroupBudget(
-            BalanceOf::<T>::one(),
+            One::one(),
             WorkingGroup::Forum,
             BalanceKind::Positive
         );

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -94,26 +94,26 @@ const MAX_VALIDATOR_COUNT: u32 = 100;
 /// Note: This was auto generated through the benchmark CLI using the `--weight-trait` flag
 pub trait WeightInfo {
     fn execute_signal_proposal(i: u32) -> Weight;
-    fn create_proposal_signal(i: u32, t: u32) -> Weight;
-    fn create_proposal_runtime_upgrade(i: u32) -> Weight;
-    fn create_proposal_funding_request(t: u32, d: u32) -> Weight;
+    fn create_proposal_signal(i: u32, t: u32, d: u32) -> Weight;
+    fn create_proposal_runtime_upgrade(i: u32, t: u32) -> Weight;
+    fn create_proposal_funding_request() -> Weight;
     fn create_proposal_set_max_validator_count() -> Weight;
-    fn create_proposal_create_working_group_lead_opening(i: u32, d: u32) -> Weight;
-    fn create_proposal_fill_working_group_lead_opening(t: u32) -> Weight;
-    fn create_proposal_update_working_group_budget(d: u32) -> Weight;
-    fn create_proposal_decrease_working_group_lead_stake(t: u32, d: u32) -> Weight;
+    fn create_proposal_create_working_group_lead_opening(i: u32, t: u32) -> Weight;
+    fn create_proposal_fill_working_group_lead_opening() -> Weight;
+    fn create_proposal_update_working_group_budget(t: u32, d: u32) -> Weight;
+    fn create_proposal_decrease_working_group_lead_stake(d: u32) -> Weight;
     fn create_proposal_slash_working_group_lead() -> Weight;
     fn create_proposal_set_working_group_lead_reward(t: u32) -> Weight;
     fn create_proposal_terminate_working_group_lead(t: u32) -> Weight;
     fn create_proposal_amend_constitution(i: u32, t: u32) -> Weight;
-    fn create_proposal_cancel_working_group_lead_opening() -> Weight;
-    fn create_proposal_set_membership_price(d: u32) -> Weight;
+    fn create_proposal_cancel_working_group_lead_opening(d: u32) -> Weight;
+    fn create_proposal_set_membership_price(t: u32, d: u32) -> Weight;
     fn create_proposal_set_council_budget_increment(t: u32, d: u32) -> Weight;
     fn create_proposal_set_councilor_reward(d: u32) -> Weight;
-    fn create_proposal_set_initial_invitation_balance(t: u32) -> Weight;
-    fn create_proposal_set_initial_invitation_count() -> Weight;
+    fn create_proposal_set_initial_invitation_balance(d: u32) -> Weight;
+    fn create_proposal_set_initial_invitation_count(t: u32, d: u32) -> Weight;
     fn create_proposal_set_membership_lead_invitation_quota() -> Weight;
-    fn create_proposal_set_referral_cut(t: u32, d: u32) -> Weight;
+    fn create_proposal_set_referral_cut(t: u32) -> Weight;
     fn update_working_group_budget_positive_forum() -> Weight;
     fn update_working_group_budget_negative_forum() -> Weight;
     fn update_working_group_budget_positive_storage() -> Weight;
@@ -122,7 +122,6 @@ pub trait WeightInfo {
     fn update_working_group_budget_negative_content() -> Weight;
     fn update_working_group_budget_positive_membership() -> Weight;
     fn update_working_group_budget_negative_membership() -> Weight;
-    fn funding_request() -> Weight;
 }
 
 type WeightInfoCodex<T> = <T as Trait>::WeightInfo;
@@ -751,15 +750,16 @@ impl<T: Trait> Module<T> {
             ProposalDetails::Signal(signal) => WeightInfoCodex::<T>::create_proposal_signal(
                 signal.len().saturated_into(),
                 title_length.saturated_into(),
+                description_length.saturated_into(),
             ),
             ProposalDetails::RuntimeUpgrade(blob) => {
-                WeightInfoCodex::<T>::create_proposal_runtime_upgrade(blob.len().saturated_into())
+                WeightInfoCodex::<T>::create_proposal_runtime_upgrade(
+                    blob.len().saturated_into(),
+                    title_length.saturated_into(),
+                )
             }
             ProposalDetails::FundingRequest(..) => {
-                WeightInfoCodex::<T>::create_proposal_funding_request(
-                    title_length.saturated_into(),
-                    description_length.saturated_into(),
-                )
+                WeightInfoCodex::<T>::create_proposal_funding_request()
             }
             ProposalDetails::SetMaxValidatorCount(..) => {
                 WeightInfoCodex::<T>::create_proposal_set_max_validator_count()
@@ -767,22 +767,20 @@ impl<T: Trait> Module<T> {
             ProposalDetails::CreateWorkingGroupLeadOpening(opening_params) => {
                 WeightInfoCodex::<T>::create_proposal_create_working_group_lead_opening(
                     opening_params.description.len().saturated_into(),
-                    description_length.saturated_into(),
-                )
-            }
-            ProposalDetails::FillWorkingGroupLeadOpening(..) => {
-                WeightInfoCodex::<T>::create_proposal_fill_working_group_lead_opening(
                     title_length.saturated_into(),
                 )
             }
+            ProposalDetails::FillWorkingGroupLeadOpening(..) => {
+                WeightInfoCodex::<T>::create_proposal_fill_working_group_lead_opening()
+            }
             ProposalDetails::UpdateWorkingGroupBudget(..) => {
                 WeightInfoCodex::<T>::create_proposal_update_working_group_budget(
+                    title_length.saturated_into(),
                     description_length.saturated_into(),
                 )
             }
             ProposalDetails::DecreaseWorkingGroupLeadStake(..) => {
                 WeightInfoCodex::<T>::create_proposal_decrease_working_group_lead_stake(
-                    title_length.saturated_into(),
                     description_length.saturated_into(),
                 )
             }
@@ -807,11 +805,14 @@ impl<T: Trait> Module<T> {
             }
             ProposalDetails::SetMembershipPrice(..) => {
                 WeightInfoCodex::<T>::create_proposal_set_membership_price(
+                    title_length.saturated_into(),
                     description_length.saturated_into(),
                 )
             }
             ProposalDetails::CancelWorkingGroupLeadOpening(..) => {
-                WeightInfoCodex::<T>::create_proposal_cancel_working_group_lead_opening()
+                WeightInfoCodex::<T>::create_proposal_cancel_working_group_lead_opening(
+                    description_length.saturated_into(),
+                )
             }
             ProposalDetails::SetCouncilBudgetIncrement(..) => {
                 WeightInfoCodex::<T>::create_proposal_set_council_budget_increment(
@@ -826,11 +827,14 @@ impl<T: Trait> Module<T> {
             }
             ProposalDetails::SetInitialInvitationBalance(..) => {
                 WeightInfoCodex::<T>::create_proposal_set_initial_invitation_balance(
-                    title_length.saturated_into(),
+                    description_length.saturated_into(),
                 )
             }
             ProposalDetails::SetInitialInvitationCount(..) => {
-                WeightInfoCodex::<T>::create_proposal_set_initial_invitation_count()
+                WeightInfoCodex::<T>::create_proposal_set_initial_invitation_count(
+                    title_length.saturated_into(),
+                    description_length.saturated_into(),
+                )
             }
             ProposalDetails::SetMembershipLeadInvitationQuota(..) => {
                 WeightInfoCodex::<T>::create_proposal_set_membership_lead_invitation_quota()
@@ -838,7 +842,6 @@ impl<T: Trait> Module<T> {
             ProposalDetails::SetReferralCut(..) => {
                 WeightInfoCodex::<T>::create_proposal_set_referral_cut(
                     title_length.saturated_into(),
-                    description_length.saturated_into(),
                 )
             }
         }

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -609,6 +609,7 @@ impl<T: Trait> Module<T> {
                     *amount != BalanceOf::<T>::zero(),
                     Error::<T>::InvalidFundingRequestProposalBalance
                 );
+
                 ensure!(
                     *amount <= <BalanceOf<T>>::from(MAX_SPENDING_PROPOSAL_VALUE),
                     Error::<T>::InvalidFundingRequestProposalBalance

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -570,8 +570,11 @@ impl<T: Trait> Module<T> {
                 );
             }
             ProposalDetails::SetMaxValidatorCount(ref new_validator_count) => {
+                // Since `set_validator_count` doesn't check that `new_validator_count`
+                // isn't less than `minimum_validator_count` we need to do this here.
+                // We shouldn't access the storage for creation checks but we do it here for the
+                // reasons just explained **as an exception**.
                 ensure!(
-                    // TODO: Should this be replaced by a const MIN_VALIDATOR_COUNT?
                     *new_validator_count >= <staking::Module<T>>::minimum_validator_count(),
                     Error::<T>::InvalidValidatorCount
                 );

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -58,6 +58,7 @@ mod types;
 #[cfg(test)]
 mod tests;
 
+use codec::{Decode, Encode};
 use frame_support::dispatch::DispatchResult;
 use frame_support::traits::Get;
 use frame_support::{decl_error, decl_module, decl_storage, ensure, print};

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -82,6 +82,10 @@ use proposals_discussion::ThreadMode;
 use proposals_engine::{
     BalanceOf, ProposalCreationParameters, ProposalObserver, ProposalParameters,
 };
+use working_group::{
+    ContentDirectoryWorkingGroupInstance, ForumWorkingGroupInstance,
+    MembershipWorkingGroupInstance, StorageWorkingGroupInstance,
+};
 
 use common::working_group::WorkingGroup;
 
@@ -580,20 +584,6 @@ decl_module! {
     }
 }
 
-// TODO: This code is repeated from runtime, see if there's somewhere to extract this that makes
-// sense
-// The forum working group instance alias.
-type ForumWorkingGroupInstance = working_group::Instance1;
-
-// The storage working group instance alias.
-type StorageWorkingGroupInstance = working_group::Instance2;
-
-// The content directory working group instance alias.
-type ContentDirectoryWorkingGroupInstance = working_group::Instance3;
-
-// The membership working group instance alias.
-type MembershipWorkingGroupInstance = working_group::Instance4;
-
 impl<T: Trait> Module<T> {
     // Ensure that the proposal details respects all the checks
     fn ensure_details_checks(details: &ProposalDetailsOf<T>) -> DispatchResult {
@@ -632,7 +622,6 @@ impl<T: Trait> Module<T> {
             }
             ProposalDetails::FillWorkingGroupLeadOpening(..) => {
                 // Note: No checks for this proposal for now
-                // TODO: shouldn't we check that it exists?
             }
             ProposalDetails::UpdateWorkingGroupBudget(..) => {
                 // Note: No checks for this proposal for now
@@ -657,7 +646,6 @@ impl<T: Trait> Module<T> {
             }
             ProposalDetails::CancelWorkingGroupLeadOpening(..) => {
                 // Note: No checks for this proposal for now
-                // TODO: Shouldn't we check that it exists?
             }
             ProposalDetails::SetMembershipPrice(..) => {
                 // Note: No checks for this proposal for now

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -82,7 +82,6 @@ use proposals_discussion::ThreadMode;
 use proposals_engine::{
     BalanceOf, ProposalCreationParameters, ProposalObserver, ProposalParameters,
 };
-use types::CouncilBalance;
 
 use common::working_group::WorkingGroup;
 

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -411,7 +411,6 @@ decl_module! {
                 WorkingGroup::Storage => working_group::Module::<T, StorageWorkingGroupInstance>::set_budget(origin, amount)?,
                 WorkingGroup::Content => working_group::Module::<T, ContentDirectoryWorkingGroupInstance>::set_budget(origin, amount)?,
                 WorkingGroup::Membership => working_group::Module::<T, MembershipWorkingGroupInstance>::set_budget(origin, amount)?,
-
             };
 
         }
@@ -472,7 +471,7 @@ impl<T: Trait> Module<T> {
                 // Note: No checks for this proposal for now
                 // TODO: shouldn't we check that it exists?
             }
-            ProposalDetails::UpdateWorkingGroupBudget(_, _, _) => {
+            ProposalDetails::UpdateWorkingGroupBudget(..) => {
                 // Note: No checks for this proposal for now
             }
             ProposalDetails::DecreaseWorkingGroupLeadStake(_, ref stake_amount, _) => {
@@ -481,7 +480,7 @@ impl<T: Trait> Module<T> {
                     Error::<T>::DecreasingStakeIsZero
                 );
             }
-            ProposalDetails::SlashWorkingGroupLead(_, _, _) => {
+            ProposalDetails::SlashWorkingGroupLead(..) => {
                 // Note: No checks for this proposal for now
             }
             ProposalDetails::SetWorkingGroupLeadReward(..) => {
@@ -493,7 +492,7 @@ impl<T: Trait> Module<T> {
             ProposalDetails::AmendConstitution(..) => {
                 // Note: No checks for this proposal for now
             }
-            ProposalDetails::CancelWorkingGroupLeadOpening(_, _) => {
+            ProposalDetails::CancelWorkingGroupLeadOpening(..) => {
                 // Note: No checks for this proposal for now
                 // TODO: Shouldn't we check that it exists?
             }
@@ -510,41 +509,35 @@ impl<T: Trait> Module<T> {
         details: &ProposalDetailsOf<T>,
     ) -> ProposalParameters<T::BlockNumber, BalanceOf<T>> {
         match details {
-            ProposalDetailsOf::<T>::Signal(..) => T::SignalProposalParameters::get(),
-            ProposalDetailsOf::<T>::RuntimeUpgrade(..) => {
-                T::RuntimeUpgradeProposalParameters::get()
-            }
-            ProposalDetailsOf::<T>::FundingRequest(..) => {
-                T::FundingRequestProposalParameters::get()
-            }
-            ProposalDetailsOf::<T>::SetMaxValidatorCount(..) => {
+            ProposalDetails::Signal(..) => T::SignalProposalParameters::get(),
+            ProposalDetails::RuntimeUpgrade(..) => T::RuntimeUpgradeProposalParameters::get(),
+            ProposalDetails::FundingRequest(..) => T::FundingRequestProposalParameters::get(),
+            ProposalDetails::SetMaxValidatorCount(..) => {
                 T::SetMaxValidatorCountProposalParameters::get()
             }
-            ProposalDetailsOf::<T>::CreateWorkingGroupLeadOpening(..) => {
-                T::CreateWorkingGroupLeadOpeningProposalParameters::get()
-            }
-            ProposalDetailsOf::<T>::FillWorkingGroupLeadOpening(..) => {
+            ProposalDetails::FillWorkingGroupLeadOpening(..) => {
                 T::FillWorkingGroupLeadOpeningProposalParameters::get()
             }
-            ProposalDetailsOf::<T>::UpdateWorkingGroupBudget(..) => {
+            ProposalDetails::UpdateWorkingGroupBudget(..) => {
                 T::UpdateWorkingGroupBudgetProposalParameters::get()
             }
-            ProposalDetailsOf::<T>::DecreaseWorkingGroupLeadStake(..) => {
+            ProposalDetails::DecreaseWorkingGroupLeadStake(..) => {
                 T::DecreaseWorkingGroupLeadStakeProposalParameters::get()
             }
-            ProposalDetailsOf::<T>::SlashWorkingGroupLead(..) => {
+            ProposalDetails::SlashWorkingGroupLead(..) => {
                 T::SlashWorkingGroupLeadProposalParameters::get()
             }
-            ProposalDetailsOf::<T>::SetWorkingGroupLeadReward(..) => {
+            ProposalDetails::SetWorkingGroupLeadReward(..) => {
                 T::SetWorkingGroupLeadRewardProposalParameters::get()
             }
-            ProposalDetailsOf::<T>::TerminateWorkingGroupLead(..) => {
+            ProposalDetails::TerminateWorkingGroupLead(..) => {
                 T::TerminateWorkingGroupLeadProposalParameters::get()
             }
-            ProposalDetailsOf::<T>::AmendConstitution(..) => {
-                T::AmendConstitutionProposalParameters::get()
+            ProposalDetails::CreateWorkingGroupLeadOpening(..) => {
+                T::CreateWorkingGroupLeadOpeningProposalParameters::get()
             }
-            ProposalDetails::SetMembershipPrice(_) => {
+            ProposalDetails::AmendConstitution(..) => T::AmendConstitutionProposalParameters::get(),
+            ProposalDetails::SetMembershipPrice(..) => {
                 T::SetMembershipPriceProposalParameters::get()
             }
             ProposalDetails::CancelWorkingGroupLeadOpening(..) => {

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -174,6 +174,20 @@ pub trait Trait:
     type SetMembershipPriceProposalParameters: Get<
         ProposalParameters<Self::BlockNumber, BalanceOf<Self>>,
     >;
+
+    /// `Set Council Budget Increment` proposal parameters.
+    type SetCouncilBudgetIncrementProposalParameters: Get<
+        ProposalParameters<Self::BlockNumber, BalanceOf<Self>>,
+    >;
+
+    /// `Set Councilor Reward` proposal parameters
+    type SetCouncilorRewardProposalParameters: Get<
+        ProposalParameters<Self::BlockNumber, BalanceOf<Self>>,
+    >;
+
+    type SetInitialInvitationBalanceProposalParameters: Get<
+        ProposalParameters<Self::BlockNumber, BalanceOf<Self>>,
+    >;
 }
 
 /// Specialized alias of GeneralProposalParams
@@ -309,9 +323,21 @@ decl_module! {
         const CancelWorkingGroupLeadOpeningProposalParameters: ProposalParameters<T::BlockNumber, BalanceOf<T>>
             = T::CancelWorkingGroupLeadOpeningProposalParameters::get();
 
-        // Exports 'Set Membership Price' proposal parameters.
+        /// Exports 'Set Membership Price' proposal parameters.
         const SetMembershipPriceProposalParameters: ProposalParameters<T::BlockNumber, BalanceOf<T>>
             = T::SetMembershipPriceProposalParameters::get();
+
+        /// Exports `Set Council Budget Increment` proposal parameters.
+        const SetCouncilBudgetIncrementProposalParameters:
+            ProposalParameters<T::BlockNumber, BalanceOf<T>> = T::SetCouncilBudgetIncrementProposalParameters::get();
+
+        /// Exports `Set Councilor Reward Proposal Parameters` proposal parameters.
+        const SetCouncilorRewardProposalParameters:
+            ProposalParameters<T::BlockNumber, BalanceOf<T>> = T::SetCouncilorRewardProposalParameters::get();
+
+        /// Exports `Set Initial Invitation Balance` proposal parameters.
+        const SetInitialInvitationBalanceProposalParameters:
+            ProposalParameters<T::BlockNumber, BalanceOf<T>> = T::SetInitialInvitationBalanceProposalParameters::get();
 
         /// Create a proposal, the type of proposal depends on the `proposal_details` variant
         #[weight = 10_000_000] // TODO: adjust weight
@@ -404,8 +430,9 @@ decl_module! {
             balance_kind: BalanceKind,
         ) {
             ensure_root(origin.clone())?;
-            // Another option would be to pass the dispatchable instead of this, this would require less changes
-            // but would need a heap allocation for the dispatchable
+
+            // TODO: Discount from council
+
             match working_group {
                 WorkingGroup::Forum =>  working_group::Module::<T, ForumWorkingGroupInstance>::set_budget(origin, amount)?,
                 WorkingGroup::Storage => working_group::Module::<T, StorageWorkingGroupInstance>::set_budget(origin, amount)?,
@@ -496,7 +523,16 @@ impl<T: Trait> Module<T> {
                 // Note: No checks for this proposal for now
                 // TODO: Shouldn't we check that it exists?
             }
-            ProposalDetails::SetMembershipPrice(_) => {
+            ProposalDetails::SetMembershipPrice(..) => {
+                // Note: No checks for this proposal for now
+            }
+            ProposalDetails::SetCouncilBudgetIncrement(..) => {
+                // Note: No checks for this proposal for now
+            }
+            ProposalDetails::SetCouncilorReward(..) => {
+                // Note: No checks for this proposal for now
+            }
+            ProposalDetails::SetInitialInvitationBalance(..) => {
                 // Note: No checks for this proposal for now
             }
         }
@@ -542,6 +578,15 @@ impl<T: Trait> Module<T> {
             }
             ProposalDetails::CancelWorkingGroupLeadOpening(..) => {
                 T::CancelWorkingGroupLeadOpeningProposalParameters::get()
+            }
+            ProposalDetails::SetCouncilBudgetIncrement(..) => {
+                T::SetCouncilBudgetIncrementProposalParameters::get()
+            }
+            ProposalDetails::SetCouncilorReward(..) => {
+                T::SetCouncilorRewardProposalParameters::get()
+            }
+            ProposalDetails::SetInitialInvitationBalance(..) => {
+                T::SetInitialInvitationBalanceProposalParameters::get()
             }
         }
     }

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -12,34 +12,27 @@
 //! module. For each proposal, [its crucial details](./enum.ProposalDetails.html) are saved to the
 //! `ProposalDetailsByProposalId` map.
 //!
-//! ### General proposals
-//! - [create_text_proposal](./struct.Module.html#method.create_text_proposal)
-//! - [create_runtime_upgrade_proposal](./struct.Module.html#method.create_runtime_upgrade_proposal)
-//! - [create_set_validator_count_proposal](./struct.Module.html#method.create_set_validator_count_proposal)
+//! To create a proposal you need to call the extrinsic `create_proposal` with the `ProposalDetails` variant
+//! corresponding to the proposal you want to create. [See the possible details with their proposal](./enum.ProposalDetails.html)
 //!
-//! ### Council and election proposals
-//! - [create_set_election_parameters_proposal](./struct.Module.html#method.create_set_election_parameters_proposal)
-//! - [create_spending_proposal](./struct.Module.html#method.create_spending_proposal)
+//! ## Extrinsics
 //!
-//! ### Working group proposals
-//! - [create_add_working_group_leader_opening_proposal](./struct.Module.html#method.create_add_working_group_leader_opening_proposal)
-//! - [create_begin_review_working_group_leader_applications_proposal](./struct.Module.html#method.create_begin_review_working_group_leader_applications_proposal)
-//! - [create_fill_working_group_leader_opening_proposal](./struct.Module.html#method.create_fill_working_group_leader_opening_proposal)
-//! - [create_set_working_group_budget_capacity_proposal](./struct.Module.html#method.create_set_working_group_budget_capacity_proposal)
-//! - [create_decrease_working_group_leader_stake_proposal](./struct.Module.html#method.create_decrease_working_group_leader_stake_proposal)
-//! - [create_slash_working_group_leader_stake_proposal](./struct.Module.html#method.create_slash_working_group_leader_stake_proposal)
-//! - [create_set_working_group_leader_reward_proposal](./struct.Module.html#method.create_set_working_group_leader_reward_proposal)
-//! - [create_terminate_working_group_leader_role_proposal](./struct.Module.html#method.create_terminate_working_group_leader_role_proposal)
+//! - [create_proposal](./struct.Module.html#method.create_proposal) - creates proposal
+//! - [execute_runtime_upgrade_proposal](./struct.Module.html#method.execute_runtime_upgrade_proposal) - Sets the
+//! runtime code
+//! - [execute_signal_proposal](./struct.Module.html#method.execute_signal_proposal) - prints the proposal to the log
+//! - [update_working_group_budget](./struct.Module.html#method.update_working_group_budget) - Move funds between
+//! council and working group
 //!
-//! ### Proposal implementations of this module
-//! - execute_text_proposal - prints the proposal to the log
-//! - execute_runtime_upgrade_proposal - sets the runtime code
 //!
 //! ### Dependencies:
 //! - [proposals engine](../substrate_proposals_engine_module/index.html)
 //! - [proposals discussion](../substrate_proposals_discussion_module/index.html)
 //! - [membership](../substrate_membership_module/index.html)
 //! - [council](../substrate_council_module/index.html)
+//! - [common](../substrate_common_module/index.html)
+//! - [staking](../substrate_staking_module/index.html)
+//! - [working_group](../substrate_working_group_module/index.html)
 //!
 //! ### Notes
 //! The module uses [ProposalEncoder](./trait.ProposalEncoder.html) to encode the proposal using its

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -158,6 +158,10 @@ pub trait Trait:
     type AmendConstitutionProposalParameters: Get<
         ProposalParameters<Self::BlockNumber, BalanceOf<Self>>,
     >;
+
+    type CancelWorkingGroupLeaderOpeningParameters: Get<
+        ProposalParameters<Self::BlockNumber, BalanceOf<Self>>,
+    >;
 }
 
 /// Specialized alias of GeneralProposalParams
@@ -434,6 +438,12 @@ impl<T: Trait> Module<T> {
             ProposalDetails::AmendConstitution(..) => {
                 // Note: No checks for this proposal for now
             }
+            ProposalDetails::CancelWorkingGroupLeaderOpening(_, _) => {
+                // Note: No checks for this proposal for now
+            }
+            ProposalDetails::SetMembershipPrice(..) => {
+                // Note: No checks for this proposal for now
+            }
         }
 
         Ok(())
@@ -475,6 +485,9 @@ impl<T: Trait> Module<T> {
             }
             ProposalDetailsOf::<T>::AmendConstitution(..) => {
                 T::AmendConstitutionProposalParameters::get()
+            }
+            ProposalDetails::CancelWorkingGroupLeaderOpening(_, _) => {
+                T::CancelWorkingGroupLeaderOpeningParameters::get()
             }
         }
     }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -517,7 +517,6 @@ impl council::Trait for Test {
     type ElectedMemberRewardPerBlock = ElectedMemberRewardPerBlock;
     type ElectedMemberRewardPeriod = ElectedMemberRewardPeriod;
 
-    type BudgetRefillAmount = BudgetRefillAmount;
     type BudgetRefillPeriod = BudgetRefillPeriod;
 
     type StakingAccountValidator = ();

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -491,7 +491,6 @@ parameter_types! {
     pub const MinCandidateStake: u64 = 11000;
     pub const CandidacyLockId: LockIdentifier = *b"council1";
     pub const CouncilorLockId: LockIdentifier = *b"council2";
-    pub const ElectedMemberRewardPerBlock: u64 = 100;
     pub const ElectedMemberRewardPeriod: u64 = 10;
     pub const BudgetRefillAmount: u64 = 1000;
     // intentionally high number that prevents side-effecting tests other than  budget refill tests
@@ -514,7 +513,6 @@ impl council::Trait for Test {
     type CandidacyLock = StakingManager<Self, CandidacyLockId>;
     type CouncilorLock = StakingManager<Self, CouncilorLockId>;
 
-    type ElectedMemberRewardPerBlock = ElectedMemberRewardPerBlock;
     type ElectedMemberRewardPeriod = ElectedMemberRewardPeriod;
 
     type BudgetRefillPeriod = BudgetRefillPeriod;

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -478,6 +478,9 @@ impl crate::Trait for Test {
     type SetCouncilBudgetIncrementProposalParameters = DefaultProposalParameters;
     type SetCouncilorRewardProposalParameters = DefaultProposalParameters;
     type SetInitialInvitationBalanceProposalParameters = DefaultProposalParameters;
+    type SetInvitationCountProposalParameters = DefaultProposalParameters;
+    type SetMembershipLeadInvitationQuotaProposalParameters = DefaultProposalParameters;
+    type SetReferralCutProposalParameters = DefaultProposalParameters;
 }
 
 parameter_types! {

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -9,7 +9,7 @@ use sp_runtime::curve::PiecewiseLinear;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
-    BuildStorage, DispatchResult, Perbill,
+    DispatchResult, Perbill,
 };
 use sp_staking::SessionIndex;
 use staking_handler::{LockComparator, StakingManager};

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -444,6 +444,7 @@ impl crate::Trait for Test {
     type SetWorkingGroupLeaderRewardProposalParameters = DefaultProposalParameters;
     type TerminateWorkingGroupLeaderRoleProposalParameters = DefaultProposalParameters;
     type AmendConstitutionProposalParameters = DefaultProposalParameters;
+    type CancelWorkingGroupLeaderOpeningParameters = DefaultProposalParameters;
 }
 
 parameter_types! {
@@ -682,9 +683,11 @@ impl LockComparator<<Test as balances::Trait>::Balance> for Test {
 }
 
 pub fn initial_test_ext() -> sp_io::TestExternalities {
-    let t = frame_system::GenesisConfig::default()
+    let mut t = frame_system::GenesisConfig::default()
         .build_storage::<Test>()
         .unwrap();
+
+    council_config.assimilate_storage(&mut t).unwrap();
 
     t.into()
 }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -460,6 +460,7 @@ pub(crate) fn default_proposal_parameters() -> ProposalParameters<u64, u64> {
 impl crate::Trait for Test {
     type MembershipOriginValidator = ();
     type ProposalEncoder = ();
+    type WeightInfo = ();
     type SetMaxValidatorCountProposalParameters = DefaultProposalParameters;
     type RuntimeUpgradeProposalParameters = DefaultProposalParameters;
     type SignalProposalParameters = DefaultProposalParameters;
@@ -660,6 +661,63 @@ impl referendum::WeightInfo for ReferendumWeightInfo {
         0
     }
     fn release_vote_stake() -> Weight {
+        0
+    }
+}
+
+impl crate::WeightInfo for () {
+    fn execute_signal_proposal(_: u32) -> Weight {
+        0
+    }
+    fn create_proposal_signal(_: u32) -> Weight {
+        0
+    }
+    fn create_proposal_runtime_upgrade(_: u32, _: u32, _: u32) -> Weight {
+        0
+    }
+    fn create_proposal_funding_request() -> Weight {
+        0
+    }
+    fn create_proposal_set_max_validator_count(_: u32, _: u32) -> Weight {
+        0
+    }
+    fn create_proposal_create_working_group_lead_opening(_: u32, _: u32, _: u32) -> Weight {
+        0
+    }
+    fn create_proposal_fill_working_group_lead_opening(_: u32, _: u32) -> Weight {
+        0
+    }
+    fn create_proposal_update_working_group_budget(_: u32) -> Weight {
+        0
+    }
+    fn create_proposal_decrease_working_group_lead_stake() -> Weight {
+        0
+    }
+    fn create_proposal_slash_working_group_lead(_: u32) -> Weight {
+        0
+    }
+    fn create_proposal_set_working_group_lead_reward(_: u32) -> Weight {
+        0
+    }
+    fn create_proposal_terminate_working_group_lead(_: u32, _: u32) -> Weight {
+        0
+    }
+    fn create_proposal_amend_constitution(_: u32, _: u32, _: u32) -> Weight {
+        0
+    }
+    fn create_proposal_cancel_working_group_lead_opening(_: u32) -> Weight {
+        0
+    }
+    fn create_proposal_set_membership_price(_: u32, _: u32) -> Weight {
+        0
+    }
+    fn create_proposal_set_council_budget_increment(_: u32) -> Weight {
+        0
+    }
+    fn create_proposal_set_councilor_reward(_: u32) -> Weight {
+        0
+    }
+    fn create_proposal_set_initial_invitation_balance(_: u32, _: u32) -> Weight {
         0
     }
 }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -474,6 +474,9 @@ impl crate::Trait for Test {
     type AmendConstitutionProposalParameters = DefaultProposalParameters;
     type CancelWorkingGroupLeadOpeningProposalParameters = DefaultProposalParameters;
     type SetMembershipPriceProposalParameters = DefaultProposalParameters;
+    type SetCouncilBudgetIncrementProposalParameters = DefaultProposalParameters;
+    type SetCouncilorRewardProposalParameters = DefaultProposalParameters;
+    type SetInitialInvitationBalanceProposalParameters = DefaultProposalParameters;
 }
 
 parameter_types! {

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -689,13 +689,13 @@ impl crate::WeightInfo for () {
     fn execute_signal_proposal(_: u32) -> Weight {
         0
     }
-    fn create_proposal_signal(_: u32, _: u32) -> Weight {
+    fn create_proposal_signal(_: u32, _: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_runtime_upgrade(_: u32) -> Weight {
+    fn create_proposal_runtime_upgrade(_: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_funding_request(_: u32, _: u32) -> Weight {
+    fn create_proposal_funding_request() -> Weight {
         0
     }
     fn create_proposal_set_max_validator_count() -> Weight {
@@ -704,13 +704,13 @@ impl crate::WeightInfo for () {
     fn create_proposal_create_working_group_lead_opening(_: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_fill_working_group_lead_opening(_: u32) -> Weight {
+    fn create_proposal_fill_working_group_lead_opening() -> Weight {
         0
     }
-    fn create_proposal_update_working_group_budget(_: u32) -> Weight {
+    fn create_proposal_update_working_group_budget(_: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_decrease_working_group_lead_stake(_: u32, _: u32) -> Weight {
+    fn create_proposal_decrease_working_group_lead_stake(_: u32) -> Weight {
         0
     }
     fn create_proposal_slash_working_group_lead() -> Weight {
@@ -725,10 +725,10 @@ impl crate::WeightInfo for () {
     fn create_proposal_amend_constitution(_: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_cancel_working_group_lead_opening() -> Weight {
+    fn create_proposal_cancel_working_group_lead_opening(_: u32) -> Weight {
         0
     }
-    fn create_proposal_set_membership_price(_: u32) -> Weight {
+    fn create_proposal_set_membership_price(_: u32, _: u32) -> Weight {
         0
     }
     fn create_proposal_set_council_budget_increment(_: u32, _: u32) -> Weight {
@@ -740,13 +740,13 @@ impl crate::WeightInfo for () {
     fn create_proposal_set_initial_invitation_balance(_: u32) -> Weight {
         0
     }
-    fn create_proposal_set_initial_invitation_count() -> Weight {
+    fn create_proposal_set_initial_invitation_count(_: u32, _: u32) -> Weight {
         0
     }
     fn create_proposal_set_membership_lead_invitation_quota() -> Weight {
         0
     }
-    fn create_proposal_set_referral_cut(_: u32, _: u32) -> Weight {
+    fn create_proposal_set_referral_cut(_: u32) -> Weight {
         0
     }
     fn update_working_group_budget_positive_forum() -> Weight {
@@ -771,9 +771,6 @@ impl crate::WeightInfo for () {
         0
     }
     fn update_working_group_budget_negative_membership() -> Weight {
-        0
-    }
-    fn funding_request() -> Weight {
         0
     }
 }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -241,11 +241,17 @@ impl VotersParameters for MockVotersParameters {
     }
 }
 
+// The forum working group instance alias.
+pub type ForumWorkingGroupInstance = working_group::Instance1;
+
 // The content directory working group instance alias.
 pub type ContentDirectoryWorkingGroupInstance = working_group::Instance3;
 
 // The storage working group instance alias.
 pub type StorageWorkingGroupInstance = working_group::Instance2;
+
+// The membership working group instance alias.
+pub type MembershipWorkingGroupInstance = working_group::Instance4;
 
 parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 100;
@@ -348,6 +354,28 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type WeightInfo = WorkingGroupWeightInfo;
 }
 
+impl working_group::Trait<ForumWorkingGroupInstance> for Test {
+    type Event = ();
+    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
+    type StakingHandler = staking_handler::StakingManager<Self, LockId2>;
+    type StakingAccountValidator = membership::Module<Test>;
+    type MemberOriginValidator = ();
+    type MinUnstakingPeriodLimit = ();
+    type RewardPeriod = ();
+    type WeightInfo = WorkingGroupWeightInfo;
+}
+
+impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
+    type Event = ();
+    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
+    type StakingHandler = StakingManager<Self, LockId2>;
+    type StakingAccountValidator = membership::Module<Test>;
+    type MemberOriginValidator = ();
+    type MinUnstakingPeriodLimit = ();
+    type RewardPeriod = ();
+    type WeightInfo = WorkingGroupWeightInfo;
+}
+
 pallet_staking_reward_curve::build! {
     const I_NPOS: PiecewiseLinear<'static> = curve!(
         min_inflation: 0_025_000,
@@ -432,19 +460,20 @@ pub(crate) fn default_proposal_parameters() -> ProposalParameters<u64, u64> {
 impl crate::Trait for Test {
     type MembershipOriginValidator = ();
     type ProposalEncoder = ();
-    type SetValidatorCountProposalParameters = DefaultProposalParameters;
+    type SetMaxValidatorCountProposalParameters = DefaultProposalParameters;
     type RuntimeUpgradeProposalParameters = DefaultProposalParameters;
-    type TextProposalParameters = DefaultProposalParameters;
-    type SpendingProposalParameters = DefaultProposalParameters;
-    type AddWorkingGroupOpeningProposalParameters = DefaultProposalParameters;
-    type FillWorkingGroupOpeningProposalParameters = DefaultProposalParameters;
-    type SetWorkingGroupBudgetCapacityProposalParameters = DefaultProposalParameters;
-    type DecreaseWorkingGroupLeaderStakeProposalParameters = DefaultProposalParameters;
-    type SlashWorkingGroupLeaderStakeProposalParameters = DefaultProposalParameters;
-    type SetWorkingGroupLeaderRewardProposalParameters = DefaultProposalParameters;
-    type TerminateWorkingGroupLeaderRoleProposalParameters = DefaultProposalParameters;
+    type SignalProposalParameters = DefaultProposalParameters;
+    type FundingRequestProposalParameters = DefaultProposalParameters;
+    type CreateWorkingGroupLeadOpeningProposalParameters = DefaultProposalParameters;
+    type FillWorkingGroupLeadOpeningProposalParameters = DefaultProposalParameters;
+    type UpdateWorkingGroupBudgetProposalParameters = DefaultProposalParameters;
+    type DecreaseWorkingGroupLeadStakeProposalParameters = DefaultProposalParameters;
+    type SlashWorkingGroupLeadProposalParameters = DefaultProposalParameters;
+    type SetWorkingGroupLeadRewardProposalParameters = DefaultProposalParameters;
+    type TerminateWorkingGroupLeadProposalParameters = DefaultProposalParameters;
     type AmendConstitutionProposalParameters = DefaultProposalParameters;
-    type CancelWorkingGroupLeaderOpeningParameters = DefaultProposalParameters;
+    type CancelWorkingGroupLeadOpeningProposalParameters = DefaultProposalParameters;
+    type SetMembershipPriceProposalParameters = DefaultProposalParameters;
 }
 
 parameter_types! {
@@ -683,11 +712,9 @@ impl LockComparator<<Test as balances::Trait>::Balance> for Test {
 }
 
 pub fn initial_test_ext() -> sp_io::TestExternalities {
-    let mut t = frame_system::GenesisConfig::default()
+    let t = frame_system::GenesisConfig::default()
         .build_storage::<Test>()
         .unwrap();
-
-    council_config.assimilate_storage(&mut t).unwrap();
 
     t.into()
 }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -9,7 +9,7 @@ use sp_runtime::curve::PiecewiseLinear;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
-    DispatchResult, Perbill,
+    BuildStorage, DispatchResult, Perbill,
 };
 use sp_staking::SessionIndex;
 use staking_handler::{LockComparator, StakingManager};
@@ -244,11 +244,11 @@ impl VotersParameters for MockVotersParameters {
 // The forum working group instance alias.
 pub type ForumWorkingGroupInstance = working_group::Instance1;
 
-// The content directory working group instance alias.
-pub type ContentDirectoryWorkingGroupInstance = working_group::Instance3;
-
 // The storage working group instance alias.
 pub type StorageWorkingGroupInstance = working_group::Instance2;
+
+// The content directory working group instance alias.
+pub type ContentDirectoryWorkingGroupInstance = working_group::Instance3;
 
 // The membership working group instance alias.
 pub type MembershipWorkingGroupInstance = working_group::Instance4;

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -16,7 +16,7 @@ use staking_handler::{LockComparator, StakingManager};
 
 use crate::BalanceOf;
 use crate::{ProposalDetailsOf, ProposalEncoder, ProposalParameters};
-use common::working_group::WorkingGroup;
+use common::working_group::{WorkingGroup, WorkingGroupBudgetHandler};
 use frame_support::dispatch::DispatchError;
 use proposals_engine::VotersParameters;
 use sp_runtime::testing::TestXt;
@@ -462,10 +462,17 @@ pub(crate) fn default_proposal_parameters() -> ProposalParameters<u64, u64> {
 macro_rules! call_wg {
     ($working_group:ident<$T:ty>, $function:ident $(,$x:expr)*) => {{
         match $working_group {
-            WorkingGroup::Content => working_group::Module::<$T, ContentDirectoryWorkingGroupInstance>::$function($($x,)*),
-            WorkingGroup::Storage => working_group::Module::<$T, StorageWorkingGroupInstance>::$function($($x,)*),
-            WorkingGroup::Forum => working_group::Module::<$T, ForumWorkingGroupInstance>::$function($($x,)*),
-            WorkingGroup::Membership => working_group::Module::<$T, MembershipWorkingGroupInstance>::$function($($x,)*),
+            WorkingGroup::Content =>
+                <working_group::Module::<$T, ContentDirectoryWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+
+            WorkingGroup::Storage =>
+                <working_group::Module::<$T, StorageWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+
+            WorkingGroup::Forum =>
+                <working_group::Module::<$T, ForumWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+
+            WorkingGroup::Membership =>
+                <working_group::Module::<$T, MembershipWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
         }
     }};
 }
@@ -498,8 +505,9 @@ impl crate::Trait for Test {
     fn get_working_group_budget(working_group: WorkingGroup) -> BalanceOf<Test> {
         call_wg!(working_group<Test>, get_budget)
     }
+
     fn set_working_group_budget(working_group: WorkingGroup, budget: BalanceOf<Test>) {
-        call_wg!(working_group<Test>, put_budget, budget)
+        call_wg!(working_group<Test>, set_budget, budget)
     }
 }
 

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -669,55 +669,91 @@ impl crate::WeightInfo for () {
     fn execute_signal_proposal(_: u32) -> Weight {
         0
     }
-    fn create_proposal_signal(_: u32) -> Weight {
+    fn create_proposal_signal(_: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_runtime_upgrade(_: u32, _: u32, _: u32) -> Weight {
+    fn create_proposal_runtime_upgrade(_: u32) -> Weight {
         0
     }
-    fn create_proposal_funding_request() -> Weight {
+    fn create_proposal_funding_request(_: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_set_max_validator_count(_: u32, _: u32) -> Weight {
+    fn create_proposal_set_max_validator_count() -> Weight {
         0
     }
-    fn create_proposal_create_working_group_lead_opening(_: u32, _: u32, _: u32) -> Weight {
+    fn create_proposal_create_working_group_lead_opening(_: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_fill_working_group_lead_opening(_: u32, _: u32) -> Weight {
+    fn create_proposal_fill_working_group_lead_opening(_: u32) -> Weight {
         0
     }
     fn create_proposal_update_working_group_budget(_: u32) -> Weight {
         0
     }
-    fn create_proposal_decrease_working_group_lead_stake() -> Weight {
+    fn create_proposal_decrease_working_group_lead_stake(_: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_slash_working_group_lead(_: u32) -> Weight {
+    fn create_proposal_slash_working_group_lead() -> Weight {
         0
     }
     fn create_proposal_set_working_group_lead_reward(_: u32) -> Weight {
         0
     }
-    fn create_proposal_terminate_working_group_lead(_: u32, _: u32) -> Weight {
+    fn create_proposal_terminate_working_group_lead(_: u32) -> Weight {
         0
     }
-    fn create_proposal_amend_constitution(_: u32, _: u32, _: u32) -> Weight {
+    fn create_proposal_amend_constitution(_: u32, _: u32) -> Weight {
         0
     }
-    fn create_proposal_cancel_working_group_lead_opening(_: u32) -> Weight {
+    fn create_proposal_cancel_working_group_lead_opening() -> Weight {
         0
     }
-    fn create_proposal_set_membership_price(_: u32, _: u32) -> Weight {
+    fn create_proposal_set_membership_price(_: u32) -> Weight {
         0
     }
-    fn create_proposal_set_council_budget_increment(_: u32) -> Weight {
+    fn create_proposal_set_council_budget_increment(_: u32, _: u32) -> Weight {
         0
     }
     fn create_proposal_set_councilor_reward(_: u32) -> Weight {
         0
     }
-    fn create_proposal_set_initial_invitation_balance(_: u32, _: u32) -> Weight {
+    fn create_proposal_set_initial_invitation_balance(_: u32) -> Weight {
+        0
+    }
+    fn create_proposal_set_initial_invitation_count() -> Weight {
+        0
+    }
+    fn create_proposal_set_membership_lead_invitation_quota() -> Weight {
+        0
+    }
+    fn create_proposal_set_referral_cut(_: u32, _: u32) -> Weight {
+        0
+    }
+    fn update_working_group_budget_positive_forum() -> Weight {
+        0
+    }
+    fn update_working_group_budget_negative_forum() -> Weight {
+        0
+    }
+    fn update_working_group_budget_positive_storage() -> Weight {
+        0
+    }
+    fn update_working_group_budget_negative_storage() -> Weight {
+        0
+    }
+    fn update_working_group_budget_positive_content() -> Weight {
+        0
+    }
+    fn update_working_group_budget_negative_content() -> Weight {
+        0
+    }
+    fn update_working_group_budget_positive_membership() -> Weight {
+        0
+    }
+    fn update_working_group_budget_negative_membership() -> Weight {
+        0
+    }
+    fn funding_request() -> Weight {
         0
     }
 }

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -310,9 +310,6 @@ fn create_funding_request_proposal_call_fails_with_incorrect_balance() {
             exact_execution_block: None,
         };
 
-        let budget_capacity = 100;
-        council::Module::<Test>::set_budget(RawOrigin::Root.into(), budget_capacity).unwrap();
-
         assert_eq!(
             ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -310,23 +310,14 @@ fn create_funding_request_proposal_call_fails_with_incorrect_balance() {
             exact_execution_block: None,
         };
 
-        let mint_capacity = 100;
-        council::Module::<Test>::set_budget(RawOrigin::Root.into(), mint_capacity).unwrap();
+        let budget_capacity = 100;
+        council::Module::<Test>::set_budget(RawOrigin::Root.into(), budget_capacity).unwrap();
 
         assert_eq!(
             ProposalCodex::create_proposal(
                 RawOrigin::Signed(1).into(),
                 general_proposal_parameters.clone(),
                 ProposalDetails::FundingRequest(0, 2),
-            ),
-            Err(Error::<Test>::InvalidFundingRequestProposalBalance.into())
-        );
-
-        assert_eq!(
-            ProposalCodex::create_proposal(
-                RawOrigin::Signed(1).into(),
-                general_proposal_parameters.clone(),
-                ProposalDetails::FundingRequest(mint_capacity + 1, 2),
             ),
             Err(Error::<Test>::InvalidFundingRequestProposalBalance.into())
         );
@@ -764,14 +755,6 @@ fn run_create_slash_working_group_leader_stake_proposal_common_checks_succeed(
     });
 }
 
-#[test]
-fn slash_stake_with_zero_staking_balance_fails() {
-    // This uses strum crate for enum iteration
-    for group in WorkingGroup::iter() {
-        run_slash_stake_with_zero_staking_balance_fails(group);
-    }
-}
-
 pub fn run_to_block(n: u64) {
     while System::block_number() < n {
         System::on_finalize(System::block_number());
@@ -857,31 +840,6 @@ fn setup_council(start_id: u64) {
             .collect::<Vec<_>>(),
         council,
     );
-}
-
-fn run_slash_stake_with_zero_staking_balance_fails(working_group: WorkingGroup) {
-    initial_test_ext().execute_with(|| {
-        increase_total_balance_issuance_using_account_id(1, 500000);
-
-        let general_proposal_parameters = GeneralProposalParameters::<Test> {
-            member_id: 1,
-            title: b"title".to_vec(),
-            description: b"body".to_vec(),
-            staking_account_id: Some(1),
-            exact_execution_block: None,
-        };
-
-        setup_council(2);
-
-        assert_eq!(
-            ProposalCodex::create_proposal(
-                RawOrigin::Signed(1).into(),
-                general_proposal_parameters.clone(),
-                ProposalDetails::SlashWorkingGroupLead(10, 0, working_group)
-            ),
-            Err(Error::<Test>::SlashingStakeIsZero.into())
-        );
-    });
 }
 
 #[test]

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -561,12 +561,11 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
 fn create_set_working_group_mint_capacity_proposal_common_checks_succeed() {
     // This uses strum crate for enum iteration
     for group in WorkingGroup::iter() {
-        run_create_set_working_group_mint_capacity_proposal_common_checks_succeed(group);
+        run_create_update_working_group_budget_proposal_common_checks_succeed(group);
     }
 }
 
-// TODO: review here
-fn run_create_set_working_group_mint_capacity_proposal_common_checks_succeed(
+fn run_create_update_working_group_budget_proposal_common_checks_succeed(
     working_group: WorkingGroup,
 ) {
     initial_test_ext().execute_with(|| {
@@ -1097,6 +1096,59 @@ fn create_amend_constitution_proposal_common_checks_succeed() {
 }
 
 #[test]
+fn create_set_council_budget_increment_common_checks_succeed() {
+    initial_test_ext().execute_with(|| {
+        increase_total_balance_issuance_using_account_id(1, 1_500_000);
+
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+            exact_execution_block: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+            exact_execution_block: None,
+        };
+
+        let set_council_budget_increment_details = ProposalDetails::SetCouncilBudgetIncrement(100);
+
+        let proposal_fixture = ProposalTestFixture {
+            insufficient_rights_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::None.into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_council_budget_increment_details.clone(),
+                )
+            },
+            empty_stake_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_council_budget_increment_details.clone(),
+                )
+            },
+            successful_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_with_staking.clone(),
+                    set_council_budget_increment_details.clone(),
+                )
+            },
+            proposal_parameters:
+                <Test as crate::Trait>::SetCouncilBudgetIncrementProposalParameters::get(),
+            proposal_details: set_council_budget_increment_details.clone(),
+        };
+        proposal_fixture.check_all();
+    });
+}
+
+#[test]
 fn create_cancel_working_group_leader_opening_proposal_common_checks_succeed() {
     // This uses strum crate for enum iteration
     for group in WorkingGroup::iter() {
@@ -1153,6 +1205,273 @@ fn run_create_cancel_working_group_leader_opening_proposal_common_checks_succeed
             proposal_parameters:
                 <Test as crate::Trait>::CancelWorkingGroupLeadOpeningProposalParameters::get(),
             proposal_details: cancel_opening_details.clone(),
+        };
+        proposal_fixture.check_all();
+    });
+}
+
+#[test]
+fn create_set_councilor_reward_proposal_common_checks_succeed() {
+    initial_test_ext().execute_with(|| {
+        let total_balance_issuance = 500000;
+        increase_total_balance_issuance(total_balance_issuance);
+
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+            exact_execution_block: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+            exact_execution_block: None,
+        };
+
+        let set_councilor_reward_details = ProposalDetails::SetCouncilorReward(100);
+
+        let proposal_fixture = ProposalTestFixture {
+            insufficient_rights_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::None.into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_councilor_reward_details.clone(),
+                )
+            },
+            empty_stake_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_councilor_reward_details.clone(),
+                )
+            },
+            successful_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_with_staking.clone(),
+                    set_councilor_reward_details.clone(),
+                )
+            },
+            proposal_parameters: <Test as crate::Trait>::SetCouncilorRewardProposalParameters::get(
+            ),
+            proposal_details: set_councilor_reward_details.clone(),
+        };
+        proposal_fixture.check_all();
+    });
+}
+
+#[test]
+fn create_set_initial_invitation_balance_proposal_common_checks_succeed() {
+    initial_test_ext().execute_with(|| {
+        increase_total_balance_issuance_using_account_id(1, 1_500_000);
+
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+            exact_execution_block: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+            exact_execution_block: None,
+        };
+
+        let set_initial_invitation_balance_details =
+            ProposalDetails::SetInitialInvitationBalance(100);
+
+        let proposal_fixture = ProposalTestFixture {
+            insufficient_rights_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::None.into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_initial_invitation_balance_details.clone(),
+                )
+            },
+            empty_stake_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_initial_invitation_balance_details.clone(),
+                )
+            },
+            successful_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_with_staking.clone(),
+                    set_initial_invitation_balance_details.clone(),
+                )
+            },
+            proposal_parameters:
+                <Test as crate::Trait>::SetInitialInvitationBalanceProposalParameters::get(),
+            proposal_details: set_initial_invitation_balance_details.clone(),
+        };
+        proposal_fixture.check_all();
+    });
+}
+
+#[test]
+fn create_set_initial_invitation_count_proposal_common_checks_succeed() {
+    initial_test_ext().execute_with(|| {
+        increase_total_balance_issuance_using_account_id(1, 1_500_000);
+
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+            exact_execution_block: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+            exact_execution_block: None,
+        };
+
+        let set_initial_invitation_count_details = ProposalDetails::SetInitialInvitationCount(100);
+
+        let proposal_fixture = ProposalTestFixture {
+            insufficient_rights_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::None.into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_initial_invitation_count_details.clone(),
+                )
+            },
+            empty_stake_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_initial_invitation_count_details.clone(),
+                )
+            },
+            successful_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_with_staking.clone(),
+                    set_initial_invitation_count_details.clone(),
+                )
+            },
+            proposal_parameters: <Test as crate::Trait>::SetInvitationCountProposalParameters::get(
+            ),
+            proposal_details: set_initial_invitation_count_details.clone(),
+        };
+        proposal_fixture.check_all();
+    });
+}
+
+#[test]
+fn create_set_membership_lead_invitation_quota_common_checks_succeed() {
+    initial_test_ext().execute_with(|| {
+        increase_total_balance_issuance_using_account_id(1, 1_500_000);
+
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+            exact_execution_block: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+            exact_execution_block: None,
+        };
+
+        let set_membership_lead_invitation_quota =
+            ProposalDetails::SetMembershipLeadInvitationQuota(100);
+
+        let proposal_fixture = ProposalTestFixture {
+            insufficient_rights_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::None.into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_membership_lead_invitation_quota.clone(),
+                )
+            },
+            empty_stake_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_membership_lead_invitation_quota.clone(),
+                )
+            },
+            successful_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_with_staking.clone(),
+                    set_membership_lead_invitation_quota.clone(),
+                )
+            },
+            proposal_parameters:
+                <Test as crate::Trait>::SetMembershipLeadInvitationQuotaProposalParameters::get(),
+            proposal_details: set_membership_lead_invitation_quota.clone(),
+        };
+        proposal_fixture.check_all();
+    });
+}
+
+#[test]
+fn create_set_referral_cut_common_checks_succeed() {
+    initial_test_ext().execute_with(|| {
+        increase_total_balance_issuance_using_account_id(1, 1_500_000);
+
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+            exact_execution_block: None,
+        };
+
+        let general_proposal_parameters_with_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+            exact_execution_block: None,
+        };
+
+        let set_referral_cut_proposal_details = ProposalDetails::SetReferralCut(100);
+
+        let proposal_fixture = ProposalTestFixture {
+            insufficient_rights_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::None.into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_referral_cut_proposal_details.clone(),
+                )
+            },
+            empty_stake_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    set_referral_cut_proposal_details.clone(),
+                )
+            },
+            successful_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_with_staking.clone(),
+                    set_referral_cut_proposal_details.clone(),
+                )
+            },
+            proposal_parameters: <Test as crate::Trait>::SetReferralCutProposalParameters::get(),
+            proposal_details: set_referral_cut_proposal_details.clone(),
         };
         proposal_fixture.check_all();
     });

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -1004,45 +1004,6 @@ fn run_create_terminate_working_group_leader_role_proposal_common_checks_succeed
 }
 
 #[test]
-fn test_funding_request_fails_permission() {
-    initial_test_ext().execute_with(|| {
-        assert_eq!(
-            ProposalCodex::funding_request(RawOrigin::Signed(0).into(), 1, 0),
-            Err(DispatchError::BadOrigin)
-        );
-    });
-}
-
-#[test]
-fn test_funding_request_fails_insufficient_fundings() {
-    initial_test_ext().execute_with(|| {
-        Council::<Test>::set_budget(RawOrigin::Root.into(), 0).unwrap();
-        assert_eq!(
-            ProposalCodex::funding_request(RawOrigin::Root.into(), 1, 0),
-            Err(Error::<Test>::InsufficientFundsForFundingRequest.into())
-        );
-    });
-}
-
-#[test]
-fn test_funding_request_succeeds() {
-    initial_test_ext().execute_with(|| {
-        let initial_budget = 100;
-        let funding_amount = 5;
-        let recieving_account = 0;
-        Council::<Test>::set_budget(RawOrigin::Root.into(), initial_budget).unwrap();
-        assert_eq!(Council::<Test>::budget(), initial_budget);
-        ProposalCodex::funding_request(RawOrigin::Root.into(), funding_amount, recieving_account)
-            .unwrap();
-        assert_eq!(Council::<Test>::budget(), initial_budget - funding_amount);
-        assert_eq!(
-            balances::Module::<Test>::free_balance(recieving_account),
-            funding_amount
-        );
-    });
-}
-
-#[test]
 fn create_amend_constitution_proposal_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
         increase_total_balance_issuance_using_account_id(1, 1_500_000);

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -74,14 +74,25 @@ pub enum ProposalDetails<Balance, BlockNumber, AccountId, WorkerId, OpeningId> {
     /// Fire the working group leader with possible slashing.
     TerminateWorkingGroupLead(TerminateRoleParameters<WorkerId, Balance>),
 
-    /// Amend constitution.
+    /// `Amend constitution` proposal.
     AmendConstitution(Vec<u8>),
 
-    /// Cancel working group leader opening.
+    /// `Cancel Working Group Lead Opening` proposal:
+    /// Cancels an opening for a working group leader
     CancelWorkingGroupLeadOpening(OpeningId, WorkingGroup),
 
-    /// Set the membership price.
+    /// `Set Membership Price` proposal:
+    /// Sets the membership price
     SetMembershipPrice(Balance),
+
+    /// `Set Council Budget Increment` proposal
+    SetCouncilBudgetIncrement(Balance),
+
+    /// `Set Councilor Reward` proposal
+    SetCouncilorReward(Balance),
+
+    /// `Set Initial Invitation Balance` proposal
+    SetInitialInvitationBalance(Balance),
 }
 
 impl<Balance, BlockNumber, AccountId, WorkerId, OpeningId> Default

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -7,7 +7,6 @@ use sp_std::vec::Vec;
 
 use common::working_group::WorkingGroup;
 
-pub(crate) use council::Balance as CouncilBalance;
 use working_group::StakePolicy;
 
 /// Encodes proposal using its details information.

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -7,6 +7,7 @@ use sp_std::vec::Vec;
 
 use common::working_group::WorkingGroup;
 
+pub(crate) use council::Balance as CouncilBalance;
 use working_group::StakePolicy;
 
 /// Encodes proposal using its details information.
@@ -26,7 +27,7 @@ pub type ProposalDetailsOf<T> = ProposalDetails<
 
 /// Kind of Balance for `Update Working Group Budget`.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Debug)]
 pub enum BalanceKind {
     /// Increasing Working Group budget decreasing Council budget
     Positive,
@@ -93,6 +94,15 @@ pub enum ProposalDetails<Balance, BlockNumber, AccountId, WorkerId, OpeningId> {
 
     /// `Set Initial Invitation Balance` proposal
     SetInitialInvitationBalance(Balance),
+
+    /// `Set Initial Invitation Count` proposal
+    SetInitialInvitationCount(u32),
+
+    /// `Set Membership Lead Invitation Quota` proposal
+    SetMembershipLeadInvitationQuota(u32),
+
+    /// `Set Referral Cut` proposal
+    SetReferralCut(Balance),
 }
 
 impl<Balance, BlockNumber, AccountId, WorkerId, OpeningId> Default

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -24,58 +24,71 @@ pub type ProposalDetailsOf<T> = ProposalDetails<
     working_group::OpeningId,
 >;
 
+/// Kind of Balance for `Update Working Group Budget`.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+pub enum BalanceKind {
+    /// Increasing Working Group budget decreasing Council budget
+    Positive,
+    /// Decreasing Working Group budget increasing Council budget
+    Negative,
+}
+
 /// Proposal details provide voters the information required for the perceived voting.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
 pub enum ProposalDetails<Balance, BlockNumber, AccountId, WorkerId, OpeningId> {
-    /// The text of the `text` proposal
-    Text(Vec<u8>),
+    /// The signal of the `Signal` proposal
+    Signal(Vec<u8>),
 
-    /// The wasm code for the `runtime upgrade` proposal
+    /// The wasm code for the `Runtime Upgrade` proposal
     RuntimeUpgrade(Vec<u8>),
 
-    /// Balance and destination account for the `spending` proposal
-    Spending(Balance, AccountId),
+    /// Balance and destination account for the `FundingRequest` proposal
+    FundingRequest(Balance, AccountId),
 
-    /// Validator count for the `set validator count` proposal
-    SetValidatorCount(u32),
+    /// `Set Max Validator Count` proposal
+    SetMaxValidatorCount(u32),
 
+    /// `Create Working Group Lead Opening` Proposal:
     /// Add opening for the working group leader position.
-    AddWorkingGroupLeaderOpening(AddOpeningParameters<BlockNumber, Balance>),
+    CreateWorkingGroupLeadOpening(CreateOpeningParameters<BlockNumber, Balance>),
 
+    /// `Fill Working Group Lead Opening` proposal:
     /// Fill opening for the working group leader position.
-    FillWorkingGroupLeaderOpening(FillOpeningParameters),
+    FillWorkingGroupLeadOpening(FillOpeningParameters),
 
-    /// Set working group budget capacity.
-    SetWorkingGroupBudgetCapacity(Balance, WorkingGroup),
+    /// `Update Working Group Budget` proposal: Set working group budget capacity.
+    UpdateWorkingGroupBudget(Balance, WorkingGroup, BalanceKind),
 
-    /// Decrease the working group leader stake.
-    DecreaseWorkingGroupLeaderStake(WorkerId, Balance, WorkingGroup),
+    /// `Decrease Working Group Lead Stake` proposal: Decrease the working group leader stake.
+    DecreaseWorkingGroupLeadStake(WorkerId, Balance, WorkingGroup),
 
-    /// Slash the working group leader stake.
-    SlashWorkingGroupLeaderStake(WorkerId, Balance, WorkingGroup),
+    /// `Slash Working Group Lead Stake` proposal:  Slash the working group leader stake.
+    SlashWorkingGroupLead(WorkerId, Balance, WorkingGroup),
 
-    /// Set working group leader reward balance.
-    SetWorkingGroupLeaderReward(WorkerId, Option<Balance>, WorkingGroup),
+    /// `Set Working Group Lead Reward` proposal: Set working group lead reward balance.
+    SetWorkingGroupLeadReward(WorkerId, Option<Balance>, WorkingGroup),
 
+    /// `Terminate Working Group Lead` proposal:
     /// Fire the working group leader with possible slashing.
-    TerminateWorkingGroupLeaderRole(TerminateRoleParameters<WorkerId, Balance>),
+    TerminateWorkingGroupLead(TerminateRoleParameters<WorkerId, Balance>),
 
     /// Amend constitution.
     AmendConstitution(Vec<u8>),
 
     /// Cancel working group leader opening.
-    CancelWorkingGroupLeaderOpening(OpeningId, WorkingGroup),
+    CancelWorkingGroupLeadOpening(OpeningId, WorkingGroup),
 
     /// Set the membership price.
     SetMembershipPrice(Balance),
 }
 
-impl<BlockNumber, AccountId, Balance, WorkerId, OpeningId> Default
+impl<Balance, BlockNumber, AccountId, WorkerId, OpeningId> Default
     for ProposalDetails<Balance, BlockNumber, AccountId, WorkerId, OpeningId>
 {
     fn default() -> Self {
-        ProposalDetails::Text(b"invalid proposal details".to_vec())
+        ProposalDetails::Signal(b"invalid proposal details".to_vec())
     }
 }
 
@@ -103,43 +116,43 @@ pub struct GeneralProposalParams<MemberId, AccountId, BlockNumber> {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
 pub struct TerminateRoleParameters<WorkerId, Balance> {
-    /// Leader worker id to fire.
+    /// Worker identifier.
     pub worker_id: WorkerId,
 
-    /// Terminate role slash penalty.
-    pub penalty: Option<Balance>,
+    /// Optional amount to be slashed.
+    pub slashing_amount: Option<Balance>,
 
-    /// Defines working group with the open position.
-    pub working_group: WorkingGroup,
+    /// Identifier for working group.
+    pub group: WorkingGroup,
 }
 
-/// Parameters for the 'fill opening for the leader position' proposal.
+/// Parameters for the 'Fill Working Group Lead' proposal.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
 pub struct FillOpeningParameters {
-    /// Finalizing opening id.
+    /// Identifier for opening in group.
     pub opening_id: working_group::OpeningId,
 
-    /// Id of the selected application.
-    pub successful_application_id: working_group::ApplicationId,
+    /// Identifier for successful applicant.
+    pub application_id: working_group::ApplicationId,
 
     /// Defines working group with the open position.
     pub working_group: WorkingGroup,
 }
 
-/// Parameters for the 'add opening for the leader position' proposal.
+/// Parameters for the 'Create Working Group Lead Opening' proposal.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
-pub struct AddOpeningParameters<BlockNumber, Balance> {
+pub struct CreateOpeningParameters<BlockNumber, Balance> {
     /// Opening description.
     pub description: Vec<u8>,
 
-    /// Stake policy for the opening.
+    /// Optional Staking policy.
     pub stake_policy: Option<StakePolicy<BlockNumber, Balance>>,
 
     /// Reward per block for the opening.
     pub reward_per_block: Option<Balance>,
 
-    /// Defines working group with the open position.
-    pub working_group: WorkingGroup,
+    /// Identifier for working group.
+    pub group: WorkingGroup,
 }

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -17,16 +17,17 @@ pub trait ProposalEncoder<T: crate::Trait> {
 
 /// _ProposalDetails_ alias for type simplification
 pub type ProposalDetailsOf<T> = ProposalDetails<
+    crate::BalanceOf<T>,
     <T as frame_system::Trait>::BlockNumber,
     <T as frame_system::Trait>::AccountId,
-    crate::BalanceOf<T>,
     working_group::WorkerId<T>,
+    working_group::OpeningId,
 >;
 
 /// Proposal details provide voters the information required for the perceived voting.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Debug)]
-pub enum ProposalDetails<BlockNumber, AccountId, Balance, WorkerId> {
+pub enum ProposalDetails<Balance, BlockNumber, AccountId, WorkerId, OpeningId> {
     /// The text of the `text` proposal
     Text(Vec<u8>),
 
@@ -62,10 +63,16 @@ pub enum ProposalDetails<BlockNumber, AccountId, Balance, WorkerId> {
 
     /// Amend constitution.
     AmendConstitution(Vec<u8>),
+
+    /// Cancel working group leader opening.
+    CancelWorkingGroupLeaderOpening(OpeningId, WorkingGroup),
+
+    /// Set the membership price.
+    SetMembershipPrice(Balance),
 }
 
-impl<BlockNumber, AccountId, Balance, WorkerId> Default
-    for ProposalDetails<BlockNumber, AccountId, Balance, WorkerId>
+impl<BlockNumber, AccountId, Balance, WorkerId, OpeningId> Default
+    for ProposalDetails<Balance, BlockNumber, AccountId, WorkerId, OpeningId>
 {
     fn default() -> Self {
         ProposalDetails::Text(b"invalid proposal details".to_vec())

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -402,7 +402,6 @@ impl council::Trait for Test {
     type ElectedMemberRewardPerBlock = ElectedMemberRewardPerBlock;
     type ElectedMemberRewardPeriod = ElectedMemberRewardPeriod;
 
-    type BudgetRefillAmount = BudgetRefillAmount;
     type BudgetRefillPeriod = BudgetRefillPeriod;
 
     type StakingAccountValidator = membership::Module<Test>;

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -376,7 +376,6 @@ parameter_types! {
     pub const MinCandidateStake: u64 = 11000;
     pub const CandidacyLockId: LockIdentifier = *b"council1";
     pub const CouncilorLockId: LockIdentifier = *b"council2";
-    pub const ElectedMemberRewardPerBlock: u64 = 100;
     pub const ElectedMemberRewardPeriod: u64 = 10;
     pub const BudgetRefillAmount: u64 = 1000;
     // intentionally high number that prevents side-effecting tests other than  budget refill tests
@@ -399,7 +398,6 @@ impl council::Trait for Test {
     type CandidacyLock = StakingManager<Self, CandidacyLockId>;
     type CouncilorLock = StakingManager<Self, CouncilorLockId>;
 
-    type ElectedMemberRewardPerBlock = ElectedMemberRewardPerBlock;
     type ElectedMemberRewardPeriod = ElectedMemberRewardPeriod;
 
     type BudgetRefillPeriod = BudgetRefillPeriod;

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -63,18 +63,6 @@ use staking_handler::StakingHandler;
 
 type WeightInfoWorkingGroup<T, I> = <T as Trait<I>>::WeightInfo;
 
-/// The forum working group instance alias.
-pub type ForumWorkingGroupInstance = Instance1;
-
-/// The storage working group instance alias.
-pub type StorageWorkingGroupInstance = Instance2;
-
-/// The content directory working group instance alias.
-pub type ContentDirectoryWorkingGroupInstance = Instance3;
-
-/// The membership working group instance alias.
-pub type MembershipWorkingGroupInstance = Instance4;
-
 /// Working group WeightInfo
 /// Note: This was auto generated through the benchmark CLI using the `--weight-trait` flag
 pub trait WeightInfo {

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -63,6 +63,18 @@ use staking_handler::StakingHandler;
 
 type WeightInfoWorkingGroup<T, I> = <T as Trait<I>>::WeightInfo;
 
+/// The forum working group instance alias.
+pub type ForumWorkingGroupInstance = Instance1;
+
+/// The storage working group instance alias.
+pub type StorageWorkingGroupInstance = Instance2;
+
+/// The content directory working group instance alias.
+pub type ContentDirectoryWorkingGroupInstance = Instance3;
+
+/// The membership working group instance alias.
+pub type MembershipWorkingGroupInstance = Instance4;
+
 /// Working group WeightInfo
 /// Note: This was auto generated through the benchmark CLI using the `--weight-trait` flag
 pub trait WeightInfo {

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -1029,16 +1029,6 @@ decl_module! {
 }
 
 impl<T: Trait<I>, I: Instance> Module<T, I> {
-    // Set working group budget
-    pub fn put_budget(new_budget: BalanceOf<T>) {
-        <Budget<T, I>>::put(new_budget);
-    }
-
-    // Gets working group budget
-    pub fn get_budget() -> BalanceOf<T> {
-        Self::budget()
-    }
-
     // Calculate weight for on_initialize
     // We assume worst case scenario in a safe manner
     // We take the most number of workers that will be processed and use it as input of the most costly function

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -1041,6 +1041,16 @@ decl_module! {
 }
 
 impl<T: Trait<I>, I: Instance> Module<T, I> {
+    // Set working group budget
+    pub fn put_budget(new_budget: BalanceOf<T>) {
+        <Budget<T, I>>::put(new_budget);
+    }
+
+    // Gets working group budget
+    pub fn get_budget() -> BalanceOf<T> {
+        Self::budget()
+    }
+
     // Calculate weight for on_initialize
     // We assume worst case scenario in a safe manner
     // We take the most number of workers that will be processed and use it as input of the most costly function

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -165,6 +165,7 @@ runtime-benchmarks = [
     "pallet-utility/runtime-benchmarks",
     "proposals-discussion/runtime-benchmarks",
     "proposals-engine/runtime-benchmarks",
+    "proposals-codex/runtime-benchmarks",
     "pallet_constitution/runtime-benchmarks",
     "working-group/runtime-benchmarks",
     "forum/runtime-benchmarks",

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -37,7 +37,7 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
                 Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(signal))
             }
             ProposalDetails::FundingRequest(balance, destination) => {
-                Call::ProposalsCodex(proposals_codex::Call::funding_request(balance, destination))
+                Call::Council(council::Call::funding_request(balance, destination))
             }
             ProposalDetails::SetMaxValidatorCount(new_validator_count) => Call::Staking(
                 pallet_staking::Call::set_validator_count(new_validator_count),

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -107,9 +107,8 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
                 Call::Council(council::Call::set_budget_increment(budget_increment))
             }
 
-            ProposalDetails::SetCouncilorReward(_councilor_reward) => {
-                // TODO: replace stub
-                Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
+            ProposalDetails::SetCouncilorReward(councilor_reward) => {
+                Call::Council(council::Call::set_councilor_reward(councilor_reward))
             }
 
             ProposalDetails::SetInitialInvitationBalance(initial_invitation_balance) => {

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -33,36 +33,40 @@ pub struct ExtrinsicProposalEncoder;
 impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
     fn encode_proposal(proposal_details: ProposalDetailsOf<Runtime>) -> Vec<u8> {
         let call = match proposal_details {
-            ProposalDetails::Text(text) => {
-                Call::ProposalsCodex(proposals_codex::Call::execute_text_proposal(text))
+            ProposalDetails::Signal(signal) => {
+                Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(signal))
             }
-            ProposalDetails::Spending(_balance, _destination) => Call::Council(
-                // TODO: This is an stub since this has been modified in
-                // the proposal branch
-                council::Call::set_budget(0),
+            ProposalDetails::FundingRequest(balance, _destination) => Call::Council(
+                // TODO This is a stub it should be changed
+                council::Call::set_budget(balance),
             ),
-            ProposalDetails::SetValidatorCount(new_validator_count) => Call::Staking(
+            ProposalDetails::SetMaxValidatorCount(new_validator_count) => Call::Staking(
                 pallet_staking::Call::set_validator_count(new_validator_count),
             ),
-            ProposalDetails::RuntimeUpgrade(wasm_code) => Call::ProposalsCodex(
-                proposals_codex::Call::execute_runtime_upgrade_proposal(wasm_code),
+            ProposalDetails::RuntimeUpgrade(blob) => Call::ProposalsCodex(
+                proposals_codex::Call::execute_runtime_upgrade_proposal(blob),
             ),
-            ProposalDetails::AddWorkingGroupLeaderOpening(add_opening_params) => {
+            ProposalDetails::CreateWorkingGroupLeadOpening(create_opening_params) => {
                 wrap_working_group_call!(
-                    add_opening_params.working_group,
-                    Wg::create_add_opening_call(add_opening_params)
+                    create_opening_params.group,
+                    Wg::create_opening_call(create_opening_params)
                 )
             }
-            ProposalDetails::FillWorkingGroupLeaderOpening(fill_opening_params) => {
+            ProposalDetails::FillWorkingGroupLeadOpening(fill_opening_params) => {
                 wrap_working_group_call!(
                     fill_opening_params.working_group,
                     Wg::create_fill_opening_call(fill_opening_params)
                 )
             }
-            ProposalDetails::SetWorkingGroupBudgetCapacity(budget, working_group) => {
-                wrap_working_group_call!(working_group, Wg::create_set_budget_capacity_call(budget))
+            ProposalDetails::UpdateWorkingGroupBudget(amount, working_group, balance_kind) => {
+                // TODO: the logic for this proposal changed!
+                Call::ProposalsCodex(proposals_codex::Call::update_working_group_budget(
+                    working_group,
+                    amount,
+                    balance_kind,
+                ))
             }
-            ProposalDetails::DecreaseWorkingGroupLeaderStake(
+            ProposalDetails::DecreaseWorkingGroupLeadStake(
                 worker_id,
                 decreasing_stake,
                 working_group,
@@ -70,36 +74,36 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
                 working_group,
                 Wg::create_decrease_stake_call(worker_id, decreasing_stake)
             ),
-            ProposalDetails::SlashWorkingGroupLeaderStake(
-                worker_id,
-                slashing_stake,
-                working_group,
-            ) => wrap_working_group_call!(
-                working_group,
-                Wg::create_slash_stake_call(worker_id, slashing_stake,)
-            ),
-            ProposalDetails::SetWorkingGroupLeaderReward(
-                worker_id,
-                reward_amount,
-                working_group,
-            ) => wrap_working_group_call!(
-                working_group,
-                Wg::create_set_reward_call(worker_id, reward_amount)
-            ),
-            ProposalDetails::TerminateWorkingGroupLeaderRole(terminate_role_params) => {
+            ProposalDetails::SlashWorkingGroupLead(worker_id, slashing_stake, working_group) => {
                 wrap_working_group_call!(
-                    terminate_role_params.working_group,
+                    working_group,
+                    Wg::create_slash_stake_call(worker_id, slashing_stake,)
+                )
+            }
+            ProposalDetails::SetWorkingGroupLeadReward(worker_id, reward_amount, working_group) => {
+                wrap_working_group_call!(
+                    working_group,
+                    Wg::create_set_reward_call(worker_id, reward_amount)
+                )
+            }
+            ProposalDetails::TerminateWorkingGroupLead(terminate_role_params) => {
+                wrap_working_group_call!(
+                    terminate_role_params.group,
                     Wg::terminate_role_call(terminate_role_params)
                 )
             }
             ProposalDetails::AmendConstitution(constitution_text) => Call::Constitution(
                 pallet_constitution::Call::amend_constitution(constitution_text),
             ),
-            ProposalDetails::CancelWorkingGroupLeaderOpening(opening_id, working_group) => {
+            ProposalDetails::CancelWorkingGroupLeadOpening(opening_id, working_group) => {
                 wrap_working_group_call!(
                     working_group,
                     Wg::cancel_working_group_leader_opening(opening_id)
                 )
+            }
+            ProposalDetails::SetMembershipPrice(_membership_price) => {
+                // TODO: Update when membership is updated
+                Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
             }
         };
 
@@ -119,17 +123,17 @@ where
     I: frame_support::traits::Instance,
 {
     // Generic call constructor for the add working group opening.
-    fn create_add_opening_call(
-        add_opening_params: proposals_codex::AddOpeningParameters<
+    fn create_opening_call(
+        create_opening_params: proposals_codex::CreateOpeningParameters<
             T::BlockNumber,
             working_group::BalanceOf<T>,
         >,
     ) -> working_group::Call<T, I> {
         working_group::Call::<T, I>::add_opening(
-            add_opening_params.description,
+            create_opening_params.description,
             OpeningType::Leader,
-            add_opening_params.stake_policy,
-            add_opening_params.reward_per_block,
+            create_opening_params.stake_policy,
+            create_opening_params.reward_per_block,
         )
     }
 
@@ -138,7 +142,7 @@ where
         fill_opening_params: proposals_codex::FillOpeningParameters,
     ) -> working_group::Call<T, I> {
         let mut successful_application_ids = BTreeSet::new();
-        successful_application_ids.insert(fill_opening_params.successful_application_id);
+        successful_application_ids.insert(fill_opening_params.application_id);
 
         working_group::Call::<T, I>::fill_opening(
             fill_opening_params.opening_id,
@@ -179,16 +183,9 @@ where
     ) -> working_group::Call<T, I> {
         working_group::Call::<T, I>::terminate_role(
             terminate_role_params.worker_id,
-            terminate_role_params.penalty,
+            terminate_role_params.slashing_amount,
             None, // The rationale is given in the proposal description
         )
-    }
-
-    // Generic call constructor for the working group 'set budget'.
-    fn create_set_budget_capacity_call(
-        budget: working_group::BalanceOf<T>,
-    ) -> working_group::Call<T, I> {
-        working_group::Call::<T, I>::set_budget(budget)
     }
 
     fn cancel_working_group_leader_opening(

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -103,9 +103,8 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
                 Call::Members(membership::Call::set_membership_price(membership_price))
             }
 
-            ProposalDetails::SetCouncilBudgetIncrement(_budget_increment) => {
-                // TODO: replace_stub
-                Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
+            ProposalDetails::SetCouncilBudgetIncrement(budget_increment) => {
+                Call::Council(council::Call::set_budget_increment(budget_increment))
             }
 
             ProposalDetails::SetCouncilorReward(_councilor_reward) => {

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -36,10 +36,9 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
             ProposalDetails::Signal(signal) => {
                 Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(signal))
             }
-            ProposalDetails::FundingRequest(balance, _destination) => Call::Council(
-                // TODO This is a stub it should be changed
-                council::Call::set_budget(balance),
-            ),
+            ProposalDetails::FundingRequest(balance, destination) => {
+                Call::ProposalsCodex(proposals_codex::Call::funding_request(balance, destination))
+            }
             ProposalDetails::SetMaxValidatorCount(new_validator_count) => Call::Staking(
                 pallet_staking::Call::set_validator_count(new_validator_count),
             ),
@@ -59,7 +58,6 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
                 )
             }
             ProposalDetails::UpdateWorkingGroupBudget(amount, working_group, balance_kind) => {
-                // TODO: the logic for this proposal changed!
                 Call::ProposalsCodex(proposals_codex::Call::update_working_group_budget(
                     working_group,
                     amount,
@@ -101,24 +99,33 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
                     Wg::cancel_working_group_leader_opening(opening_id)
                 )
             }
-            ProposalDetails::SetMembershipPrice(_membership_price) => {
-                // TODO: Update when membership is updated
-                Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
+            ProposalDetails::SetMembershipPrice(membership_price) => {
+                Call::Members(membership::Call::set_membership_price(membership_price))
             }
 
             ProposalDetails::SetCouncilBudgetIncrement(_budget_increment) => {
-                // TODO: Update when membership is updated
+                // TODO: replace_stub
                 Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
             }
 
             ProposalDetails::SetCouncilorReward(_councilor_reward) => {
-                // TODO: Update when membership is updated
+                // TODO: replace stub
                 Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
             }
 
-            ProposalDetails::SetInitialInvitationBalance(_initial_invitaiton_balance) => {
-                // TODO: Update when membership is updated
-                Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
+            ProposalDetails::SetInitialInvitationBalance(initial_invitation_balance) => {
+                Call::Members(membership::Call::set_initial_invitation_balance(
+                    initial_invitation_balance,
+                ))
+            }
+            ProposalDetails::SetInitialInvitationCount(new_default_invite_count) => Call::Members(
+                membership::Call::set_initial_invitation_count(new_default_invite_count),
+            ),
+            ProposalDetails::SetMembershipLeadInvitationQuota(new_invite_count) => Call::Members(
+                membership::Call::set_leader_invitation_quota(new_invite_count),
+            ),
+            ProposalDetails::SetReferralCut(new_referral_cut) => {
+                Call::Members(membership::Call::set_referral_cut(new_referral_cut))
             }
         };
 

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -77,7 +77,7 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
             ProposalDetails::SlashWorkingGroupLead(worker_id, slashing_stake, working_group) => {
                 wrap_working_group_call!(
                     working_group,
-                    Wg::create_slash_stake_call(worker_id, slashing_stake,)
+                    Wg::create_slash_stake_call(worker_id, slashing_stake)
                 )
             }
             ProposalDetails::SetWorkingGroupLeadReward(worker_id, reward_amount, working_group) => {

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -95,6 +95,12 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
             ProposalDetails::AmendConstitution(constitution_text) => Call::Constitution(
                 pallet_constitution::Call::amend_constitution(constitution_text),
             ),
+            ProposalDetails::CancelWorkingGroupLeaderOpening(opening_id, working_group) => {
+                wrap_working_group_call!(
+                    working_group,
+                    Wg::cancel_working_group_leader_opening(opening_id)
+                )
+            }
         };
 
         call.encode()
@@ -183,5 +189,11 @@ where
         budget: working_group::BalanceOf<T>,
     ) -> working_group::Call<T, I> {
         working_group::Call::<T, I>::set_budget(budget)
+    }
+
+    fn cancel_working_group_leader_opening(
+        opening_id: working_group::OpeningId,
+    ) -> working_group::Call<T, I> {
+        working_group::Call::<T, I>::cancel_opening(opening_id)
     }
 }

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -105,6 +105,21 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
                 // TODO: Update when membership is updated
                 Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
             }
+
+            ProposalDetails::SetCouncilBudgetIncrement(_budget_increment) => {
+                // TODO: Update when membership is updated
+                Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
+            }
+
+            ProposalDetails::SetCouncilorReward(_councilor_reward) => {
+                // TODO: Update when membership is updated
+                Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
+            }
+
+            ProposalDetails::SetInitialInvitationBalance(_initial_invitaiton_balance) => {
+                // TODO: Update when membership is updated
+                Call::ProposalsCodex(proposals_codex::Call::execute_signal_proposal(Vec::new()))
+            }
         };
 
         call.encode()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -812,6 +812,7 @@ impl proposals_codex::Trait for Runtime {
     type TerminateWorkingGroupLeaderRoleProposalParameters =
         TerminateWorkingGroupLeaderRoleProposalParameters;
     type AmendConstitutionProposalParameters = AmendConstitutionProposalParameters;
+    type CancelWorkingGroupLeaderOpeningParameters = CancelWorkingGroupLeaderOpeningParameters;
 }
 
 impl pallet_constitution::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -474,7 +474,6 @@ parameter_types! {
     pub const IdlePeriodDuration: BlockNumber = 27;
     pub const CouncilSize: u64 = 3;
     pub const MinCandidateStake: u64 = 11000;
-    pub const ElectedMemberRewardPerBlock: u64 = 100;
     pub const ElectedMemberRewardPeriod: BlockNumber = 10;
     pub const DefaultBudgetIncrement: u64 = 1000;
     pub const BudgetRefillPeriod: BlockNumber = 1000;
@@ -554,7 +553,6 @@ impl council::Trait for Runtime {
 
     type StakingAccountValidator = Members;
 
-    type ElectedMemberRewardPerBlock = ElectedMemberRewardPerBlock;
     type ElectedMemberRewardPeriod = ElectedMemberRewardPeriod;
 
     type BudgetRefillPeriod = BudgetRefillPeriod;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -59,6 +59,10 @@ use council::ReferendumConnection;
 use referendum::{CastVote, OptionResult};
 use staking_handler::{LockComparator, StakingManager};
 use storage::data_object_storage_registry;
+use working_group::{
+    ContentDirectoryWorkingGroupInstance, ForumWorkingGroupInstance,
+    MembershipWorkingGroupInstance, StorageWorkingGroupInstance,
+};
 
 // Node dependencies
 pub use common;
@@ -658,18 +662,6 @@ impl LockComparator<<Runtime as pallet_balances::Trait>::Balance> for Runtime {
             .any(|lock| !ALLOWED_LOCK_COMBINATIONS.contains(&(*new_lock, *lock)))
     }
 }
-
-// The forum working group instance alias.
-pub type ForumWorkingGroupInstance = working_group::Instance1;
-
-// The storage working group instance alias.
-pub type StorageWorkingGroupInstance = working_group::Instance2;
-
-// The content directory working group instance alias.
-pub type ContentDirectoryWorkingGroupInstance = working_group::Instance3;
-
-// The membership working group instance alias.
-pub type MembershipWorkingGroupInstance = working_group::Instance4;
 
 parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 100;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -817,6 +817,10 @@ impl proposals_codex::Trait for Runtime {
     type SetCouncilorRewardProposalParameters = SetCouncilorRewardProposalParameters;
     type SetInitialInvitationBalanceProposalParameters =
         SetInitialInvitationBalanceProposalParameters;
+    type SetInvitationCountProposalParameters = SetInvitationCountProposalParameters;
+    type SetMembershipLeadInvitationQuotaProposalParameters =
+        SetMembershipLeadInvitationQuotaProposalParameters;
+    type SetReferralCutProposalParameters = SetReferralCutProposalParameters;
     type WeightInfo = weights::proposals_codex::WeightInfo;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -817,6 +817,7 @@ impl proposals_codex::Trait for Runtime {
     type SetCouncilorRewardProposalParameters = SetCouncilorRewardProposalParameters;
     type SetInitialInvitationBalanceProposalParameters =
         SetInitialInvitationBalanceProposalParameters;
+    type WeightInfo = weights::proposals_codex::WeightInfo;
 }
 
 impl pallet_constitution::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -55,7 +55,7 @@ pub use runtime_api::*;
 
 use integration::proposals::{CouncilManager, ExtrinsicProposalEncoder};
 
-use common::working_group::WorkingGroup;
+use common::working_group::{WorkingGroup, WorkingGroupBudgetHandler};
 use council::ReferendumConnection;
 use referendum::{CastVote, OptionResult};
 use staking_handler::{LockComparator, StakingManager};
@@ -791,12 +791,12 @@ parameter_types! {
 }
 
 macro_rules! call_wg {
-    ($working_group:ident<$T:ty>, $function:ident $(,$x:expr)*) => {{
+    ($working_group:ident, $function:ident $(,$x:expr)*) => {{
         match $working_group {
-            WorkingGroup::Content => working_group::Module::<$T, ContentDirectoryWorkingGroupInstance>::$function($($x,)*),
-            WorkingGroup::Storage => working_group::Module::<$T, StorageWorkingGroupInstance>::$function($($x,)*),
-            WorkingGroup::Forum => working_group::Module::<$T, ForumWorkingGroupInstance>::$function($($x,)*),
-            WorkingGroup::Membership => working_group::Module::<$T, MembershipWorkingGroupInstance>::$function($($x,)*),
+            WorkingGroup::Content => <ContentDirectoryWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
+            WorkingGroup::Storage => <StorageWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
+            WorkingGroup::Forum => <ForumWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
+            WorkingGroup::Membership => <MembershipWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
         }
     }};
 }
@@ -832,10 +832,10 @@ impl proposals_codex::Trait for Runtime {
     type SetReferralCutProposalParameters = SetReferralCutProposalParameters;
     type WeightInfo = weights::proposals_codex::WeightInfo;
     fn get_working_group_budget(working_group: WorkingGroup) -> Balance {
-        call_wg!(working_group<Runtime>, get_budget)
+        call_wg!(working_group, get_budget)
     }
     fn set_working_group_budget(working_group: WorkingGroup, budget: Balance) {
-        call_wg!(working_group<Runtime>, put_budget, budget)
+        call_wg!(working_group, set_budget, budget)
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -813,6 +813,10 @@ impl proposals_codex::Trait for Runtime {
     type CancelWorkingGroupLeadOpeningProposalParameters =
         CancelWorkingGroupLeadOpeningProposalParameters;
     type SetMembershipPriceProposalParameters = SetMembershipPriceProposalParameters;
+    type SetCouncilBudgetIncrementProposalParameters = SetCouncilBudgetIncrementProposalParameters;
+    type SetCouncilorRewardProposalParameters = SetCouncilorRewardProposalParameters;
+    type SetInitialInvitationBalanceProposalParameters =
+        SetInitialInvitationBalanceProposalParameters;
 }
 
 impl pallet_constitution::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -795,24 +795,24 @@ parameter_types! {
 impl proposals_codex::Trait for Runtime {
     type MembershipOriginValidator = Members;
     type ProposalEncoder = ExtrinsicProposalEncoder;
-    type SetValidatorCountProposalParameters = SetValidatorCountProposalParameters;
+    type SetMaxValidatorCountProposalParameters = SetMaxValidatorCountProposalParameters;
     type RuntimeUpgradeProposalParameters = RuntimeUpgradeProposalParameters;
-    type TextProposalParameters = TextProposalParameters;
-    type SpendingProposalParameters = SpendingProposalParameters;
-    type AddWorkingGroupOpeningProposalParameters = AddWorkingGroupOpeningProposalParameters;
-    type FillWorkingGroupOpeningProposalParameters = FillWorkingGroupOpeningProposalParameters;
-    type SetWorkingGroupBudgetCapacityProposalParameters =
-        SetWorkingGroupBudgetCapacityProposalParameters;
-    type DecreaseWorkingGroupLeaderStakeProposalParameters =
-        DecreaseWorkingGroupLeaderStakeProposalParameters;
-    type SlashWorkingGroupLeaderStakeProposalParameters =
-        SlashWorkingGroupLeaderStakeProposalParameters;
-    type SetWorkingGroupLeaderRewardProposalParameters =
-        SetWorkingGroupLeaderRewardProposalParameters;
-    type TerminateWorkingGroupLeaderRoleProposalParameters =
-        TerminateWorkingGroupLeaderRoleProposalParameters;
+    type SignalProposalParameters = SignalProposalParameters;
+    type FundingRequestProposalParameters = FundingRequestProposalParameters;
+    type CreateWorkingGroupLeadOpeningProposalParameters =
+        CreateWorkingGroupLeadOpeningProposalParameters;
+    type FillWorkingGroupLeadOpeningProposalParameters =
+        FillWorkingGroupLeadOpeningProposalParameters;
+    type UpdateWorkingGroupBudgetProposalParameters = UpdateWorkingGroupBudgetProposalParameters;
+    type DecreaseWorkingGroupLeadStakeProposalParameters =
+        DecreaseWorkingGroupLeadStakeProposalParameters;
+    type SlashWorkingGroupLeadProposalParameters = SlashWorkingGroupLeadProposalParameters;
+    type SetWorkingGroupLeadRewardProposalParameters = SetWorkingGroupLeadRewardProposalParameters;
+    type TerminateWorkingGroupLeadProposalParameters = TerminateWorkingGroupLeadProposalParameters;
     type AmendConstitutionProposalParameters = AmendConstitutionProposalParameters;
-    type CancelWorkingGroupLeaderOpeningParameters = CancelWorkingGroupLeaderOpeningParameters;
+    type CancelWorkingGroupLeadOpeningProposalParameters =
+        CancelWorkingGroupLeadOpeningProposalParameters;
+    type SetMembershipPriceProposalParameters = SetMembershipPriceProposalParameters;
 }
 
 impl pallet_constitution::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -476,7 +476,7 @@ parameter_types! {
     pub const MinCandidateStake: u64 = 11000;
     pub const ElectedMemberRewardPerBlock: u64 = 100;
     pub const ElectedMemberRewardPeriod: BlockNumber = 10;
-    pub const BudgetRefillAmount: u64 = 1000;
+    pub const DefaultBudgetIncrement: u64 = 1000;
     pub const BudgetRefillPeriod: BlockNumber = 1000;
     pub const MaxWinnerTargetCount: u64 = 10;
 }
@@ -557,7 +557,6 @@ impl council::Trait for Runtime {
     type ElectedMemberRewardPerBlock = ElectedMemberRewardPerBlock;
     type ElectedMemberRewardPeriod = ElectedMemberRewardPeriod;
 
-    type BudgetRefillAmount = BudgetRefillAmount;
     type BudgetRefillPeriod = BudgetRefillPeriod;
 
     type WeightInfo = weights::council::WeightInfo;

--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -223,7 +223,7 @@ pub(crate) fn set_council_budget_increment_proposal() -> ProposalParameters<Bloc
 pub(crate) fn set_councilor_reward_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 72200,
-        grace_period: 72200,
+        grace_period: 0,
         approval_quorum_percentage: 80,
         approval_threshold_percentage: 100,
         slashing_quorum_percentage: 60,

--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -172,3 +172,18 @@ pub(crate) fn amend_constitution_proposal() -> ProposalParameters<BlockNumber, B
         constitutionality: 1,
     }
 }
+
+// TODO: decide on parameters
+// Proposal parameters for the 'Amend constitution' proposal
+pub(crate) fn cancel_working_group_leader_opening() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 72200,
+        grace_period: 72200,
+        approval_quorum_percentage: 80,
+        approval_threshold_percentage: 100,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(1_000_000),
+        constitutionality: 1,
+    }
+}

--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -248,3 +248,49 @@ pub(crate) fn set_initial_invitation_balance_proposal() -> ProposalParameters<Bl
         constitutionality: 1,
     }
 }
+
+// TODO: decide on parameters
+// Proposal parameters for the 'Set Initial Invitation Quota' proposal
+pub(crate) fn set_membership_lead_invitation_quota_proposal(
+) -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 72200,
+        grace_period: 0,
+        approval_quorum_percentage: 80,
+        approval_threshold_percentage: 100,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(1_000_000),
+        constitutionality: 1,
+    }
+}
+
+// TODO: decide on parameters
+// Proposal parameters for the 'Set Referral Cut' proposal
+pub(crate) fn set_referral_cut_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 72200,
+        grace_period: 0,
+        approval_quorum_percentage: 80,
+        approval_threshold_percentage: 100,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(1_000_000),
+        constitutionality: 1,
+    }
+}
+
+// TODO: decide on parameters
+// Proposal parameters for the 'Set Initial Invitation Count' proposal
+pub(crate) fn set_invitation_count_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 72200,
+        grace_period: 0,
+        approval_quorum_percentage: 80,
+        approval_threshold_percentage: 100,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(1_000_000),
+        constitutionality: 1,
+    }
+}

--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -2,8 +2,8 @@
 
 use crate::{Balance, BlockNumber, ProposalParameters};
 
-// Proposal parameters for the 'Set validator count' proposal
-pub(crate) fn set_validator_count_proposal() -> ProposalParameters<BlockNumber, Balance> {
+// Proposal parameters for the 'Set Max Validator Count' proposal
+pub(crate) fn set_max_validator_count_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 43200,
         grace_period: 0,
@@ -16,7 +16,7 @@ pub(crate) fn set_validator_count_proposal() -> ProposalParameters<BlockNumber, 
     }
 }
 
-// Proposal parameters for the upgrade runtime proposal
+// Proposal parameters for the 'Runtime Upgrade' proposal
 pub(crate) fn runtime_upgrade_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 72000,
@@ -30,8 +30,8 @@ pub(crate) fn runtime_upgrade_proposal() -> ProposalParameters<BlockNumber, Bala
     }
 }
 
-// Proposal parameters for the text proposal
-pub(crate) fn text_proposal() -> ProposalParameters<BlockNumber, Balance> {
+// Proposal parameters for the 'Signal' proposal
+pub(crate) fn signal_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 72000,
         grace_period: 0,
@@ -44,8 +44,8 @@ pub(crate) fn text_proposal() -> ProposalParameters<BlockNumber, Balance> {
     }
 }
 
-// Proposal parameters for the 'Spending' proposal
-pub(crate) fn spending_proposal() -> ProposalParameters<BlockNumber, Balance> {
+// Proposal parameters for the 'Funding Request' proposal
+pub(crate) fn funding_request_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 72000,
         grace_period: 14400,
@@ -57,8 +57,9 @@ pub(crate) fn spending_proposal() -> ProposalParameters<BlockNumber, Balance> {
         constitutionality: 1,
     }
 }
-// Proposal parameters for the 'Add working group opening' proposal
-pub(crate) fn add_working_group_opening_proposal() -> ProposalParameters<BlockNumber, Balance> {
+// Proposal parameters for the 'Create Working Group Lead Opening' proposal
+pub(crate) fn create_working_group_lead_opening_proposal(
+) -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 72000,
         grace_period: 0,
@@ -71,66 +72,8 @@ pub(crate) fn add_working_group_opening_proposal() -> ProposalParameters<BlockNu
     }
 }
 
-// Proposal parameters for the 'Fill working group opening' proposal
-pub(crate) fn fill_working_group_opening_proposal() -> ProposalParameters<BlockNumber, Balance> {
-    ProposalParameters {
-        voting_period: 43200,
-        grace_period: 0,
-        approval_quorum_percentage: 60,
-        approval_threshold_percentage: 75,
-        slashing_quorum_percentage: 60,
-        slashing_threshold_percentage: 80,
-        required_stake: Some(50000),
-        constitutionality: 1,
-    }
-}
-
-// Proposal parameters for the 'Set working group budget capacity' proposal
-pub(crate) fn set_working_group_budget_capacity_proposal(
-) -> ProposalParameters<BlockNumber, Balance> {
-    ProposalParameters {
-        voting_period: 43200,
-        grace_period: 0,
-        approval_quorum_percentage: 60,
-        approval_threshold_percentage: 75,
-        slashing_quorum_percentage: 60,
-        slashing_threshold_percentage: 80,
-        required_stake: Some(50000),
-        constitutionality: 1,
-    }
-}
-
-// Proposal parameters for the 'Decrease working group leader stake' proposal
-pub(crate) fn decrease_working_group_leader_stake_proposal(
-) -> ProposalParameters<BlockNumber, Balance> {
-    ProposalParameters {
-        voting_period: 43200,
-        grace_period: 0,
-        approval_quorum_percentage: 60,
-        approval_threshold_percentage: 75,
-        slashing_quorum_percentage: 60,
-        slashing_threshold_percentage: 80,
-        required_stake: Some(50000),
-        constitutionality: 1,
-    }
-}
-
-// Proposal parameters for the 'Slash working group leader stake' proposal
-pub fn slash_working_group_leader_stake_proposal() -> ProposalParameters<BlockNumber, Balance> {
-    ProposalParameters {
-        voting_period: 43200,
-        grace_period: 0,
-        approval_quorum_percentage: 60,
-        approval_threshold_percentage: 75,
-        slashing_quorum_percentage: 60,
-        slashing_threshold_percentage: 80,
-        required_stake: Some(50000),
-        constitutionality: 1,
-    }
-}
-
-// Proposal parameters for the 'Set working group leader reward' proposal
-pub(crate) fn set_working_group_leader_reward_proposal() -> ProposalParameters<BlockNumber, Balance>
+// Proposal parameters for the 'Fill Working Group Lead Opening' proposal
+pub(crate) fn fill_working_group_lead_opening_proposal() -> ProposalParameters<BlockNumber, Balance>
 {
     ProposalParameters {
         voting_period: 43200,
@@ -144,9 +87,65 @@ pub(crate) fn set_working_group_leader_reward_proposal() -> ProposalParameters<B
     }
 }
 
-// Proposal parameters for the 'Terminate working group leader role' proposal
-pub(crate) fn terminate_working_group_leader_role_proposal(
+// Proposal parameters for the 'Update Working Group Budget' proposal
+pub(crate) fn update_working_group_budget_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 43200,
+        grace_period: 0,
+        approval_quorum_percentage: 60,
+        approval_threshold_percentage: 75,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(50000),
+        constitutionality: 1,
+    }
+}
+
+// Proposal parameters for the 'Decrease Working Group Lead Stake' proposal
+pub(crate) fn decrease_working_group_lead_stake_proposal(
 ) -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 43200,
+        grace_period: 0,
+        approval_quorum_percentage: 60,
+        approval_threshold_percentage: 75,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(50000),
+        constitutionality: 1,
+    }
+}
+
+// Proposal parameters for the 'Slash Working Group Lead' proposal
+pub fn slash_working_group_lead_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 43200,
+        grace_period: 0,
+        approval_quorum_percentage: 60,
+        approval_threshold_percentage: 75,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(50000),
+        constitutionality: 1,
+    }
+}
+
+// Proposal parameters for the 'Set Working Group Lead Reward' proposal
+pub(crate) fn set_working_group_lead_reward_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 43200,
+        grace_period: 0,
+        approval_quorum_percentage: 60,
+        approval_threshold_percentage: 75,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(50000),
+        constitutionality: 1,
+    }
+}
+
+// Proposal parameters for the 'Terminate Working Group Lead' proposal
+pub(crate) fn terminate_working_group_lead_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 72200,
         grace_period: 0,
@@ -159,7 +158,7 @@ pub(crate) fn terminate_working_group_leader_role_proposal(
     }
 }
 
-// Proposal parameters for the 'Amend constitution' proposal
+// Proposal parameters for the 'Amend Constitution' proposal
 pub(crate) fn amend_constitution_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 72200,
@@ -174,8 +173,24 @@ pub(crate) fn amend_constitution_proposal() -> ProposalParameters<BlockNumber, B
 }
 
 // TODO: decide on parameters
-// Proposal parameters for the 'Amend constitution' proposal
-pub(crate) fn cancel_working_group_leader_opening() -> ProposalParameters<BlockNumber, Balance> {
+// Proposal parameters for the 'Cancel Working Group Lead Opening' proposal
+pub(crate) fn cancel_working_group_lead_opening_proposal(
+) -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 72200,
+        grace_period: 72200,
+        approval_quorum_percentage: 80,
+        approval_threshold_percentage: 100,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(1_000_000),
+        constitutionality: 1,
+    }
+}
+
+// TODO: decide on parameters
+// Proposal parameters for the 'Set Membership Price' proposal
+pub(crate) fn set_membership_price_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 72200,
         grace_period: 72200,

--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -202,3 +202,49 @@ pub(crate) fn set_membership_price_proposal() -> ProposalParameters<BlockNumber,
         constitutionality: 1,
     }
 }
+
+// TODO: decide on parameters
+// Proposal parameters for the 'Set Council Budget Increment' proposal
+pub(crate) fn set_council_budget_increment_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 72200,
+        grace_period: 72200,
+        approval_quorum_percentage: 80,
+        approval_threshold_percentage: 100,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(1_000_000),
+        constitutionality: 1,
+    }
+}
+
+// TODO: decide on parameters
+// Proposal parameters for the 'Set Councilor Reward' proposal
+pub(crate) fn set_councilor_reward_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 72200,
+        grace_period: 72200,
+        approval_quorum_percentage: 80,
+        approval_threshold_percentage: 100,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(1_000_000),
+        constitutionality: 1,
+    }
+}
+
+// TODO: decide on parameters
+// Proposal parameters for the 'Set Initial Invitation Balance' proposal
+pub(crate) fn set_initial_invitation_balance_proposal() -> ProposalParameters<BlockNumber, Balance>
+{
+    ProposalParameters {
+        voting_period: 72200,
+        grace_period: 72200,
+        approval_quorum_percentage: 80,
+        approval_threshold_percentage: 100,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(1_000_000),
+        constitutionality: 1,
+    }
+}

--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -208,7 +208,7 @@ pub(crate) fn set_membership_price_proposal() -> ProposalParameters<BlockNumber,
 pub(crate) fn set_council_budget_increment_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 72200,
-        grace_period: 72200,
+        grace_period: 0,
         approval_quorum_percentage: 80,
         approval_threshold_percentage: 100,
         slashing_quorum_percentage: 60,

--- a/runtime/src/proposals_configuration/mod.rs
+++ b/runtime/src/proposals_configuration/mod.rs
@@ -47,6 +47,12 @@ parameter_types! {
         ALL_PROPOSALS_PARAMETERS.set_councilor_reward_proposal;
     pub SetInitialInvitationBalanceProposalParameters: ProposalParameters<BlockNumber, Balance> =
         ALL_PROPOSALS_PARAMETERS.set_initial_invitation_balance_proposal;
+    pub SetMembershipLeadInvitationQuotaProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.set_membership_lead_invitation_quota_proposal;
+    pub SetReferralCutProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.set_referral_cut_proposal;
+    pub SetInvitationCountProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.set_invitation_count_proposal;
 }
 
 ///////////
@@ -69,6 +75,9 @@ struct AllProposalsParameters {
     pub set_council_budget_increment_proposal: ProposalParameters<BlockNumber, Balance>,
     pub set_councilor_reward_proposal: ProposalParameters<BlockNumber, Balance>,
     pub set_initial_invitation_balance_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub set_membership_lead_invitation_quota_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub set_referral_cut_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub set_invitation_count_proposal: ProposalParameters<BlockNumber, Balance>,
 }
 
 // to initialize parameters only once.
@@ -153,7 +162,18 @@ fn convert_json_object_to_proposal_parameters(
         init_proposal_parameter_object!(params, jo.clone(), set_membership_price_proposal);
         init_proposal_parameter_object!(params, jo.clone(), set_council_budget_increment_proposal);
         init_proposal_parameter_object!(params, jo.clone(), set_councilor_reward_proposal);
-        init_proposal_parameter_object!(params, jo, set_initial_invitation_balance_proposal);
+        init_proposal_parameter_object!(
+            params,
+            jo.clone(),
+            set_initial_invitation_balance_proposal
+        );
+        init_proposal_parameter_object!(
+            params,
+            jo.clone(),
+            set_membership_lead_invitation_quota_proposal
+        );
+        init_proposal_parameter_object!(params, jo.clone(), set_referral_cut_proposal);
+        init_proposal_parameter_object!(params, jo, set_invitation_count_proposal);
     }
 
     params
@@ -280,5 +300,9 @@ fn default_parameters() -> AllProposalsParameters {
         set_councilor_reward_proposal: defaults::set_councilor_reward_proposal(),
         set_initial_invitation_balance_proposal: defaults::set_initial_invitation_balance_proposal(
         ),
+        set_membership_lead_invitation_quota_proposal:
+            defaults::set_membership_lead_invitation_quota_proposal(),
+        set_referral_cut_proposal: defaults::set_referral_cut_proposal(),
+        set_invitation_count_proposal: defaults::set_invitation_count_proposal(),
     }
 }

--- a/runtime/src/proposals_configuration/mod.rs
+++ b/runtime/src/proposals_configuration/mod.rs
@@ -22,37 +22,44 @@ mod tests;
 /////////// Proposal parameters definition
 
 parameter_types! {
-    pub SetValidatorCountProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.set_validator_count_proposal;
+    pub SetMaxValidatorCountProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.set_max_validator_count_proposal;
     pub RuntimeUpgradeProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.runtime_upgrade_proposal;
-    pub TextProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.text_proposal;
-    pub SpendingProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.spending_proposal;
-    pub AddWorkingGroupOpeningProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.add_working_group_opening_proposal;
-    pub FillWorkingGroupOpeningProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.fill_working_group_opening_proposal;
-    pub SetWorkingGroupBudgetCapacityProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.set_working_group_budget_capacity_proposal;
-    pub DecreaseWorkingGroupLeaderStakeProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.decrease_working_group_leader_stake_proposal;
-    pub SlashWorkingGroupLeaderStakeProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.slash_working_group_leader_stake_proposal;
-    pub SetWorkingGroupLeaderRewardProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.set_working_group_leader_reward_proposal;
-    pub TerminateWorkingGroupLeaderRoleProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.terminate_working_group_leader_role_proposal;
+    pub SignalProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.signal_proposal;
+    pub FundingRequestProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.funding_request_proposal;
+    pub CreateWorkingGroupLeadOpeningProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.create_working_group_lead_opening_proposal;
+    pub FillWorkingGroupLeadOpeningProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.fill_working_group_lead_opening_proposal;
+    pub UpdateWorkingGroupBudgetProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.update_working_group_budget_proposal;
+    pub DecreaseWorkingGroupLeadStakeProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.decrease_working_group_lead_stake_proposal;
+    pub SlashWorkingGroupLeadProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.slash_working_group_lead_proposal;
+    pub SetWorkingGroupLeadRewardProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.set_working_group_lead_reward_proposal;
+    pub TerminateWorkingGroupLeadProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.terminate_working_group_lead_proposal;
     pub AmendConstitutionProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.amend_constitution_proposal;
-    pub CancelWorkingGroupLeaderOpeningParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.cancel_working_group_leader_opening;
+    pub CancelWorkingGroupLeadOpeningProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.cancel_working_group_lead_opening_proposal;
+    pub SetMembershipPriceProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.set_membership_price_proposal;
 }
 
 ///////////
 
 struct AllProposalsParameters {
-    pub set_validator_count_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub set_max_validator_count_proposal: ProposalParameters<BlockNumber, Balance>,
     pub runtime_upgrade_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub text_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub spending_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub add_working_group_opening_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub fill_working_group_opening_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub set_working_group_budget_capacity_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub decrease_working_group_leader_stake_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub slash_working_group_leader_stake_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub set_working_group_leader_reward_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub terminate_working_group_leader_role_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub signal_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub funding_request_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub create_working_group_lead_opening_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub fill_working_group_lead_opening_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub update_working_group_budget_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub decrease_working_group_lead_stake_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub slash_working_group_lead_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub set_working_group_lead_reward_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub terminate_working_group_lead_proposal: ProposalParameters<BlockNumber, Balance>,
     pub amend_constitution_proposal: ProposalParameters<BlockNumber, Balance>,
-    pub cancel_working_group_leader_opening: ProposalParameters<BlockNumber, Balance>,
+    pub cancel_working_group_lead_opening_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub set_membership_price_proposal: ProposalParameters<BlockNumber, Balance>,
 }
 
 // to initialize parameters only once.
@@ -105,39 +112,36 @@ fn convert_json_object_to_proposal_parameters(
     let mut params = default_parameters();
 
     if let lite_json::JsonValue::Object(jo) = json {
-        init_proposal_parameter_object!(params, jo.clone(), set_validator_count_proposal);
+        init_proposal_parameter_object!(params, jo.clone(), set_max_validator_count_proposal);
         init_proposal_parameter_object!(params, jo.clone(), runtime_upgrade_proposal);
-        init_proposal_parameter_object!(params, jo.clone(), text_proposal);
-        init_proposal_parameter_object!(params, jo.clone(), spending_proposal);
-        init_proposal_parameter_object!(params, jo.clone(), add_working_group_opening_proposal);
-        init_proposal_parameter_object!(params, jo.clone(), fill_working_group_opening_proposal);
+        init_proposal_parameter_object!(params, jo.clone(), signal_proposal);
+        init_proposal_parameter_object!(params, jo.clone(), funding_request_proposal);
         init_proposal_parameter_object!(
             params,
             jo.clone(),
-            set_working_group_budget_capacity_proposal
+            create_working_group_lead_opening_proposal
         );
         init_proposal_parameter_object!(
             params,
             jo.clone(),
-            decrease_working_group_leader_stake_proposal
+            fill_working_group_lead_opening_proposal
         );
+        init_proposal_parameter_object!(params, jo.clone(), update_working_group_budget_proposal);
         init_proposal_parameter_object!(
             params,
             jo.clone(),
-            slash_working_group_leader_stake_proposal
+            decrease_working_group_lead_stake_proposal
         );
-        init_proposal_parameter_object!(
-            params,
-            jo.clone(),
-            set_working_group_leader_reward_proposal
-        );
-        init_proposal_parameter_object!(
-            params,
-            jo.clone(),
-            terminate_working_group_leader_role_proposal
-        );
+        init_proposal_parameter_object!(params, jo.clone(), slash_working_group_lead_proposal);
+        init_proposal_parameter_object!(params, jo.clone(), set_working_group_lead_reward_proposal);
+        init_proposal_parameter_object!(params, jo.clone(), terminate_working_group_lead_proposal);
         init_proposal_parameter_object!(params, jo.clone(), amend_constitution_proposal);
-        init_proposal_parameter_object!(params, jo, cancel_working_group_leader_opening);
+        init_proposal_parameter_object!(
+            params,
+            jo.clone(),
+            cancel_working_group_lead_opening_proposal
+        );
+        init_proposal_parameter_object!(params, jo, set_membership_price_proposal);
     }
 
     params
@@ -242,23 +246,23 @@ fn extract_numeric_parameter(
 // Returns all default proposal parameters.
 fn default_parameters() -> AllProposalsParameters {
     AllProposalsParameters {
-        set_validator_count_proposal: defaults::set_validator_count_proposal(),
+        set_max_validator_count_proposal: defaults::set_max_validator_count_proposal(),
         runtime_upgrade_proposal: defaults::runtime_upgrade_proposal(),
-        text_proposal: defaults::text_proposal(),
-        spending_proposal: defaults::spending_proposal(),
-        add_working_group_opening_proposal: defaults::add_working_group_opening_proposal(),
-        fill_working_group_opening_proposal: defaults::fill_working_group_opening_proposal(),
-        set_working_group_budget_capacity_proposal:
-            defaults::set_working_group_budget_capacity_proposal(),
-        decrease_working_group_leader_stake_proposal:
-            defaults::decrease_working_group_leader_stake_proposal(),
-        slash_working_group_leader_stake_proposal:
-            defaults::slash_working_group_leader_stake_proposal(),
-        set_working_group_leader_reward_proposal:
-            defaults::set_working_group_leader_reward_proposal(),
-        terminate_working_group_leader_role_proposal:
-            defaults::terminate_working_group_leader_role_proposal(),
+        signal_proposal: defaults::signal_proposal(),
+        funding_request_proposal: defaults::funding_request_proposal(),
+        create_working_group_lead_opening_proposal:
+            defaults::create_working_group_lead_opening_proposal(),
+        fill_working_group_lead_opening_proposal:
+            defaults::fill_working_group_lead_opening_proposal(),
+        update_working_group_budget_proposal: defaults::update_working_group_budget_proposal(),
+        decrease_working_group_lead_stake_proposal:
+            defaults::decrease_working_group_lead_stake_proposal(),
+        slash_working_group_lead_proposal: defaults::slash_working_group_lead_proposal(),
+        set_working_group_lead_reward_proposal: defaults::set_working_group_lead_reward_proposal(),
+        terminate_working_group_lead_proposal: defaults::terminate_working_group_lead_proposal(),
         amend_constitution_proposal: defaults::amend_constitution_proposal(),
-        cancel_working_group_leader_opening: defaults::cancel_working_group_leader_opening(),
+        cancel_working_group_lead_opening_proposal:
+            defaults::cancel_working_group_lead_opening_proposal(),
+        set_membership_price_proposal: defaults::set_membership_price_proposal(),
     }
 }

--- a/runtime/src/proposals_configuration/mod.rs
+++ b/runtime/src/proposals_configuration/mod.rs
@@ -41,6 +41,12 @@ parameter_types! {
     pub CancelWorkingGroupLeadOpeningProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.cancel_working_group_lead_opening_proposal;
     pub SetMembershipPriceProposalParameters: ProposalParameters<BlockNumber, Balance> =
         ALL_PROPOSALS_PARAMETERS.set_membership_price_proposal;
+    pub SetCouncilBudgetIncrementProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.set_council_budget_increment_proposal;
+    pub SetCouncilorRewardProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.set_councilor_reward_proposal;
+    pub SetInitialInvitationBalanceProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        ALL_PROPOSALS_PARAMETERS.set_initial_invitation_balance_proposal;
 }
 
 ///////////
@@ -60,6 +66,9 @@ struct AllProposalsParameters {
     pub amend_constitution_proposal: ProposalParameters<BlockNumber, Balance>,
     pub cancel_working_group_lead_opening_proposal: ProposalParameters<BlockNumber, Balance>,
     pub set_membership_price_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub set_council_budget_increment_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub set_councilor_reward_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub set_initial_invitation_balance_proposal: ProposalParameters<BlockNumber, Balance>,
 }
 
 // to initialize parameters only once.
@@ -141,7 +150,10 @@ fn convert_json_object_to_proposal_parameters(
             jo.clone(),
             cancel_working_group_lead_opening_proposal
         );
-        init_proposal_parameter_object!(params, jo, set_membership_price_proposal);
+        init_proposal_parameter_object!(params, jo.clone(), set_membership_price_proposal);
+        init_proposal_parameter_object!(params, jo.clone(), set_council_budget_increment_proposal);
+        init_proposal_parameter_object!(params, jo.clone(), set_councilor_reward_proposal);
+        init_proposal_parameter_object!(params, jo, set_initial_invitation_balance_proposal);
     }
 
     params
@@ -264,5 +276,9 @@ fn default_parameters() -> AllProposalsParameters {
         cancel_working_group_lead_opening_proposal:
             defaults::cancel_working_group_lead_opening_proposal(),
         set_membership_price_proposal: defaults::set_membership_price_proposal(),
+        set_council_budget_increment_proposal: defaults::set_council_budget_increment_proposal(),
+        set_councilor_reward_proposal: defaults::set_councilor_reward_proposal(),
+        set_initial_invitation_balance_proposal: defaults::set_initial_invitation_balance_proposal(
+        ),
     }
 }

--- a/runtime/src/proposals_configuration/mod.rs
+++ b/runtime/src/proposals_configuration/mod.rs
@@ -34,6 +34,7 @@ parameter_types! {
     pub SetWorkingGroupLeaderRewardProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.set_working_group_leader_reward_proposal;
     pub TerminateWorkingGroupLeaderRoleProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.terminate_working_group_leader_role_proposal;
     pub AmendConstitutionProposalParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.amend_constitution_proposal;
+    pub CancelWorkingGroupLeaderOpeningParameters: ProposalParameters<BlockNumber, Balance> = ALL_PROPOSALS_PARAMETERS.cancel_working_group_leader_opening;
 }
 
 ///////////
@@ -51,6 +52,7 @@ struct AllProposalsParameters {
     pub set_working_group_leader_reward_proposal: ProposalParameters<BlockNumber, Balance>,
     pub terminate_working_group_leader_role_proposal: ProposalParameters<BlockNumber, Balance>,
     pub amend_constitution_proposal: ProposalParameters<BlockNumber, Balance>,
+    pub cancel_working_group_leader_opening: ProposalParameters<BlockNumber, Balance>,
 }
 
 // to initialize parameters only once.
@@ -134,7 +136,8 @@ fn convert_json_object_to_proposal_parameters(
             jo.clone(),
             terminate_working_group_leader_role_proposal
         );
-        init_proposal_parameter_object!(params, jo, amend_constitution_proposal);
+        init_proposal_parameter_object!(params, jo.clone(), amend_constitution_proposal);
+        init_proposal_parameter_object!(params, jo, cancel_working_group_leader_opening);
     }
 
     params
@@ -256,5 +259,6 @@ fn default_parameters() -> AllProposalsParameters {
         terminate_working_group_leader_role_proposal:
             defaults::terminate_working_group_leader_role_proposal(),
         amend_constitution_proposal: defaults::amend_constitution_proposal(),
+        cancel_working_group_leader_opening: defaults::cancel_working_group_leader_opening(),
     }
 }

--- a/runtime/src/proposals_configuration/sample_proposal_parameters.json
+++ b/runtime/src/proposals_configuration/sample_proposal_parameters.json
@@ -1,24 +1,25 @@
 {
-  "_comment": "This is a sample 'Proposal parameters' JSON file to enable conditional runtime compilation.",
-  "set_validator_count_proposal": {
-    "voting_period": 1,
-    "grace_period": 2,
-    "approval_quorum_percentage": 3,
-    "approval_threshold_percentage": 4,
-    "slashing_quorum_percentage": 5,
-    "slashing_threshold_percentage": 6,
-    "required_stake": 7,
-    "constitutionality": 8
-  },
-  "runtime_upgrade_proposal" : {},
-  "text_proposal": {},
-  "spending_proposal": {},
-  "add_working_group_opening_proposal": {},
-  "fill_working_group_opening_proposal": {},
-  "set_working_group_budget_capacity_proposal": {},
-  "decrease_working_group_leader_stake_proposal": {},
-  "slash_working_group_leader_stake_proposal": {},
-  "set_working_group_leader_reward_proposal": {},
-  "terminate_working_group_leader_role_proposal": {},
-  "amend_constitution_proposal": {}
+    "_comment": "This is a sample 'Proposal parameters' JSON file to enable conditional runtime compilation.",
+    "set_validator_count_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "runtime_upgrade_proposal": {},
+    "text_proposal": {},
+    "spending_proposal": {},
+    "add_working_group_opening_proposal": {},
+    "fill_working_group_opening_proposal": {},
+    "set_working_group_budget_capacity_proposal": {},
+    "decrease_working_group_leader_stake_proposal": {},
+    "slash_working_group_leader_stake_proposal": {},
+    "set_working_group_leader_reward_proposal": {},
+    "terminate_working_group_leader_role_proposal": {},
+    "amend_constitution_proposal": {},
+    "cancel_working_group_leader_opening": {}
 }

--- a/runtime/src/proposals_configuration/sample_proposal_parameters.json
+++ b/runtime/src/proposals_configuration/sample_proposal_parameters.json
@@ -1,6 +1,6 @@
 {
     "_comment": "This is a sample 'Proposal parameters' JSON file to enable conditional runtime compilation.",
-    "set_validator_count_proposal": {
+    "set_max_validator_count_proposal": {
         "voting_period": 1,
         "grace_period": 2,
         "approval_quorum_percentage": 3,
@@ -10,16 +10,194 @@
         "required_stake": 7,
         "constitutionality": 8
     },
-    "runtime_upgrade_proposal": {},
-    "text_proposal": {},
-    "spending_proposal": {},
-    "add_working_group_opening_proposal": {},
-    "fill_working_group_opening_proposal": {},
-    "set_working_group_budget_capacity_proposal": {},
-    "decrease_working_group_leader_stake_proposal": {},
-    "slash_working_group_leader_stake_proposal": {},
-    "set_working_group_leader_reward_proposal": {},
-    "terminate_working_group_leader_role_proposal": {},
-    "amend_constitution_proposal": {},
-    "cancel_working_group_leader_opening": {}
+    "runtime_upgrade_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "signal_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "funding_request_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "create_working_group_lead_opening_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "fill_working_group_lead_opening_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "update_working_group_budget_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "decrease_working_group_lead_stake_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "slash_working_group_lead_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "set_working_group_lead_reward_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "terminate_working_group_lead_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "amend_constitution_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "cancel_working_group_lead_opening_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "set_membership_price_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "set_council_budget_increment_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "set_councilor_reward_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "set_initial_invitation_balance_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "set_membership_lead_invitation_quota_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "set_referral_cut_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    },
+    "set_invitation_count_proposal": {
+        "voting_period": 1,
+        "grace_period": 2,
+        "approval_quorum_percentage": 3,
+        "approval_threshold_percentage": 4,
+        "slashing_quorum_percentage": 5,
+        "slashing_threshold_percentage": 6,
+        "required_stake": 7,
+        "constitutionality": 8
+    }
 }

--- a/runtime/src/proposals_configuration/tests.rs
+++ b/runtime/src/proposals_configuration/tests.rs
@@ -4,7 +4,7 @@ use crate::ProposalParameters;
 #[ignore]
 #[test]
 fn proposal_parameters_are_initialized() {
-    let actual_params = super::SetValidatorCountProposalParameters::get();
+    let actual_params = super::SetMaxValidatorCountProposalParameters::get();
     let expected_params = ProposalParameters {
         voting_period: 1,
         grace_period: 2,

--- a/runtime/src/proposals_configuration/tests.rs
+++ b/runtime/src/proposals_configuration/tests.rs
@@ -1,10 +1,371 @@
 use crate::ProposalParameters;
 
 // Enable during the conditional compilation tests.
-#[ignore]
 #[test]
-fn proposal_parameters_are_initialized() {
+#[ignore]
+fn proposal_parameters_are_initialized_max_validators() {
     let actual_params = super::SetMaxValidatorCountProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_runtime_upgrade() {
+    let actual_params = super::RuntimeUpgradeProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_signal() {
+    let actual_params = super::SignalProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_funding_request() {
+    let actual_params = super::FundingRequestProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_create_wg_lead_opening() {
+    let actual_params = super::CreateWorkingGroupLeadOpeningProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_wg_fill_lead_opening() {
+    let actual_params = super::FillWorkingGroupLeadOpeningProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_update_budget() {
+    let actual_params = super::UpdateWorkingGroupBudgetProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_decrease_wg_lead_stake() {
+    let actual_params = super::DecreaseWorkingGroupLeadStakeProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_slash_wg_lead() {
+    let actual_params = super::SlashWorkingGroupLeadProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_set_wg_lead_reward() {
+    let actual_params = super::SetWorkingGroupLeadRewardProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_terminate_wg_lead() {
+    let actual_params = super::TerminateWorkingGroupLeadProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_amend_constitution() {
+    let actual_params = super::AmendConstitutionProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_cancel_wg_lead_opening() {
+    let actual_params = super::CancelWorkingGroupLeadOpeningProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_set_membership_price() {
+    let actual_params = super::SetMembershipPriceProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_set_council_budget_increment() {
+    let actual_params = super::SetCouncilBudgetIncrementProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_set_councilor_reward() {
+    let actual_params = super::SetCouncilorRewardProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_set_initial_invitation_balance() {
+    let actual_params = super::SetInitialInvitationBalanceProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_set_membership_invitaiton_quota() {
+    let actual_params = super::SetMembershipLeadInvitationQuotaProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_set_referral_cut() {
+    let actual_params = super::SetReferralCutProposalParameters::get();
+    let expected_params = ProposalParameters {
+        voting_period: 1,
+        grace_period: 2,
+        approval_quorum_percentage: 3,
+        approval_threshold_percentage: 4,
+        slashing_quorum_percentage: 5,
+        slashing_threshold_percentage: 6,
+        required_stake: Some(7),
+        constitutionality: 8,
+    };
+
+    assert_eq!(expected_params, actual_params);
+}
+
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_set_invitation_count() {
+    let actual_params = super::SetInvitationCountProposalParameters::get();
     let expected_params = ProposalParameters {
         voting_period: 1,
         grace_period: 2,

--- a/runtime/src/proposals_configuration/tests.rs
+++ b/runtime/src/proposals_configuration/tests.rs
@@ -1,11 +1,7 @@
-use crate::ProposalParameters;
+use crate::{Balance, BlockNumber, ProposalParameters};
 
-// Enable during the conditional compilation tests.
-#[test]
-#[ignore]
-fn proposal_parameters_are_initialized_max_validators() {
-    let actual_params = super::SetMaxValidatorCountProposalParameters::get();
-    let expected_params = ProposalParameters {
+fn default_proposal_parameters() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
         voting_period: 1,
         grace_period: 2,
         approval_quorum_percentage: 3,
@@ -14,9 +10,16 @@ fn proposal_parameters_are_initialized_max_validators() {
         slashing_threshold_percentage: 6,
         required_stake: Some(7),
         constitutionality: 8,
-    };
+    }
+}
 
-    assert_eq!(expected_params, actual_params);
+// Enable during the conditional compilation tests.
+#[test]
+#[ignore]
+fn proposal_parameters_are_initialized_max_validators() {
+    let actual_params = super::SetMaxValidatorCountProposalParameters::get();
+
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -24,18 +27,8 @@ fn proposal_parameters_are_initialized_max_validators() {
 #[ignore]
 fn proposal_parameters_are_initialized_runtime_upgrade() {
     let actual_params = super::RuntimeUpgradeProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -43,18 +36,8 @@ fn proposal_parameters_are_initialized_runtime_upgrade() {
 #[ignore]
 fn proposal_parameters_are_initialized_signal() {
     let actual_params = super::SignalProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -62,18 +45,8 @@ fn proposal_parameters_are_initialized_signal() {
 #[ignore]
 fn proposal_parameters_are_initialized_funding_request() {
     let actual_params = super::FundingRequestProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -81,18 +54,8 @@ fn proposal_parameters_are_initialized_funding_request() {
 #[ignore]
 fn proposal_parameters_are_initialized_create_wg_lead_opening() {
     let actual_params = super::CreateWorkingGroupLeadOpeningProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -100,18 +63,8 @@ fn proposal_parameters_are_initialized_create_wg_lead_opening() {
 #[ignore]
 fn proposal_parameters_are_initialized_wg_fill_lead_opening() {
     let actual_params = super::FillWorkingGroupLeadOpeningProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -119,18 +72,8 @@ fn proposal_parameters_are_initialized_wg_fill_lead_opening() {
 #[ignore]
 fn proposal_parameters_are_initialized_update_budget() {
     let actual_params = super::UpdateWorkingGroupBudgetProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -138,18 +81,8 @@ fn proposal_parameters_are_initialized_update_budget() {
 #[ignore]
 fn proposal_parameters_are_initialized_decrease_wg_lead_stake() {
     let actual_params = super::DecreaseWorkingGroupLeadStakeProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -157,18 +90,8 @@ fn proposal_parameters_are_initialized_decrease_wg_lead_stake() {
 #[ignore]
 fn proposal_parameters_are_initialized_slash_wg_lead() {
     let actual_params = super::SlashWorkingGroupLeadProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -176,18 +99,8 @@ fn proposal_parameters_are_initialized_slash_wg_lead() {
 #[ignore]
 fn proposal_parameters_are_initialized_set_wg_lead_reward() {
     let actual_params = super::SetWorkingGroupLeadRewardProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -195,18 +108,8 @@ fn proposal_parameters_are_initialized_set_wg_lead_reward() {
 #[ignore]
 fn proposal_parameters_are_initialized_terminate_wg_lead() {
     let actual_params = super::TerminateWorkingGroupLeadProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -214,18 +117,8 @@ fn proposal_parameters_are_initialized_terminate_wg_lead() {
 #[ignore]
 fn proposal_parameters_are_initialized_amend_constitution() {
     let actual_params = super::AmendConstitutionProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -233,18 +126,8 @@ fn proposal_parameters_are_initialized_amend_constitution() {
 #[ignore]
 fn proposal_parameters_are_initialized_cancel_wg_lead_opening() {
     let actual_params = super::CancelWorkingGroupLeadOpeningProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -252,18 +135,8 @@ fn proposal_parameters_are_initialized_cancel_wg_lead_opening() {
 #[ignore]
 fn proposal_parameters_are_initialized_set_membership_price() {
     let actual_params = super::SetMembershipPriceProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -271,18 +144,8 @@ fn proposal_parameters_are_initialized_set_membership_price() {
 #[ignore]
 fn proposal_parameters_are_initialized_set_council_budget_increment() {
     let actual_params = super::SetCouncilBudgetIncrementProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -290,18 +153,8 @@ fn proposal_parameters_are_initialized_set_council_budget_increment() {
 #[ignore]
 fn proposal_parameters_are_initialized_set_councilor_reward() {
     let actual_params = super::SetCouncilorRewardProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -309,18 +162,8 @@ fn proposal_parameters_are_initialized_set_councilor_reward() {
 #[ignore]
 fn proposal_parameters_are_initialized_set_initial_invitation_balance() {
     let actual_params = super::SetInitialInvitationBalanceProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -328,18 +171,8 @@ fn proposal_parameters_are_initialized_set_initial_invitation_balance() {
 #[ignore]
 fn proposal_parameters_are_initialized_set_membership_invitaiton_quota() {
     let actual_params = super::SetMembershipLeadInvitationQuotaProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -347,18 +180,8 @@ fn proposal_parameters_are_initialized_set_membership_invitaiton_quota() {
 #[ignore]
 fn proposal_parameters_are_initialized_set_referral_cut() {
     let actual_params = super::SetReferralCutProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }
 
 // Enable during the conditional compilation tests.
@@ -366,16 +189,6 @@ fn proposal_parameters_are_initialized_set_referral_cut() {
 #[ignore]
 fn proposal_parameters_are_initialized_set_invitation_count() {
     let actual_params = super::SetInvitationCountProposalParameters::get();
-    let expected_params = ProposalParameters {
-        voting_period: 1,
-        grace_period: 2,
-        approval_quorum_percentage: 3,
-        approval_threshold_percentage: 4,
-        slashing_quorum_percentage: 5,
-        slashing_threshold_percentage: 6,
-        required_stake: Some(7),
-        constitutionality: 8,
-    };
 
-    assert_eq!(expected_params, actual_params);
+    assert_eq!(default_proposal_parameters(), actual_params);
 }

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -284,6 +284,7 @@ impl_runtime_apis! {
             use frame_system::RawOrigin;
             use crate::ProposalsDiscussion;
             use crate::ProposalsEngine;
+            use crate::ProposalsCodex;
             use crate::Constitution;
             use crate::Forum;
             use crate::ContentDirectoryWorkingGroup;
@@ -351,6 +352,7 @@ impl_runtime_apis! {
 
             // Joystream Benchmarks
             add_benchmark!(params, batches, proposals_discussion, ProposalsDiscussion);
+            add_benchmark!(params, batches, proposals_codex, ProposalsCodex);
             add_benchmark!(params, batches, proposals_engine, ProposalsEngine);
             add_benchmark!(params, batches, forum, Forum);
             add_benchmark!(params, batches, pallet_constitution, Constitution);

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -807,6 +807,36 @@ fn set_referral_cut_proposal_succeeds() {
 }
 
 #[test]
+fn set_budget_increment_proposal_succeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 10;
+        let account_id: [u8; 32] = [member_id; 32];
+        let budget_increment = 500;
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
+            };
+
+            ProposalCodex::create_proposal(
+                RawOrigin::Signed(account_id.into()).into(),
+                general_proposal_parameters,
+                ProposalDetails::SetCouncilBudgetIncrement(budget_increment),
+            )
+        })
+        .with_member_id(member_id as u64);
+
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(Council::budget_increment(), budget_increment);
+    });
+}
+
+#[test]
 fn proposal_reactivation_succeeds() {
     initial_test_ext().execute_with(|| {
         setup_members(5);

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -837,6 +837,36 @@ fn set_budget_increment_proposal_succeds() {
 }
 
 #[test]
+fn set_councilor_reward_proposal_succeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 10;
+        let account_id: [u8; 32] = [member_id; 32];
+        let councilor_reward = 100;
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
+            };
+
+            ProposalCodex::create_proposal(
+                RawOrigin::Signed(account_id.into()).into(),
+                general_proposal_parameters,
+                ProposalDetails::SetCouncilorReward(councilor_reward),
+            )
+        })
+        .with_member_id(member_id as u64);
+
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(Council::councilor_reward(), councilor_reward);
+    });
+}
+
+#[test]
 fn proposal_reactivation_succeeds() {
     initial_test_ext().execute_with(|| {
         setup_members(5);

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -5,7 +5,7 @@
 mod working_group_proposals;
 
 use crate::tests::run_to_block;
-use crate::{ProposalCancellationFee, Runtime};
+use crate::{MembershipWorkingGroupInstance, ProposalCancellationFee, Runtime};
 use codec::Encode;
 use proposals_codex::{GeneralProposalParameters, ProposalDetails};
 use proposals_engine::{
@@ -18,6 +18,7 @@ use frame_support::traits::Currency;
 use frame_support::{StorageMap, StorageValue};
 use frame_system::RawOrigin;
 use sp_runtime::AccountId32;
+use sp_std::collections::btree_set::BTreeSet;
 
 use super::{
     increase_total_balance_issuance_using_account_id, initial_test_ext, insert_member,
@@ -31,6 +32,9 @@ pub type Balances = pallet_balances::Module<Runtime>;
 pub type System = frame_system::Module<Runtime>;
 pub type ProposalsEngine = proposals_engine::Module<Runtime>;
 pub type ProposalCodex = proposals_codex::Module<Runtime>;
+pub type Council = council::Module<Runtime>;
+pub type Membership = membership::Module<Runtime>;
+pub type MembershipWorkingGroup = working_group::Module<Runtime, MembershipWorkingGroupInstance>;
 
 fn setup_members(count: u8) {
     for i in 0..count {
@@ -390,6 +394,8 @@ where
     member_id: u64,
     setup_environment: bool,
     proposal_id: u32,
+    lead_id: u64,
+    set_member_lead: bool,
 }
 
 impl<SuccessfulCall> CodexProposalTestFixture<SuccessfulCall>
@@ -402,6 +408,8 @@ where
             member_id: 1,
             setup_environment: true,
             proposal_id: 1,
+            lead_id: 11,
+            set_member_lead: false,
         }
     }
 
@@ -428,6 +436,47 @@ where
             ..self
         }
     }
+
+    fn with_lead_id(self, lead_id: u64) -> Self {
+        Self { lead_id, ..self }
+    }
+
+    fn with_set_member_lead(self, set_member_lead: bool) -> Self {
+        Self {
+            set_member_lead,
+            ..self
+        }
+    }
+}
+
+fn set_membership_leader(lead_account_id: AccountId32, lead_id: u64) {
+    MembershipWorkingGroup::add_opening(
+        RawOrigin::Root.into(),
+        vec![0u8],
+        working_group::OpeningType::Leader,
+        None,
+        None,
+    )
+    .unwrap();
+
+    let application = working_group::ApplyOnOpeningParameters::<Runtime> {
+        member_id: lead_id.clone().into(),
+        opening_id: 0,
+        role_account_id: lead_account_id.clone(),
+        reward_account_id: lead_account_id.clone(),
+        description: vec![0u8],
+        stake_parameters: None,
+    };
+
+    MembershipWorkingGroup::apply_on_opening(
+        RawOrigin::Signed(lead_account_id).into(),
+        application,
+    )
+    .unwrap();
+    let mut successful_application_ids = BTreeSet::new();
+    successful_application_ids.insert(0);
+    MembershipWorkingGroup::fill_opening(RawOrigin::Root.into(), 0, successful_application_ids)
+        .unwrap();
 }
 
 impl<SuccessfulCall> CodexProposalTestFixture<SuccessfulCall>
@@ -440,6 +489,10 @@ where
         if self.setup_environment {
             setup_members(15);
             setup_council(0);
+            if self.set_member_lead {
+                let lead_account_id = [self.lead_id as u8; 32].into();
+                set_membership_leader(lead_account_id, self.lead_id);
+            }
 
             increase_total_balance_issuance_using_account_id(account_id.clone().into(), 1_500_000);
         }
@@ -483,18 +536,18 @@ fn text_proposal_execution_succeeds() {
     });
 }
 
-/* TODO: Test will be commented out until Spending proposal is changed with the new
- * FundingRequest
 #[test]
-fn spending_proposal_execution_succeeds() {
+fn funding_request_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
         let member_id = 10;
         let account_id: [u8; 32] = [member_id; 32];
-        let new_balance = pallet_council::Balance::<Runtime>::from(5555u32);
+        let council_budget = 5_000_000;
+        let funding = 5000;
 
         let target_account_id: [u8; 32] = [12; 32];
+        let target_account_id: AccountId32 = target_account_id.clone().into();
 
-        assert!(Council::set_budget(RawOrigin::Root.into(), new_balance).is_ok());
+        assert!(Council::set_budget(RawOrigin::Root.into(), council_budget).is_ok());
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
@@ -508,22 +561,19 @@ fn spending_proposal_execution_succeeds() {
             ProposalCodex::create_proposal(
                 RawOrigin::Signed(account_id.clone().into()).into(),
                 general_proposal_parameters,
-                ProposalDetails::FundingRequest(new_balance, target_account_id.clone().into()),
+                ProposalDetails::FundingRequest(funding, target_account_id.clone()),
             )
         })
         .with_member_id(member_id as u64);
 
-        let converted_account_id: AccountId32 = target_account_id.clone().into();
-        assert_eq!(Balances::free_balance(converted_account_id.clone()), 0);
+        assert_eq!(Balances::free_balance(target_account_id.clone()), 0);
 
         codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+        run_to_block(86410);
 
-        run_to_block(14410);
-
-        assert_eq!(Balances::free_balance(converted_account_id), new_balance);
+        assert_eq!(Balances::free_balance(target_account_id), funding);
     });
 }
-*/
 
 #[test]
 fn set_validator_count_proposal_execution_succeeds() {
@@ -594,6 +644,165 @@ fn amend_constitution_proposal_execution_succeeds() {
         .with_member_id(member_id as u64);
 
         codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+    });
+}
+
+#[test]
+fn set_membership_price_proposal_execution_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 10;
+        let account_id: [u8; 32] = [member_id; 32];
+        let membership_price = 100;
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
+            };
+
+            ProposalCodex::create_proposal(
+                RawOrigin::Signed(account_id.into()).into(),
+                general_proposal_parameters,
+                ProposalDetails::SetMembershipPrice(membership_price),
+            )
+        })
+        .with_member_id(member_id as u64);
+
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(Membership::membership_price(), membership_price);
+    });
+}
+
+#[test]
+fn set_initial_invitation_balance_proposal_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 10;
+        let account_id: [u8; 32] = [member_id; 32];
+        let initial_invitation_balance = 100;
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
+            };
+
+            ProposalCodex::create_proposal(
+                RawOrigin::Signed(account_id.into()).into(),
+                general_proposal_parameters,
+                ProposalDetails::SetInitialInvitationBalance(initial_invitation_balance),
+            )
+        })
+        .with_member_id(member_id as u64);
+
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(
+            Membership::initial_invitation_balance(),
+            initial_invitation_balance
+        );
+    });
+}
+
+#[test]
+fn set_initial_invitation_count_proposal_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 10;
+        let account_id: [u8; 32] = [member_id; 32];
+        let new_default_invite_count = 50;
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
+            };
+
+            ProposalCodex::create_proposal(
+                RawOrigin::Signed(account_id.into()).into(),
+                general_proposal_parameters,
+                ProposalDetails::SetInitialInvitationCount(new_default_invite_count),
+            )
+        })
+        .with_member_id(member_id as u64);
+
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(
+            Membership::initial_invitation_count(),
+            new_default_invite_count
+        );
+    });
+}
+
+#[test]
+fn set_membership_leader_invitation_quota_proposal_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 10;
+        let account_id: [u8; 32] = [member_id; 32];
+        let new_invite_count = 30;
+        let lead_id = 11;
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
+            };
+
+            ProposalCodex::create_proposal(
+                RawOrigin::Signed(account_id.into()).into(),
+                general_proposal_parameters,
+                ProposalDetails::SetMembershipLeadInvitationQuota(new_invite_count),
+            )
+        })
+        .with_member_id(member_id as u64)
+        .with_set_member_lead(true)
+        .with_lead_id(lead_id);
+
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(Membership::membership(lead_id).invites, new_invite_count);
+    });
+}
+
+#[test]
+fn set_referral_cut_proposal_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = 10;
+        let account_id: [u8; 32] = [member_id; 32];
+        let referral_cut = 500;
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id.into(),
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.into()),
+                exact_execution_block: None,
+            };
+
+            ProposalCodex::create_proposal(
+                RawOrigin::Signed(account_id.into()).into(),
+                general_proposal_parameters,
+                ProposalDetails::SetReferralCut(referral_cut),
+            )
+        })
+        .with_member_id(member_id as u64);
+
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        assert_eq!(Membership::referral_cut(), referral_cut);
     });
 }
 

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -115,7 +115,7 @@ impl Default for DummyProposalFixture {
         let title = b"title".to_vec();
         let description = b"description".to_vec();
         let dummy_proposal =
-            proposals_codex::Call::<Runtime>::execute_text_proposal(b"text".to_vec());
+            proposals_codex::Call::<Runtime>::execute_signal_proposal(b"signal".to_vec());
 
         DummyProposalFixture {
             parameters: ProposalParameters {
@@ -474,7 +474,7 @@ fn text_proposal_execution_succeeds() {
             ProposalCodex::create_proposal(
                 RawOrigin::Signed(account_id.into()).into(),
                 general_proposal_parameters,
-                ProposalDetails::Text(b"text".to_vec()),
+                ProposalDetails::Signal(b"signal".to_vec()),
             )
         })
         .with_member_id(member_id as u64);
@@ -508,7 +508,7 @@ fn spending_proposal_execution_succeeds() {
             ProposalCodex::create_proposal(
                 RawOrigin::Signed(account_id.clone().into()).into(),
                 general_proposal_parameters,
-                ProposalDetails::Spending(new_balance, target_account_id.clone().into()),
+                ProposalDetails::FundingRequest(new_balance, target_account_id.clone().into()),
             )
         })
         .with_member_id(member_id as u64);
@@ -558,7 +558,7 @@ fn set_validator_count_proposal_execution_succeeds() {
             ProposalCodex::create_proposal(
                 RawOrigin::Signed(account_id.clone().into()).into(),
                 general_proposal_parameters,
-                ProposalDetails::SetValidatorCount(new_validator_count),
+                ProposalDetails::SetMaxValidatorCount(new_validator_count),
             )
         })
         .disable_setup_enviroment();

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -5,7 +5,7 @@ use super::*;
 
 use common::working_group::WorkingGroup;
 use frame_system::RawOrigin;
-use proposals_codex::AddOpeningParameters;
+use proposals_codex::CreateOpeningParameters;
 use strum::IntoEnumIterator;
 use working_group::StakeParameters;
 
@@ -26,11 +26,11 @@ fn add_opening(
     account_id: [u8; 32],
     stake_policy: Option<working_group::StakePolicy<BlockNumber, Balance>>,
     sequence_number: u32, // action sequence number to align with other actions
-    working_group: WorkingGroup,
+    group: WorkingGroup,
 ) -> u64 {
     let expected_proposal_id = sequence_number;
 
-    let opening_id = match working_group {
+    let opening_id = match group {
         WorkingGroup::Content => {
             let opening_id = ContentDirectoryWorkingGroup::next_opening_id();
             assert!(!<working_group::OpeningById<
@@ -83,11 +83,11 @@ fn add_opening(
         ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            ProposalDetails::AddWorkingGroupLeaderOpening(AddOpeningParameters {
+            ProposalDetails::CreateWorkingGroupLeadOpening(CreateOpeningParameters {
                 description: Vec::new(),
                 stake_policy: stake_policy.clone(),
                 reward_per_block: None,
-                working_group,
+                group,
             }),
         )
     })
@@ -95,7 +95,7 @@ fn add_opening(
 
     codex_extrinsic_test_fixture.call_extrinsic_and_assert();
 
-    match working_group {
+    match group {
         WorkingGroup::Content => assert!(working_group::OpeningById::<
             Runtime,
             ContentDirectoryWorkingGroupInstance,
@@ -120,7 +120,7 @@ fn fill_opening(
     member_id: MemberId,
     account_id: [u8; 32],
     opening_id: u64,
-    successful_application_id: u64,
+    application_id: u64,
     sequence_number: u32, // action sequence number to align with other actions
     working_group: WorkingGroup,
 ) {
@@ -142,13 +142,11 @@ fn fill_opening(
         ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            ProposalDetails::FillWorkingGroupLeaderOpening(
-                proposals_codex::FillOpeningParameters {
-                    opening_id,
-                    successful_application_id,
-                    working_group,
-                },
-            ),
+            ProposalDetails::FillWorkingGroupLeadOpening(proposals_codex::FillOpeningParameters {
+                opening_id,
+                application_id,
+                working_group,
+            }),
         )
     })
     .disable_setup_enviroment()
@@ -183,7 +181,7 @@ fn decrease_stake(
         ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            ProposalDetails::DecreaseWorkingGroupLeaderStake(
+            ProposalDetails::DecreaseWorkingGroupLeadStake(
                 leader_worker_id,
                 stake_amount,
                 working_group,
@@ -219,11 +217,7 @@ fn slash_stake(
         ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            ProposalDetails::SlashWorkingGroupLeaderStake(
-                leader_worker_id,
-                stake_amount,
-                working_group,
-            ),
+            ProposalDetails::SlashWorkingGroupLead(leader_worker_id, stake_amount, working_group),
         )
     })
     .disable_setup_enviroment()
@@ -258,7 +252,7 @@ fn set_reward(
         ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            ProposalDetails::SetWorkingGroupLeaderReward(
+            ProposalDetails::SetWorkingGroupLeadReward(
                 leader_worker_id,
                 Some(reward_amount),
                 working_group,
@@ -300,7 +294,11 @@ fn set_mint_capacity<
         ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            ProposalDetails::SetWorkingGroupBudgetCapacity(mint_capacity, working_group),
+            ProposalDetails::UpdateWorkingGroupBudget(
+                mint_capacity,
+                working_group,
+                proposals_codex::BalanceKind::Positive,
+            ),
         )
     })
     .with_setup_enviroment(setup_environment)
@@ -313,9 +311,9 @@ fn terminate_role(
     member_id: MemberId,
     account_id: [u8; 32],
     leader_worker_id: u64,
-    penalty: Option<u128>,
+    slashing_amount: Option<Balance>,
     sequence_number: u32, // action sequence number to align with other actions
-    working_group: WorkingGroup,
+    group: WorkingGroup,
 ) {
     let expected_proposal_id = sequence_number;
 
@@ -335,13 +333,11 @@ fn terminate_role(
         ProposalCodex::create_proposal(
             RawOrigin::Signed(account_id.into()).into(),
             general_proposal_parameters,
-            ProposalDetails::TerminateWorkingGroupLeaderRole(
-                proposals_codex::TerminateRoleParameters {
-                    worker_id: leader_worker_id,
-                    penalty,
-                    working_group,
-                },
-            ),
+            ProposalDetails::TerminateWorkingGroupLead(proposals_codex::TerminateRoleParameters {
+                worker_id: leader_worker_id,
+                slashing_amount: slashing_amount.clone(),
+                group,
+            }),
         )
     })
     .disable_setup_enviroment()
@@ -1217,7 +1213,7 @@ fn run_create_terminate_group_leader_role_proposal_with_slashing_execution_succe
             member_id,
             account_id,
             leader_worker_id.into(),
-            Some(stake_amount),
+            stake_amount.into(),
             4,
             working_group,
         );

--- a/runtime/src/weights/mod.rs
+++ b/runtime/src/weights/mod.rs
@@ -27,6 +27,7 @@ pub mod pallet_utility;
 pub mod council;
 pub mod forum;
 pub mod pallet_constitution;
+pub mod proposals_codex;
 pub mod proposals_discussion;
 pub mod proposals_engine;
 pub mod referendum;

--- a/runtime/src/weights/proposals_codex.rs
+++ b/runtime/src/weights/proposals_codex.rs
@@ -1,0 +1,133 @@
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+
+pub struct WeightInfo;
+impl proposals_codex::WeightInfo for WeightInfo {
+    fn execute_signal_proposal(i: u32) -> Weight {
+        (16_059_000 as Weight).saturating_add((41_000 as Weight).saturating_mul(i as Weight))
+    }
+    // WARNING! Some components were not used: ["t", "d"]
+    fn create_proposal_signal(i: u32) -> Weight {
+        (663_482_000 as Weight)
+            .saturating_add((246_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_runtime_upgrade(i: u32, t: u32, d: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((298_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((13_792_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((140_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t", "d"]
+    fn create_proposal_funding_request() -> Weight {
+        (1_011_708_000 as Weight)
+            .saturating_add(DbWeight::get().reads(8 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_set_max_validator_count(t: u32, d: u32) -> Weight {
+        (737_501_000 as Weight)
+            .saturating_add((3_119_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((20_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_create_working_group_lead_opening(i: u32, t: u32, d: u32) -> Weight {
+        (393_931_000 as Weight)
+            .saturating_add((383_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((6_783_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((164_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_fill_working_group_lead_opening(t: u32, d: u32) -> Weight {
+        (566_718_000 as Weight)
+            .saturating_add((3_073_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((20_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t"]
+    fn create_proposal_update_working_group_budget(d: u32) -> Weight {
+        (697_884_000 as Weight)
+            .saturating_add((4_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t", "d"]
+    fn create_proposal_decrease_working_group_lead_stake() -> Weight {
+        (660_344_000 as Weight)
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t"]
+    fn create_proposal_slash_working_group_lead(d: u32) -> Weight {
+        (650_009_000 as Weight)
+            .saturating_add((4_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t"]
+    fn create_proposal_set_working_group_lead_reward(d: u32) -> Weight {
+        (641_391_000 as Weight)
+            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_terminate_working_group_lead(t: u32, d: u32) -> Weight {
+        (640_488_000 as Weight)
+            .saturating_add((55_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_amend_constitution(i: u32, t: u32, d: u32) -> Weight {
+        (527_420_000 as Weight)
+            .saturating_add((278_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((1_785_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((21_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["d"]
+    fn create_proposal_cancel_working_group_lead_opening(t: u32) -> Weight {
+        (644_736_000 as Weight)
+            .saturating_add((50_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_set_membership_price(t: u32, d: u32) -> Weight {
+        (638_989_000 as Weight)
+            .saturating_add((53_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t"]
+    fn create_proposal_set_council_budget_increment(d: u32) -> Weight {
+        (635_709_000 as Weight)
+            .saturating_add((16_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["d"]
+    fn create_proposal_set_councilor_reward(t: u32) -> Weight {
+        (648_346_000 as Weight)
+            .saturating_add((110_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_set_initial_invitation_balance(t: u32, d: u32) -> Weight {
+        (632_164_000 as Weight)
+            .saturating_add((271_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+}

--- a/runtime/src/weights/proposals_codex.rs
+++ b/runtime/src/weights/proposals_codex.rs
@@ -8,126 +8,189 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl proposals_codex::WeightInfo for WeightInfo {
     fn execute_signal_proposal(i: u32) -> Weight {
-        (16_059_000 as Weight).saturating_add((41_000 as Weight).saturating_mul(i as Weight))
+        (14_621_000 as Weight).saturating_add((44_000 as Weight).saturating_mul(i as Weight))
     }
-    // WARNING! Some components were not used: ["t", "d"]
-    fn create_proposal_signal(i: u32) -> Weight {
-        (663_482_000 as Weight)
-            .saturating_add((246_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    fn create_proposal_runtime_upgrade(i: u32, t: u32, d: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((298_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((13_792_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((140_000 as Weight).saturating_mul(d as Weight))
+    // WARNING! Some components were not used: ["d"]
+    fn create_proposal_signal(i: u32, t: u32) -> Weight {
+        (670_987_000 as Weight)
+            .saturating_add((273_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((565_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t", "d"]
-    fn create_proposal_funding_request() -> Weight {
-        (1_011_708_000 as Weight)
-            .saturating_add(DbWeight::get().reads(8 as Weight))
+    fn create_proposal_runtime_upgrade(i: u32) -> Weight {
+        (707_989_000 as Weight)
+            .saturating_add((280_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
-    fn create_proposal_set_max_validator_count(t: u32, d: u32) -> Weight {
-        (737_501_000 as Weight)
-            .saturating_add((3_119_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((20_000 as Weight).saturating_mul(d as Weight))
+    fn create_proposal_funding_request(t: u32, d: u32) -> Weight {
+        (585_920_000 as Weight)
+            .saturating_add((1_192_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((14_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
-    fn create_proposal_create_working_group_lead_opening(i: u32, t: u32, d: u32) -> Weight {
-        (393_931_000 as Weight)
-            .saturating_add((383_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((6_783_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((164_000 as Weight).saturating_mul(d as Weight))
+    // WARNING! Some components were not used: ["t", "d"]
+    fn create_proposal_set_max_validator_count() -> Weight {
+        (676_799_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t"]
+    fn create_proposal_create_working_group_lead_opening(i: u32, d: u32) -> Weight {
+        (634_447_000 as Weight)
+            .saturating_add((401_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((30_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
-    fn create_proposal_fill_working_group_lead_opening(t: u32, d: u32) -> Weight {
-        (566_718_000 as Weight)
-            .saturating_add((3_073_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((20_000 as Weight).saturating_mul(d as Weight))
+    // WARNING! Some components were not used: ["d"]
+    fn create_proposal_fill_working_group_lead_opening(t: u32) -> Weight {
+        (664_380_000 as Weight)
+            .saturating_add((57_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t"]
     fn create_proposal_update_working_group_budget(d: u32) -> Weight {
-        (697_884_000 as Weight)
-            .saturating_add((4_000 as Weight).saturating_mul(d as Weight))
+        (655_799_000 as Weight)
+            .saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_decrease_working_group_lead_stake(t: u32, d: u32) -> Weight {
+        (626_011_000 as Weight)
+            .saturating_add((757_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((6_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t", "d"]
-    fn create_proposal_decrease_working_group_lead_stake() -> Weight {
-        (660_344_000 as Weight)
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    // WARNING! Some components were not used: ["t"]
-    fn create_proposal_slash_working_group_lead(d: u32) -> Weight {
-        (650_009_000 as Weight)
-            .saturating_add((4_000 as Weight).saturating_mul(d as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    // WARNING! Some components were not used: ["t"]
-    fn create_proposal_set_working_group_lead_reward(d: u32) -> Weight {
-        (641_391_000 as Weight)
-            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    fn create_proposal_terminate_working_group_lead(t: u32, d: u32) -> Weight {
-        (640_488_000 as Weight)
-            .saturating_add((55_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    fn create_proposal_amend_constitution(i: u32, t: u32, d: u32) -> Weight {
-        (527_420_000 as Weight)
-            .saturating_add((278_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((1_785_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((21_000 as Weight).saturating_mul(d as Weight))
+    fn create_proposal_slash_working_group_lead() -> Weight {
+        (685_880_000 as Weight)
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["d"]
-    fn create_proposal_cancel_working_group_lead_opening(t: u32) -> Weight {
-        (644_736_000 as Weight)
-            .saturating_add((50_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    fn create_proposal_set_membership_price(t: u32, d: u32) -> Weight {
-        (638_989_000 as Weight)
-            .saturating_add((53_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    // WARNING! Some components were not used: ["t"]
-    fn create_proposal_set_council_budget_increment(d: u32) -> Weight {
-        (635_709_000 as Weight)
-            .saturating_add((16_000 as Weight).saturating_mul(d as Weight))
+    fn create_proposal_set_working_group_lead_reward(t: u32) -> Weight {
+        (644_706_000 as Weight)
+            .saturating_add((98_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["d"]
-    fn create_proposal_set_councilor_reward(t: u32) -> Weight {
-        (648_346_000 as Weight)
-            .saturating_add((110_000 as Weight).saturating_mul(t as Weight))
+    fn create_proposal_terminate_working_group_lead(t: u32) -> Weight {
+        (666_916_000 as Weight)
+            .saturating_add((131_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
-    fn create_proposal_set_initial_invitation_balance(t: u32, d: u32) -> Weight {
-        (632_164_000 as Weight)
-            .saturating_add((271_000 as Weight).saturating_mul(t as Weight))
+    // WARNING! Some components were not used: ["d"]
+    fn create_proposal_amend_constitution(i: u32, t: u32) -> Weight {
+        (723_614_000 as Weight)
+            .saturating_add((292_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((478_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t", "d"]
+    fn create_proposal_cancel_working_group_lead_opening() -> Weight {
+        (651_882_000 as Weight)
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t"]
+    fn create_proposal_set_membership_price(d: u32) -> Weight {
+        (646_017_000 as Weight)
             .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_set_council_budget_increment(t: u32, d: u32) -> Weight {
+        (637_702_000 as Weight)
+            .saturating_add((283_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t"]
+    fn create_proposal_set_councilor_reward(d: u32) -> Weight {
+        (650_165_000 as Weight)
+            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["d"]
+    fn create_proposal_set_initial_invitation_balance(t: u32) -> Weight {
+        (647_828_000 as Weight)
+            .saturating_add((29_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t", "d"]
+    fn create_proposal_set_initial_invitation_count() -> Weight {
+        (652_119_000 as Weight)
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t", "d"]
+    fn create_proposal_set_membership_lead_invitation_quota() -> Weight {
+        (1_534_657_000 as Weight)
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_set_referral_cut(t: u32, d: u32) -> Weight {
+        (538_230_000 as Weight)
+            .saturating_add((2_331_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((26_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn update_working_group_budget_positive_forum() -> Weight {
+        (186_049_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn update_working_group_budget_negative_forum() -> Weight {
+        (186_498_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn update_working_group_budget_positive_storage() -> Weight {
+        (185_745_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn update_working_group_budget_negative_storage() -> Weight {
+        (185_138_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn update_working_group_budget_positive_content() -> Weight {
+        (186_835_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn update_working_group_budget_negative_content() -> Weight {
+        (186_768_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn update_working_group_budget_positive_membership() -> Weight {
+        (186_077_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn update_working_group_budget_negative_membership() -> Weight {
+        (186_014_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn funding_request() -> Weight {
+        (296_081_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
     }
 }

--- a/runtime/src/weights/proposals_codex.rs
+++ b/runtime/src/weights/proposals_codex.rs
@@ -8,188 +8,184 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl proposals_codex::WeightInfo for WeightInfo {
     fn execute_signal_proposal(i: u32) -> Weight {
-        (14_621_000 as Weight).saturating_add((44_000 as Weight).saturating_mul(i as Weight))
+        (16_042_000 as Weight).saturating_add((41_000 as Weight).saturating_mul(i as Weight))
+    }
+    fn create_proposal_signal(i: u32, t: u32, d: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((296_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((10_652_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((14_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["d"]
-    fn create_proposal_signal(i: u32, t: u32) -> Weight {
-        (670_987_000 as Weight)
-            .saturating_add((273_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((565_000 as Weight).saturating_mul(t as Weight))
+    fn create_proposal_runtime_upgrade(i: u32, t: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((370_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((34_716_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t", "d"]
-    fn create_proposal_runtime_upgrade(i: u32) -> Weight {
-        (707_989_000 as Weight)
-            .saturating_add((280_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    fn create_proposal_funding_request(t: u32, d: u32) -> Weight {
-        (585_920_000 as Weight)
-            .saturating_add((1_192_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((14_000 as Weight).saturating_mul(d as Weight))
+    fn create_proposal_funding_request() -> Weight {
+        (748_303_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t", "d"]
     fn create_proposal_set_max_validator_count() -> Weight {
-        (676_799_000 as Weight)
+        (731_233_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
-    // WARNING! Some components were not used: ["t"]
-    fn create_proposal_create_working_group_lead_opening(i: u32, d: u32) -> Weight {
-        (634_447_000 as Weight)
-            .saturating_add((401_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((30_000 as Weight).saturating_mul(d as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
     // WARNING! Some components were not used: ["d"]
-    fn create_proposal_fill_working_group_lead_opening(t: u32) -> Weight {
-        (664_380_000 as Weight)
-            .saturating_add((57_000 as Weight).saturating_mul(t as Weight))
+    fn create_proposal_create_working_group_lead_opening(i: u32, t: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((485_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((23_755_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    // WARNING! Some components were not used: ["t", "d"]
+    fn create_proposal_fill_working_group_lead_opening() -> Weight {
+        (999_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_update_working_group_budget(t: u32, d: u32) -> Weight {
+        (420_054_000 as Weight)
+            .saturating_add((5_853_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((76_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t"]
-    fn create_proposal_update_working_group_budget(d: u32) -> Weight {
-        (655_799_000 as Weight)
-            .saturating_add((2_000 as Weight).saturating_mul(d as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    fn create_proposal_decrease_working_group_lead_stake(t: u32, d: u32) -> Weight {
-        (626_011_000 as Weight)
-            .saturating_add((757_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((6_000 as Weight).saturating_mul(d as Weight))
+    fn create_proposal_decrease_working_group_lead_stake(d: u32) -> Weight {
+        (778_605_000 as Weight)
+            .saturating_add((12_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t", "d"]
     fn create_proposal_slash_working_group_lead() -> Weight {
-        (685_880_000 as Weight)
+        (758_609_000 as Weight)
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["d"]
     fn create_proposal_set_working_group_lead_reward(t: u32) -> Weight {
-        (644_706_000 as Weight)
-            .saturating_add((98_000 as Weight).saturating_mul(t as Weight))
+        (641_272_000 as Weight)
+            .saturating_add((53_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["d"]
     fn create_proposal_terminate_working_group_lead(t: u32) -> Weight {
-        (666_916_000 as Weight)
-            .saturating_add((131_000 as Weight).saturating_mul(t as Weight))
+        (628_976_000 as Weight)
+            .saturating_add((1_434_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["d"]
     fn create_proposal_amend_constitution(i: u32, t: u32) -> Weight {
-        (723_614_000 as Weight)
-            .saturating_add((292_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((478_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(10 as Weight))
-    }
-    // WARNING! Some components were not used: ["t", "d"]
-    fn create_proposal_cancel_working_group_lead_opening() -> Weight {
-        (651_882_000 as Weight)
+        (301_477_000 as Weight)
+            .saturating_add((328_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((5_947_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t"]
-    fn create_proposal_set_membership_price(d: u32) -> Weight {
-        (646_017_000 as Weight)
-            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
+    fn create_proposal_cancel_working_group_lead_opening(d: u32) -> Weight {
+        (717_016_000 as Weight)
+            .saturating_add((4_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(10 as Weight))
+    }
+    fn create_proposal_set_membership_price(t: u32, d: u32) -> Weight {
+        (648_039_000 as Weight)
+            .saturating_add((350_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((3_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     fn create_proposal_set_council_budget_increment(t: u32, d: u32) -> Weight {
-        (637_702_000 as Weight)
-            .saturating_add((283_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((2_000 as Weight).saturating_mul(d as Weight))
+        (544_120_000 as Weight)
+            .saturating_add((1_986_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((22_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t"]
     fn create_proposal_set_councilor_reward(d: u32) -> Weight {
-        (650_165_000 as Weight)
-            .saturating_add((1_000 as Weight).saturating_mul(d as Weight))
+        (679_828_000 as Weight)
+            .saturating_add((8_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
-    // WARNING! Some components were not used: ["d"]
-    fn create_proposal_set_initial_invitation_balance(t: u32) -> Weight {
-        (647_828_000 as Weight)
-            .saturating_add((29_000 as Weight).saturating_mul(t as Weight))
+    // WARNING! Some components were not used: ["t"]
+    fn create_proposal_set_initial_invitation_balance(d: u32) -> Weight {
+        (647_942_000 as Weight)
+            .saturating_add((7_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
-    // WARNING! Some components were not used: ["t", "d"]
-    fn create_proposal_set_initial_invitation_count() -> Weight {
-        (652_119_000 as Weight)
+    fn create_proposal_set_initial_invitation_count(t: u32, d: u32) -> Weight {
+        (622_013_000 as Weight)
+            .saturating_add((2_003_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((7_000 as Weight).saturating_mul(d as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     // WARNING! Some components were not used: ["t", "d"]
     fn create_proposal_set_membership_lead_invitation_quota() -> Weight {
-        (1_534_657_000 as Weight)
+        (688_083_000 as Weight)
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
-    fn create_proposal_set_referral_cut(t: u32, d: u32) -> Weight {
-        (538_230_000 as Weight)
-            .saturating_add((2_331_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((26_000 as Weight).saturating_mul(d as Weight))
+    // WARNING! Some components were not used: ["d"]
+    fn create_proposal_set_referral_cut(t: u32) -> Weight {
+        (638_572_000 as Weight)
+            .saturating_add((353_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(10 as Weight))
     }
     fn update_working_group_budget_positive_forum() -> Weight {
-        (186_049_000 as Weight)
+        (101_370_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_working_group_budget_negative_forum() -> Weight {
-        (186_498_000 as Weight)
+        (101_227_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_working_group_budget_positive_storage() -> Weight {
-        (185_745_000 as Weight)
+        (101_047_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_working_group_budget_negative_storage() -> Weight {
-        (185_138_000 as Weight)
+        (101_188_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_working_group_budget_positive_content() -> Weight {
-        (186_835_000 as Weight)
+        (101_790_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_working_group_budget_negative_content() -> Weight {
-        (186_768_000 as Weight)
+        (101_742_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_working_group_budget_positive_membership() -> Weight {
-        (186_077_000 as Weight)
+        (100_238_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_working_group_budget_negative_membership() -> Weight {
-        (186_014_000 as Weight)
-            .saturating_add(DbWeight::get().reads(2 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
-    }
-    fn funding_request() -> Weight {
-        (296_081_000 as Weight)
+        (100_460_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }

--- a/scripts/generate-weights.sh
+++ b/scripts/generate-weights.sh
@@ -47,6 +47,7 @@ benchmark pallet_session
 # Joystrem benchmarks
 benchmark proposals_discussion
 benchmark proposals_engine
+benchmark proposals_codex
 benchmark pallet_constitution
 benchmark working_group
 benchmark council

--- a/scripts/run-proposal-configuration-tests.sh
+++ b/scripts/run-proposal-configuration-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+
+ALL_PROPOSALS_PARAMETERS_JSON=`cat runtime/src/proposals_configuration/sample_proposal_parameters.json` cargo test proposals_configuration::tests -- --ignored
+


### PR DESCRIPTION
# This PR addresses #1748 and #1864

In this PR I did the following things:
* For existing proposals updated the names to closely match those in the handbook
  * Text -> Signal
  * Spending -> Funding Request
  * Set Validator Count -> Set Max Validator Count
  * Add Working Group Leader Opening -> Create Working Group Lead Opening
  * Fill Working Group Leader Opening -> Fill Working Group Lead Opening
  * Set Working Group Budget Capacity ->  Update Working Group Budget
  * Decrease Working Group Leader Stake -> Decrease Working Group Lead Stake
  * Slash Working Group Leader Stake -> Slash Working Group Lead
  * Set Working Group Leader Reward -> Set Working Group Lead Reward
  * Terminate Working Group Leader Role -> Terminate Working Group Lead
* Removed old proposals no longer in the handbook
* Added new proposals:
  * Cancel Working Group Lead Opening
  * Set Membership Price
  * Set Council Budget Increment
  * Set Councilor Reward
  * Set Initial Invitation Balance
  * Set Initial Invitation Count
  * Set Membership Lead Invitation Quota
  * Set Referral Cut
  * **Note:** _Update Budget Request_ and _Funding Request_ changed significantly
* Needed to change the `Balance` type in `Council` to the `Balance` in the `balances` pallet to be able to update the budget of `WorkingGroup` with the budget from `Council`
* Updated `councilor_reward` and `budget_incrment` to be part of the storage as to be able to be updated with `Set Council Budget Increment` and `Set Councilor Reward`

### Also, I have a couple of open questions:
* In [`Set Max Validator Count`](https://joystream.gitbook.io/joystream-handbook/governance/proposals#set-max-validator-count) we use `<staking::Module<T>>::minimum_validator_count()` instead of `MIN_VALIDATOR_COUNT`. Is this okay?


### [Handbook companion PR](https://github.com/Joystream/handbook/pull/27)