### PR TITLE
content-metadata: channels and videos can be in multiple categories

### DIFF
--- a/content-metadata-protobuf/README.md
+++ b/content-metadata-protobuf/README.md
@@ -43,7 +43,7 @@ yarn && yarn build
 ### Generating docs
 
 ```
-yarn generate-docs
+yarn generate-doc
 ```
 
 ### Tests

--- a/content-metadata-protobuf/compiled/proto/Channel_pb.d.ts
+++ b/content-metadata-protobuf/compiled/proto/Channel_pb.d.ts
@@ -34,10 +34,10 @@ export class ChannelMetadata extends jspb.Message {
   getAvatarPhoto(): number | undefined;
   setAvatarPhoto(value: number): void;
 
-  hasCategory(): boolean;
-  clearCategory(): void;
-  getCategory(): number | undefined;
-  setCategory(value: number): void;
+  clearCategoriesList(): void;
+  getCategoriesList(): Array<number>;
+  setCategoriesList(value: Array<number>): void;
+  addCategories(value: number, index?: number): number;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): ChannelMetadata.AsObject;
@@ -57,7 +57,7 @@ export namespace ChannelMetadata {
     language?: string,
     coverPhoto?: number,
     avatarPhoto?: number,
-    category?: number,
+    categoriesList: Array<number>,
   }
 }
 

--- a/content-metadata-protobuf/compiled/proto/Channel_pb.js
+++ b/content-metadata-protobuf/compiled/proto/Channel_pb.js
@@ -27,7 +27,7 @@ goog.exportSymbol('proto.ChannelMetadata', null, global);
  * @constructor
  */
 proto.ChannelMetadata = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.ChannelMetadata.repeatedFields_, null);
 };
 goog.inherits(proto.ChannelMetadata, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
@@ -58,6 +58,13 @@ if (goog.DEBUG && !COMPILED) {
    */
   proto.ChannelCategoryMetadata.displayName = 'proto.ChannelCategoryMetadata';
 }
+
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.ChannelMetadata.repeatedFields_ = [7];
 
 
 
@@ -96,7 +103,7 @@ proto.ChannelMetadata.toObject = function(includeInstance, msg) {
     language: (f = jspb.Message.getField(msg, 4)) == null ? undefined : f,
     coverPhoto: (f = jspb.Message.getField(msg, 5)) == null ? undefined : f,
     avatarPhoto: (f = jspb.Message.getField(msg, 6)) == null ? undefined : f,
-    category: (f = jspb.Message.getField(msg, 7)) == null ? undefined : f
+    categoriesList: (f = jspb.Message.getRepeatedField(msg, 7)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -158,8 +165,10 @@ proto.ChannelMetadata.deserializeBinaryFromReader = function(msg, reader) {
       msg.setAvatarPhoto(value);
       break;
     case 7:
-      var value = /** @type {number} */ (reader.readUint64());
-      msg.setCategory(value);
+      var values = /** @type {!Array<number>} */ (reader.isDelimited() ? reader.readPackedUint64() : [reader.readUint64()]);
+      for (var i = 0; i < values.length; i++) {
+        msg.addCategories(values[i]);
+      }
       break;
     default:
       reader.skipField();
@@ -232,9 +241,9 @@ proto.ChannelMetadata.serializeBinaryToWriter = function(message, writer) {
       f
     );
   }
-  f = /** @type {number} */ (jspb.Message.getField(message, 7));
-  if (f != null) {
-    writer.writeUint64(
+  f = message.getCategoriesList();
+  if (f.length > 0) {
+    writer.writePackedUint64(
       7,
       f
     );
@@ -459,38 +468,39 @@ proto.ChannelMetadata.prototype.hasAvatarPhoto = function() {
 
 
 /**
- * optional uint64 category = 7;
- * @return {number}
+ * repeated uint64 categories = 7;
+ * @return {!Array<number>}
  */
-proto.ChannelMetadata.prototype.getCategory = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 7, 0));
+proto.ChannelMetadata.prototype.getCategoriesList = function() {
+  return /** @type {!Array<number>} */ (jspb.Message.getRepeatedField(this, 7));
+};
+
+
+/**
+ * @param {!Array<number>} value
+ * @return {!proto.ChannelMetadata} returns this
+ */
+proto.ChannelMetadata.prototype.setCategoriesList = function(value) {
+  return jspb.Message.setField(this, 7, value || []);
 };
 
 
 /**
  * @param {number} value
+ * @param {number=} opt_index
  * @return {!proto.ChannelMetadata} returns this
  */
-proto.ChannelMetadata.prototype.setCategory = function(value) {
-  return jspb.Message.setField(this, 7, value);
+proto.ChannelMetadata.prototype.addCategories = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 7, value, opt_index);
 };
 
 
 /**
- * Clears the field making it undefined.
+ * Clears the list making it empty but non-null.
  * @return {!proto.ChannelMetadata} returns this
  */
-proto.ChannelMetadata.prototype.clearCategory = function() {
-  return jspb.Message.setField(this, 7, undefined);
-};
-
-
-/**
- * Returns whether this field is set.
- * @return {boolean}
- */
-proto.ChannelMetadata.prototype.hasCategory = function() {
-  return jspb.Message.getField(this, 7) != null;
+proto.ChannelMetadata.prototype.clearCategoriesList = function() {
+  return this.setCategoriesList([]);
 };
 
 

--- a/content-metadata-protobuf/compiled/proto/Playlist_pb.js
+++ b/content-metadata-protobuf/compiled/proto/Playlist_pb.js
@@ -161,7 +161,7 @@ proto.PlaylistMetadata.serializeBinaryToWriter = function(message, writer) {
   }
   f = message.getVideosList();
   if (f.length > 0) {
-    writer.writeRepeatedUint64(
+    writer.writePackedUint64(
       2,
       f
     );

--- a/content-metadata-protobuf/compiled/proto/Video_pb.d.ts
+++ b/content-metadata-protobuf/compiled/proto/Video_pb.d.ts
@@ -175,10 +175,10 @@ export class VideoMetadata extends jspb.Message {
   setPersonsList(value: Array<number>): void;
   addPersons(value: number, index?: number): number;
 
-  hasCategory(): boolean;
-  clearCategory(): void;
-  getCategory(): number | undefined;
-  setCategory(value: number): void;
+  clearCategoriesList(): void;
+  getCategoriesList(): Array<number>;
+  setCategoriesList(value: Array<number>): void;
+  addCategories(value: number, index?: number): number;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): VideoMetadata.AsObject;
@@ -207,7 +207,7 @@ export namespace VideoMetadata {
     isPublic?: boolean,
     isExplicit?: boolean,
     personsList: Array<number>,
-    category?: number,
+    categoriesList: Array<number>,
   }
 }
 

--- a/content-metadata-protobuf/compiled/proto/Video_pb.js
+++ b/content-metadata-protobuf/compiled/proto/Video_pb.js
@@ -814,7 +814,7 @@ proto.MediaType.prototype.hasMimeMediaType = function() {
  * @private {!Array<number>}
  * @const
  */
-proto.VideoMetadata.repeatedFields_ = [15];
+proto.VideoMetadata.repeatedFields_ = [15,16];
 
 
 
@@ -862,7 +862,7 @@ proto.VideoMetadata.toObject = function(includeInstance, msg) {
     isPublic: (f = jspb.Message.getBooleanField(msg, 13)) == null ? undefined : f,
     isExplicit: (f = jspb.Message.getBooleanField(msg, 14)) == null ? undefined : f,
     personsList: (f = jspb.Message.getRepeatedField(msg, 15)) == null ? undefined : f,
-    category: (f = jspb.Message.getField(msg, 16)) == null ? undefined : f
+    categoriesList: (f = jspb.Message.getRepeatedField(msg, 16)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -965,8 +965,10 @@ proto.VideoMetadata.deserializeBinaryFromReader = function(msg, reader) {
       }
       break;
     case 16:
-      var value = /** @type {number} */ (reader.readUint64());
-      msg.setCategory(value);
+      var values = /** @type {!Array<number>} */ (reader.isDelimited() ? reader.readPackedUint64() : [reader.readUint64()]);
+      for (var i = 0; i < values.length; i++) {
+        msg.addCategories(values[i]);
+      }
       break;
     default:
       reader.skipField();
@@ -1105,9 +1107,9 @@ proto.VideoMetadata.serializeBinaryToWriter = function(message, writer) {
       f
     );
   }
-  f = /** @type {number} */ (jspb.Message.getField(message, 16));
-  if (f != null) {
-    writer.writeUint64(
+  f = message.getCategoriesList();
+  if (f.length > 0) {
+    writer.writePackedUint64(
       16,
       f
     );
@@ -1660,38 +1662,39 @@ proto.VideoMetadata.prototype.clearPersonsList = function() {
 
 
 /**
- * optional uint64 category = 16;
- * @return {number}
+ * repeated uint64 categories = 16;
+ * @return {!Array<number>}
  */
-proto.VideoMetadata.prototype.getCategory = function() {
-  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 16, 0));
+proto.VideoMetadata.prototype.getCategoriesList = function() {
+  return /** @type {!Array<number>} */ (jspb.Message.getRepeatedField(this, 16));
+};
+
+
+/**
+ * @param {!Array<number>} value
+ * @return {!proto.VideoMetadata} returns this
+ */
+proto.VideoMetadata.prototype.setCategoriesList = function(value) {
+  return jspb.Message.setField(this, 16, value || []);
 };
 
 
 /**
  * @param {number} value
+ * @param {number=} opt_index
  * @return {!proto.VideoMetadata} returns this
  */
-proto.VideoMetadata.prototype.setCategory = function(value) {
-  return jspb.Message.setField(this, 16, value);
+proto.VideoMetadata.prototype.addCategories = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 16, value, opt_index);
 };
 
 
 /**
- * Clears the field making it undefined.
+ * Clears the list making it empty but non-null.
  * @return {!proto.VideoMetadata} returns this
  */
-proto.VideoMetadata.prototype.clearCategory = function() {
-  return jspb.Message.setField(this, 16, undefined);
-};
-
-
-/**
- * Returns whether this field is set.
- * @return {boolean}
- */
-proto.VideoMetadata.prototype.hasCategory = function() {
-  return jspb.Message.getField(this, 16) != null;
+proto.VideoMetadata.prototype.clearCategoriesList = function() {
+  return this.setCategoriesList([]);
 };
 
 

--- a/content-metadata-protobuf/doc/index.md
+++ b/content-metadata-protobuf/doc/index.md
@@ -64,7 +64,7 @@
 | language | [string](#string) | optional | ISO_639-1 Language [Code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) |
 | cover_photo | [uint32](#uint32) | optional | index into external [assets array](#.Assets) |
 | avatar_photo | [uint32](#uint32) | optional | index into external [assets array](#.Assets) |
-| category | [uint64](#uint64) | optional | Channel Category Id |
+| categories | [uint64](#uint64) | repeated | Categories which the channel belongs to |
 
 
 
@@ -295,7 +295,7 @@ Publication status before joystream
 | is_public | [bool](#bool) | optional | Should video be publicy visible yet |
 | is_explicit | [bool](#bool) | optional | Does Video have explicit language or scenes |
 | persons | [uint64](#uint64) | repeated | Person(s) referenced by PersonId involved in this video |
-| category | [uint64](#uint64) | optional | Video Category Id |
+| categories | [uint64](#uint64) | repeated | Categories the video belongs to |
 
 
 

--- a/content-metadata-protobuf/proto/Channel.proto
+++ b/content-metadata-protobuf/proto/Channel.proto
@@ -18,8 +18,8 @@ message ChannelMetadata {
     // index into external [assets array](#.Assets)
     optional uint32 avatar_photo  = 6;
 
-    // Channel Category Id
-    optional uint64 category = 7;
+    // Categories which the channel belongs to
+    repeated uint64 categories = 7 [packed=true];
 }
 
 message ChannelCategoryMetadata {

--- a/content-metadata-protobuf/proto/Playlist.proto
+++ b/content-metadata-protobuf/proto/Playlist.proto
@@ -3,5 +3,5 @@ syntax = "proto2";
 message PlaylistMetadata {
     optional string title = 1;
     // Videos in the playlist
-    repeated uint64 videos = 2;
+    repeated uint64 videos = 2 [packed=true];
 }

--- a/content-metadata-protobuf/proto/Video.proto
+++ b/content-metadata-protobuf/proto/Video.proto
@@ -78,8 +78,8 @@ message VideoMetadata {
     // Person(s) referenced by PersonId involved in this video
     repeated uint64 persons = 15 [packed=true];
 
-    // Video Category Id
-    optional uint64 category = 16;
+    // Categories the video belongs to
+    repeated uint64 categories = 16 [packed=true];
 }
 
 message VideoCategoryMetadata {

--- a/content-metadata-protobuf/test/channel.ts
+++ b/content-metadata-protobuf/test/channel.ts
@@ -16,7 +16,7 @@ describe('Channel Metadata', () => {
     channel.setLanguage(language)
     channel.setAvatarPhoto(0)
     channel.setCoverPhoto(1)
-    channel.setCategory(100)
+    channel.setCategoriesList([100, 200])
 
     assert.deepEqual(channel.toObject(), {
       title,
@@ -25,7 +25,7 @@ describe('Channel Metadata', () => {
       language,
       avatarPhoto: 0,
       coverPhoto: 1,
-      category: 100,
+      categoriesList: [100, 200],
     })
 
     assert.deepEqual(ChannelMetadata.deserializeBinary(channel.serializeBinary()), channel)

--- a/content-metadata-protobuf/test/video.ts
+++ b/content-metadata-protobuf/test/video.ts
@@ -23,7 +23,7 @@ describe('Video Metadata', () => {
     meta.setIsExplicit(false)
     meta.setVideo(0)
     meta.setThumbnailPhoto(1)
-    meta.setCategory(101)
+    meta.setCategoriesList([101, 102])
 
     assert.deepEqual(meta.toObject(), {
       title,
@@ -49,7 +49,7 @@ describe('Video Metadata', () => {
       thumbnailPhoto: 1,
       video: 0,
       personsList: [],
-      category: 101,
+      categoriesList: [101, 102],
     })
 
     // sanity check - encoding / decoding works


### PR DESCRIPTION
Allow metadata for Channels and Videos to support multiple categories, as discussed in https://github.com/Joystream/joystream/issues/2165#issuecomment-782026174