### PR TITLE
CLI: Add missing axios dependency, fix api:setUri connection error

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -44,7 +44,7 @@ $ npm install -g @joystream/cli
 $ joystream-cli COMMAND
 running command...
 $ joystream-cli (-v|--version|version)
-@joystream/cli/0.3.0 linux-x64 node-v12.18.2
+@joystream/cli/0.3.2 linux-x64 node-v13.12.0
 $ joystream-cli --help [COMMAND]
 USAGE
   $ joystream-cli COMMAND

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/cli",
   "description": "Command Line Interface for Joystream community and governance activities",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Leszek Wiesner",
   "bin": {
     "joystream-cli": "./bin/run"

--- a/cli/package.json
+++ b/cli/package.json
@@ -38,7 +38,8 @@
     "moment": "^2.24.0",
     "proper-lockfile": "^4.1.1",
     "slug": "^2.1.1",
-    "tslib": "^1.11.1"
+    "tslib": "^1.11.1",
+    "axios": "^0.21.1"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",

--- a/cli/src/commands/api/setUri.ts
+++ b/cli/src/commands/api/setUri.ts
@@ -15,8 +15,8 @@ export default class ApiSetUri extends ApiCommandBase {
   ]
 
   async init() {
-    this.forceSkipApiUriPrompt = true
-    await super.init()
+    // Pass "skipConnection" arg to prevent command from exiting if current api uri is invalid
+    await super.init(true)
   }
 
   async run() {

--- a/cli/src/commands/media/uploadVideo.ts
+++ b/cli/src/commands/media/uploadVideo.ts
@@ -204,6 +204,7 @@ export default class UploadVideoCommand extends MediaCommandBase {
           'Content-Length': fileSize.toString(),
         },
         maxContentLength: MAX_FILE_SIZE,
+        maxBodyLength: MAX_FILE_SIZE,
       }
       await axios.put(uploadUrl, fileStream, config)
       cli.action.stop()

--- a/yarn.lock
+++ b/yarn.lock
@@ -7234,6 +7234,13 @@ axios@^0.19.0, axios@^0.19.2:
   dependencies:
     follow-redirects "1.5.10"
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 babel-code-frame@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -13321,6 +13328,11 @@ follow-redirects@^1.0.0:
   integrity sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==
   dependencies:
     debug "^3.0.0"
+
+follow-redirects@^1.10.0:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
+  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION
CLI bug fixes:
- Adding missing `axios` dependency
- Fixing `api:setUri` connection issue (users were unable to change api uri in case connection via the current one was unsuccesful)