### PR TITLE
Proposals codex cleanup unused storage value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-proposals-codex"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/runtime-modules/proposals/codex/Cargo.toml
+++ b/runtime-modules/proposals/codex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-proposals-codex'
-version = '4.0.1'
+version = '4.0.2'
 authors = ['Joystream contributors']
 edition = '2018'
 

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -159,17 +159,6 @@ fn create_proposal_verify<T: Trait>(
         thread_id,
         "Proposal and thread ID doesn't match"
     );
-
-    assert!(
-        ProposalDetailsByProposalId::<T>::contains_key(proposal_id),
-        "Proposal details not stored"
-    );
-
-    assert_eq!(
-        ProposalDetailsByProposalId::<T>::get(proposal_id),
-        proposal_details,
-        "Proposal details doesn't match"
-    );
 }
 
 fn set_wg_and_council_budget<T: Trait>(budget: u32, group: WorkingGroup) {

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -9,8 +9,7 @@
 //! During the proposal creation, `codex` also create a discussion thread using the `discussion`
 //! proposals module. `Codex` uses predefined parameters (eg.:`voting_period`) for each proposal and
 //! encodes extrinsic calls from dependency modules in order to create proposals inside the `engine`
-//! module. For each proposal, [its crucial details](./enum.ProposalDetails.html) are saved to the
-//! `ProposalDetailsByProposalId` map.
+//! module.
 //!
 //! To create a proposal you need to call the extrinsic `create_proposal` with the `ProposalDetails` variant
 //! corresponding to the proposal you want to create. [See the possible details with their proposal](./enum.ProposalDetails.html)
@@ -327,9 +326,6 @@ decl_storage! {
         /// Map proposal id to its discussion thread id
         pub ThreadIdByProposalId get(fn thread_id_by_proposal_id):
             map hasher(blake2_128_concat) T::ProposalId => T::ThreadId;
-
-        /// Map proposal id to proposal details
-        pub ProposalDetailsByProposalId: map hasher(blake2_128_concat) T::ProposalId => ProposalDetailsOf<T>;
     }
 }
 
@@ -441,7 +437,7 @@ decl_module! {
             Self::ensure_details_checks(&proposal_details)?;
 
             let proposal_parameters = Self::get_proposal_parameters(&proposal_details);
-            let proposal_code = T::ProposalEncoder::encode_proposal(proposal_details.clone());
+            let proposal_code = T::ProposalEncoder::encode_proposal(proposal_details);
 
             let account_id =
                 T::MembershipOriginValidator::ensure_member_controller_account_origin(
@@ -480,7 +476,6 @@ decl_module! {
                 <proposals_engine::Module<T>>::create_proposal(proposal_creation_params)?;
 
             <ThreadIdByProposalId<T>>::insert(proposal_id, discussion_thread_id);
-            <ProposalDetailsByProposalId<T>>::insert(proposal_id, proposal_details);
         }
 
 // *************** Extrinsic to execute
@@ -891,7 +886,6 @@ impl<T: Trait> Module<T> {
 impl<T: Trait> ProposalObserver<T> for Module<T> {
     fn proposal_removed(proposal_id: &<T as proposals_engine::Trait>::ProposalId) {
         <ThreadIdByProposalId<T>>::remove(proposal_id);
-        <ProposalDetailsByProposalId<T>>::remove(proposal_id);
 
         let thread_id = Self::thread_id_by_proposal_id(proposal_id);
 

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -42,7 +42,6 @@ where
     empty_stake_call: EmptyStakeCall,
     successful_call: SuccessfulCall,
     proposal_parameters: ProposalParameters<u64, u64>,
-    proposal_details: ProposalDetails<u64, u64, u64, u64, u64>,
 }
 
 impl<InsufficientRightsCall, EmptyStakeCall, SuccessfulCall>
@@ -80,10 +79,6 @@ where
         let proposal = ProposalsEngine::proposals(proposal_id);
         // check for correct proposal parameters
         assert_eq!(proposal.parameters, self.proposal_parameters);
-
-        // proposal details was set
-        let details = <crate::ProposalDetailsByProposalId<Test>>::get(proposal_id);
-        assert_eq!(details, self.proposal_details);
     }
 
     pub fn check_all(&self) {
@@ -139,7 +134,6 @@ fn create_signal_proposal_common_checks_succeed() {
                 )
             },
             proposal_parameters: <Test as crate::Trait>::SignalProposalParameters::get(),
-            proposal_details: signal_proposal_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -213,7 +207,6 @@ fn create_runtime_upgrade_common_checks_succeed() {
                 )
             },
             proposal_parameters: <Test as crate::Trait>::RuntimeUpgradeProposalParameters::get(),
-            proposal_details: proposal_details_upgrade.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -297,7 +290,6 @@ fn create_funding_request_proposal_common_checks_succeed() {
                 )
             },
             proposal_parameters: <Test as crate::Trait>::FundingRequestProposalParameters::get(),
-            proposal_details: funding_request_proposal.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -478,7 +470,6 @@ fn create_set_max_validator_count_proposal_common_checks_succeed() {
             },
             proposal_parameters:
                 <Test as crate::Trait>::SetMaxValidatorCountProposalParameters::get(),
-            proposal_details: validator_count_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -579,7 +570,6 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(gr
             },
             proposal_parameters:
                 <Test as crate::Trait>::CreateWorkingGroupLeadOpeningProposalParameters::get(),
-            proposal_details: add_leader_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -650,7 +640,6 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
             },
             proposal_parameters:
                 <Test as crate::Trait>::FillWorkingGroupLeadOpeningProposalParameters::get(),
-            proposal_details: fill_opening_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -713,7 +702,6 @@ fn run_create_update_working_group_budget_proposal_common_checks_succeed(
             },
             proposal_parameters:
                 <Test as crate::Trait>::UpdateWorkingGroupBudgetProposalParameters::get(),
-            proposal_details: budget_capacity_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -779,7 +767,6 @@ fn run_create_decrease_working_group_leader_stake_proposal_common_checks_succeed
             },
             proposal_parameters:
                 <Test as crate::Trait>::DecreaseWorkingGroupLeadStakeProposalParameters::get(),
-            proposal_details: decrease_lead_stake_details_success.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -844,7 +831,6 @@ fn run_create_slash_working_group_leader_stake_proposal_common_checks_succeed(
             },
             proposal_parameters:
                 <Test as crate::Trait>::SlashWorkingGroupLeadProposalParameters::get(),
-            proposal_details: slash_lead_details_success.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1027,7 +1013,6 @@ fn run_create_set_working_group_leader_reward_proposal_common_checks_succeed(
             },
             proposal_parameters:
                 <Test as crate::Trait>::SlashWorkingGroupLeadProposalParameters::get(),
-            proposal_details: set_lead_reward_details_success.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1096,7 +1081,6 @@ fn run_create_terminate_working_group_leader_role_proposal_common_checks_succeed
             },
             proposal_parameters:
                 <Test as crate::Trait>::TerminateWorkingGroupLeadProposalParameters::get(),
-            proposal_details: terminate_lead_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1149,7 +1133,6 @@ fn create_amend_constitution_proposal_common_checks_succeed() {
                 )
             },
             proposal_parameters: <Test as crate::Trait>::AmendConstitutionProposalParameters::get(),
-            proposal_details: amend_constitution_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1202,7 +1185,6 @@ fn create_set_council_budget_increment_common_checks_succeed() {
             },
             proposal_parameters:
                 <Test as crate::Trait>::SetCouncilBudgetIncrementProposalParameters::get(),
-            proposal_details: set_council_budget_increment_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1264,7 +1246,6 @@ fn run_create_cancel_working_group_leader_opening_proposal_common_checks_succeed
             },
             proposal_parameters:
                 <Test as crate::Trait>::CancelWorkingGroupLeadOpeningProposalParameters::get(),
-            proposal_details: cancel_opening_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1318,7 +1299,6 @@ fn create_set_councilor_reward_proposal_common_checks_succeed() {
             },
             proposal_parameters: <Test as crate::Trait>::SetCouncilorRewardProposalParameters::get(
             ),
-            proposal_details: set_councilor_reward_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1372,7 +1352,6 @@ fn create_set_initial_invitation_balance_proposal_common_checks_succeed() {
             },
             proposal_parameters:
                 <Test as crate::Trait>::SetInitialInvitationBalanceProposalParameters::get(),
-            proposal_details: set_initial_invitation_balance_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1425,7 +1404,6 @@ fn create_set_initial_invitation_count_proposal_common_checks_succeed() {
             },
             proposal_parameters: <Test as crate::Trait>::SetInvitationCountProposalParameters::get(
             ),
-            proposal_details: set_initial_invitation_count_details.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1479,7 +1457,6 @@ fn create_set_membership_lead_invitation_quota_common_checks_succeed() {
             },
             proposal_parameters:
                 <Test as crate::Trait>::SetMembershipLeadInvitationQuotaProposalParameters::get(),
-            proposal_details: set_membership_lead_invitation_quota.clone(),
         };
         proposal_fixture.check_all();
     });
@@ -1531,7 +1508,6 @@ fn create_set_referral_cut_common_checks_succeed() {
                 )
             },
             proposal_parameters: <Test as crate::Trait>::SetReferralCutProposalParameters::get(),
-            proposal_details: set_referral_cut_proposal_details.clone(),
         };
         proposal_fixture.check_all();
     });


### PR DESCRIPTION
Removes `ProposalDetailsByProposalId` since it's no longer in use.