### PR TITLE
Weight to fee function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,7 +1407,7 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "serde",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "sp-arithmetic",
  "sp-core",
  "sp-inherents",
@@ -2383,6 +2383,7 @@ dependencies = [
  "pallet-working-group",
  "parity-scale-codec",
  "serde",
+ "smallvec 1.6.0",
  "sp-api",
  "sp-application-crypto",
  "sp-arithmetic",
@@ -2565,7 +2566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0315ef2f688e33844400b31f11c263f2b3dc21d8b9355c6891c5f185fae43f9a"
 dependencies = [
  "parity-util-mem",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
 ]
 
 [[package]]
@@ -2594,7 +2595,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "regex",
  "rocksdb",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
 ]
 
 [[package]]
@@ -2686,7 +2687,7 @@ dependencies = [
  "parity-multiaddr",
  "parking_lot 0.10.2",
  "pin-project 0.4.27",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "wasm-timer",
 ]
 
@@ -2717,7 +2718,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2 0.8.2",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "thiserror",
  "unsigned-varint 0.4.0",
  "void",
@@ -2770,7 +2771,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
 ]
 
 [[package]]
@@ -2794,7 +2795,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "unsigned-varint 0.4.0",
  "wasm-timer",
 ]
@@ -2811,7 +2812,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "wasm-timer",
 ]
 
@@ -2835,7 +2836,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "uint",
  "unsigned-varint 0.4.0",
  "void",
@@ -2859,7 +2860,7 @@ dependencies = [
  "log",
  "net2",
  "rand 0.7.3",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "void",
  "wasm-timer",
 ]
@@ -2964,7 +2965,7 @@ dependencies = [
  "lru 0.6.1",
  "minicbor",
  "rand 0.7.3",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "unsigned-varint 0.5.1",
  "wasm-timer",
 ]
@@ -2980,7 +2981,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "rand 0.7.3",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "void",
  "wasm-timer",
 ]
@@ -3446,7 +3447,7 @@ dependencies = [
  "futures 0.3.8",
  "log",
  "pin-project 1.0.2",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "unsigned-varint 0.5.1",
 ]
 
@@ -4230,7 +4231,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "serde",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -4399,7 +4400,7 @@ dependencies = [
  "parity-util-mem-derive",
  "parking_lot 0.10.2",
  "primitive-types",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "winapi 0.3.9",
 ]
 
@@ -4524,7 +4525,7 @@ dependencies = [
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "winapi 0.3.9",
 ]
 
@@ -4539,7 +4540,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "winapi 0.3.9",
 ]
 
@@ -6543,9 +6544,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
 
 [[package]]
 name = "snow"
@@ -7088,7 +7089,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "rand 0.7.3",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
@@ -8040,7 +8041,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -8058,7 +8059,7 @@ dependencies = [
  "hashbrown 0.8.2",
  "log",
  "rustc-hex",
- "smallvec 1.5.0",
+ "smallvec 1.6.0",
 ]
 
 [[package]]

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -428,7 +428,11 @@ decl_module! {
         /// - DB:
         ///    - O(1) doesn't depend on the state or parameters
         /// # </weight>
-        #[weight = Module::<T>::get_create_proposal_weight(&general_proposal_parameters, &proposal_details)]
+        #[weight = Module::<T>::get_create_proposal_weight(
+                &general_proposal_parameters,
+                &proposal_details
+            )
+        ]
         pub fn create_proposal(
             origin,
             general_proposal_parameters: GeneralProposalParameters<T>,
@@ -525,6 +529,13 @@ decl_module! {
         }
 
         /// Update working group budget
+        /// <weight>
+        ///
+        /// ## Weight
+        /// `O (1)` Doesn't depend on the state or parameters
+        /// - DB:
+        ///    - O(1) doesn't depend on the state or parameters
+        /// # </weight>
         #[weight = Module::<T>::get_update_working_group_budget_weight(&working_group, &balance_kind)]
         pub fn update_working_group_budget(
             origin,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 lazy_static = {version = "1.4.0", features = ["spin_no_std"] }
 lite-json = { version = '0.1.3', default-features = false}
 codec = { package = 'parity-scale-codec', version = '1.3.4', default-features = false, features = ['derive'] }
+smallvec = "1.6.0"
 
 # Substrate primitives
 sp-std = { package = 'sp-std', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -200,24 +200,40 @@ pub mod currency {
 
 #[cfg(test)]
 mod tests {
-    use super::currency::CENTS;
+    use super::currency::{CENTS, DOLLARS};
     use super::fees::WeightToFee;
+    use crate::{ExtrinsicBaseWeight, MaximumBlockWeight};
     use frame_support::weights::WeightToFeePolynomial;
     use pallet_balances::WeightInfo;
 
-    /*
-     * TODO: Add a test for the maximum weight
-     */
-
     #[test]
     // This function tests that the fee for `pallet_balances::transfer` of weight is correct
-    fn extrinsic_base_fee_is_correct() {
-        // Transfer fee should be less than half a cent and should be non-zero (Initially ~30)
+    fn extrinsic_transfer_fee_is_correct() {
+        // Transfer fee should be less than 100 tokens and should be non-zero (Initially ~30)
         let transfer_weight = crate::weights::pallet_balances::WeightInfo::transfer();
         println!("Transfer weight: {}", transfer_weight);
         let transfer_fee = WeightToFee::calc(&transfer_weight);
         println!("Transfer fee: {}", transfer_fee);
-        let expected_fee = CENTS / 2; // 100
-        assert!(0 < transfer_fee && transfer_fee < expected_fee);
+        assert!(0 < transfer_fee && transfer_fee < 100);
+    }
+
+    #[test]
+    // This function tests that the fee for `MAXIMUM_BLOCK_WEIGHT` of weight is correct
+    fn full_block_fee_is_correct() {
+        // A full block should cost 16 DOLLARS
+        println!("Base: {}", ExtrinsicBaseWeight::get());
+        let x = WeightToFee::calc(&MaximumBlockWeight::get());
+        let y = 16 * DOLLARS;
+        assert!(x.max(y) - x.min(y) < 1);
+    }
+
+    #[test]
+    // This function tests that the fee for `ExtrinsicBaseWeight` of weight is correct
+    fn extrinsic_base_fee_is_correct() {
+        // `ExtrinsicBaseWeight` should cost 1/10 of a CENT
+        println!("Base: {}", ExtrinsicBaseWeight::get());
+        let x = WeightToFee::calc(&ExtrinsicBaseWeight::get());
+        let y = CENTS / 10;
+        assert!(x.max(y) - x.min(y) < 1);
     }
 }

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -189,12 +189,35 @@ lazy_static! {
 pub mod currency {
     use super::Balance;
 
-    pub const DOTS: Balance = 1_000_000_000_000;
-    pub const DOLLARS: Balance = DOTS;
-    pub const CENTS: Balance = DOLLARS / 100;
-    pub const MILLICENTS: Balance = CENTS / 1_000;
+    pub const JOYS: Balance = 250_000_000;
+    pub const DOLLARS: Balance = JOYS / 12500; // 20_000
+    pub const CENTS: Balance = DOLLARS / 100; // 200
 
     pub const fn deposit(items: u32, bytes: u32) -> Balance {
         items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::currency::CENTS;
+    use super::fees::WeightToFee;
+    use frame_support::weights::WeightToFeePolynomial;
+    use pallet_balances::WeightInfo;
+
+    /*
+     * TODO: Add a test for the maximum weight
+     */
+
+    #[test]
+    // This function tests that the fee for `pallet_balances::transfer` of weight is correct
+    fn extrinsic_base_fee_is_correct() {
+        // Transfer fee should be less than half a cent and should be non-zero (Initially ~30)
+        let transfer_weight = crate::weights::pallet_balances::WeightInfo::transfer();
+        println!("Transfer weight: {}", transfer_weight);
+        let transfer_fee = WeightToFee::calc(&transfer_weight);
+        println!("Transfer fee: {}", transfer_fee);
+        let expected_fee = CENTS / 2; // 100
+        assert!(0 < transfer_fee && transfer_fee < expected_fee);
     }
 }

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -1,3 +1,4 @@
+use super::Balance;
 use crate::{BlockNumber, Moment};
 use frame_support::parameter_types;
 use frame_support::traits::LockIdentifier;
@@ -37,6 +38,68 @@ pub const DAYS: BlockNumber = HOURS * 24;
 
 // 1 in 4 blocks (on average, not counting collisions) will be primary babe blocks.
 pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);
+
+/// This module is based on https://w3f-research.readthedocs.io/en/latest/polkadot/economics/1-token-economics.html#relay-chain-transaction-fees-and-per-block-transaction-limits
+/// It was copied from Polkadot's implementation
+pub mod fees {
+    use super::{parameter_types, Balance};
+    use frame_support::weights::constants::ExtrinsicBaseWeight;
+    use frame_support::weights::{
+        WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
+    };
+    use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
+    use smallvec::smallvec;
+    use sp_runtime::FixedPointNumber;
+    pub use sp_runtime::Perbill;
+    use sp_runtime::Perquintill;
+
+    parameter_types! {
+        /// The portion of the `NORMAL_DISPATCH_RATIO` that we adjust the fees with. Blocks filled less
+        /// than this will decrease the weight and more will increase.
+        pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
+        /// The adjustment variable of the runtime. Higher values will cause `TargetBlockFullness` to
+        /// change the fees more rapidly.
+        pub AdjustmentVariable: Multiplier = Multiplier::saturating_from_rational(3, 100_000);
+        /// Minimum amount of the multiplier. This value cannot be too low. A test case should ensure
+        /// that combined with `AdjustmentVariable`, we can recover from the minimum.
+        /// See `multiplier_can_grow_from_zero`.
+        pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_000u128);
+    }
+
+    /// Parameterized slow adjusting fee updated based on
+    /// https://w3f-research.readthedocs.io/en/latest/polkadot/economics/1-token-economics.html#-2.-slow-adjusting-mechanism
+    pub type SlowAdjustingFeeUpdate<R> =
+        TargetedFeeAdjustment<R, TargetBlockFullness, AdjustmentVariable, MinimumMultiplier>;
+
+    /// The block saturation level. Fees will be updates based on this value.
+    pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
+
+    /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
+    /// node's balance type.
+    ///
+    /// This should typically create a mapping between the following ranges:
+    ///   - [0, MAXIMUM_BLOCK_WEIGHT]
+    ///   - [Balance::min, Balance::max]
+    ///
+    /// Yet, it can be used for any other sort of change to weight-fee. Some examples being:
+    ///   - Setting it to `0` will essentially disable the weight fee.
+    ///   - Setting it to `1` will cause the literal `#[weight = x]` values to be charged.
+    pub struct WeightToFee;
+    impl WeightToFeePolynomial for WeightToFee {
+        type Balance = Balance;
+        fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+            // in Polkadot, extrinsic base weight (smallest non-zero weight) is mapped to 1/10 CENT:
+            let p = super::currency::CENTS;
+            let q = 10 * Balance::from(ExtrinsicBaseWeight::get());
+            smallvec![WeightToFeeCoefficient {
+                degree: 1,
+                negative: false,
+                coeff_frac: Perbill::from_rational_approximation(p % q, q),
+                coeff_integer: p / q,
+            }]
+        }
+    }
+}
 
 parameter_types! {
     pub const VotingLockId: LockIdentifier = [0; 8];
@@ -123,14 +186,13 @@ lazy_static! {
     });
 }
 
-/// Tests only
-#[cfg(any(feature = "std", test))]
 pub mod currency {
-    use crate::primitives::Balance;
+    use super::Balance;
 
-    pub const MILLICENTS: Balance = 1_000_000_000;
-    pub const CENTS: Balance = 1_000 * MILLICENTS; // assume this is worth about a cent.
-    pub const DOLLARS: Balance = 100 * CENTS;
+    pub const DOTS: Balance = 1_000_000_000_000;
+    pub const DOLLARS: Balance = DOTS;
+    pub const CENTS: Balance = DOLLARS / 100;
+    pub const MILLICENTS: Balance = CENTS / 1_000;
 
     pub const fn deposit(items: u32, bytes: u32) -> Balance {
         items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS

--- a/runtime/src/integration/transactions.rs
+++ b/runtime/src/integration/transactions.rs
@@ -1,26 +1,11 @@
 use codec::Encode;
 use frame_support::debug;
-use frame_support::weights::{WeightToFeeCoefficients, WeightToFeePolynomial};
 use sp_runtime::generic;
 use sp_runtime::generic::SignedPayload;
 use sp_runtime::SaturatedConversion;
 
-use crate::{AccountId, Balance, BlockHashCount, Index, SignedExtra, UncheckedExtrinsic};
+use crate::{AccountId, BlockHashCount, Index, SignedExtra, UncheckedExtrinsic};
 use crate::{Call, Runtime, System};
-
-/// Stub for zero transaction weights.
-pub struct NoWeights;
-impl WeightToFeePolynomial for NoWeights {
-    type Balance = Balance;
-
-    fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-        Default::default()
-    }
-
-    fn calc(_weight: &u64) -> Self::Balance {
-        Default::default()
-    }
-}
 
 /// 'Create transaction' default implementation.
 pub(crate) fn create_transaction<

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -261,15 +261,19 @@ impl pallet_balances::Trait for Runtime {
 }
 
 parameter_types! {
-    pub const TransactionByteFee: Balance = 0; // TODO: adjust fee
+    pub const TransactionByteFee: Balance = 10 * constants::currency::MILLICENTS;
 }
 
 impl pallet_transaction_payment::Trait for Runtime {
     type Currency = Balances;
+    // TODO: Implement a function that sends %80 of fee to treasury and %20 to author
+    // and %100 of the tip to author.
+    // See: https://w3f-research.readthedocs.io/en/latest/polkadot/economics/1-token-economics.html#setting-transaction-fees
+    // and https://w3f-research.readthedocs.io/en/latest/polkadot/economics/1-token-economics.html#-2.-slow-adjusting-mechanism
     type OnTransactionPayment = ();
     type TransactionByteFee = TransactionByteFee;
-    type WeightToFee = integration::transactions::NoWeights; // TODO: adjust weight
-    type FeeMultiplierUpdate = (); // TODO: adjust fee
+    type WeightToFee = constants::fees::WeightToFee;
+    type FeeMultiplierUpdate = constants::fees::SlowAdjustingFeeUpdate<Self>;
 }
 
 impl pallet_sudo::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -263,7 +263,7 @@ impl pallet_balances::Trait for Runtime {
 }
 
 parameter_types! {
-    pub const TransactionByteFee: Balance = 10 * constants::currency::MILLICENTS;
+    pub const TransactionByteFee: Balance = 1;
 }
 
 type NegativeImbalance = <Balances as Currency<AccountId>>::NegativeImbalance;

--- a/runtime/src/tests/fee_tests.rs
+++ b/runtime/src/tests/fee_tests.rs
@@ -1,0 +1,28 @@
+use super::initial_test_ext;
+use crate::constants::currency::{CENTS, DOLLARS};
+use crate::MaximumBlockWeight;
+use crate::Runtime;
+use frame_support::weights::WeightToFeePolynomial;
+use pallet_balances::WeightInfo;
+use pallet_transaction_payment::Module as TransactionPayment;
+
+#[test]
+// This test that the fee for an standard runtime upgrade is as we expect if it pays fee
+// Note: we expect an average runtime upgrade to have a length of ~3MB
+fn runtime_upgrade_total_fee_is_correct() {
+    // We expect the total fee to be 16 DOLLARS(maximum block weight) + 15 DOLLARS from
+    // byte fee + 1/10 CENT from base weight fee
+    initial_test_ext().execute_with(|| {
+        let dispatch_info = frame_support::weights::DispatchInfo {
+            weight: MaximumBlockWeight::get(),
+            class: frame_support::weights::DispatchClass::Operational,
+            pays_fee: frame_support::weights::Pays::Yes,
+        };
+        let x = TransactionPayment::<Runtime>::compute_fee(3_000_000, &dispatch_info, 0);
+        let weight_fee = 16 * DOLLARS; // MaximumBlockWeight fee
+        let length_fee = 3 * 50 * DOLLARS; // 50 * DOLLARS = 1M
+        let base_weight_fee = CENTS / 10;
+        let y = weight_fee + length_fee + base_weight_fee;
+        assert_eq!(x.max(y) - x.min(y), 0);
+    });
+}

--- a/runtime/src/tests/fee_tests.rs
+++ b/runtime/src/tests/fee_tests.rs
@@ -2,8 +2,6 @@ use super::initial_test_ext;
 use crate::constants::currency::{CENTS, DOLLARS};
 use crate::MaximumBlockWeight;
 use crate::Runtime;
-use frame_support::weights::WeightToFeePolynomial;
-use pallet_balances::WeightInfo;
 use pallet_transaction_payment::Module as TransactionPayment;
 
 #[test]

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -4,6 +4,7 @@
 #[macro_use]
 
 mod proposals_integration;
+mod fee_tests;
 mod storage_integration;
 
 use crate::{BlockNumber, ReferendumInstance, Runtime};


### PR DESCRIPTION
# Adressing #1867

This PR adds the parameters for `pallet_transaction_payment`

This includes: 
* `TransactionByteFee`: is 1, since it's the minimum non-zero we can use.
* `WeightToFee`: The value here is also the same as in [Polkadot](https://github.com/paritytech/polkadot/blob/v0.8.26/runtime/polkadot/src/constants.rs#L70)
* `FeeMultiplierUpdate`: The value here is also the same as in [Polkadot](https://github.com/paritytech/polkadot/blob/v0.8.26/runtime/common/src/lib.rs#L85)

These values for the multiplier update function are based on [this document](https://w3f-research.readthedocs.io/en/latest/polkadot/economics/1-token-economics.html#relay-chain-transaction-fees-and-per-block-transaction-limits).

The value for `JOYS` is set to the total number of tokens in the runtime.

To decide on the constants for `WeightToFee` we set the target value of a `transfer` on 20. But to have more rounded values we set DOLLARS on `JOYS / 12500`. This gives us a `transfer` value of 30, having the advantage of keeping the same `WeightToFee` function as Polkadot, this doesn't matter since thanks to `FeeMultiplierUpdate` the value will evolve to have the optimal value to have %25 average block saturation. 

Also, the value for `TransactionByteFee` makes the cost for creating a Runtime Upgrade proposal at least 3M JOYS if we assume an average of 3MB for the length of a Runtime Upgrade and the cost for executing it 6M JOYS(3M for the length and 3M for the block weight), this might seem high, but we will settle with this until we can upgrade the runtime to have more decimal places for the JOYS which would allow us to have a byte fee less than 1.