### PR TITLE
Fix ignored tests in council 

### DIFF
--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -44,8 +44,6 @@ pub const VOTER_BASE_ID: u64 = 4000;
 pub const CANDIDATE_BASE_ID: u64 = VOTER_BASE_ID + VOTER_CANDIDATE_OFFSET;
 pub const VOTER_CANDIDATE_OFFSET: u64 = 1000;
 
-pub const INVALID_USER_MEMBER: u64 = 9999;
-
 // multiplies topup value so that candidate/voter can candidate/vote multiple times
 pub const TOPUP_MULTIPLIER: u64 = 10;
 
@@ -135,8 +133,8 @@ impl common::origin::MemberOriginValidator<Origin, u64, u64> for () {
 }
 
 impl common::StakingAccountValidator<Runtime> for () {
-    fn is_member_staking_account(_: &u64, _: &u64) -> bool {
-        true
+    fn is_member_staking_account(member_id: &u64, account_id: &u64) -> bool {
+        *member_id == *account_id
     }
 }
 

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -195,27 +195,6 @@ fn council_vote_for_winner_stakes_longer() {
     });
 }
 
-// Test that only valid members can candidate.
-#[test]
-#[ignore] // ignore until `StakeHandler::is_member_staking_account()` properly implemented
-fn council_candidacy_invalid_member() {
-    let config = default_genesis_config();
-
-    build_test_externalities(config).execute_with(|| {
-        let council_settings = CouncilSettings::<Runtime>::extract_settings();
-
-        let stake = council_settings.min_candidate_stake;
-        let candidate = MockUtils::generate_candidate(INVALID_USER_MEMBER, stake);
-
-        Mocks::announce_candidacy(
-            candidate.origin.clone(),
-            candidate.account_id.clone(),
-            candidate.candidate.stake.clone(),
-            Err(Error::MemberIdNotMatchAccount),
-        );
-    });
-}
-
 // Test that candidate can withdraw valid candidacy.
 #[test]
 fn council_candidacy_withdraw_candidacy() {
@@ -1344,9 +1323,6 @@ fn council_membership_checks() {
             candidate2.candidate.staking_account_id,
         );
 
-        // TODO: uncomment this once StakingHandler's `is_member_staking_account` is properly
-        // implemented
-        /*
         // test that staking_account_id has to be associated with membership_id
         Mocks::announce_candidacy_raw(
             candidate1.origin.clone(),
@@ -1354,9 +1330,8 @@ fn council_membership_checks() {
             candidate2.candidate.staking_account_id.clone(), // second candidate's account id
             candidate1.candidate.reward_account_id.clone(),
             candidate1.candidate.stake.clone(),
-            Err(Error::MembershipIdNotMatchAccount),
+            Err(Error::MemberIdNotMatchAccount),
         );
-        */
 
         // test that reward_account_id not associated with membership_id can be used
         Mocks::announce_candidacy_raw(


### PR DESCRIPTION
I removed the ignored tests since it was already tested by a commented test in `council_membership_checks`. So I uncommented it and fixed and then erased the old ignored test.