### PR TITLE
Charge for thread and post creation

### DIFF
--- a/node/src/chain_spec/forum_config.rs
+++ b/node/src/chain_spec/forum_config.rs
@@ -2,7 +2,7 @@ use codec::Decode;
 use node_runtime::{
     forum,
     forum::{Category, Post, Thread},
-    AccountId, ForumConfig, Moment, PostId, Runtime, ThreadId,
+    AccountId, Balance, ForumConfig, Moment, PostId, Runtime, ThreadId,
 };
 use serde::Deserialize;
 use sp_core::H256;
@@ -11,10 +11,13 @@ use std::{fs, path::Path};
 type CategoryId = <Runtime as forum::Trait>::CategoryId;
 type ForumUserId = forum::ForumUserId<Runtime>;
 type ModeratorId = forum::ModeratorId<Runtime>;
+type Hash = H256;
+type PostOf = Post<ForumUserId, ThreadId, Hash>;
+
 type ThreadOf = (
     CategoryId,
     ThreadId,
-    Thread<ForumUserId, CategoryId, Moment, H256>,
+    Thread<ForumUserId, CategoryId, Moment, Hash, PostId, PostOf, Balance>,
 );
 
 #[derive(Decode)]
@@ -136,7 +139,6 @@ fn create(_forum_sudo: AccountId, forum_data: EncodedForumData) -> ForumConfig {
     ForumConfig {
         category_by_id: forum_data.categories,
         thread_by_id: forum_data.threads,
-        post_by_id: forum_data.posts,
         category_by_moderator: forum_data.category_by_moderator,
         next_category_id,
         next_thread_id,

--- a/node/src/chain_spec/forum_config.rs
+++ b/node/src/chain_spec/forum_config.rs
@@ -12,7 +12,7 @@ type CategoryId = <Runtime as forum::Trait>::CategoryId;
 type ForumUserId = forum::ForumUserId<Runtime>;
 type ModeratorId = forum::ModeratorId<Runtime>;
 type Hash = H256;
-type PostOf = Post<ForumUserId, ThreadId, Hash>;
+type PostOf = Post<ForumUserId, Hash>;
 
 type ThreadOf = (
     CategoryId,
@@ -23,7 +23,7 @@ type ThreadOf = (
 #[derive(Decode)]
 struct ForumData {
     categories: Vec<(CategoryId, Category<CategoryId, ThreadId, H256>)>,
-    posts: Vec<(ThreadId, PostId, Post<ForumUserId, ThreadId, H256>)>,
+    posts: Vec<(ThreadId, PostId, Post<ForumUserId, H256>)>,
     threads: Vec<ThreadOf>,
     category_by_moderator: Vec<(CategoryId, ModeratorId, ())>,
     data_migration_done: bool,

--- a/runtime-modules/forum/Cargo.toml
+++ b/runtime-modules/forum/Cargo.toml
@@ -15,10 +15,10 @@ sp-std = { package = 'sp-std', default-features = false, git = 'https://github.c
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 common = { package = 'pallet-common', default-features = false, path = '../common'}
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
+balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 
 # Benchmarking dependencies
 frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
 membership = { package = 'pallet-membership', default-features = false, path = '../membership', optional = true}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group', optional = true}
 staking-handler = { package = 'pallet-staking-handler', default-features = false, path = '../staking-handler', optional = true}
@@ -29,7 +29,6 @@ sp-core = { package = 'sp-core', default-features = false, git = 'https://github
 membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group'}
 staking-handler = { package = 'pallet-staking-handler', default-features = false, path = '../staking-handler'}
-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 
 [features]
 default = ['std']
@@ -38,7 +37,6 @@ runtime-benchmarks = [
 	'membership',
 	'working-group',
 	'staking-handler',
-	'balances',
     'sp-core',
 ]
 std = [
@@ -52,4 +50,5 @@ std = [
 	'sp-io/std',
 	'pallet-timestamp/std',
 	'common/std',
+    'balances/std',
 ]

--- a/runtime-modules/forum/Cargo.toml
+++ b/runtime-modules/forum/Cargo.toml
@@ -15,7 +15,6 @@ sp-std = { package = 'sp-std', default-features = false, git = 'https://github.c
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 common = { package = 'pallet-common', default-features = false, path = '../common'}
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 
 # Benchmarking dependencies
 frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
@@ -23,17 +22,20 @@ membership = { package = 'pallet-membership', default-features = false, path = '
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group', optional = true}
 staking-handler = { package = 'pallet-staking-handler', default-features = false, path = '../staking-handler', optional = true}
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
+balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
 
 [dev-dependencies]
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group'}
 staking-handler = { package = 'pallet-staking-handler', default-features = false, path = '../staking-handler'}
+balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 
 [features]
 default = ['std']
 runtime-benchmarks = [
     'frame-benchmarking',
+    'balances',
 	'membership',
 	'working-group',
 	'staking-handler',

--- a/runtime-modules/forum/src/benchmarking.rs
+++ b/runtime-modules/forum/src/benchmarking.rs
@@ -735,7 +735,7 @@ benchmarks! {
 
         assert_eq!(
             T::Currency::free_balance(&caller_id),
-            initial_balance - T::BasePayOffForThreadCleanUp::get() - T::PostDeposit::get(),
+            initial_balance - T::ThreadDeposit::get() - T::PostDeposit::get(),
         );
 
         // Ensure category num_direct_threads updated successfully.
@@ -757,7 +757,7 @@ benchmarks! {
             author_id: forum_user_id.saturated_into(),
             archived: false,
             poll: poll.clone(),
-            cleanup_pay_off: T::BasePayOffForThreadCleanUp::get() + T::PostDeposit::get(),
+            cleanup_pay_off: T::ThreadDeposit::get() + T::PostDeposit::get(),
             posts
         };
 
@@ -934,7 +934,7 @@ benchmarks! {
         assert_eq!(
             T::Currency::free_balance(&caller_id),
             initial_balance +
-            T::BasePayOffForThreadCleanUp::get() +
+            T::ThreadDeposit::get() +
             CurrencyBalance::<T>::from(
                 max_posts_in_thread.try_into().unwrap()
             ) * T::PostDeposit::get()
@@ -1002,7 +1002,7 @@ benchmarks! {
         assert_eq!(
             T::Currency::free_balance(&caller_id),
             initial_balance +
-            T::BasePayOffForThreadCleanUp::get() +
+            T::ThreadDeposit::get() +
             CurrencyBalance::<T>::from(max_posts_in_thread.try_into().unwrap()) *
             T::PostDeposit::get()
         );

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -7,6 +7,7 @@ pub use serde::{Deserialize, Serialize};
 
 use codec::{Codec, Decode, Encode};
 pub use frame_support::dispatch::DispatchResult;
+use frame_support::traits::{Currency, ExistenceRequirement};
 use frame_support::weights::Weight;
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, ensure, traits::Get, Parameter,
@@ -14,8 +15,10 @@ use frame_support::{
 use frame_system::ensure_signed;
 use sp_arithmetic::traits::{BaseArithmetic, One};
 pub use sp_io::storage::clear_prefix;
-use sp_runtime::traits::{MaybeSerialize, Member};
-use sp_runtime::SaturatedConversion;
+use sp_runtime::traits::{AccountIdConversion, MaybeSerialize, Member, Saturating};
+use sp_runtime::{ModuleId, SaturatedConversion};
+use sp_std::collections::btree_map::BTreeMap;
+use sp_std::fmt::Debug;
 use sp_std::prelude::*;
 
 use common::origin::MemberOriginValidator;
@@ -32,6 +35,20 @@ pub type ModeratorId<T> = common::ActorId<T>;
 /// Forum user ID alias for the member of the system.
 pub type ForumUserId<T> = common::MemberId<T>;
 type WeightInfoForum<T> = <T as Trait>::WeightInfo;
+
+/// Balance alias for `balances` module.
+pub type BalanceOf<T> = <T as balances::Trait>::Balance;
+
+/// Alias for the thread
+pub type ThreadOf<T> = Thread<
+    ForumUserId<T>,
+    <T as Trait>::CategoryId,
+    <T as pallet_timestamp::Trait>::Moment,
+    <T as frame_system::Trait>::Hash,
+    <T as Trait>::PostId,
+    Post<ForumUserId<T>, <T as Trait>::ThreadId, <T as frame_system::Trait>::Hash>,
+    BalanceOf<T>,
+>;
 
 /// pallet_forum WeightInfo.
 /// Note: This was auto generated through the benchmark CLI using the `--weight-trait` flag
@@ -63,7 +80,9 @@ pub trait WeightInfo {
     fn set_stickied_threads_moderator(i: u32, j: u32) -> Weight;
 }
 
-pub trait Trait: frame_system::Trait + pallet_timestamp::Trait + common::Trait {
+pub trait Trait:
+    frame_system::Trait + pallet_timestamp::Trait + common::Trait + balances::Trait
+{
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
 
     type CategoryId: Parameter
@@ -110,8 +129,21 @@ pub trait Trait: frame_system::Trait + pallet_timestamp::Trait + common::Trait {
         + From<u64>
         + Into<u64>;
 
+    /// Base deposit for any thread (note: thread creation also needs a `PostDeposit` since
+    /// creating a thread means also creating a post)
+    type StartingCleanupPayOff: Get<Self::Balance>;
+
+    /// Deposit needed to create a post
+    type PostDeposit: Get<Self::Balance>;
+
+    /// Maximum depth for nested categories
     type MaxCategoryDepth: Get<u64>;
+
+    /// Type defining the limits for different Storage items in the forum pallet
     type MapLimits: StorageLimits;
+
+    /// The forum module Id, used to derive the account Id to hold the thread bounty
+    type ModuleId: Get<ModuleId>;
 
     /// Weight information for extrinsics in this pallet.
     type WeightInfo: WeightInfo;
@@ -194,7 +226,7 @@ pub struct Post<ForumUserId, ThreadId, Hash> {
 /// Represents a thread
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Debug, Eq)]
-pub struct Thread<ForumUserId, CategoryId, Moment, Hash> {
+pub struct Thread<ForumUserId, CategoryId, Moment, Hash, PostId: sp_std::cmp::Ord, Post, Balance> {
     /// Title hash
     pub title_hash: Hash,
 
@@ -210,8 +242,14 @@ pub struct Thread<ForumUserId, CategoryId, Moment, Hash> {
     /// poll description.
     pub poll: Option<Poll<Moment, Hash>>,
 
-    // Number of posts in thread, needed for map limit checks
+    /// Number of posts in thread, needed for map limit checks
     pub num_direct_posts: u32,
+
+    /// Post in thread
+    pub posts: BTreeMap<PostId, Post>,
+
+    /// Pay off by deleting
+    pub cleanup_pay_off: Balance,
 }
 
 /// Represents a category
@@ -302,6 +340,9 @@ decl_error! {
         /// Thread is immutable, i.e. archived.
         ThreadImmutable,
 
+        /// Not enough balance to create thread
+        InsufficientBalanceForThreadCreation,
+
         // Errors about post.
 
         /// Post does not exist.
@@ -309,6 +350,9 @@ decl_error! {
 
         /// Account does not match post author.
         AccountDoesNotMatchPostAuthor,
+
+        /// Not enough balance to post
+        InsufficientBalanceForPost,
 
         // Errors about category.
 
@@ -384,15 +428,10 @@ decl_storage! {
 
         /// Map thread identifier to corresponding thread.
         pub ThreadById get(fn thread_by_id) config(): double_map hasher(blake2_128_concat)
-            T::CategoryId, hasher(blake2_128_concat) T::ThreadId =>
-                Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>;
+            T::CategoryId, hasher(blake2_128_concat) T::ThreadId => ThreadOf<T>;
 
         /// Thread identifier value to be used for next Thread in threadById.
         pub NextThreadId get(fn next_thread_id) config(): T::ThreadId;
-
-        /// Map post identifier to corresponding post.
-        pub PostById get(fn post_by_id) config(): double_map  hasher(blake2_128_concat) T::ThreadId,
-            hasher(blake2_128_concat) T::PostId => Post<ForumUserId<T>, T::ThreadId, T::Hash>;
 
         /// Post identifier value to be used for for next post created.
         pub NextPostId get(fn next_post_id) config(): T::PostId;
@@ -612,7 +651,7 @@ decl_module! {
             let account_id = ensure_signed(origin)?;
 
             // Ensure actor can update category
-            let category = Self::ensure_can_moderate_category(account_id, &actor, &category_id)?;
+            let category = Self::ensure_can_moderate_category(&account_id, &actor, &category_id)?;
 
             // No change, invalid transaction
             if new_archival_status == category.archived {
@@ -710,7 +749,7 @@ decl_module! {
 
             let account_id = ensure_signed(origin)?;
 
-            Self::ensure_can_create_thread(account_id, &forum_user_id, &category_id)?;
+            Self::ensure_can_create_thread(&account_id, &forum_user_id, &category_id)?;
 
             // Ensure poll is valid
             if let Some(ref data) = poll {
@@ -728,8 +767,8 @@ decl_module! {
             // Create and add new thread
             let new_thread_id = <NextThreadId<T>>::get();
 
-            // Add inital post to thread
-            let _ = Self::add_new_post(new_thread_id, &text, forum_user_id);
+
+            let cleanup_pay_off = T::StartingCleanupPayOff::get();
 
             // Build a new thread
             let new_thread = Thread {
@@ -738,13 +777,21 @@ decl_module! {
                 author_id: forum_user_id,
                 archived: false,
                 poll: poll.clone(),
-                num_direct_posts: 1,
+                num_direct_posts: 0,
+                posts: BTreeMap::new(),
+                cleanup_pay_off,
             };
 
             // Store thread
             <ThreadById<T>>::mutate(category_id, new_thread_id, |value| {
                 *value = new_thread.clone()
             });
+
+            // Reserve cleanup pay off in the thread account
+            Self::transfer_to_thread_account(cleanup_pay_off, new_thread_id, &account_id);
+
+            // Add inital post to thread
+            let _ = Self::add_new_post(&account_id, new_thread_id, category_id, &text, forum_user_id);
 
             // Update next thread id
             <NextThreadId<T>>::mutate(|n| *n += One::one());
@@ -879,11 +926,14 @@ decl_module! {
 
             let account_id = ensure_signed(origin)?;
 
-            let thread = Self::ensure_can_moderate_thread(account_id, &actor, &category_id, &thread_id)?;
+            let thread = Self::ensure_can_moderate_thread(&account_id, &actor, &category_id, &thread_id)?;
 
             //
             // == MUTATION SAFE ==
             //
+
+            // Pay off to thread deleter
+            Self::pay_off(thread_id, thread.cleanup_pay_off, &account_id);
 
             // Delete thread
             Self::delete_thread_inner(thread.category_id, thread_id);
@@ -961,7 +1011,7 @@ decl_module! {
             let account_id = ensure_signed(origin)?;
 
             // get forum user id.
-            Self::ensure_is_forum_user(account_id, &forum_user_id)?;
+            Self::ensure_is_forum_user(&account_id, &forum_user_id)?;
 
             // Get thread
             let (_, thread) = Self::ensure_thread_is_mutable(&category_id, &thread_id)?;
@@ -1040,11 +1090,13 @@ decl_module! {
             let account_id = ensure_signed(origin)?;
 
             // Ensure actor is allowed to moderate post
-            let thread = Self::ensure_can_moderate_thread(account_id, &actor, &category_id, &thread_id)?;
+            let thread = Self::ensure_can_moderate_thread(&account_id, &actor, &category_id, &thread_id)?;
 
             //
             // == MUTATION SAFE ==
             //
+
+            Self::slash_thread_account(thread_id, thread.cleanup_pay_off);
 
             // Delete thread
             Self::delete_thread_inner(thread.category_id, thread_id);
@@ -1079,7 +1131,7 @@ decl_module! {
             let account_id = ensure_signed(origin)?;
 
             // Make sure thread exists and is mutable
-            let (_, thread) = Self::ensure_can_add_post(account_id, &forum_user_id, &category_id, &thread_id)?;
+            let (_, thread) = Self::ensure_can_add_post(&account_id, &forum_user_id, &category_id, &thread_id)?;
 
             // Ensure map limits are not reached
             Self::ensure_map_limits::<<<T>::MapLimits as StorageLimits>::MaxPostsInThread>(
@@ -1091,10 +1143,13 @@ decl_module! {
             //
 
             // Add new post
-            let (post_id, _) = Self::add_new_post(thread_id, text.as_slice(), forum_user_id);
-
-            // Update thread's post counter
-            <ThreadById<T>>::mutate(thread.category_id, thread_id, |c| c.num_direct_posts += 1);
+            let (post_id, _) = Self::add_new_post(
+                    &account_id,
+                    thread_id,
+                    category_id,
+                    text.as_slice(),
+                    forum_user_id
+                );
 
             // Generate event
             Self::deposit_event(
@@ -1124,7 +1179,7 @@ decl_module! {
             let account_id = ensure_signed(origin)?;
 
             // Check that account is forum member
-            Self::ensure_is_forum_user(account_id, &forum_user_id)?;
+            Self::ensure_is_forum_user(&account_id, &forum_user_id)?;
 
             // Make sure there exists a mutable post with post id `post_id`
             Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?;
@@ -1162,10 +1217,10 @@ decl_module! {
             let account_id = ensure_signed(origin)?;
 
             // Check that account is forum member
-            Self::ensure_is_forum_user(account_id, &forum_user_id)?;
+            Self::ensure_is_forum_user(&account_id, &forum_user_id)?;
 
             // Make sure there exists a mutable post with post id `post_id`
-            let post = Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?;
+            let mut post = Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?;
 
             // Signer does not match creator of post with identifier postId
             ensure!(post.author_id == forum_user_id, Error::<T>::AccountDoesNotMatchPostAuthor);
@@ -1176,7 +1231,11 @@ decl_module! {
 
             // Update post text
             let text_hash = T::calculate_hash(&new_text);
-            <PostById<T>>::mutate(post.thread_id, post_id, |p| p.text_hash = text_hash);
+            post.text_hash = text_hash;
+
+            <ThreadById<T>>::mutate(category_id, thread_id,
+                |thread| thread.posts.insert(post_id, post)
+            );
 
             // Generate event
             Self::deposit_event(RawEvent::PostTextUpdated(
@@ -1277,8 +1336,39 @@ decl_module! {
 }
 
 impl<T: Trait> Module<T> {
-    pub fn add_new_post(
+    fn slash_thread_account(thread_id: T::ThreadId, amount: BalanceOf<T>) {
+        let thread_account_id = T::ModuleId::get().into_sub_account(thread_id);
+        let _ = <balances::Module<T> as Currency<T::AccountId>>::slash(&thread_account_id, amount);
+    }
+
+    fn pay_off(thread_id: T::ThreadId, amount: BalanceOf<T>, account_id: &T::AccountId) {
+        let thread_account_id = T::ModuleId::get().into_sub_account(thread_id);
+        let _ = <balances::Module<T> as Currency<T::AccountId>>::transfer(
+            &thread_account_id,
+            account_id,
+            amount,
+            ExistenceRequirement::AllowDeath,
+        );
+    }
+
+    fn transfer_to_thread_account(
+        amount: BalanceOf<T>,
         thread_id: T::ThreadId,
+        account_id: &T::AccountId,
+    ) {
+        let thread_account_id = T::ModuleId::get().into_sub_account(thread_id);
+        let _ = <balances::Module<T> as Currency<T::AccountId>>::transfer(
+            account_id,
+            &thread_account_id,
+            amount,
+            ExistenceRequirement::KeepAlive,
+        );
+    }
+
+    pub fn add_new_post(
+        account_id: &T::AccountId,
+        thread_id: T::ThreadId,
+        category_id: T::CategoryId,
         text: &[u8],
         author_id: ForumUserId<T>,
     ) -> (T::PostId, Post<ForumUserId<T>, T::ThreadId, T::Hash>) {
@@ -1292,8 +1382,15 @@ impl<T: Trait> Module<T> {
             author_id,
         };
 
-        // Store post
-        <PostById<T>>::mutate(thread_id, new_post_id, |value| *value = new_post.clone());
+        let mut thread = <ThreadById<T>>::get(category_id, thread_id);
+        thread.posts.insert(new_post_id, new_post.clone());
+        thread.num_direct_posts += 1;
+
+        let post_deposit = T::PostDeposit::get();
+        thread.cleanup_pay_off = thread.cleanup_pay_off.saturating_add(post_deposit);
+        Self::transfer_to_thread_account(post_deposit, thread_id, &account_id);
+
+        <ThreadById<T>>::insert(category_id, thread_id, thread);
 
         // Update next post id
         <NextPostId<T>>::mutate(|n| *n += One::one());
@@ -1305,20 +1402,15 @@ impl<T: Trait> Module<T> {
         // Delete thread
         <ThreadById<T>>::remove(category_id, thread_id);
 
-        // Delete all thread's posts
-        <PostById<T>>::remove_prefix(thread_id);
-
         // decrease category's thread counter
         <CategoryById<T>>::mutate(category_id, |category| category.num_direct_threads -= 1);
     }
 
     fn delete_post_inner(category_id: T::CategoryId, thread_id: T::ThreadId, post_id: T::PostId) {
-        // Delete post
-        <PostById<T>>::remove(thread_id, post_id);
-
         // Decrease thread's post counter
         <ThreadById<T>>::mutate(category_id, thread_id, |thread| {
-            thread.num_direct_posts -= 1
+            thread.num_direct_posts -= 1;
+            thread.posts.remove(&post_id);
         });
     }
 
@@ -1354,7 +1446,7 @@ impl<T: Trait> Module<T> {
         post_id: &T::PostId,
     ) -> Result<Post<ForumUserId<T>, T::ThreadId, T::Hash>, Error<T>> {
         // Make sure post exists
-        let post = Self::ensure_post_exists(thread_id, post_id)?;
+        let post = Self::ensure_post_exists(category_id, thread_id, post_id)?;
 
         // and make sure thread is mutable
         Self::ensure_thread_is_mutable(category_id, thread_id)?;
@@ -1363,14 +1455,21 @@ impl<T: Trait> Module<T> {
     }
 
     fn ensure_post_exists(
+        category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
         post_id: &T::PostId,
     ) -> Result<Post<ForumUserId<T>, T::ThreadId, T::Hash>, Error<T>> {
-        if !<PostById<T>>::contains_key(thread_id, post_id) {
+        if !<ThreadById<T>>::contains_key(category_id, thread_id) {
             return Err(Error::<T>::PostDoesNotExist);
         }
 
-        Ok(<PostById<T>>::get(thread_id, post_id))
+        let thread = <ThreadById<T>>::get(category_id, thread_id);
+
+        thread
+            .posts
+            .get(post_id)
+            .cloned()
+            .ok_or_else(|| Error::<T>::PostDoesNotExist)
     }
 
     fn ensure_can_moderate_post(
@@ -1381,7 +1480,7 @@ impl<T: Trait> Module<T> {
         post_id: &T::PostId,
     ) -> Result<Post<ForumUserId<T>, T::ThreadId, T::Hash>, Error<T>> {
         // Ensure the moderator can moderate the category
-        Self::ensure_can_moderate_category(account_id, &actor, &category_id)?;
+        Self::ensure_can_moderate_category(&account_id, &actor, &category_id)?;
 
         // Make sure post exists and is mutable
         let post = Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?;
@@ -1392,13 +1491,7 @@ impl<T: Trait> Module<T> {
     fn ensure_thread_is_mutable(
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
-    ) -> Result<
-        (
-            Category<T::CategoryId, T::ThreadId, T::Hash>,
-            Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>,
-        ),
-        Error<T>,
-    > {
+    ) -> Result<(Category<T::CategoryId, T::ThreadId, T::Hash>, ThreadOf<T>), Error<T>> {
         // Make sure thread exists
         let thread = Self::ensure_thread_exists(category_id, thread_id)?;
 
@@ -1417,15 +1510,9 @@ impl<T: Trait> Module<T> {
         actor: &PrivilegedActor<T>,
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
-    ) -> Result<
-        (
-            Category<T::CategoryId, T::ThreadId, T::Hash>,
-            Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>,
-        ),
-        Error<T>,
-    > {
+    ) -> Result<(Category<T::CategoryId, T::ThreadId, T::Hash>, ThreadOf<T>), Error<T>> {
         // Check actor's role
-        Self::ensure_actor_role(account_id, actor)?;
+        Self::ensure_actor_role(&account_id, actor)?;
 
         let (category, thread) = Self::ensure_thread_is_mutable(category_id, thread_id)?;
 
@@ -1438,7 +1525,7 @@ impl<T: Trait> Module<T> {
     fn ensure_thread_exists(
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
-    ) -> Result<Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>, Error<T>> {
+    ) -> Result<ThreadOf<T>, Error<T>> {
         if !<ThreadById<T>>::contains_key(category_id, thread_id) {
             return Err(Error::<T>::ThreadDoesNotExist);
         }
@@ -1451,9 +1538,9 @@ impl<T: Trait> Module<T> {
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
         forum_user_id: &ForumUserId<T>,
-    ) -> Result<Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>, Error<T>> {
+    ) -> Result<ThreadOf<T>, Error<T>> {
         // Check that account is forum member
-        Self::ensure_is_forum_user(account_id, &forum_user_id)?;
+        Self::ensure_is_forum_user(&account_id, &forum_user_id)?;
 
         // Ensure thread is mutable
         let (_, thread) = Self::ensure_thread_is_mutable(category_id, thread_id)?;
@@ -1465,7 +1552,7 @@ impl<T: Trait> Module<T> {
     }
 
     fn ensure_is_thread_author(
-        thread: &Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>,
+        thread: &ThreadOf<T>,
         forum_user_id: &ForumUserId<T>,
     ) -> Result<(), Error<T>> {
         ensure!(
@@ -1477,15 +1564,15 @@ impl<T: Trait> Module<T> {
     }
 
     fn ensure_actor_role(
-        account_id: T::AccountId,
+        account_id: &T::AccountId,
         actor: &PrivilegedActor<T>,
     ) -> Result<(), Error<T>> {
         match actor {
             PrivilegedActor::Lead => {
-                Self::ensure_is_forum_lead_account(&account_id)?;
+                Self::ensure_is_forum_lead_account(account_id)?;
             }
             PrivilegedActor::Moderator(moderator_id) => {
-                Self::ensure_is_moderator_account(&account_id, &moderator_id)?;
+                Self::ensure_is_moderator_account(account_id, &moderator_id)?;
             }
         };
         Ok(())
@@ -1501,11 +1588,11 @@ impl<T: Trait> Module<T> {
 
     /// Ensure forum user id registered and its account id matched
     fn ensure_is_forum_user(
-        account_id: T::AccountId,
+        account_id: &T::AccountId,
         forum_user_id: &ForumUserId<T>,
     ) -> Result<(), Error<T>> {
         let is_member =
-            T::MemberOriginValidator::is_member_controller_account(forum_user_id, &account_id);
+            T::MemberOriginValidator::is_member_controller_account(forum_user_id, account_id);
 
         ensure!(is_member, Error::<T>::ForumUserIdNotMatchAccount);
         Ok(())
@@ -1525,11 +1612,11 @@ impl<T: Trait> Module<T> {
 
     // Ensure actor can manipulate thread.
     fn ensure_can_moderate_thread(
-        account_id: T::AccountId,
+        account_id: &T::AccountId,
         actor: &PrivilegedActor<T>,
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
-    ) -> Result<Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>, Error<T>> {
+    ) -> Result<ThreadOf<T>, Error<T>> {
         // Check that account is forum member
         Self::ensure_can_moderate_category(account_id, actor, category_id)?;
 
@@ -1544,13 +1631,13 @@ impl<T: Trait> Module<T> {
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
         new_category_id: &T::CategoryId,
-    ) -> Result<Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>, Error<T>> {
+    ) -> Result<ThreadOf<T>, Error<T>> {
         ensure!(
             category_id != new_category_id,
             Error::<T>::ThreadMoveInvalid,
         );
 
-        let thread = Self::ensure_can_moderate_thread(account_id, actor, category_id, thread_id)
+        let thread = Self::ensure_can_moderate_thread(&account_id, actor, category_id, thread_id)
             .map_err(|_| Error::<T>::ModeratorModerateOriginCategory)?;
 
         Self::ensure_can_moderate_category_path(actor, new_category_id)
@@ -1665,7 +1752,7 @@ impl<T: Trait> Module<T> {
         category_id: &T::CategoryId,
     ) -> Result<Category<T::CategoryId, T::ThreadId, T::Hash>, Error<T>> {
         // Check actor's role
-        Self::ensure_actor_role(account_id, actor)?;
+        Self::ensure_actor_role(&account_id, actor)?;
 
         // Ensure category exists
         let category = Self::ensure_category_exists(category_id)?;
@@ -1697,7 +1784,7 @@ impl<T: Trait> Module<T> {
 
     /// check if an account can moderate a category.
     fn ensure_can_moderate_category(
-        account_id: T::AccountId,
+        account_id: &T::AccountId,
         actor: &PrivilegedActor<T>,
         category_id: &T::CategoryId,
     ) -> Result<Category<T::CategoryId, T::ThreadId, T::Hash>, Error<T>> {
@@ -1806,7 +1893,7 @@ impl<T: Trait> Module<T> {
     }
 
     fn ensure_can_create_thread(
-        account_id: T::AccountId,
+        account_id: &T::AccountId,
         forum_user_id: &ForumUserId<T>,
         category_id: &T::CategoryId,
     ) -> Result<Category<T::CategoryId, T::ThreadId, T::Hash>, Error<T>> {
@@ -1819,23 +1906,33 @@ impl<T: Trait> Module<T> {
             category.num_direct_threads as u64,
         )?;
 
+        // The balance for creation of thread is the base cost plus the cost of a single post
+        let minimum_balance = T::StartingCleanupPayOff::get() + T::PostDeposit::get();
+        ensure!(
+            Self::ensure_enough_balance(minimum_balance, &account_id),
+            Error::<T>::InsufficientBalanceForThreadCreation
+        );
+
         Ok(category)
     }
 
+    fn ensure_enough_balance(balance: BalanceOf<T>, account_id: &T::AccountId) -> bool {
+        balances::Module::<T>::usable_balance(account_id) >= balance
+    }
+
     fn ensure_can_add_post(
-        account_id: T::AccountId,
+        account_id: &T::AccountId,
         forum_user_id: &ForumUserId<T>,
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
-    ) -> Result<
-        (
-            Category<T::CategoryId, T::ThreadId, T::Hash>,
-            Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>,
-        ),
-        Error<T>,
-    > {
+    ) -> Result<(Category<T::CategoryId, T::ThreadId, T::Hash>, ThreadOf<T>), Error<T>> {
         // Check that account is forum member
         Self::ensure_is_forum_user(account_id, &forum_user_id)?;
+
+        ensure!(
+            Self::ensure_enough_balance(T::PostDeposit::get(), &account_id),
+            Error::<T>::InsufficientBalanceForPost
+        );
 
         let (category, thread) = Self::ensure_thread_is_mutable(category_id, thread_id)?;
 
@@ -1849,7 +1946,7 @@ impl<T: Trait> Module<T> {
         stickied_ids: &[T::ThreadId],
     ) -> Result<Category<T::CategoryId, T::ThreadId, T::Hash>, Error<T>> {
         // Ensure actor can moderate the category
-        let category = Self::ensure_can_moderate_category(account_id, &actor, &category_id)?;
+        let category = Self::ensure_can_moderate_category(&account_id, &actor, &category_id)?;
 
         // Ensure all thread id valid and is under the category
         for item in stickied_ids {
@@ -1861,7 +1958,7 @@ impl<T: Trait> Module<T> {
 
     /// Check the vote is valid
     fn ensure_vote_is_valid(
-        thread: Thread<ForumUserId<T>, T::CategoryId, T::Moment, T::Hash>,
+        thread: ThreadOf<T>,
         index: u32,
     ) -> Result<Poll<T::Moment, T::Hash>, Error<T>> {
         // Ensure poll exists

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -131,7 +131,7 @@ pub trait Trait: frame_system::Trait + pallet_timestamp::Trait + common::Trait {
 
     /// Base deposit for any thread (note: thread creation also needs a `PostDeposit` since
     /// creating a thread means also creating a post)
-    type BasePayOffForThreadCleanUp: Get<
+    type ThreadDeposit: Get<
         <Self::Currency as frame_support::traits::Currency<Self::AccountId>>::Balance,
     >;
 
@@ -768,7 +768,7 @@ decl_module! {
             let new_thread_id = <NextThreadId<T>>::get();
 
 
-            let cleanup_pay_off = T::BasePayOffForThreadCleanUp::get();
+            let cleanup_pay_off = T::ThreadDeposit::get();
 
             // Build a new thread
             let new_thread = Thread {
@@ -1906,7 +1906,7 @@ impl<T: Trait> Module<T> {
         )?;
 
         // The balance for creation of thread is the base cost plus the cost of a single post
-        let minimum_balance = T::BasePayOffForThreadCleanUp::get() + T::PostDeposit::get();
+        let minimum_balance = T::ThreadDeposit::get() + T::PostDeposit::get();
         ensure!(
             Self::ensure_enough_balance(minimum_balance, &account_id),
             Error::<T>::InsufficientBalanceForThreadCreation

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -317,7 +317,7 @@ parameter_types! {
     pub const MaxModeratorsForCategory: u64 = 3;
     pub const MaxCategories: u64 = 40;
     pub const MaxPollAlternativesNumber: u64 = 20;
-    pub const BasePayOffForThreadCleanUp: u64 = 100;
+    pub const ThreadDeposit: u64 = 100;
     pub const PostDeposit: u64 = 10;
     pub const ForumModuleId: ModuleId = ModuleId(*b"m0:forum"); // module : forum
 }
@@ -344,7 +344,7 @@ impl Trait for Runtime {
     type MapLimits = MapLimits;
     type WorkingGroup = ();
     type MemberOriginValidator = ();
-    type BasePayOffForThreadCleanUp = BasePayOffForThreadCleanUp;
+    type ThreadDeposit = ThreadDeposit;
     type PostDeposit = PostDeposit;
 
     type ModuleId = ForumModuleId;
@@ -676,7 +676,7 @@ pub fn create_thread_mock(
         assert_eq!(
             balances::Module::<Runtime>::free_balance(&account_id),
             initial_balance
-                - <Runtime as Trait>::BasePayOffForThreadCleanUp::get()
+                - <Runtime as Trait>::ThreadDeposit::get()
                 - <Runtime as Trait>::PostDeposit::get()
         );
     } else {

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -348,6 +348,7 @@ impl Trait for Runtime {
     type PostDeposit = PostDeposit;
 
     type ModuleId = ForumModuleId;
+    type Currency = Balances;
 
     fn calculate_hash(text: &[u8]) -> Self::Hash {
         Self::Hashing::hash(text)
@@ -1267,3 +1268,4 @@ pub type Timestamp = pallet_timestamp::Module<Runtime>;
 
 /// Export forum module on a test runtime
 pub type TestForumModule = Module<Runtime>;
+pub type Balances = balances::Module<Runtime>;

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -57,7 +57,7 @@ impl frame_system::Trait for Runtime {
     type BlockNumber = u64;
     type Hash = H256;
     type Hashing = BlakeTwo256;
-    type AccountId = u64;
+    type AccountId = u128;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
     type Event = TestEvent;
@@ -95,8 +95,8 @@ impl balances::Trait for Runtime {
 }
 
 impl common::Trait for Runtime {
-    type MemberId = u64;
-    type ActorId = u64;
+    type MemberId = u128;
+    type ActorId = u128;
 }
 
 parameter_types! {
@@ -317,7 +317,7 @@ parameter_types! {
     pub const MaxModeratorsForCategory: u64 = 3;
     pub const MaxCategories: u64 = 40;
     pub const MaxPollAlternativesNumber: u64 = 20;
-    pub const StartingCleanupPayOff: u64 = 100;
+    pub const BasePayOffForThreadCleanUp: u64 = 100;
     pub const PostDeposit: u64 = 10;
     pub const ForumModuleId: ModuleId = ModuleId(*b"m0:forum"); // module : forum
 }
@@ -344,7 +344,7 @@ impl Trait for Runtime {
     type MapLimits = MapLimits;
     type WorkingGroup = ();
     type MemberOriginValidator = ();
-    type StartingCleanupPayOff = StartingCleanupPayOff;
+    type BasePayOffForThreadCleanUp = BasePayOffForThreadCleanUp;
     type PostDeposit = PostDeposit;
 
     type ModuleId = ForumModuleId;
@@ -356,11 +356,11 @@ impl Trait for Runtime {
     type WeightInfo = ();
 }
 
-impl common::origin::MemberOriginValidator<Origin, u64, u64> for () {
+impl common::origin::MemberOriginValidator<Origin, u128, u128> for () {
     fn ensure_member_controller_account_origin(
         origin: Origin,
-        member_id: u64,
-    ) -> Result<u64, DispatchError> {
+        member_id: u128,
+    ) -> Result<u128, DispatchError> {
         let account_id = ensure_signed(origin).unwrap();
         ensure!(
             Self::is_member_controller_account(&member_id, &account_id),
@@ -369,7 +369,7 @@ impl common::origin::MemberOriginValidator<Origin, u64, u64> for () {
         Ok(account_id)
     }
 
-    fn is_member_controller_account(member_id: &u64, account_id: &u64) -> bool {
+    fn is_member_controller_account(member_id: &u128, account_id: &u128) -> bool {
         let allowed_accounts = [
             FORUM_LEAD_ORIGIN_ID,
             NOT_FORUM_LEAD_ORIGIN_ID,
@@ -529,7 +529,7 @@ pub const FORUM_MODERATOR_2_ORIGIN_ID: <Runtime as frame_system::Trait>::Account
 pub const FORUM_MODERATOR_2_ORIGIN: OriginType = OriginType::Signed(FORUM_MODERATOR_2_ORIGIN_ID);
 
 const EXTRA_MODERATOR_COUNT: usize = 5;
-pub const EXTRA_MODERATORS: [u64; EXTRA_MODERATOR_COUNT] = [125, 126, 127, 128, 129];
+pub const EXTRA_MODERATORS: [u128; EXTRA_MODERATOR_COUNT] = [125, 126, 127, 128, 129];
 
 pub fn good_category_title() -> Vec<u8> {
     b"Great new category".to_vec()
@@ -675,7 +675,7 @@ pub fn create_thread_mock(
         assert_eq!(
             balances::Module::<Runtime>::free_balance(&account_id),
             initial_balance
-                - <Runtime as Trait>::StartingCleanupPayOff::get()
+                - <Runtime as Trait>::BasePayOffForThreadCleanUp::get()
                 - <Runtime as Trait>::PostDeposit::get()
         );
     } else {

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -13,7 +13,7 @@ use staking_handler::LockComparator;
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types};
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, Hash, IdentityLookup},
+    traits::{BlakeTwo256, Hash, IdentityLookup, Zero},
     DispatchError, Perbill,
 };
 
@@ -317,6 +317,9 @@ parameter_types! {
     pub const MaxModeratorsForCategory: u64 = 3;
     pub const MaxCategories: u64 = 40;
     pub const MaxPollAlternativesNumber: u64 = 20;
+    pub const StartingCleanupPayOff: u64 = 100;
+    pub const PostDeposit: u64 = 10;
+    pub const ForumModuleId: ModuleId = ModuleId(*b"m0:forum"); // module : forum
 }
 
 pub struct MapLimits;
@@ -341,6 +344,10 @@ impl Trait for Runtime {
     type MapLimits = MapLimits;
     type WorkingGroup = ();
     type MemberOriginValidator = ();
+    type StartingCleanupPayOff = StartingCleanupPayOff;
+    type PostDeposit = PostDeposit;
+
+    type ModuleId = ForumModuleId;
 
     fn calculate_hash(text: &[u8]) -> Self::Hash {
         Self::Hashing::hash(text)
@@ -627,6 +634,7 @@ pub fn create_category_mock(
 
 pub fn create_thread_mock(
     origin: OriginType,
+    account_id: <Runtime as frame_system::Trait>::AccountId,
     forum_user_id: ForumUserId<Runtime>,
     category_id: <Runtime as Trait>::CategoryId,
     title: Vec<u8>,
@@ -637,6 +645,8 @@ pub fn create_thread_mock(
     result: DispatchResult,
 ) -> <Runtime as Trait>::ThreadId {
     let thread_id = TestForumModule::next_thread_id();
+    let initial_balance = balances::Module::<Runtime>::free_balance(&account_id);
+
     assert_eq!(
         TestForumModule::create_thread(
             mock_origin(origin.clone()),
@@ -660,6 +670,18 @@ pub fn create_thread_mock(
                 text.clone(),
                 poll_data.clone()
             ))
+        );
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&account_id),
+            initial_balance
+                - <Runtime as Trait>::StartingCleanupPayOff::get()
+                - <Runtime as Trait>::PostDeposit::get()
+        );
+    } else {
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&account_id),
+            initial_balance
         );
     }
     thread_id
@@ -703,15 +725,19 @@ pub fn edit_thread_title_mock(
 
 pub fn delete_thread_mock(
     origin: OriginType,
+    account_id: <Runtime as frame_system::Trait>::AccountId,
     moderator_id: ModeratorId<Runtime>,
     category_id: <Runtime as Trait>::CategoryId,
     thread_id: <Runtime as Trait>::PostId,
     result: DispatchResult,
 ) {
+    let initial_balance = balances::Module::<Runtime>::free_balance(&account_id);
+
     let num_direct_threads = match <CategoryById<Runtime>>::contains_key(category_id) {
         true => <CategoryById<Runtime>>::get(category_id).num_direct_threads,
         false => 0,
     };
+    let thread_payment = <ThreadById<Runtime>>::get(category_id, thread_id).cleanup_pay_off;
     assert_eq!(
         TestForumModule::delete_thread(
             mock_origin(origin.clone()),
@@ -734,6 +760,16 @@ pub fn delete_thread_mock(
                 PrivilegedActor::Moderator(moderator_id),
                 category_id
             ))
+        );
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&account_id),
+            initial_balance + thread_payment
+        );
+    } else {
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&account_id),
+            initial_balance
         );
     }
 }
@@ -806,6 +842,7 @@ pub fn update_thread_archival_status_mock(
 
 pub fn create_post_mock(
     origin: OriginType,
+    account_id: <Runtime as frame_system::Trait>::AccountId,
     forum_user_id: ForumUserId<Runtime>,
     category_id: <Runtime as Trait>::CategoryId,
     thread_id: <Runtime as Trait>::ThreadId,
@@ -813,6 +850,7 @@ pub fn create_post_mock(
     result: DispatchResult,
 ) -> <Runtime as Trait>::PostId {
     let post_id = TestForumModule::next_post_id();
+    let initial_balance = balances::Module::<Runtime>::free_balance(account_id);
     assert_eq!(
         TestForumModule::add_post(
             mock_origin(origin.clone()),
@@ -834,6 +872,16 @@ pub fn create_post_mock(
                 thread_id,
                 text
             ))
+        );
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&account_id),
+            initial_balance - <Runtime as Trait>::PostDeposit::get()
+        );
+    } else {
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&account_id),
+            initial_balance
         );
     };
     post_id
@@ -860,8 +908,9 @@ pub fn edit_post_text_mock(
         result
     );
     if result.is_ok() {
+        let thread = TestForumModule::thread_by_id(category_id, thread_id);
         assert_eq!(
-            TestForumModule::post_by_id(thread_id, post_id).text_hash,
+            thread.posts.get(&post_id).unwrap().text_hash,
             Runtime::calculate_hash(new_text.as_slice()),
         );
         assert_eq!(
@@ -1012,6 +1061,7 @@ pub fn moderate_thread_mock(
     rationale: Vec<u8>,
     result: DispatchResult,
 ) -> <Runtime as Trait>::ThreadId {
+    let thread_account_id = <Runtime as Trait>::ModuleId::get().into_sub_account(thread_id);
     assert_eq!(
         TestForumModule::moderate_thread(
             mock_origin(origin),
@@ -1032,6 +1082,11 @@ pub fn moderate_thread_mock(
                 PrivilegedActor::Moderator(moderator_id),
                 category_id
             ))
+        );
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&thread_account_id),
+            BalanceOf::<Runtime>::zero()
         );
     }
     thread_id
@@ -1058,7 +1113,8 @@ pub fn moderate_post_mock(
         result
     );
     if result.is_ok() {
-        assert!(!<PostById<Runtime>>::contains_key(thread_id, post_id));
+        let thread = <ThreadById<Runtime>>::get(category_id, thread_id);
+        assert!(!thread.posts.contains_key(&post_id));
         assert_eq!(
             System::events().last().unwrap().event,
             TestEvent::forum_mod(RawEvent::PostModerated(
@@ -1156,7 +1212,6 @@ pub fn create_genesis_config(data_migration_done: bool) -> GenesisConfig<Runtime
         category_counter: 0,
         thread_by_id: vec![],
         next_thread_id: 1,
-        post_by_id: vec![],
         next_post_id: 1,
 
         category_by_moderator: vec![],

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -3,6 +3,7 @@
 use super::*;
 use crate::mock::*;
 use frame_support::assert_err;
+use frame_support::traits::Currency;
 
 /// test cases are arranged as two layers.
 /// first layer is each method in defined in module.

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -1109,7 +1109,7 @@ fn delete_thread() {
             Ok(()),
         );
 
-        current_balance -= <Runtime as Trait>::BasePayOffForThreadCleanUp::get();
+        current_balance -= <Runtime as Trait>::ThreadDeposit::get();
         current_balance -= <Runtime as Trait>::PostDeposit::get();
 
         assert_eq!(
@@ -1602,8 +1602,7 @@ fn add_post_balance() {
     with_test_externalities(|| {
         balances::Module::<Runtime>::make_free_balance_be(
             &forum_lead,
-            <Runtime as Trait>::PostDeposit::get()
-                + <Runtime as Trait>::BasePayOffForThreadCleanUp::get(),
+            <Runtime as Trait>::PostDeposit::get() + <Runtime as Trait>::ThreadDeposit::get(),
         );
         let category_id = create_category_mock(
             origin.clone(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -650,7 +650,7 @@ parameter_types! {
     pub const MaxModeratorsForCategory: u64 = 20;
     pub const MaxCategories: u64 = 20;
     pub const MaxPollAlternativesNumber: u64 = 20;
-    pub const StartingCleanupPayOff: u64 = 30;
+    pub const BasePayOffForThreadCleanUp: u64 = 30;
     pub const PostDeposit: u64 = 10;
     pub const ForumModuleId: ModuleId = ModuleId(*b"mo:forum"); // module : forum
 }
@@ -674,7 +674,7 @@ impl forum::Trait for Runtime {
     type PostReactionId = u64;
     type MaxCategoryDepth = MaxCategoryDepth;
 
-    type StartingCleanupPayOff = StartingCleanupPayOff;
+    type BasePayOffForThreadCleanUp = BasePayOffForThreadCleanUp;
     type PostDeposit = PostDeposit;
     type ModuleId = ForumModuleId;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -43,7 +43,7 @@ use sp_core::crypto::KeyTypeId;
 use sp_core::Hasher;
 use sp_runtime::curve::PiecewiseLinear;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT, IdentityLookup, OpaqueKeys, Saturating};
-use sp_runtime::{create_runtime_str, generic, impl_opaque_keys, Perbill};
+use sp_runtime::{create_runtime_str, generic, impl_opaque_keys, ModuleId, Perbill};
 use sp_std::boxed::Box;
 use sp_std::vec::Vec;
 #[cfg(feature = "std")]
@@ -650,6 +650,9 @@ parameter_types! {
     pub const MaxModeratorsForCategory: u64 = 20;
     pub const MaxCategories: u64 = 20;
     pub const MaxPollAlternativesNumber: u64 = 20;
+    pub const StartingCleanupPayOff: u64 = 30;
+    pub const PostDeposit: u64 = 10;
+    pub const ForumModuleId: ModuleId = ModuleId(*b"mo:forum"); // module : forum
 }
 
 pub struct MapLimits;
@@ -670,6 +673,10 @@ impl forum::Trait for Runtime {
     type CategoryId = u64;
     type PostReactionId = u64;
     type MaxCategoryDepth = MaxCategoryDepth;
+
+    type StartingCleanupPayOff = StartingCleanupPayOff;
+    type PostDeposit = PostDeposit;
+    type ModuleId = ForumModuleId;
 
     type MapLimits = MapLimits;
     type WeightInfo = weights::forum::WeightInfo;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -687,6 +687,8 @@ impl forum::Trait for Runtime {
 
     type WorkingGroup = ForumWorkingGroup;
     type MemberOriginValidator = Members;
+
+    type Currency = Balances;
 }
 
 impl LockComparator<<Runtime as pallet_balances::Trait>::Balance> for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -650,7 +650,7 @@ parameter_types! {
     pub const MaxModeratorsForCategory: u64 = 20;
     pub const MaxCategories: u64 = 20;
     pub const MaxPollAlternativesNumber: u64 = 20;
-    pub const BasePayOffForThreadCleanUp: u64 = 30;
+    pub const ThreadDeposit: u64 = 30;
     pub const PostDeposit: u64 = 10;
     pub const ForumModuleId: ModuleId = ModuleId(*b"mo:forum"); // module : forum
 }
@@ -674,7 +674,7 @@ impl forum::Trait for Runtime {
     type PostReactionId = u64;
     type MaxCategoryDepth = MaxCategoryDepth;
 
-    type BasePayOffForThreadCleanUp = BasePayOffForThreadCleanUp;
+    type ThreadDeposit = ThreadDeposit;
     type PostDeposit = PostDeposit;
     type ModuleId = ForumModuleId;
 


### PR DESCRIPTION
# Fix `forum_pallet` for #2196 

In #2196 we found that thread/post creation has a low cost and can be used to fill up the storage.

To prevent this we add a cost to creating a thread or post and then pay the sum of those costs to the deleted of the thread to incentivize deletion.

Furthermore, we move the posts from their own storage to within the thread storage as part of the `Thread` struct to improve deletion times.

This also fixes Joystream/audits#5