### PR TITLE
Withdraw funds from bounty.

### DIFF
--- a/runtime-modules/bounty/src/benchmarking.rs
+++ b/runtime-modules/bounty/src/benchmarking.rs
@@ -231,7 +231,7 @@ benchmarks! {
     }: _ (RawOrigin::Signed(account_id.clone()), member_id, bounty_id, amount)
     verify {
         assert_eq!(Balances::<T>::usable_balance(&account_id), T::Balance::max_value() - amount);
-        assert_last_event::<T>(Event::<T>::MaxFundingReached(bounty_id).into());
+        assert_last_event::<T>(Event::<T>::BountyMaxFundingReached(bounty_id).into());
     }
 }
 

--- a/runtime-modules/bounty/src/benchmarking.rs
+++ b/runtime-modules/bounty/src/benchmarking.rs
@@ -18,8 +18,8 @@ use frame_system::Module as System;
 use membership::Module as Membership;
 
 use crate::{
-    BalanceOf, Bounties, BountyCreationParameters, BountyCreator, BountyMilestone, Call, Event,
-    Module, Trait,
+    BalanceOf, Bounties, BountyCreationParameters, BountyCreator, BountyMilestone, BountyStage,
+    Call, Event, Module, Trait,
 };
 
 pub fn run_to_block<T: Trait>(target_block: T::BlockNumber) {
@@ -321,6 +321,12 @@ benchmarks! {
 
         Bounty::<T>::cancel_bounty(RawOrigin::Root.into(), creator.clone(), bounty_id).unwrap();
 
+        let bounty = Bounty::<T>::bounties(bounty_id);
+        assert!(matches!(
+            Bounty::<T>::get_bounty_stage(&bounty),
+            BountyStage::Withdrawal {cherry_needs_withdrawal: true, ..}
+        ));
+
     }: withdraw_creator_funding(RawOrigin::Root, creator.clone(), bounty_id)
     verify {
         assert!(!Bounties::<T>::contains_key(bounty_id));
@@ -360,6 +366,12 @@ benchmarks! {
             creator.clone(),
             bounty_id
         ).unwrap();
+
+        let bounty = Bounty::<T>::bounties(bounty_id);
+        assert!(matches!(
+            Bounty::<T>::get_bounty_stage(&bounty),
+            BountyStage::Withdrawal {cherry_needs_withdrawal: true, ..}
+        ));
 
     }: withdraw_creator_funding(RawOrigin::Signed(account_id), creator.clone(), bounty_id)
     verify {

--- a/runtime-modules/bounty/src/benchmarking.rs
+++ b/runtime-modules/bounty/src/benchmarking.rs
@@ -117,7 +117,7 @@ benchmarks! {
         let bounty_id: T::BountyId = 1u32.into();
 
         assert!(Bounties::<T>::contains_key(bounty_id));
-        assert_eq!(Module::<T>::bounty_count(), 1); // Bounty counter was updated.
+        assert_eq!(Bounty::<T>::bounty_count(), 1); // Bounty counter was updated.
         assert_last_event::<T>(Event::<T>::BountyCreated(bounty_id, params).into());
     }
 
@@ -143,7 +143,7 @@ benchmarks! {
         let bounty_id: T::BountyId = 1u32.into();
 
         assert!(Bounties::<T>::contains_key(bounty_id));
-        assert_eq!(Module::<T>::bounty_count(), 1); // Bounty counter was updated.
+        assert_eq!(Bounty::<T>::bounty_count(), 1); // Bounty counter was updated.
         assert_last_event::<T>(Event::<T>::BountyCreated(bounty_id, params).into());
     }
 
@@ -161,14 +161,14 @@ benchmarks! {
             ..Default::default()
         };
 
-        Module::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
 
-        let bounty_id: T::BountyId = Module::<T>::bounty_count().into();
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
 
         assert!(Bounties::<T>::contains_key(bounty_id));
     }: cancel_bounty(RawOrigin::Root, creator.clone(), bounty_id)
     verify {
-        let bounty = <crate::Bounties<T>>::get(bounty_id);
+        let bounty = Bounty::<T>::bounties(bounty_id);
 
         assert!(matches!(bounty.milestone, BountyMilestone::Canceled));
         assert_last_event::<T>(Event::<T>::BountyCanceled(bounty_id, creator).into());
@@ -190,18 +190,18 @@ benchmarks! {
             ..Default::default()
         };
 
-        Module::<T>::create_bounty(
+        Bounty::<T>::create_bounty(
             RawOrigin::Signed(account_id.clone()).into(),
             params,
             Vec::new()
         ).unwrap();
 
-        let bounty_id: T::BountyId = Module::<T>::bounty_count().into();
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
 
         assert!(Bounties::<T>::contains_key(bounty_id));
     }: cancel_bounty(RawOrigin::Signed(account_id), creator.clone(), bounty_id)
     verify {
-        let bounty = <crate::Bounties<T>>::get(bounty_id);
+        let bounty = Bounty::<T>::bounties(bounty_id);
 
         assert!(matches!(bounty.milestone, BountyMilestone::Canceled));
         assert_last_event::<T>(Event::<T>::BountyCanceled(bounty_id, creator).into());
@@ -214,14 +214,14 @@ benchmarks! {
             ..Default::default()
         };
 
-        Module::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
 
-        let bounty_id: T::BountyId = Module::<T>::bounty_count().into();
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
 
         assert!(Bounties::<T>::contains_key(bounty_id));
     }: _ (RawOrigin::Root, bounty_id)
     verify {
-        let bounty = <crate::Bounties<T>>::get(bounty_id);
+        let bounty = Bounty::<T>::bounties(bounty_id);
 
         assert!(matches!(bounty.milestone, BountyMilestone::Canceled));
         assert_last_event::<T>(Event::<T>::BountyVetoed(bounty_id).into());
@@ -238,9 +238,9 @@ benchmarks! {
 
         let (account_id, member_id) = member_funded_account::<T>("member1", 0);
 
-        Module::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
 
-        let bounty_id: T::BountyId = Module::<T>::bounty_count().into();
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
 
         assert!(Bounties::<T>::contains_key(bounty_id));
     }: _ (RawOrigin::Signed(account_id.clone()), member_id, bounty_id, amount)
@@ -265,13 +265,13 @@ benchmarks! {
 
         let (account_id, member_id) = member_funded_account::<T>("member1", 0);
 
-        Module::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
 
-        let bounty_id: T::BountyId = Module::<T>::bounty_count().into();
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
 
         assert!(Bounties::<T>::contains_key(bounty_id));
 
-        Module::<T>::fund_bounty(
+        Bounty::<T>::fund_bounty(
             RawOrigin::Signed(account_id.clone()).into(),
             member_id,
             bounty_id,
@@ -300,17 +300,17 @@ benchmarks! {
             ..Default::default()
         };
 
-        Module::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
 
-        let bounty_id: T::BountyId = Module::<T>::bounty_count().into();
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
 
         assert!(Bounties::<T>::contains_key(bounty_id));
 
-        Module::<T>::cancel_bounty(RawOrigin::Root.into(), creator.clone(), bounty_id).unwrap();
+        Bounty::<T>::cancel_bounty(RawOrigin::Root.into(), creator.clone(), bounty_id).unwrap();
 
     }: withdraw_creator_funding(RawOrigin::Root, creator.clone(), bounty_id)
     verify {
-        let bounty = <crate::Bounties<T>>::get(bounty_id);
+        let bounty = Bounty::<T>::bounties(bounty_id);
 
         assert!(matches!(bounty.milestone, BountyMilestone::Canceled));
         assert_last_event::<T>(Event::<T>::BountyCreatorFundingWithdrawal(bounty_id, creator).into());
@@ -332,17 +332,17 @@ benchmarks! {
             ..Default::default()
         };
 
-        Module::<T>::create_bounty(
+        Bounty::<T>::create_bounty(
             RawOrigin::Signed(account_id.clone()).into(),
             params,
             Vec::new()
         ).unwrap();
 
-        let bounty_id: T::BountyId = Module::<T>::bounty_count().into();
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
 
         assert!(Bounties::<T>::contains_key(bounty_id));
 
-        Module::<T>::cancel_bounty(
+        Bounty::<T>::cancel_bounty(
             RawOrigin::Signed(account_id.clone()).into(),
             creator.clone(),
             bounty_id
@@ -350,7 +350,7 @@ benchmarks! {
 
     }: withdraw_creator_funding(RawOrigin::Signed(account_id), creator.clone(), bounty_id)
     verify {
-        let bounty = <crate::Bounties<T>>::get(bounty_id);
+        let bounty = Bounty::<T>::bounties(bounty_id);
 
         assert!(matches!(bounty.milestone, BountyMilestone::Canceled));
         assert_last_event::<T>(Event::<T>::BountyCreatorFundingWithdrawal(bounty_id, creator).into());

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -992,9 +992,12 @@ impl<T: Trait> Module<T> {
         bounty: &Bounty<T>,
         funding_amount: BalanceOf<T>,
     ) -> BalanceOf<T> {
-        //TODO: don't count creator_funding.
-        let funding_share =
-            Perbill::from_rational_approximation(funding_amount, bounty.total_funding);
+        //We don't count creator_funding.
+        let total_funding = bounty
+            .total_funding
+            .saturating_sub(bounty.creation_params.creator_funding);
+
+        let funding_share = Perbill::from_rational_approximation(funding_amount, total_funding);
 
         // cherry share
         funding_share * bounty.creation_params.cherry
@@ -1019,6 +1022,8 @@ impl<T: Trait> Module<T> {
     fn remove_bounty(bounty_id: &T::BountyId) {
         <Bounties<T>>::remove(bounty_id);
         <BountyContributions<T>>::remove_prefix(bounty_id);
+
+        //TODO: slash the rest
 
         Self::deposit_event(RawEvent::BountyRemoved(*bounty_id));
     }

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -8,6 +8,10 @@
 //! - [cancel_bounty](./struct.Module.html#method.cancel_bounty) - cancels a bounty
 //! - [veto_bounty](./struct.Module.html#method.veto_bounty) - vetoes a bounty
 //! - [fund_bounty](./struct.Module.html#method.fund_bounty) - provide funding for a bounty
+//! - [withdraw_member_funding](./struct.Module.html#method.withdraw_member_funding) - withdraw
+//! funding for a failed bounty.
+//! - [withdraw_creator_funding](./struct.Module.html#method.withdraw_creator_funding) - withdraw
+//! funding for a failed or canceled bounty..
 
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -27,7 +27,7 @@ mod benchmarking;
 // TODO: add assertion for the created bounty object content
 // TODO: use Bounty instead of Module in benchmarking
 // TODO: add more fine-grained errors.
-// TODO: max funding reached on initial creator funding greator than minimal amount
+// TODO: max funding reached on initial creator funding greater than minimal amount
 
 /// pallet_bounty WeightInfo.
 /// Note: This was auto generated through the benchmark CLI using the `--weight-trait` flag
@@ -39,6 +39,8 @@ pub trait WeightInfo {
     fn veto_bounty() -> Weight;
     fn fund_bounty() -> Weight;
     fn withdraw_member_funding() -> Weight;
+    fn withdraw_creator_funding_by_council() -> Weight;
+    fn withdraw_creator_funding_by_member() -> Weight;
 }
 
 type WeightInfoBounty<T> = <T as Trait>::WeightInfo;
@@ -562,7 +564,15 @@ decl_module! {
         }
 
         /// Withdraw creator funding.
-        #[weight = 10000000] //TODO adjust weight
+        /// # <weight>
+        ///
+        /// ## weight
+        /// `O (1)`
+        /// - db:
+        ///    - `O(1)` doesn't depend on the state or parameters
+        /// # </weight>
+        #[weight = WeightInfoBounty::<T>::withdraw_creator_funding_by_member()
+              .max(WeightInfoBounty::<T>::withdraw_creator_funding_by_council())]
         pub fn withdraw_creator_funding(
             origin,
             creator: BountyCreator<MemberId<T>>,

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -33,6 +33,7 @@ pub trait WeightInfo {
     fn cancel_bounty_by_council() -> Weight;
     fn veto_bounty() -> Weight;
     fn fund_bounty() -> Weight;
+    fn withdraw_member_funding() -> Weight;
 }
 
 type WeightInfoBounty<T> = <T as Trait>::WeightInfo;
@@ -497,7 +498,14 @@ decl_module! {
         }
 
         /// Withdraw funding.
-        #[weight = 10000000] //TODO: adjust weight
+        /// # <weight>
+        ///
+        /// ## weight
+        /// `O (1)`
+        /// - db:
+        ///    - `O(1)` doesn't depend on the state or parameters
+        /// # </weight>
+        #[weight = WeightInfoBounty::<T>::withdraw_member_funding()]
         pub fn withdraw_member_funding(
             origin,
             member_id: MemberId<T>,

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -202,7 +202,7 @@ pub enum BountyStage {
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]
 pub enum BountyMilestone<BlockNumber> {
     /// Bounty was created at given block number.
-    /// Boolean value defines whether the bounty has some funding contributions
+    /// Boolean value defines whether the bounty has some funding contributions.
     Created {
         /// Bounty creation block.
         created_at: BlockNumber,

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -18,7 +18,7 @@ pub fn run_to_block(n: u64) {
     }
 }
 
-pub fn increase_total_balance_issuance_using_account_id(account_id: u64, balance: u64) {
+pub fn increase_total_balance_issuance_using_account_id(account_id: u128, balance: u64) {
     let initial_balance = Balances::total_issuance();
     {
         let _ = Balances::deposit_creating(&account_id, balance);
@@ -26,7 +26,7 @@ pub fn increase_total_balance_issuance_using_account_id(account_id: u64, balance
     assert_eq!(Balances::total_issuance(), initial_balance + balance);
 }
 
-pub fn increase_account_balance(account_id: &u64, balance: u64) {
+pub fn increase_account_balance(account_id: &u128, balance: u64) {
     let _ = Balances::deposit_creating(&account_id, balance);
 }
 
@@ -51,7 +51,7 @@ impl EventFixture {
 
 pub const DEFAULT_BOUNTY_MAX_AMOUNT: u64 = 1000;
 pub struct CreateBountyFixture {
-    origin: RawOrigin<u64>,
+    origin: RawOrigin<u128>,
     metadata: Vec<u8>,
     creator: BountyCreator<u64>,
     funding_period: Option<u64>,
@@ -81,7 +81,7 @@ impl CreateBountyFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+    pub fn with_origin(self, origin: RawOrigin<u128>) -> Self {
         Self { origin, ..self }
     }
 
@@ -198,7 +198,7 @@ impl CreateBountyFixture {
 }
 
 pub struct CancelBountyFixture {
-    origin: RawOrigin<u64>,
+    origin: RawOrigin<u128>,
     creator: BountyCreator<u64>,
     bounty_id: u64,
 }
@@ -212,7 +212,7 @@ impl CancelBountyFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+    pub fn with_origin(self, origin: RawOrigin<u128>) -> Self {
         Self { origin, ..self }
     }
 
@@ -245,7 +245,7 @@ impl CancelBountyFixture {
 }
 
 pub struct VetoBountyFixture {
-    origin: RawOrigin<u64>,
+    origin: RawOrigin<u128>,
     bounty_id: u64,
 }
 
@@ -257,7 +257,7 @@ impl VetoBountyFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+    pub fn with_origin(self, origin: RawOrigin<u128>) -> Self {
         Self { origin, ..self }
     }
 
@@ -279,7 +279,7 @@ impl VetoBountyFixture {
 }
 
 pub struct FundBountyFixture {
-    origin: RawOrigin<u64>,
+    origin: RawOrigin<u128>,
     member_id: u64,
     bounty_id: u64,
     amount: u64,
@@ -295,7 +295,7 @@ impl FundBountyFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+    pub fn with_origin(self, origin: RawOrigin<u128>) -> Self {
         Self { origin, ..self }
     }
 
@@ -335,7 +335,7 @@ impl FundBountyFixture {
 }
 
 pub struct WithdrawMemberFundingFixture {
-    origin: RawOrigin<u64>,
+    origin: RawOrigin<u128>,
     member_id: u64,
     bounty_id: u64,
 }
@@ -349,7 +349,7 @@ impl WithdrawMemberFundingFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+    pub fn with_origin(self, origin: RawOrigin<u128>) -> Self {
         Self { origin, ..self }
     }
 
@@ -373,7 +373,7 @@ impl WithdrawMemberFundingFixture {
 }
 
 pub struct WithdrawCreatorFundingFixture {
-    origin: RawOrigin<u64>,
+    origin: RawOrigin<u128>,
     creator: BountyCreator<u64>,
     bounty_id: u64,
 }
@@ -387,7 +387,7 @@ impl WithdrawCreatorFundingFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+    pub fn with_origin(self, origin: RawOrigin<u128>) -> Self {
         Self { origin, ..self }
     }
 

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -341,3 +341,44 @@ impl WithdrawMemberFundingFixture {
         assert_eq!(actual_result, expected_result);
     }
 }
+
+pub struct WithdrawCreatorFundingFixture {
+    origin: RawOrigin<u64>,
+    creator: BountyCreator<u64>,
+    bounty_id: u64,
+}
+
+impl WithdrawCreatorFundingFixture {
+    pub fn default() -> Self {
+        Self {
+            origin: RawOrigin::Root,
+            creator: BountyCreator::Council,
+            bounty_id: 1,
+        }
+    }
+
+    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
+        Self { origin, ..self }
+    }
+
+    pub fn with_creator_member_id(self, member_id: u64) -> Self {
+        Self {
+            creator: BountyCreator::Member(member_id),
+            ..self
+        }
+    }
+
+    pub fn with_bounty_id(self, bounty_id: u64) -> Self {
+        Self { bounty_id, ..self }
+    }
+
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let actual_result = Bounty::withdraw_creator_funding(
+            self.origin.clone().into(),
+            self.creator.clone(),
+            self.bounty_id.clone(),
+        );
+
+        assert_eq!(actual_result, expected_result);
+    }
+}

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -26,6 +26,10 @@ pub fn increase_total_balance_issuance_using_account_id(account_id: u64, balance
     assert_eq!(Balances::total_issuance(), initial_balance + balance);
 }
 
+pub fn increase_account_balance(account_id: &u64, balance: u64) {
+    let _ = Balances::deposit_creating(&account_id, balance);
+}
+
 pub struct EventFixture;
 impl EventFixture {
     pub fn assert_last_crate_event(expected_raw_event: RawEvent<u64, u64, u64, u64>) {
@@ -279,7 +283,7 @@ impl FundBountyFixture {
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_bounty_funding =
-            Bounty::funding_by_bounty_by_member(self.bounty_id, self.member_id);
+            Bounty::contribution_by_bounty_by_member(self.bounty_id, self.member_id);
 
         let actual_result = Bounty::fund_bounty(
             self.origin.clone().into(),
@@ -291,7 +295,7 @@ impl FundBountyFixture {
         assert_eq!(actual_result, expected_result);
 
         let new_bounty_funding =
-            Bounty::funding_by_bounty_by_member(self.bounty_id, self.member_id);
+            Bounty::contribution_by_bounty_by_member(self.bounty_id, self.member_id);
         if actual_result.is_ok() {
             assert_eq!(new_bounty_funding, old_bounty_funding + self.amount);
         } else {

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -139,6 +139,12 @@ impl crate::WeightInfo for () {
     fn withdraw_member_funding() -> u64 {
         0
     }
+    fn withdraw_creator_funding_by_council() -> u64 {
+        0
+    }
+    fn withdraw_creator_funding_by_member() -> u64 {
+        0
+    }
 }
 
 impl common::Trait for Test {

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -93,7 +93,7 @@ impl Trait for Test {
     type CouncilBudgetManager = CouncilBudgetManager;
 }
 
-const COUNCIL_BUDGET_ACCOUNT_ID: u64 = 90000000;
+pub const COUNCIL_BUDGET_ACCOUNT_ID: u64 = 90000000;
 pub struct CouncilBudgetManager;
 impl common::council::CouncilBudgetManager<u64> for CouncilBudgetManager {
     fn get_budget() -> u64 {

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -9,7 +9,7 @@ use sp_core::H256;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
-    Perbill,
+    ModuleId, Perbill,
 };
 
 use crate::{Module, Trait};
@@ -55,6 +55,7 @@ parameter_types! {
     pub const MaximumBlockWeight: u32 = 1024;
     pub const MaximumBlockLength: u32 = 2 * 1024;
     pub const AvailableBlockRatio: Perbill = Perbill::one();
+    pub const BountyModuleId: ModuleId = ModuleId(*b"m:bounty"); // module : bounty
 }
 
 impl frame_system::Trait for Test {
@@ -65,7 +66,7 @@ impl frame_system::Trait for Test {
     type BlockNumber = u64;
     type Hash = H256;
     type Hashing = BlakeTwo256;
-    type AccountId = u64;
+    type AccountId = u128;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
     type Event = TestEvent;
@@ -87,13 +88,14 @@ impl frame_system::Trait for Test {
 
 impl Trait for Test {
     type Event = TestEvent;
+    type ModuleId = BountyModuleId;
     type BountyId = u64;
     type MemberOriginValidator = ();
     type WeightInfo = ();
     type CouncilBudgetManager = CouncilBudgetManager;
 }
 
-pub const COUNCIL_BUDGET_ACCOUNT_ID: u64 = 90000000;
+pub const COUNCIL_BUDGET_ACCOUNT_ID: u128 = 90000000;
 pub struct CouncilBudgetManager;
 impl common::council::CouncilBudgetManager<u64> for CouncilBudgetManager {
     fn get_budget() -> u64 {
@@ -152,17 +154,17 @@ impl common::Trait for Test {
     type ActorId = u64;
 }
 
-impl common::origin::MemberOriginValidator<Origin, u64, u64> for () {
+impl common::origin::MemberOriginValidator<Origin, u64, u128> for () {
     fn ensure_member_controller_account_origin(
         origin: Origin,
-        _account_id: u64,
-    ) -> Result<u64, DispatchError> {
+        _member_id: u64,
+    ) -> Result<u128, DispatchError> {
         let signed_account_id = frame_system::ensure_signed(origin)?;
 
         Ok(signed_account_id)
     }
 
-    fn is_member_controller_account(_member_id: &u64, _account_id: &u64) -> bool {
+    fn is_member_controller_account(_member_id: &u64, _account_id: &u128) -> bool {
         true
     }
 }
@@ -352,7 +354,7 @@ impl council::Trait for Test {
 }
 
 impl common::StakingAccountValidator<Test> for () {
-    fn is_member_staking_account(_: &u64, _: &u64) -> bool {
+    fn is_member_staking_account(_: &u64, _: &u128) -> bool {
         true
     }
 }

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -136,6 +136,9 @@ impl crate::WeightInfo for () {
     fn fund_bounty() -> u64 {
         0
     }
+    fn withdraw_member_funding() -> u64 {
+        0
+    }
 }
 
 impl common::Trait for Test {

--- a/runtime-modules/bounty/src/tests/mod.rs
+++ b/runtime-modules/bounty/src/tests/mod.rs
@@ -429,7 +429,7 @@ fn fund_bounty_succeeds_with_reaching_max_funding_amount() {
             BountyMilestone::MaxFundingReached(starting_block)
         );
 
-        EventFixture::assert_last_crate_event(RawEvent::MaxFundingReached(bounty_id));
+        EventFixture::assert_last_crate_event(RawEvent::BountyMaxFundingReached(bounty_id));
     });
 }
 

--- a/runtime-modules/bounty/src/tests/mod.rs
+++ b/runtime-modules/bounty/src/tests/mod.rs
@@ -7,6 +7,7 @@ use frame_system::RawOrigin;
 use sp_runtime::DispatchError;
 
 use crate::tests::fixtures::WithdrawCreatorFundingFixture;
+use crate::tests::mocks::Balances;
 use crate::{BountyCreator, BountyMilestone, Error, RawEvent};
 use common::council::CouncilBudgetManager;
 use fixtures::{
@@ -728,6 +729,11 @@ fn withdraw_member_funding_removes_bounty() {
         increase_account_balance(&COUNCIL_BUDGET_ACCOUNT_ID, initial_balance);
         increase_account_balance(&account_id, initial_balance);
 
+        println!(
+            "Initial: {}",
+            Balances::usable_balance(&Bounty::bounty_account_id(1u64))
+        );
+
         CreateBountyFixture::default()
             .with_max_amount(max_amount)
             .with_min_amount(max_amount)
@@ -738,6 +744,11 @@ fn withdraw_member_funding_removes_bounty() {
 
         let bounty_id = 1u64;
 
+        println!(
+            "After creation: {}",
+            Balances::usable_balance(&Bounty::bounty_account_id(bounty_id))
+        );
+
         FundBountyFixture::default()
             .with_origin(RawOrigin::Signed(account_id))
             .with_member_id(member_id)
@@ -746,9 +757,19 @@ fn withdraw_member_funding_removes_bounty() {
 
         run_to_block(funding_period + starting_block + 1);
 
+        println!(
+            "Before creator withdrawal: {}",
+            Balances::usable_balance(&Bounty::bounty_account_id(bounty_id))
+        );
+
         WithdrawCreatorFundingFixture::default()
             .with_bounty_id(bounty_id)
             .call_and_assert(Ok(()));
+
+        println!(
+            "Before member withdrawal: {}",
+            Balances::usable_balance(&Bounty::bounty_account_id(bounty_id))
+        );
 
         WithdrawMemberFundingFixture::default()
             .with_bounty_id(bounty_id)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -43,7 +43,7 @@ use sp_core::crypto::KeyTypeId;
 use sp_core::Hasher;
 use sp_runtime::curve::PiecewiseLinear;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, IdentityLookup, OpaqueKeys, Saturating};
-use sp_runtime::{create_runtime_str, generic, impl_opaque_keys, Perbill};
+use sp_runtime::{create_runtime_str, generic, impl_opaque_keys, ModuleId, Perbill};
 use sp_std::boxed::Box;
 use sp_std::vec::Vec;
 #[cfg(feature = "std")]
@@ -874,8 +874,13 @@ impl pallet_constitution::Trait for Runtime {
     type WeightInfo = weights::pallet_constitution::WeightInfo;
 }
 
+parameter_types! {
+    pub const BountyModuleId: ModuleId = ModuleId(*b"m:bounty"); // module : bounty
+}
+
 impl bounty::Trait for Runtime {
     type Event = Event;
+    type ModuleId = BountyModuleId;
     type BountyId = u64;
     type MemberOriginValidator = Members;
     type WeightInfo = weights::bounty::WeightInfo;

--- a/runtime/src/weights/bounty.rs
+++ b/runtime/src/weights/bounty.rs
@@ -9,33 +9,38 @@ pub struct WeightInfo;
 impl bounty::WeightInfo for WeightInfo {
     // WARNING! Some components were not used: ["i"]
     fn create_bounty_by_council() -> Weight {
-        (211_150_000 as Weight)
+        (230_005_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     // WARNING! Some components were not used: ["i"]
     fn create_bounty_by_member() -> Weight {
-        (389_946_000 as Weight)
+        (409_582_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn cancel_bounty_by_council() -> Weight {
-        (208_000_000 as Weight)
+        (303_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn cancel_bounty_by_member() -> Weight {
-        (315_000_000 as Weight)
+        (386_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn veto_bounty() -> Weight {
-        (206_000_000 as Weight)
+        (298_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn fund_bounty() -> Weight {
-        (547_000_000 as Weight)
+        (668_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
+    fn withdraw_member_funding() -> Weight {
+        (529_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }

--- a/runtime/src/weights/bounty.rs
+++ b/runtime/src/weights/bounty.rs
@@ -9,39 +9,49 @@ pub struct WeightInfo;
 impl bounty::WeightInfo for WeightInfo {
     // WARNING! Some components were not used: ["i"]
     fn create_bounty_by_council() -> Weight {
-        (230_005_000 as Weight)
+        (236_486_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     // WARNING! Some components were not used: ["i"]
     fn create_bounty_by_member() -> Weight {
-        (409_582_000 as Weight)
+        (416_178_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn cancel_bounty_by_council() -> Weight {
-        (303_000_000 as Weight)
+        (300_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn cancel_bounty_by_member() -> Weight {
-        (386_000_000 as Weight)
+        (407_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn veto_bounty() -> Weight {
-        (298_000_000 as Weight)
+        (297_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn fund_bounty() -> Weight {
-        (668_000_000 as Weight)
+        (645_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn withdraw_member_funding() -> Weight {
-        (529_000_000 as Weight)
+        (479_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
+    }
+    fn withdraw_creator_funding_by_council() -> Weight {
+        (226_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn withdraw_creator_funding_by_member() -> Weight {
+        (376_000_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
     }
 }


### PR DESCRIPTION
### Changes
- added `withdraw_member_funding` extrinsic
- added `withdraw_creator_funding` extrinsic
- introduced bounty accounts.
- introduced bounty removal in some cases

### Implementation comments
- when the cherry can't be distributed fully among the funders - the remainder gets burned
- bounty state could be removed during either `withdraw_member_funding` or `withdraw_creator_funding`extrinsics. The actual removal occurs when all possible withdrawals are completed.

### Open questions
- Should we migrate a council budget to the account to eliminate slashes/deposit_creations? 
- How do we prevent bad bounty creation (eg.: funding_period = 0, creator_funding = 0)? Should we limit active bounties number for a member or we rely on the extrinsic fee? 

[Main issue](https://github.com/Joystream/joystream/issues/1998)