### PR TITLE
Add events for proposal codex

### DIFF
--- a/runtime-modules/common/src/lib.rs
+++ b/runtime-modules/common/src/lib.rs
@@ -62,7 +62,7 @@ pub struct BlockAndTime<BlockNumber, Moment> {
 
 /// Parameters for the 'Funding Request' proposal.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
 pub struct FundingRequestParameters<Balance, AccountId> {
     /// Single reciever account of funding request
     pub account: AccountId,

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -18,9 +18,6 @@ use sp_std::prelude::*;
 const SEED: u32 = 0;
 const MAX_BYTES: u32 = 16384;
 
-// Note: We use proposals_engine::Trait::Event here because crate::Trait
-// doesn't implement Event and we only use this function to assert events
-// from the proposals_engine pallet
 fn assert_last_event<T: Trait>(generic_event: <T as Trait>::Event) {
     let events = System::<T>::events();
     let system_event: <T as frame_system::Trait>::Event = generic_event.into();

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -21,7 +21,7 @@ const MAX_BYTES: u32 = 16384;
 // Note: We use proposals_engine::Trait::Event here because crate::Trait
 // doesn't implement Event and we only use this function to assert events
 // from the proposals_engine pallet
-fn assert_last_event<T: Trait>(generic_event: <T as proposals_engine::Trait>::Event) {
+fn assert_last_event<T: Trait>(generic_event: <T as Trait>::Event) {
     let events = System::<T>::events();
     let system_event: <T as frame_system::Trait>::Event = generic_event.into();
     assert!(
@@ -95,6 +95,7 @@ fn create_proposal_parameters<T: Trait + membership::Trait>(
 fn create_proposal_verify<T: Trait>(
     account_id: T::AccountId,
     member_id: T::MemberId,
+    proposal_parameters: GeneralProposalParameters<T>,
     proposal_details: ProposalDetailsOf<T>,
 ) {
     assert_eq!(Discussion::<T>::thread_count(), 1, "No threads created");
@@ -141,14 +142,14 @@ fn create_proposal_verify<T: Trait>(
         1,
         "Proposal count not updated"
     );
+
     assert_eq!(
         Engine::<T>::active_proposal_count(),
         1,
         "Active proposal count not updated"
     );
-    assert_last_event::<T>(
-        proposals_engine::RawEvent::ProposalCreated(member_id, proposal_id).into(),
-    );
+
+    assert_last_event::<T>(RawEvent::ProposalCreated(proposal_parameters, proposal_details).into());
 
     assert!(
         ThreadIdByProposalId::<T>::contains_key(proposal_id),
@@ -217,9 +218,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::Signal(vec![0u8; i.try_into().unwrap()]);
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details,
+        );
     }
 
     create_proposal_runtime_upgrade {
@@ -230,9 +240,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::RuntimeUpgrade(vec![0u8; i.try_into().unwrap()]);
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_funding_request {
@@ -255,9 +274,18 @@ benchmarks! {
         }
 
         let proposal_details = ProposalDetails::FundingRequest(funding_requests);
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_set_max_validator_count {
@@ -267,9 +295,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::SetMaxValidatorCount(MAX_VALIDATOR_COUNT);
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_create_working_group_lead_opening {
@@ -285,9 +322,18 @@ benchmarks! {
             reward_per_block: None,
             group: WorkingGroup::Forum,
         });
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_fill_working_group_lead_opening {
@@ -301,9 +347,18 @@ benchmarks! {
             application_id: working_group::ApplicationId::zero(),
             working_group: WorkingGroup::Forum,
         });
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters.clone(),
+            proposal_details
+        );
     }
 
     create_proposal_update_working_group_budget {
@@ -317,9 +372,18 @@ benchmarks! {
             WorkingGroup::Forum,
             BalanceKind::Positive
         );
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_decrease_working_group_lead_stake {
@@ -333,9 +397,18 @@ benchmarks! {
             BalanceOf::<T>::one(),
             WorkingGroup::Forum,
         );
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_slash_working_group_lead {
@@ -349,9 +422,18 @@ benchmarks! {
             BalanceOf::<T>::one(),
             WorkingGroup::Forum,
         );
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_set_working_group_lead_reward {
@@ -365,9 +447,18 @@ benchmarks! {
             None,
             WorkingGroup::Forum,
         );
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_terminate_working_group_lead {
@@ -383,9 +474,18 @@ benchmarks! {
                 group: WorkingGroup::Forum,
             }
         );
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_amend_constitution {
@@ -396,9 +496,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::AmendConstitution(vec![0u8; i.try_into().unwrap()]);
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_cancel_working_group_lead_opening {
@@ -410,21 +519,39 @@ benchmarks! {
         let proposal_details = ProposalDetails::CancelWorkingGroupLeadOpening(
             working_group::OpeningId::zero(),
             WorkingGroup::Forum);
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_set_membership_price {
         let t in ...;
         let d in ...;
 
-        let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
+        let (account_id, member_id, general_proposal_parameters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::SetMembershipPrice(BalanceOf::<T>::one());
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_parameters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_parameters,
+            proposal_details
+        );
     }
 
     create_proposal_set_council_budget_increment {
@@ -434,9 +561,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::SetCouncilBudgetIncrement(BalanceOf::<T>::one());
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_set_councilor_reward {
@@ -446,9 +582,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::SetCouncilorReward(BalanceOf::<T>::one());
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_set_initial_invitation_balance {
@@ -458,9 +603,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::SetInitialInvitationBalance(BalanceOf::<T>::one());
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_set_initial_invitation_count {
@@ -470,9 +624,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::SetInitialInvitationCount(One::one());
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_set_membership_lead_invitation_quota {
@@ -482,9 +645,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::SetMembershipLeadInvitationQuota(One::one());
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     create_proposal_set_referral_cut {
@@ -494,9 +666,18 @@ benchmarks! {
         let (account_id, member_id, general_proposal_paramters) = create_proposal_parameters::<T>(t, d);
 
         let proposal_details = ProposalDetails::SetReferralCut(One::one());
-    }: create_proposal(RawOrigin::Signed(account_id.clone()), general_proposal_paramters, proposal_details.clone())
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
     verify {
-        create_proposal_verify::<T>(account_id, member_id, proposal_details);
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
     }
 
     update_working_group_budget_positive_forum {

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -267,15 +267,27 @@ decl_event! {
         BalanceKind = BalanceKind
     {
         /// A proposal was created
+        /// Params:
+        /// - General proposal parameter. Parameters shared by all proposals
+        /// - Proposal Details. Parameter of proposal with a variant for each kind of proposal
         ProposalCreated(GeneralProposalParameters, ProposalDetailsOf),
 
         /// A signal proposal was executed
+        /// Params:
+        /// - Signal given when creating the corresponding proposal
         Signaled(Vec<u8>),
 
         /// A runtime upgrade was executed
+        /// Params:
+        /// - New code encoded in bytes
         RuntimeUpgraded(Vec<u8>),
 
         /// An `Update Working Group Budget` proposal was executed
+        /// Params:
+        /// - Working group which budget is being updated
+        /// - Amount of balance being moved
+        /// - Enum variant with positive indicating funds moved torwards working group and negative
+        /// and negative funds moving from the working group
         UpdatedWorkingGroupBudget(WorkingGroup, Balance, BalanceKind),
     }
 }
@@ -467,7 +479,7 @@ decl_module! {
             // TODO: encode_proposal could take a reference instead of moving to prevent cloning
             // since the encode trait takes a reference to `self`.
             // (Note: this is an useful change since this could be a ~3MB copy in the case of
-            // a Runtime Upgrade)
+            // a Runtime Upgrade). See: https://github.com/Joystream/joystream/issues/2161
             let proposal_code = T::ProposalEncoder::encode_proposal(proposal_details.clone());
 
             let account_id =

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -266,9 +266,16 @@ decl_event! {
         Balance = BalanceOf<T>,
         BalanceKind = BalanceKind
     {
+        /// A proposal was created
         ProposalCreated(GeneralProposalParameters, ProposalDetailsOf),
+
+        /// A signal proposal was executed
         Signaled(Vec<u8>),
+
+        /// A runtime upgrade was executed
         RuntimeUpgraded(Vec<u8>),
+
+        /// An `Update Working Group Budget` proposal was executed
         UpdatedWorkingGroupBudget(WorkingGroup, Balance, BalanceKind),
     }
 }

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -262,8 +262,14 @@ decl_event! {
     pub enum Event<T> where
         GeneralProposalParameters = GeneralProposalParameters<T>,
         ProposalDetailsOf = ProposalDetailsOf<T>,
+        WorkingGroup = WorkingGroup,
+        Balance = BalanceOf<T>,
+        BalanceKind = BalanceKind
     {
         ProposalCreated(GeneralProposalParameters, ProposalDetailsOf),
+        Signaled(Vec<u8>),
+        RuntimeUpgraded(Vec<u8>),
+        UpdatedWorkingGroupBudget(WorkingGroup, Balance, BalanceKind),
     }
 }
 
@@ -518,6 +524,8 @@ decl_module! {
             ensure_root(origin)?;
 
             // Signal proposal stub: no code implied.
+
+            Self::deposit_event(RawEvent::Signaled(signal));
         }
 
         /// Runtime upgrade proposal extrinsic.
@@ -538,9 +546,11 @@ decl_module! {
 
             print("Runtime upgrade proposal execution started.");
 
-            <frame_system::Module<T>>::set_code(origin, wasm)?;
+            <frame_system::Module<T>>::set_code(origin, wasm.clone())?;
 
             print("Runtime upgrade proposal execution finished.");
+
+            Self::deposit_event(RawEvent::RuntimeUpgraded(wasm));
         }
 
         /// Update working group budget
@@ -578,6 +588,8 @@ decl_module! {
                     Council::<T>::set_budget(origin, current_budget.saturating_add(amount))?;
                 }
             }
+
+            Self::deposit_event(RawEvent::UpdatedWorkingGroupBudget(working_group, amount, balance_kind));
         }
 
     }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
 use frame_support::traits::LockIdentifier;
-use frame_support::{impl_outer_dispatch, impl_outer_origin, parameter_types, weights::Weight};
+use frame_support::{
+    impl_outer_dispatch, impl_outer_event, impl_outer_origin, parameter_types, weights::Weight,
+};
 pub use frame_system;
 use frame_system::{EnsureOneOf, EnsureRoot, EnsureSigned};
 use sp_core::H256;
@@ -35,6 +37,29 @@ parameter_types! {
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+}
+
+mod proposals_codex_mod {
+    pub use crate::Event;
+}
+
+impl_outer_event! {
+    pub enum TestEvent for Test {
+        proposals_codex_mod<T>,
+        frame_system<T>,
+        balances<T>,
+        staking<T>,
+        council<T>,
+        proposals_discussion<T>,
+        proposals_engine<T>,
+        referendum Instance0 <T>,
+        membership<T>,
+        working_group Instance0 <T>,
+        working_group Instance1 <T>,
+        working_group Instance2 <T>,
+        working_group Instance3 <T>,
+        working_group Instance4 <T>,
+    }
 }
 
 impl_outer_dispatch! {
@@ -111,7 +136,7 @@ impl membership::WeightInfo for Weights {
 }
 
 impl membership::Trait for Test {
-    type Event = ();
+    type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type WorkingGroup = ();
     type WeightInfo = Weights;
@@ -166,7 +191,7 @@ parameter_types! {
 impl balances::Trait for Test {
     type Balance = u64;
     type DustRemoval = ();
-    type Event = ();
+    type Event = TestEvent;
     type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
     type WeightInfo = ();
@@ -185,7 +210,7 @@ parameter_types! {
 pub struct MockProposalsEngineWeight;
 
 impl proposals_engine::Trait for Test {
-    type Event = ();
+    type Event = TestEvent;
     type ProposerOriginValidator = ();
     type CouncilOriginValidator = ();
     type TotalVotersCounter = MockVotersParameters;
@@ -277,7 +302,7 @@ parameter_types! {
 pub struct MockProposalsDiscussionWeight;
 
 impl proposals_discussion::Trait for Test {
-    type Event = ();
+    type Event = TestEvent;
     type AuthorOriginValidator = ();
     type CouncilOriginValidator = ();
     type ThreadId = u64;
@@ -327,7 +352,7 @@ parameter_types! {
 
 pub struct WorkingGroupWeightInfo;
 impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
-    type Event = ();
+    type Event = TestEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
     type StakingHandler = StakingManager<Self, LockId1>;
     type StakingAccountValidator = membership::Module<Test>;
@@ -410,7 +435,7 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
 }
 
 impl working_group::Trait<StorageWorkingGroupInstance> for Test {
-    type Event = ();
+    type Event = TestEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
     type StakingHandler = StakingManager<Self, LockId2>;
     type StakingAccountValidator = membership::Module<Test>;
@@ -421,7 +446,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
 }
 
 impl working_group::Trait<ForumWorkingGroupInstance> for Test {
-    type Event = ();
+    type Event = TestEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
     type StakingHandler = staking_handler::StakingManager<Self, LockId2>;
     type StakingAccountValidator = membership::Module<Test>;
@@ -432,7 +457,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Test {
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
-    type Event = ();
+    type Event = TestEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
     type StakingHandler = StakingManager<Self, LockId2>;
     type StakingAccountValidator = membership::Module<Test>;
@@ -463,7 +488,7 @@ impl staking::Trait for Test {
     type UnixTime = Timestamp;
     type CurrencyToVote = ();
     type RewardRemainder = ();
-    type Event = ();
+    type Event = TestEvent;
     type Slash = ();
     type Reward = ();
     type SessionsPerEra = SessionsPerEra;
@@ -542,6 +567,7 @@ macro_rules! call_wg {
 }
 
 impl crate::Trait for Test {
+    type Event = TestEvent;
     type MembershipOriginValidator = ();
     type ProposalEncoder = ();
     type WeightInfo = ();
@@ -592,7 +618,7 @@ parameter_types! {
 pub type ReferendumInstance = referendum::Instance0;
 
 impl council::Trait for Test {
-    type Event = ();
+    type Event = TestEvent;
 
     type Referendum = referendum::Module<Test, ReferendumInstance>;
 
@@ -676,7 +702,7 @@ parameter_types! {
 }
 
 impl referendum::Trait<ReferendumInstance> for Test {
-    type Event = ();
+    type Event = TestEvent;
 
     type MaxSaltLength = MaxSaltLength;
 
@@ -873,7 +899,7 @@ impl frame_system::Trait for Test {
     type AccountId = u64;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
-    type Event = ();
+    type Event = TestEvent;
     type BlockHashCount = BlockHashCount;
     type MaximumBlockWeight = MaximumBlockWeight;
     type DbWeight = ();

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -5,6 +5,7 @@ use frame_support::storage::StorageMap;
 use frame_support::traits::Currency;
 use frame_support::traits::{OnFinalize, OnInitialize};
 use frame_system::{EventRecord, RawOrigin};
+use sp_arithmetic::traits::One;
 use sp_std::convert::TryInto;
 
 use common::working_group::WorkingGroup;
@@ -414,6 +415,175 @@ fn create_funding_request_proposal_call_fails_with_incorrect_number_of_accounts(
                 ),
             ),
             Err(Error::<Test>::InvalidFundingRequestProposalNumberOfAccount.into())
+        );
+    });
+}
+
+#[test]
+fn execute_signal_proposal_fails() {
+    initial_test_ext().execute_with(|| {
+        assert_eq!(
+            ProposalCodex::execute_signal_proposal(RawOrigin::Signed(0).into(), vec![0]),
+            Err(DispatchError::BadOrigin)
+        );
+    });
+}
+
+#[test]
+fn execute_signal_proposal_succeds() {
+    initial_test_ext().execute_with(|| {
+        let signal = vec![0];
+        assert_eq!(
+            ProposalCodex::execute_signal_proposal(RawOrigin::Root.into(), signal.clone()),
+            Ok(())
+        );
+
+        assert_last_event(RawEvent::Signaled(signal).into());
+    });
+}
+
+#[test]
+fn execute_runtime_upgrade_proposal_fails() {
+    initial_test_ext().execute_with(|| {
+        assert_eq!(
+            ProposalCodex::execute_runtime_upgrade_proposal(RawOrigin::Signed(0).into(), vec![0]),
+            Err(DispatchError::BadOrigin)
+        );
+    });
+}
+
+#[test]
+fn update_working_group_budget_fails_permissions() {
+    for wg in WorkingGroup::iter() {
+        run_update_working_group_budget_fails_permissions(wg);
+    }
+}
+
+fn run_update_working_group_budget_fails_permissions(wg: WorkingGroup) {
+    initial_test_ext().execute_with(|| {
+        assert_eq!(
+            ProposalCodex::update_working_group_budget(
+                RawOrigin::Signed(0).into(),
+                wg,
+                Zero::zero(),
+                BalanceKind::Positive
+            ),
+            Err(DispatchError::BadOrigin)
+        );
+    });
+}
+
+#[test]
+fn update_working_group_budget_fails_positive() {
+    for wg in WorkingGroup::iter() {
+        run_update_working_group_budget_fails_positive(wg);
+    }
+}
+
+fn run_update_working_group_budget_fails_positive(wg: WorkingGroup) {
+    initial_test_ext().execute_with(|| {
+        assert_eq!(council::Module::<Test>::budget(), 0);
+        assert_eq!(
+            ProposalCodex::update_working_group_budget(
+                RawOrigin::Root.into(),
+                wg,
+                One::one(),
+                BalanceKind::Positive
+            ),
+            Err(Error::<Test>::InsufficientFundsForBudgetUpdate.into())
+        );
+    });
+}
+
+#[test]
+fn update_working_group_budget_fails_negative() {
+    for wg in WorkingGroup::iter() {
+        run_update_working_group_budget_fails_negative(wg);
+    }
+}
+
+fn run_update_working_group_budget_fails_negative(wg: WorkingGroup) {
+    initial_test_ext().execute_with(|| {
+        assert_eq!(<Test as Trait>::get_working_group_budget(wg), 0);
+        assert_eq!(
+            ProposalCodex::update_working_group_budget(
+                RawOrigin::Root.into(),
+                wg,
+                One::one(),
+                BalanceKind::Negative
+            ),
+            Err(Error::<Test>::InsufficientFundsForBudgetUpdate.into())
+        );
+    });
+}
+
+#[test]
+fn update_working_group_budget_succeeds_positive() {
+    for wg in WorkingGroup::iter() {
+        run_update_working_group_budget_succeeds_positive(wg);
+    }
+}
+
+fn run_update_working_group_budget_succeeds_positive(wg: WorkingGroup) {
+    initial_test_ext().execute_with(|| {
+        let budget = 100000;
+        let funding_amount = 1;
+        council::Module::<Test>::set_budget(RawOrigin::Root.into(), budget).unwrap();
+        assert_eq!(council::Module::<Test>::budget(), budget);
+        assert_eq!(<Test as Trait>::get_working_group_budget(wg), 0);
+        assert_eq!(
+            ProposalCodex::update_working_group_budget(
+                RawOrigin::Root.into(),
+                wg,
+                funding_amount,
+                BalanceKind::Positive
+            ),
+            Ok(())
+        );
+
+        assert_eq!(council::Module::<Test>::budget(), budget - funding_amount);
+        assert_eq!(
+            <Test as Trait>::get_working_group_budget(wg),
+            funding_amount
+        );
+        assert_last_event(
+            RawEvent::UpdatedWorkingGroupBudget(wg, funding_amount, BalanceKind::Positive).into(),
+        );
+    });
+}
+
+#[test]
+fn update_working_group_budget_succeeds_negative() {
+    for wg in WorkingGroup::iter() {
+        run_update_working_group_budget_succeeds_negative(wg);
+    }
+}
+
+fn run_update_working_group_budget_succeeds_negative(wg: WorkingGroup) {
+    initial_test_ext().execute_with(|| {
+        let budget = 100000;
+        let funding_amount = 1;
+        <Test as Trait>::set_working_group_budget(wg, budget);
+        assert_eq!(council::Module::<Test>::budget(), 0);
+        assert_eq!(<Test as Trait>::get_working_group_budget(wg), budget);
+
+        assert_eq!(
+            ProposalCodex::update_working_group_budget(
+                RawOrigin::Root.into(),
+                wg,
+                funding_amount,
+                BalanceKind::Negative,
+            ),
+            Ok(())
+        );
+
+        assert_eq!(council::Module::<Test>::budget(), funding_amount);
+        assert_eq!(
+            <Test as Trait>::get_working_group_budget(wg),
+            budget - funding_amount
+        );
+        assert_last_event(
+            RawEvent::UpdatedWorkingGroupBudget(wg, funding_amount, BalanceKind::Negative).into(),
         );
     });
 }

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -27,7 +27,7 @@ pub type ProposalDetailsOf<T> = ProposalDetails<
 
 /// Kind of Balance for `Update Working Group Budget`.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, Copy, PartialEq, Debug)]
+#[derive(Encode, Decode, Clone, Copy, PartialEq, Debug, Eq)]
 pub enum BalanceKind {
     /// Increasing Working Group budget decreasing Council budget
     Positive,
@@ -37,7 +37,7 @@ pub enum BalanceKind {
 
 /// Proposal details provide voters the information required for the perceived voting.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
 pub enum ProposalDetails<Balance, BlockNumber, AccountId, WorkerId, OpeningId> {
     /// The signal of the `Signal` proposal
     Signal(Vec<u8>),
@@ -135,7 +135,7 @@ pub struct GeneralProposalParams<MemberId, AccountId, BlockNumber> {
 
 /// Parameters for the 'terminate the leader position' proposal.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
 pub struct TerminateRoleParameters<WorkerId, Balance> {
     /// Worker identifier.
     pub worker_id: WorkerId,
@@ -149,7 +149,7 @@ pub struct TerminateRoleParameters<WorkerId, Balance> {
 
 /// Parameters for the 'Fill Working Group Lead' proposal.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
 pub struct FillOpeningParameters {
     /// Identifier for opening in group.
     pub opening_id: working_group::OpeningId,
@@ -163,7 +163,7 @@ pub struct FillOpeningParameters {
 
 /// Parameters for the 'Create Working Group Lead Opening' proposal.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, PartialEq, Debug)]
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
 pub struct CreateOpeningParameters<BlockNumber, Balance> {
     /// Opening description.
     pub description: Vec<u8>,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -832,6 +832,7 @@ macro_rules! call_wg {
 }
 
 impl proposals_codex::Trait for Runtime {
+    type Event = Event;
     type MembershipOriginValidator = Members;
     type ProposalEncoder = ExtrinsicProposalEncoder;
     type SetMaxValidatorCountProposalParameters = SetMaxValidatorCountProposalParameters;
@@ -934,7 +935,7 @@ construct_runtime!(
         // --- Proposals
         ProposalsEngine: proposals_engine::{Module, Call, Storage, Event<T>},
         ProposalsDiscussion: proposals_discussion::{Module, Call, Storage, Event<T>},
-        ProposalsCodex: proposals_codex::{Module, Call, Storage},
+        ProposalsCodex: proposals_codex::{Module, Call, Storage, Event<T>},
         // --- Working groups
         ForumWorkingGroup: working_group::<Instance1>::{Module, Call, Storage, Event<T>},
         StorageWorkingGroup: working_group::<Instance2>::{Module, Call, Storage, Event<T>},


### PR DESCRIPTION
# Fixes #2126 

This PR:
* Adds events for proposal creation in proposal codex
* Adds events for the other extrinsics in proposal codex
* Tests for the events in benchmarks and tests
* Add tests for the execution extrinsics(Note: there is no test for runtime upgrade succeeding) 