### PR TITLE
Council and referendum move finalize to initialize and add weights

### DIFF
--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -882,6 +882,7 @@ impl<T: Trait> Module<T> {
     }
 
     fn calculate_on_initialize_weight(mb_candidate_count: Option<u64>) -> Weight {
+        // Minimum weight for progress stage
         let weight = T::WeightInfo::try_progress_stage_idle()
             .max(T::WeightInfo::try_progress_stage_announcing_restart());
 

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -132,7 +132,7 @@ impl WeightInfo for () {
     fn try_progress_stage_idle() -> Weight {
         0
     }
-    fn try_progress_stage_announcing_start_election() -> Weight {
+    fn try_progress_stage_announcing_start_election(_: u32) -> Weight {
         0
     }
     fn try_progress_stage_announcing_restart() -> Weight {
@@ -325,10 +325,10 @@ impl referendum::Trait<ReferendumInstance> for Runtime {
 
 pub struct ReferendumWeightInfo;
 impl referendum::WeightInfo for ReferendumWeightInfo {
-    fn on_finalize_revealing(_: u32) -> Weight {
+    fn on_initialize_revealing(_: u32) -> Weight {
         0
     }
-    fn on_finalize_voting() -> Weight {
+    fn on_initialize_voting() -> Weight {
         0
     }
     fn vote() -> Weight {

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1108,10 +1108,12 @@ fn council_budget_refill_can_be_planned() {
 
         Mocks::plan_budget_refill(origin.clone(), next_refill, Ok(()));
 
-        assert_eq!(frame_system::Module::<Runtime>::block_number(), 1);
+        let current_block = frame_system::Module::<Runtime>::block_number();
+
+        assert_eq!(current_block, 1);
 
         // forward to one block before refill
-        MockUtils::increase_block_number(next_refill - 2);
+        MockUtils::increase_block_number(next_refill - current_block - 1);
 
         assert_eq!(
             frame_system::Module::<Runtime>::block_number(),

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -357,7 +357,7 @@ fn council_announcement_reset_on_not_enough_winners() {
         Mocks::simulate_council_cycle(params.clone());
 
         // forward to finish election / start idle period
-        MockUtils::increase_block_number(council_settings.reveal_stage_duration + 1);
+        MockUtils::increase_block_number(council_settings.reveal_stage_duration);
 
         // check announcements were reset
         Mocks::check_announcing_period(
@@ -399,21 +399,21 @@ fn council_two_consecutive_rounds() {
             (
                 candidates[3].candidate.clone(),
                 candidates[3].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[0].candidate.clone(),
                 candidates[0].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[1].candidate.clone(),
                 candidates[1].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
@@ -463,21 +463,21 @@ fn council_two_consecutive_rounds() {
             (
                 candidates[3].candidate.clone(),
                 candidates[3].membership_id,
-                council_settings.cycle_duration + council_settings.election_duration - 1,
+                council_settings.cycle_duration + council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[1].candidate.clone(),
                 candidates[1].membership_id,
-                council_settings.cycle_duration + council_settings.election_duration - 1,
+                council_settings.cycle_duration + council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[2].candidate.clone(),
                 candidates[2].membership_id,
-                council_settings.cycle_duration + council_settings.election_duration - 1,
+                council_settings.cycle_duration + council_settings.election_duration,
                 0,
             )
                 .into(),
@@ -590,21 +590,21 @@ fn council_candidate_stake_can_be_unlocked() {
             (
                 candidates[3].candidate.clone(),
                 candidates[3].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[0].candidate.clone(),
                 candidates[0].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[1].candidate.clone(),
                 candidates[1].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
@@ -698,21 +698,21 @@ fn council_candidate_stake_automaticly_converted() {
             (
                 candidates[3].candidate.clone(),
                 candidates[3].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[0].candidate.clone(),
                 candidates[0].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[1].candidate.clone(),
                 candidates[1].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
@@ -789,21 +789,21 @@ fn council_member_stake_is_locked() {
             (
                 candidates[3].candidate.clone(),
                 candidates[3].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[0].candidate.clone(),
                 candidates[0].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[1].candidate.clone(),
                 candidates[1].membership_id,
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
                 0,
             )
                 .into(),
@@ -884,21 +884,21 @@ fn council_member_stake_automaticly_unlocked() {
             (
                 candidates[3].candidate.clone(),
                 candidates[3].membership_id,
-                council_settings.cycle_duration + council_settings.election_duration - 1,
+                council_settings.cycle_duration + council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[1].candidate.clone(),
                 candidates[1].membership_id,
-                council_settings.cycle_duration + council_settings.election_duration - 1,
+                council_settings.cycle_duration + council_settings.election_duration,
                 0,
             )
                 .into(),
             (
                 candidates[2].candidate.clone(),
                 candidates[2].membership_id,
-                council_settings.cycle_duration + council_settings.election_duration - 1,
+                council_settings.cycle_duration + council_settings.election_duration,
                 0,
             )
                 .into(),
@@ -1108,14 +1108,23 @@ fn council_budget_refill_can_be_planned() {
 
         Mocks::plan_budget_refill(origin.clone(), next_refill, Ok(()));
 
+        assert_eq!(frame_system::Module::<Runtime>::block_number(), 1);
+
         // forward to one block before refill
-        MockUtils::increase_block_number(next_refill - 1);
+        MockUtils::increase_block_number(next_refill - 2);
+
+        assert_eq!(
+            frame_system::Module::<Runtime>::block_number(),
+            next_refill - 1
+        );
 
         // check no refill happened yet
         Mocks::check_budget_refill(0, next_refill);
 
         // forward to after block refill
         MockUtils::increase_block_number(1);
+
+        assert_eq!(frame_system::Module::<Runtime>::block_number(), next_refill);
 
         // check budget was increased
         Mocks::check_budget_refill(
@@ -1142,11 +1151,11 @@ fn council_rewards_are_paid() {
         let params = Mocks::run_full_council_cycle(0, &[], 0);
 
         // calculate council member last reward block
+        // the duration of the complete cycle minus the part of the idle cycle where there was
+        // no time to pay out the the reward
         let last_payment_block = council_settings.cycle_duration
-            + (<Runtime as Trait>::ElectedMemberRewardPeriod::get()
-                - (council_settings.idle_stage_duration
-                    % <Runtime as Trait>::ElectedMemberRewardPeriod::get()))
-            - 1; // -1 because current block is not finalized yet
+            - (council_settings.idle_stage_duration
+                % <Runtime as Trait>::ElectedMemberRewardPeriod::get());
         let tmp_council_members: Vec<CouncilMemberOf<Runtime>> = params
             .expected_final_council_members
             .iter()
@@ -1188,10 +1197,8 @@ fn council_missed_rewards_are_paid_later() {
         MockUtils::increase_block_number(<Runtime as Trait>::ElectedMemberRewardPeriod::get());
 
         let last_payment_block = council_settings.cycle_duration
-            + (reward_period
-                - (council_settings.idle_stage_duration
-                    % <Runtime as Trait>::ElectedMemberRewardPeriod::get()))
-            - 1; // -1 because current block is not finalized yet
+            - (council_settings.idle_stage_duration
+                % <Runtime as Trait>::ElectedMemberRewardPeriod::get());
 
         // check unpaid rewards were discarded
         for council_member in CouncilMembers::<Runtime>::get() {
@@ -1199,8 +1206,7 @@ fn council_missed_rewards_are_paid_later() {
             assert_eq!(
                 council_member.last_payment_block,
                 //last_payment_block + reward_period,
-                // -1 because council was elected (last_payment_block set) in on_finalize
-                council_settings.election_duration - 1,
+                council_settings.election_duration,
             );
         }
 
@@ -1239,11 +1245,11 @@ fn council_discard_remaining_rewards_on_depose() {
         let params = Mocks::run_full_council_cycle(0, &[], 0);
 
         // calculate council member last reward block
+        // the duration of the complete cycle minus the part of the idle cycle where there was
+        // no time to pay out the the reward
         let last_payment_block = council_settings.cycle_duration
-            + (<Runtime as Trait>::ElectedMemberRewardPeriod::get()
-                - (council_settings.idle_stage_duration
-                    % <Runtime as Trait>::ElectedMemberRewardPeriod::get()))
-            - 1; // -1 because current block is not finalized yet
+            - (council_settings.idle_stage_duration
+                % <Runtime as Trait>::ElectedMemberRewardPeriod::get());
         let tmp_council_members: Vec<CouncilMemberOf<Runtime>> = params
             .expected_final_council_members
             .iter()
@@ -1282,7 +1288,12 @@ fn council_budget_auto_refill() {
         let start_balance = Budget::<Runtime>::get();
 
         // forward before next refill
-        MockUtils::increase_block_number(council_settings.budget_refill_period - 1);
+        // Note: initial block is 1 so current_block + budget_refill_period - 2 = budget_refill_period - 1
+        MockUtils::increase_block_number(council_settings.budget_refill_period - 2);
+        assert_eq!(
+            frame_system::Module::<Runtime>::block_number(),
+            council_settings.budget_refill_period - 1
+        );
 
         assert_eq!(Budget::<Runtime>::get(), start_balance,);
 

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -483,7 +483,7 @@ impl council::WeightInfo for CouncilWeightInfo {
     fn try_progress_stage_idle() -> Weight {
         0
     }
-    fn try_progress_stage_announcing_start_election() -> Weight {
+    fn try_progress_stage_announcing_start_election(_: u32) -> Weight {
         0
     }
     fn try_progress_stage_announcing_restart() -> Weight {
@@ -586,10 +586,10 @@ impl referendum::Trait<ReferendumInstance> for Test {
 
 pub struct ReferendumWeightInfo;
 impl referendum::WeightInfo for ReferendumWeightInfo {
-    fn on_finalize_revealing(_: u32) -> Weight {
+    fn on_initialize_revealing(_: u32) -> Weight {
         0
     }
-    fn on_finalize_voting() -> Weight {
+    fn on_initialize_voting() -> Weight {
         0
     }
     fn vote() -> Weight {

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -132,10 +132,10 @@ impl referendum::Trait<ReferendumInstance> for Test {
 
 pub struct ReferendumWeightInfo;
 impl referendum::WeightInfo for ReferendumWeightInfo {
-    fn on_finalize_revealing(_: u32) -> Weight {
+    fn on_initialize_revealing(_: u32) -> Weight {
         0
     }
-    fn on_finalize_voting() -> Weight {
+    fn on_initialize_voting() -> Weight {
         0
     }
     fn vote() -> Weight {
@@ -402,7 +402,7 @@ impl council::WeightInfo for CouncilWeightInfo {
     fn try_progress_stage_idle() -> Weight {
         0
     }
-    fn try_progress_stage_announcing_start_election() -> Weight {
+    fn try_progress_stage_announcing_start_election(_: u32) -> Weight {
         0
     }
     fn try_progress_stage_announcing_restart() -> Weight {

--- a/runtime-modules/referendum/src/lib.rs
+++ b/runtime-modules/referendum/src/lib.rs
@@ -381,7 +381,7 @@ decl_module! {
         /////////////////// Lifetime ///////////////////////////////////////////
 
         // No origin so this is a priviledged call
-        fn on_initialize() -> Weight{
+        fn on_initialize() -> Weight {
             Self::try_progress_stage(frame_system::Module::<T>::block_number());
 
             T::WeightInfo::on_initialize_voting()

--- a/runtime-modules/referendum/src/lib.rs
+++ b/runtime-modules/referendum/src/lib.rs
@@ -150,8 +150,8 @@ pub type CanRevealResult<T, I> = (
 /// referendum WeightInfo
 /// Note: This was auto generated through the benchmark CLI using the `--weight-trait` flag
 pub trait WeightInfo {
-    fn on_finalize_revealing(i: u32) -> Weight;
-    fn on_finalize_voting() -> Weight;
+    fn on_initialize_revealing(i: u32) -> Weight;
+    fn on_initialize_voting() -> Weight;
     fn vote() -> Weight;
     fn reveal_vote_space_for_new_winner(i: u32) -> Weight;
     fn reveal_vote_space_not_in_winners(i: u32) -> Weight;
@@ -384,7 +384,8 @@ decl_module! {
         fn on_initialize() -> Weight{
             Self::try_progress_stage(frame_system::Module::<T>::block_number());
 
-            1_000_000 // TODO: Replace
+            T::WeightInfo::on_initialize_voting()
+                .max(T::WeightInfo::on_initialize_revealing(MAX_WINNERS))
         }
 
         /////////////////// User actions ///////////////////////////////////////

--- a/runtime-modules/referendum/src/lib.rs
+++ b/runtime-modules/referendum/src/lib.rs
@@ -381,8 +381,10 @@ decl_module! {
         /////////////////// Lifetime ///////////////////////////////////////////
 
         // No origin so this is a priviledged call
-        fn on_finalize(now: T::BlockNumber) {
-            Self::try_progress_stage(now);
+        fn on_initialize() -> Weight{
+            Self::try_progress_stage(frame_system::Module::<T>::block_number());
+
+            1_000_000 // TODO: Replace
         }
 
         /////////////////// User actions ///////////////////////////////////////
@@ -493,12 +495,12 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
         match Stage::<T, I>::get() {
             ReferendumStage::Inactive => (),
             ReferendumStage::Voting(stage_data) => {
-                if now == stage_data.started + T::VoteStageDuration::get() - 1.into() {
+                if now == stage_data.started + T::VoteStageDuration::get() {
                     Self::end_voting_period(stage_data);
                 }
             }
             ReferendumStage::Revealing(stage_data) => {
-                if now == stage_data.started + T::RevealStageDuration::get() - 1.into() {
+                if now == stage_data.started + T::RevealStageDuration::get() {
                     Self::end_reveal_period(stage_data);
                 }
             }
@@ -611,7 +613,7 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
         Stage::<T, I>::put(ReferendumStage::Voting(ReferendumStageVoting::<
             T::BlockNumber,
         > {
-            started: <frame_system::Module<T>>::block_number() + 1.into(),
+            started: <frame_system::Module<T>>::block_number(),
             winning_target_count: *winning_target_count,
             current_cycle_id: *cycle_id,
         }));
@@ -624,7 +626,7 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
             T,
             I,
         > {
-            started: <frame_system::Module<T>>::block_number() + 1.into(),
+            started: <frame_system::Module<T>>::block_number(),
             winning_target_count: old_stage.winning_target_count,
             intermediate_winners: vec![],
             current_cycle_id: old_stage.current_cycle_id,

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -10,7 +10,7 @@ use crate::{
 pub use crate::DefaultInstance;
 
 use frame_support::dispatch::DispatchResult;
-use frame_support::traits::{Currency, LockIdentifier, OnFinalize};
+use frame_support::traits::{Currency, LockIdentifier, OnFinalize, OnInitialize};
 use frame_support::weights::Weight;
 use frame_support::{
     impl_outer_event, impl_outer_origin, parameter_types, StorageMap, StorageValue,
@@ -19,6 +19,7 @@ use frame_system::{EnsureOneOf, EnsureRoot, EnsureSigned, RawOrigin};
 use pallet_balances;
 use rand::Rng;
 use sp_core::H256;
+use sp_runtime::traits::One;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
@@ -388,13 +389,23 @@ where
     }
 
     pub fn increase_block_number(increase: u64) -> () {
-        let block_number = frame_system::Module::<T>::block_number();
+        let mut block_number = frame_system::Module::<T>::block_number();
 
-        for i in 0..increase {
-            let tmp_index: T::BlockNumber = block_number + i.into();
+        for _ in 0..increase {
+            <frame_system::Module<T> as OnFinalize<T::BlockNumber>>::on_finalize(block_number);
+            <Module<T, I> as OnFinalize<T::BlockNumber>>::on_finalize(block_number);
+            block_number = block_number + One::one();
+            frame_system::Module::<T>::set_block_number(block_number);
+            <frame_system::Module<T> as OnInitialize<T::BlockNumber>>::on_initialize(block_number);
+            <Module<T, I> as OnInitialize<T::BlockNumber>>::on_initialize(block_number);
+        }
+    }
 
-            <Module<T, I> as OnFinalize<T::BlockNumber>>::on_finalize(tmp_index);
-            frame_system::Module::<T>::set_block_number(tmp_index + 1.into());
+    pub fn move_to_block(block_number: T::BlockNumber) {
+        let mut current_block = frame_system::Module::<T>::block_number();
+        while current_block < block_number {
+            Self::increase_block_number(1);
+            current_block = frame_system::Module::<T>::block_number();
         }
     }
 
@@ -529,7 +540,7 @@ impl InstanceMocks<Runtime, DefaultInstance> {
         assert_eq!(
             Stage::<Runtime, DefaultInstance>::get(),
             ReferendumStage::Voting(ReferendumStageVoting {
-                started: block_number + 1, // actual voting starts in the next block (thats why +1)
+                started: block_number,
                 winning_target_count,
                 current_cycle_id: cycle_id,
             }),

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -134,10 +134,10 @@ impl Trait for Runtime {
 }
 
 impl WeightInfo for () {
-    fn on_finalize_revealing(_: u32) -> Weight {
+    fn on_initialize_revealing(_: u32) -> Weight {
         0
     }
-    fn on_finalize_voting() -> Weight {
+    fn on_initialize_voting() -> Weight {
         0
     }
     fn vote() -> Weight {

--- a/runtime-modules/referendum/src/tests.rs
+++ b/runtime-modules/referendum/src/tests.rs
@@ -236,7 +236,8 @@ fn finish_voting() {
 
         let voting_stage_duration = <Runtime as Trait>::VoteStageDuration::get();
 
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id.clone());
     });
@@ -275,7 +276,8 @@ fn reveal() {
             cycle_id.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         Mocks::reveal_vote(
@@ -329,7 +331,8 @@ fn reveal_reveal_stage_not_running() {
             cycle_id.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         MockUtils::increase_block_number(reveal_stage_duration);
@@ -364,7 +367,8 @@ fn reveal_no_vote() {
             cycle_id,
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         MockUtils::increase_block_number(reveal_stage_duration);
@@ -414,7 +418,8 @@ fn reveal_salt_too_long() {
             cycle_id.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         Mocks::reveal_vote(
@@ -459,7 +464,8 @@ fn reveal_invalid_vote() {
             cycle_id.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Runtime::feature_option_id_valid(false);
 
@@ -506,7 +512,8 @@ fn reveal_invalid_commitment_proof() {
             cycle_id.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         Mocks::reveal_vote(
@@ -553,7 +560,9 @@ fn finish_revealing_period() {
             cycle_id.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         Mocks::reveal_vote(
@@ -623,7 +632,9 @@ fn finish_revealing_period_vote_power() {
             cycle_id.clone(),
             Ok(()),
         ); // vote for second option by prominent user
-        MockUtils::increase_block_number(voting_stage_duration);
+
+        // Voting start at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         Mocks::reveal_vote(
@@ -640,6 +651,7 @@ fn finish_revealing_period_vote_power() {
             option_to_vote_for2,
             Ok(()),
         );
+
         MockUtils::increase_block_number(reveal_stage_duration);
 
         // option 2 should win because prominent user has more powerfull vote with the same stake
@@ -672,7 +684,8 @@ fn winners_no_vote_revealed() {
         let winning_target_count = 1;
 
         Mocks::start_referendum_extrinsic(origin.clone(), winning_target_count, cycle_id, Ok(()));
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         MockUtils::increase_block_number(reveal_stage_duration);
         Mocks::check_revealing_finished(vec![], MockUtils::transform_results(vec![]));
@@ -738,7 +751,8 @@ fn winners_multiple_winners() {
             cycle_id.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
 
@@ -829,7 +843,8 @@ fn winners_multiple_winners_extra() {
             cycle_id.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         Mocks::reveal_vote(
@@ -894,7 +909,8 @@ fn winners_multiple_not_enough() {
             cycle_id.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id);
         Mocks::reveal_vote(
@@ -953,7 +969,8 @@ fn referendum_release_stake() {
             cycle_id1.clone(),
             Ok(()),
         );
-        MockUtils::increase_block_number(voting_stage_duration);
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
 
         Mocks::check_voting_finished(winning_target_count, cycle_id1);
         Mocks::reveal_vote(

--- a/runtime/src/weights/council.rs
+++ b/runtime/src/weights/council.rs
@@ -8,51 +8,51 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl council::WeightInfo for WeightInfo {
     fn try_process_budget() -> Weight {
-        (31_193_947_000 as Weight)
+        (1_073_084_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn try_progress_stage_idle() -> Weight {
-        (4_419_823_000 as Weight)
+        (125_532_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
-    // WARNING! Some components were not used: ["i"]
-    fn try_progress_stage_announcing_start_election() -> Weight {
-        (7_343_164_000 as Weight)
+    fn try_progress_stage_announcing_start_election(i: u32) -> Weight {
+        (245_660_000 as Weight)
+            .saturating_add((110_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn try_progress_stage_announcing_restart() -> Weight {
-        (4_096_882_000 as Weight)
+        (130_948_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn announce_candidacy() -> Weight {
-        (17_070_500_000 as Weight)
+        (552_521_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn release_candidacy_stake() -> Weight {
-        (13_005_597_000 as Weight)
+        (428_377_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn set_candidacy_note(i: u32) -> Weight {
-        (10_510_218_000 as Weight)
-            .saturating_add((5_732_000 as Weight).saturating_mul(i as Weight))
+        (294_186_000 as Weight)
+            .saturating_add((190_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn withdraw_candidacy() -> Weight {
-        (13_471_527_000 as Weight)
+        (441_997_000 as Weight)
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn set_budget() -> Weight {
-        (2_301_070_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        (72_037_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn plan_budget_refill() -> Weight {
-        (2_147_298_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        (66_173_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
 }

--- a/runtime/src/weights/referendum.rs
+++ b/runtime/src/weights/referendum.rs
@@ -7,49 +7,49 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 pub struct WeightInfo;
 impl referendum::WeightInfo for WeightInfo {
-    fn on_finalize_revealing(i: u32) -> Weight {
-        (162_562_000 as Weight)
-            .saturating_add((3_788_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(2 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+    fn on_initialize_revealing(i: u32) -> Weight {
+        (256_993_000 as Weight)
+            .saturating_add((5_242_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
     }
-    fn on_finalize_voting() -> Weight {
-        (107_830_000 as Weight)
+    fn on_initialize_voting() -> Weight {
+        (145_807_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn vote() -> Weight {
-        (413_778_000 as Weight)
-            .saturating_add(DbWeight::get().reads(4 as Weight))
+        (443_261_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn reveal_vote_space_for_new_winner(i: u32) -> Weight {
-        (516_980_000 as Weight)
-            .saturating_add((7_355_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+        (501_934_000 as Weight)
+            .saturating_add((12_406_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn reveal_vote_space_not_in_winners(i: u32) -> Weight {
-        (379_026_000 as Weight)
-            .saturating_add((6_028_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+        (557_731_000 as Weight)
+            .saturating_add((7_068_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn reveal_vote_space_replace_last_winner(i: u32) -> Weight {
-        (395_050_000 as Weight)
-            .saturating_add((6_563_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+        (470_304_000 as Weight)
+            .saturating_add((9_542_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn reveal_vote_already_existing(i: u32) -> Weight {
-        (816_985_000 as Weight)
-            .saturating_add((5_962_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+        (503_012_000 as Weight)
+            .saturating_add((9_931_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn release_vote_stake() -> Weight {
-        (460_316_000 as Weight)
-            .saturating_add(DbWeight::get().reads(3 as Weight))
+        (387_201_000 as Weight)
+            .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
 }


### PR DESCRIPTION
# Tracking #1934 

* Moves `on_finalize` to `on_initialize` to be able to use weights in the function.
* Fixes testing for these changes.
* Add weights to the `on_intialize` on both pallets