### PR TITLE
storage-node: fix broken proxying to ipfs gateway

### DIFF
--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -161,12 +161,12 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
       }
     },
 
-    async get(req, res) {
-      proxy(req, res)
+    async get(req, res, next) {
+      proxy(req, res, next)
     },
 
-    async head(req, res) {
-      proxy(req, res)
+    async head(req, res, next) {
+      proxy(req, res, next)
     },
   }
 


### PR DESCRIPTION
After merging and updating sumer branch with https://github.com/Joystream/joystream/pull/2182 I observed an issue with http-proxy-middleware failing with `next` is not defined error.

So just back porting fix to master, just in-case although I'm not able re-produce the error on master branch.