### PR TITLE
Working group: make apply opening stake mandatory and store relation between application and opening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-working-group"
-version = "4.1.0"
+version = "5.0.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-working-group"
-version = "4.0.1"
+version = "4.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/analyses/fee-analysis/analysis_cli/analysis.py
+++ b/analyses/fee-analysis/analysis_cli/analysis.py
@@ -63,7 +63,7 @@ def calc_total_price_given_params(extrinsic, weight_coeff, market_cap, issuance,
 
 
 def calc_total_fee(extrinsic, weight_coeff, length_coeff, params, lengths, weights):
-    return weight_to_fee(calc_weight(weights[extrinsic], extrinsic, params) + EXTRINSIC_BASE_WEIGHT, weight_coeff) + \
+    return weight_to_fee(calc_weight(weights[extrinsic], extrinsic, params), weight_coeff) + \
         length_to_fee(lengths.get(extrinsic, 0), length_coeff)
 
 

--- a/analyses/fee-analysis/analysis_cli/config.json
+++ b/analyses/fee-analysis/analysis_cli/config.json
@@ -1,5 +1,5 @@
 {
-    "weight_coefficient": 2,
+    "weight_coefficient": 0.00000016,
     "issuance": 250000000,
     "length_coefficient": 1,
     "min_market_cap": 1250000,

--- a/runtime-modules/forum/src/benchmarking.rs
+++ b/runtime-modules/forum/src/benchmarking.rs
@@ -2,7 +2,7 @@
 use super::*;
 use balances::Module as Balances;
 use core::convert::TryInto;
-use frame_benchmarking::{account, benchmarks};
+use frame_benchmarking::{account, benchmarks, Zero};
 use frame_support::storage::StorageMap;
 use frame_support::traits::Currency;
 use frame_system::Module as System;
@@ -12,7 +12,7 @@ use sp_runtime::traits::Bounded;
 use sp_std::collections::btree_set::BTreeSet;
 use working_group::{
     ApplicationById, ApplicationId, ApplyOnOpeningParameters, OpeningById, OpeningId, OpeningType,
-    WorkerById,
+    StakeParameters, StakePolicy, WorkerById,
 };
 
 // We create this trait because we need to be compatible with the runtime
@@ -182,7 +182,13 @@ fn add_opening_helper<T: Trait + working_group::Trait<ForumWorkingGroupInstance>
         add_opening_origin.clone(),
         vec![],
         *job_opening_type,
-        None,
+        StakePolicy {
+            stake_amount:
+                <T as working_group::Trait<ForumWorkingGroupInstance>>::MinimumStakeForOpening::get(
+                ),
+            leaving_unstaking_period: <T as
+                working_group::Trait<ForumWorkingGroupInstance>>::MinUnstakingPeriodLimit::get() + One::one(),
+        },
         Some(One::one()),
     )
     .unwrap();
@@ -210,7 +216,10 @@ fn apply_on_opening_helper<T: Trait + working_group::Trait<ForumWorkingGroupInst
             role_account_id: applicant_id.clone(),
             reward_account_id: applicant_id.clone(),
             description: vec![],
-            stake_parameters: None,
+            stake_parameters: StakeParameters {
+                stake: <T as working_group::Trait<ForumWorkingGroupInstance>>::MinimumStakeForOpening::get(),
+                staking_account_id: applicant_id.clone()
+            },
         },
     )
     .unwrap();

--- a/runtime-modules/forum/src/benchmarking.rs
+++ b/runtime-modules/forum/src/benchmarking.rs
@@ -2,7 +2,7 @@
 use super::*;
 use balances::Module as Balances;
 use core::convert::TryInto;
-use frame_benchmarking::{account, benchmarks, Zero};
+use frame_benchmarking::{account, benchmarks};
 use frame_support::storage::StorageMap;
 use frame_support::traits::Currency;
 use frame_system::Module as System;

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -217,11 +217,7 @@ impl working_group::WeightInfo for Weights {
         unimplemented!()
     }
 
-    fn leave_role_immediatly() -> u64 {
-        unimplemented!()
-    }
-
-    fn leave_role_later() -> u64 {
+    fn leave_role(_: u32) -> u64 {
         unimplemented!()
     }
 }

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -103,6 +103,7 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: [u8; 8] = [9; 8];
     pub const InviteMemberLockId: [u8; 8] = [9; 8];
+    pub const MinimumStakeForOpening: u32 = 50;
 }
 
 // The forum working group instance alias.
@@ -117,6 +118,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = Weights;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl LockComparator<<Runtime as balances::Trait>::Balance> for Runtime {

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -107,6 +107,7 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [9; 8];
     pub const DefaultInitialInvitationBalance: u64 = 100;
+    pub const MinimumStakeForOpening: u32 = 50;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -118,6 +119,7 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = Weights;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl LockComparator<u64> for Test {

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -218,11 +218,7 @@ impl working_group::WeightInfo for Weights {
         unimplemented!()
     }
 
-    fn leave_role_immediatly() -> u64 {
-        unimplemented!()
-    }
-
-    fn leave_role_later() -> u64 {
+    fn leave_role(_: u32) -> u64 {
         unimplemented!()
     }
 }

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -4,7 +4,7 @@ use crate::Module as Codex;
 use balances::Module as Balances;
 use common::working_group::WorkingGroup;
 use common::BalanceKind;
-use frame_benchmarking::{account, benchmarks};
+use frame_benchmarking::{account, benchmarks, Zero};
 use frame_support::sp_runtime::traits::Bounded;
 use frame_support::traits::Currency;
 use frame_system::EventRecord;
@@ -162,7 +162,12 @@ fn create_proposal_verify<T: Trait>(
 }
 
 benchmarks! {
-    where_clause { where T: membership::Trait, T: council::Trait }
+    where_clause {
+        where T: membership::Trait,
+        T: council::Trait,
+        T: working_group::Trait<working_group::Instance1>
+    }
+
     _ {
         let t in 1 .. T::TitleMaxLength::get() => ();
         let d in 1 .. T::DescriptionMaxLength::get() => ();
@@ -307,7 +312,12 @@ benchmarks! {
         let proposal_details = ProposalDetails::CreateWorkingGroupLeadOpening(
             CreateOpeningParameters {
                 description: vec![0u8; i.try_into().unwrap()],
-                stake_policy: None,
+                stake_policy: working_group::StakePolicy {
+                    stake_amount:
+                        <T as working_group::Trait<working_group::Instance1>>
+                            ::MinimumStakeForOpening::get(),
+                    leaving_unstaking_period: Zero::zero(),
+                },
                 reward_per_block: None,
                 group: WorkingGroup::Forum,
         });

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -426,10 +426,7 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn add_opening(_: u32) -> Weight {
         0
     }
-    fn leave_role_immediatly() -> Weight {
-        0
-    }
-    fn leave_role_later() -> Weight {
+    fn leave_role(_: u32) -> Weight {
         0
     }
 }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -346,6 +346,7 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 100;
     pub const LockId1: [u8; 8] = [1; 8];
     pub const LockId2: [u8; 8] = [2; 8];
+    pub const MinimumStakeForOpening: u32 = 50;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -358,6 +359,7 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {
@@ -441,6 +443,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::Trait<ForumWorkingGroupInstance> for Test {
@@ -452,6 +455,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -463,6 +467,7 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 pallet_staking_reward_curve::build! {

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -11,6 +11,7 @@ use common::working_group::WorkingGroup;
 use common::BalanceKind;
 use proposals_engine::ProposalParameters;
 use referendum::ReferendumManager;
+use working_group::StakePolicy;
 
 use crate::*;
 use crate::{Error, ProposalDetails};
@@ -619,7 +620,11 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(gr
 
         let add_opening_parameters = CreateOpeningParameters {
             description: b"some text".to_vec(),
-            stake_policy: None,
+            stake_policy: StakePolicy {
+                stake_amount: <Test as working_group::Trait<working_group::Instance1>>::MinimumStakeForOpening::get() as
+                    u64,
+                leaving_unstaking_period: 0 as u64,
+            },
             reward_per_block: None,
             group,
         };

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -177,7 +177,7 @@ pub struct CreateOpeningParameters<BlockNumber, Balance> {
     pub description: Vec<u8>,
 
     /// Optional Staking policy.
-    pub stake_policy: Option<StakePolicy<BlockNumber, Balance>>,
+    pub stake_policy: StakePolicy<BlockNumber, Balance>,
 
     /// Reward per block for the opening.
     pub reward_per_block: Option<Balance>,

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -293,10 +293,7 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn add_opening(_: u32) -> Weight {
         0
     }
-    fn leave_role_immediatly() -> Weight {
-        0
-    }
-    fn leave_role_later() -> Weight {
+    fn leave_role(_: u32) -> Weight {
         0
     }
 }

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -213,6 +213,7 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId1: [u8; 8] = [1; 8];
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const MinimumStakeForOpening: u32 = 50;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -225,6 +226,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {
@@ -348,7 +350,7 @@ pub(crate) fn hire_storage_provider() -> (u64, u64) {
     let storage_provider = working_group::Worker::<Test> {
         member_id: 1,
         role_account_id,
-        staking_account_id: None,
+        staking_account_id: 1,
         reward_account_id: role_account_id,
         started_leaving_at: None,
         job_unstaking_period: 0,

--- a/runtime-modules/storage/src/tests/data_object_type_registry.rs
+++ b/runtime-modules/storage/src/tests/data_object_type_registry.rs
@@ -15,7 +15,7 @@ impl SetLeadFixture {
         let worker = working_group::Worker::<Test> {
             member_id: DEFAULT_LEADER_MEMBER_ID,
             role_account_id: DEFAULT_LEADER_ACCOUNT_ID,
-            staking_account_id: None,
+            staking_account_id: DEFAULT_LEADER_ACCOUNT_ID,
             reward_account_id: DEFAULT_LEADER_ACCOUNT_ID,
             started_leaving_at: None,
             job_unstaking_period: 0,

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -237,10 +237,7 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn add_opening(_: u32) -> Weight {
         0
     }
-    fn leave_role_immediatly() -> Weight {
-        0
-    }
-    fn leave_role_later() -> Weight {
+    fn leave_role(_: u32) -> Weight {
         0
     }
 }

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -157,6 +157,7 @@ parameter_types! {
     pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const MinimumStakeForOpening: u32 = 50;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -169,6 +170,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {
@@ -500,7 +502,7 @@ pub(crate) fn hire_storage_provider() -> (u64, u32) {
     let storage_provider = working_group::Worker::<Test> {
         member_id: 1,
         role_account_id,
-        staking_account_id: None,
+        staking_account_id: 1,
         reward_account_id: role_account_id,
         started_leaving_at: None,
         job_unstaking_period: 0,

--- a/runtime-modules/utility/src/tests/mocks.rs
+++ b/runtime-modules/utility/src/tests/mocks.rs
@@ -414,10 +414,7 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
     fn add_opening(_: u32) -> Weight {
         0
     }
-    fn leave_role_immediatly() -> Weight {
-        0
-    }
-    fn leave_role_later() -> Weight {
+    fn leave_role(_: u32) -> Weight {
         0
     }
 }

--- a/runtime-modules/utility/src/tests/mocks.rs
+++ b/runtime-modules/utility/src/tests/mocks.rs
@@ -334,6 +334,7 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 100;
     pub const LockId1: [u8; 8] = [1; 8];
     pub const LockId2: [u8; 8] = [2; 8];
+    pub const MinimumStakeForOpening: u32 = 50;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -346,6 +347,7 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {
@@ -429,6 +431,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::Trait<ForumWorkingGroupInstance> for Test {
@@ -440,6 +443,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -451,6 +455,7 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 parameter_types! {

--- a/runtime-modules/working-group/Cargo.toml
+++ b/runtime-modules/working-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-working-group"
-version = "4.1.0"
+version = "5.0.0"
 authors = ['Joystream contributors']
 edition = '2018'
 

--- a/runtime-modules/working-group/Cargo.toml
+++ b/runtime-modules/working-group/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-working-group"
-version = "4.0.1"
+version = "4.1.0"
 authors = ['Joystream contributors']
 edition = '2018'
 

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -905,10 +905,7 @@ benchmarks_instance! {
         );
     }
 
-    // Generally speaking this seems to be always the best case scenario
-    // but since it's so obviously a different branch I think it's a good idea
-    // to leave this branch and use tha max between these 2
-    leave_role_later {
+    leave_role {
         let i in 0 .. MAX_BYTES;
         // Workers with stake can't leave immediatly
         let (caller_id, caller_worker_id) = insert_a_worker::<T, I>(
@@ -937,9 +934,9 @@ mod tests {
     use frame_support::assert_ok;
 
     #[test]
-    fn test_leave_role_later() {
+    fn test_leave_role() {
         build_test_externalities().execute_with(|| {
-            assert_ok!(test_benchmark_leave_role_later::<Test>());
+            assert_ok!(test_benchmark_leave_role::<Test>());
         });
     }
 

--- a/runtime-modules/working-group/src/checks.rs
+++ b/runtime-modules/working-group/src/checks.rs
@@ -34,7 +34,7 @@ pub(crate) fn ensure_origin_for_opening_type<T: Trait<I>, I: Instance>(
 
 // Check opening: returns the opening by id if it is exists.
 pub(crate) fn ensure_opening_exists<T: Trait<I>, I: Instance>(
-    opening_id: &OpeningId,
+    opening_id: OpeningId,
 ) -> Result<Opening<T::BlockNumber, BalanceOf<T>>, Error<T, I>> {
     ensure!(
         <crate::OpeningById::<T, I>>::contains_key(opening_id),
@@ -188,19 +188,17 @@ pub(crate) fn ensure_origin_for_worker_operation<T: Trait<I>, I: Instance>(
 
 // Check opening: verifies stake policy for the opening.
 pub(crate) fn ensure_valid_stake_policy<T: Trait<I>, I: Instance>(
-    stake_policy: &Option<StakePolicy<T::BlockNumber, BalanceOf<T>>>,
+    stake_policy: &StakePolicy<T::BlockNumber, BalanceOf<T>>,
 ) -> Result<(), DispatchError> {
-    if let Some(stake_policy) = stake_policy {
-        ensure!(
-            stake_policy.stake_amount != Zero::zero(),
-            Error::<T, I>::CannotStakeZero
-        );
+    ensure!(
+        stake_policy.stake_amount >= T::MinimumStakeForOpening::get(),
+        Error::<T, I>::BelowMinimumStakes
+    );
 
-        ensure!(
-            stake_policy.leaving_unstaking_period > T::MinUnstakingPeriodLimit::get(),
-            Error::<T, I>::UnstakingPeriodLessThanMinimum
-        );
-    }
+    ensure!(
+        stake_policy.leaving_unstaking_period > T::MinUnstakingPeriodLimit::get(),
+        Error::<T, I>::UnstakingPeriodLessThanMinimum
+    );
 
     Ok(())
 }
@@ -222,19 +220,12 @@ pub(crate) fn ensure_valid_reward_per_block<T: Trait<I>, I: Instance>(
 // Check application: verifies that proposed stake is enough for the opening.
 pub(crate) fn ensure_application_stake_match_opening<T: Trait<I>, I: Instance>(
     opening: &Opening<T::BlockNumber, BalanceOf<T>>,
-    stake_parameters: &Option<StakeParameters<T::AccountId, BalanceOf<T>>>,
+    stake_parameters: &StakeParameters<T::AccountId, BalanceOf<T>>,
 ) -> DispatchResult {
-    let opening_stake_balance = opening
-        .stake_policy
-        .clone()
-        .unwrap_or_default()
-        .stake_amount;
-
-    let application_stake_balance = stake_parameters.clone().unwrap_or_default().stake;
-
-    if application_stake_balance < opening_stake_balance {
-        return Err(Error::<T, I>::ApplicationStakeDoesntMatchOpening.into());
-    }
+    ensure!(
+        opening.stake_policy.stake_amount <= stake_parameters.stake,
+        Error::<T, I>::ApplicationStakeDoesntMatchOpening
+    );
 
     Ok(())
 }

--- a/runtime-modules/working-group/src/errors.rs
+++ b/runtime-modules/working-group/src/errors.rs
@@ -42,8 +42,8 @@ decl_error! {
         /// Signer is not worker role account.
         SignerIsNotWorkerRoleAccount,
 
-        /// Cannot stake zero.
-        CannotStakeZero,
+        /// Staking less than the lower bound.
+        BelowMinimumStakes,
 
         /// Insufficient balance to cover stake.
         InsufficientBalanceToCoverStake,
@@ -72,9 +72,6 @@ decl_error! {
         /// Specified unstaking period is less then minimum set for the group.
         UnstakingPeriodLessThanMinimum,
 
-        /// Requested operation with stake is impossible because of stake was not defined for the role.
-        CannotChangeStakeWithoutStakingAccount,
-
         /// Invalid spending amount.
         CannotSpendZero,
 
@@ -86,5 +83,8 @@ decl_error! {
 
         /// Cannot decrease stake - stake delta greater than initial stake.
         CannotDecreaseStakeDeltaGreaterThanStake,
+
+        /// Trying to fill opening with an application for other opening
+        ApplicationsNotForOpening,
     }
 }

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -430,10 +430,12 @@ decl_module! {
                   Error::<T, I>::InvalidStakingAccountForMember
             );
 
-              ensure!(
-                  T::StakingHandler::is_account_free_of_conflicting_stakes(&p.stake_parameters.staking_account_id),
-                  Error::<T, I>::ConflictStakesOnAccount
-              );
+            ensure!(
+              T::StakingHandler::is_account_free_of_conflicting_stakes(
+                  &p.stake_parameters.staking_account_id
+              ),
+              Error::<T, I>::ConflictStakesOnAccount
+            );
 
               ensure!(
                   T::StakingHandler::is_enough_balance_for_stake(
@@ -521,10 +523,12 @@ decl_module! {
                 checks::ensure_succesful_applications_exist::<T, I>(&successful_application_ids)?;
 
             // Check that all applications are for the intended opening
-            if !checked_applications_info.iter()
-                .all(|info| info.application.opening_id == opening_id) {
-                return Err(Error::<T, I>::ApplicationsNotForOpening.into());
-            }
+            ensure!(
+                checked_applications_info.iter()
+                .all(|info| info.application.opening_id == opening_id),
+                Error::<T, I>::ApplicationsNotForOpening
+            );
+
 
             // Check for a single application for a leader.
             if matches!(opening.opening_type, OpeningType::Leader) {

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -118,6 +118,9 @@ pub trait Trait<I: Instance = DefaultInstance>:
 
     /// Weight information for extrinsics in this pallet.
     type WeightInfo: WeightInfo;
+
+    /// Minimum stake required for an opening
+    type MinimumStakeForOpening: Get<Self::Balance>;
 }
 
 decl_event!(
@@ -141,7 +144,7 @@ decl_event!(
         /// - Opening Type(Lead or Worker)
         /// - Stake Policy for the opening
         /// - Reward per block
-        OpeningAdded(OpeningId, Vec<u8>, OpeningType, Option<StakePolicy>, Option<Balance>),
+        OpeningAdded(OpeningId, Vec<u8>, OpeningType, StakePolicy, Option<Balance>),
 
         /// Emits on adding the application for the worker opening.
         /// Params:
@@ -358,7 +361,7 @@ decl_module! {
             origin,
             description: Vec<u8>,
             opening_type: OpeningType,
-            stake_policy: Option<StakePolicy<T::BlockNumber, BalanceOf<T>>>,
+            stake_policy: StakePolicy<T::BlockNumber, BalanceOf<T>>,
             reward_per_block: Option<BalanceOf<T>>
         ){
             checks::ensure_origin_for_opening_type::<T, I>(origin, opening_type)?;
@@ -414,39 +417,38 @@ decl_module! {
             T::MemberOriginValidator::ensure_member_controller_account_origin(origin, p.member_id)?;
 
             // Ensure job opening exists.
-            let opening = checks::ensure_opening_exists::<T, I>(&p.opening_id)?;
+            let opening = checks::ensure_opening_exists::<T, I>(p.opening_id)?;
 
             // Ensure that proposed stake is enough for the opening.
             checks::ensure_application_stake_match_opening::<T, I>(&opening, &p.stake_parameters)?;
 
             // Checks external conditions for staking.
-            if let Some(sp) = p.stake_parameters.clone() {
-                ensure!(
-                    T::StakingAccountValidator::is_member_staking_account(
-                        &p.member_id,
-                        &sp.staking_account_id
-                    ),
-                    Error::<T, I>::InvalidStakingAccountForMember
-                );
+            ensure!(
+                  T::StakingAccountValidator::is_member_staking_account(
+                      &p.member_id,
+                      &p.stake_parameters.staking_account_id
+                  ),
+                  Error::<T, I>::InvalidStakingAccountForMember
+            );
 
-                ensure!(
-                    T::StakingHandler::is_account_free_of_conflicting_stakes(&sp.staking_account_id),
-                    Error::<T, I>::ConflictStakesOnAccount
-                );
+              ensure!(
+                  T::StakingHandler::is_account_free_of_conflicting_stakes(&p.stake_parameters.staking_account_id),
+                  Error::<T, I>::ConflictStakesOnAccount
+              );
 
-                ensure!(
-                    T::StakingHandler::is_enough_balance_for_stake(&sp.staking_account_id, sp.stake),
-                    Error::<T, I>::InsufficientBalanceToCoverStake
-                );
-            }
+              ensure!(
+                  T::StakingHandler::is_enough_balance_for_stake(
+                    &p.stake_parameters.staking_account_id,
+                    p.stake_parameters.stake
+                  ),
+                  Error::<T, I>::InsufficientBalanceToCoverStake
+              );
 
             //
             // == MUTATION SAFE ==
             //
 
-            if let Some(sp) = p.stake_parameters.clone() {
-                T::StakingHandler::lock(&sp.staking_account_id, sp.stake);
-            }
+            T::StakingHandler::lock(&p.stake_parameters.staking_account_id, p.stake_parameters.stake);
 
             let hashed_description = T::Hashing::hash(&p.description);
 
@@ -454,8 +456,9 @@ decl_module! {
             let application = Application::<T>::new(
                 &p.role_account_id,
                 &p.reward_account_id,
-                &p.stake_parameters.as_ref().map(|sp| sp.staking_account_id.clone()),
+                &p.stake_parameters.staking_account_id,
                 &p.member_id,
+                p.opening_id,
                 hashed_description.as_ref().to_vec(),
             );
 
@@ -483,7 +486,9 @@ decl_module! {
         ///    - O(A)
         /// # </weight>
         #[weight =
-            WeightInfoWorkingGroup::<T, I>::fill_opening_worker(successful_application_ids.len().saturated_into())
+            WeightInfoWorkingGroup::<T, I>::fill_opening_worker(
+                successful_application_ids.len().saturated_into()
+            )
             .max(WeightInfoWorkingGroup::<T, I>::fill_opening_lead())
         ]
         pub fn fill_opening(
@@ -492,13 +497,14 @@ decl_module! {
             successful_application_ids: BTreeSet<ApplicationId>,
         ) {
             // Ensure job opening exists.
-            let opening = checks::ensure_opening_exists::<T, I>(&opening_id)?;
+            let opening = checks::ensure_opening_exists::<T, I>(opening_id)?;
 
             checks::ensure_origin_for_opening_type::<T, I>(origin, opening.opening_type)?;
 
             // Ensure we're not exceeding the maximum worker number.
             let potential_worker_number =
                 Self::active_worker_count() + (successful_application_ids.len() as u32);
+
             ensure!(
                 potential_worker_number <= T::MaxWorkerNumberLimit::get(),
                 Error::<T, I>::MaxActiveWorkerNumberExceeded
@@ -506,14 +512,27 @@ decl_module! {
 
             // Cannot hire a lead when another leader exists.
             if matches!(opening.opening_type, OpeningType::Leader) {
-                ensure!(!<CurrentLead<T,I>>::exists(), Error::<T, I>::CannotHireLeaderWhenLeaderExists);
+                ensure!(
+                    !<CurrentLead<T,I>>::exists(),
+                    Error::<T, I>::CannotHireLeaderWhenLeaderExists
+                );
             }
 
-            let checked_applications_info = checks::ensure_succesful_applications_exist::<T, I>(&successful_application_ids)?;
+            let checked_applications_info =
+                checks::ensure_succesful_applications_exist::<T, I>(&successful_application_ids)?;
+
+            // Check that all applications are for the intended opening
+            if !checked_applications_info.iter()
+                .all(|info| info.application.opening_id == opening_id) {
+                return Err(Error::<T, I>::ApplicationsNotForOpening.into());
+            }
 
             // Check for a single application for a leader.
             if matches!(opening.opening_type, OpeningType::Leader) {
-                ensure!(successful_application_ids.len() == 1, Error::<T, I>::CannotHireMultipleLeaders);
+                ensure!(
+                    successful_application_ids.len() == 1,
+                    Error::<T, I>::CannotHireMultipleLeaders
+                );
             }
 
             //
@@ -635,22 +654,12 @@ decl_module! {
             // Ensuring worker actually exists.
             let worker = checks::ensure_worker_exists::<T,I>(&worker_id)?;
 
-            if penalty.is_some() {
-                // Ensure worker has a stake.
-                ensure!(
-                    worker.staking_account_id.is_some(),
-                    Error::<T, I>::CannotChangeStakeWithoutStakingAccount
-                );
-            }
-
             //
             // == MUTATION SAFE ==
             //
 
             if let Some(penalty) = penalty {
-                if let Some(staking_account_id) = worker.staking_account_id.clone() {
-                    Self::slash(worker_id, &staking_account_id, penalty, rationale.clone());
-                }
+                Self::slash(worker_id, &worker.staking_account_id, penalty, rationale.clone());
             }
 
             // Trigger the event
@@ -687,12 +696,6 @@ decl_module! {
             // Ensuring worker actually exists.
             let worker = checks::ensure_worker_exists::<T,I>(&worker_id)?;
 
-            // Ensure worker has a stake.
-            ensure!(
-                worker.staking_account_id.is_some(),
-                Error::<T, I>::CannotChangeStakeWithoutStakingAccount
-            );
-
             ensure!(
                 penalty != <BalanceOf<T>>::zero(),
                 Error::<T, I>::StakeBalanceCannotBeZero
@@ -702,9 +705,7 @@ decl_module! {
             // == MUTATION SAFE ==
             //
 
-            if let Some(staking_account_id) = worker.staking_account_id {
-                Self::slash(worker_id, &staking_account_id, penalty, rationale)
-            }
+            Self::slash(worker_id, &worker.staking_account_id, penalty, rationale)
         }
 
         /// Decreases the regular worker/lead stake and returns the remainder to the
@@ -726,12 +727,6 @@ decl_module! {
 
             let worker = checks::ensure_worker_exists::<T,I>(&worker_id)?;
 
-            // Ensure worker has a stake.
-            ensure!(
-                worker.staking_account_id.is_some(),
-                Error::<T, I>::CannotChangeStakeWithoutStakingAccount
-            );
-
             // Ensure the worker is active.
             ensure!(!worker.is_leaving(), Error::<T, I>::WorkerIsLeaving);
 
@@ -742,30 +737,26 @@ decl_module! {
             );
 
             // Ensure enough stake to decrease.
-            if let Some(staking_account_id) = worker.staking_account_id.clone(){
-                let current_stake = T::StakingHandler::current_stake(&staking_account_id);
+            let current_stake = T::StakingHandler::current_stake(&worker.staking_account_id);
 
-                ensure!(
-                    current_stake > stake_balance_delta,
-                    Error::<T, I>::CannotDecreaseStakeDeltaGreaterThanStake
-                );
-            }
+            ensure!(
+                current_stake > stake_balance_delta,
+                Error::<T, I>::CannotDecreaseStakeDeltaGreaterThanStake
+            );
 
             //
             // == MUTATION SAFE ==
             //
 
-             if let Some(staking_account_id) = worker.staking_account_id{
-                let current_stake = T::StakingHandler::current_stake(&staking_account_id);
+            let current_stake = T::StakingHandler::current_stake(&worker.staking_account_id);
 
-                // Cannot possibly overflow because of the already performed check.
-                let new_stake = current_stake.saturating_sub(stake_balance_delta);
+            // Cannot possibly overflow because of the already performed check.
+            let new_stake = current_stake.saturating_sub(stake_balance_delta);
 
-                // This external module call both checks and mutates the state.
-                T::StakingHandler::set_stake(&staking_account_id, new_stake)?;
+            // This external module call both checks and mutates the state.
+            T::StakingHandler::set_stake(&worker.staking_account_id, new_stake)?;
 
-                Self::deposit_event(RawEvent::StakeDecreased(worker_id, stake_balance_delta));
-            }
+            Self::deposit_event(RawEvent::StakeDecreased(worker_id, stake_balance_delta));
         }
 
         /// Increases the regular worker/lead stake, demands a worker origin.
@@ -786,38 +777,31 @@ decl_module! {
             // Ensure the worker is active.
             ensure!(!worker.is_leaving(), Error::<T, I>::WorkerIsLeaving);
 
-            // Ensure worker has a stake.
-            ensure!(
-                worker.staking_account_id.is_some(),
-                Error::<T, I>::CannotChangeStakeWithoutStakingAccount
-            );
-
             ensure!(
                 stake_balance_delta != <BalanceOf<T>>::zero(),
                 Error::<T, I>::StakeBalanceCannotBeZero
             );
 
-            if let Some(staking_account_id) = worker.staking_account_id.clone() {
-                ensure!(
-                    T::StakingHandler::is_enough_balance_for_stake(&staking_account_id, stake_balance_delta),
-                    Error::<T, I>::InsufficientBalanceToCoverStake
-                );
-            }
+            ensure!(
+                T::StakingHandler::is_enough_balance_for_stake(
+                    &worker.staking_account_id,
+                    stake_balance_delta
+                ),
+                Error::<T, I>::InsufficientBalanceToCoverStake
+            );
 
             //
             // == MUTATION SAFE ==
             //
 
-            if let Some(staking_account_id) = worker.staking_account_id {
-                let current_stake = T::StakingHandler::current_stake(&staking_account_id);
+            let current_stake = T::StakingHandler::current_stake(&worker.staking_account_id);
 
-                let new_stake = current_stake.saturating_add(stake_balance_delta);
+            let new_stake = current_stake.saturating_add(stake_balance_delta);
 
-                // This external module call both checks and mutates the state.
-                T::StakingHandler::set_stake(&staking_account_id, new_stake)?;
+            // This external module call both checks and mutates the state.
+            T::StakingHandler::set_stake(&worker.staking_account_id, new_stake)?;
 
-                Self::deposit_event(RawEvent::StakeIncreased(worker_id, stake_balance_delta));
-            }
+            Self::deposit_event(RawEvent::StakeIncreased(worker_id, stake_balance_delta));
         }
 
         /// Withdraw the worker application. Can be done by the worker only.
@@ -850,9 +834,8 @@ decl_module! {
             // == MUTATION SAFE ==
             //
 
-            if let Some(staking_account_id) = application_info.application.staking_account_id.clone() {
-                T::StakingHandler::unlock(&staking_account_id);
-            }
+            T::StakingHandler::unlock(&application_info.application.staking_account_id);
+
             // Remove an application.
             <ApplicationById<T, I>>::remove(application_info.application_id);
 
@@ -876,7 +859,7 @@ decl_module! {
             opening_id: OpeningId,
         ) {
             // Ensure job opening exists.
-            let opening = checks::ensure_opening_exists::<T, I>(&opening_id)?;
+            let opening = checks::ensure_opening_exists::<T, I>(opening_id)?;
 
             checks::ensure_origin_for_opening_type::<T, I>(origin, opening.opening_type)?;
 
@@ -1174,10 +1157,7 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
             &application_info.application.role_account_id,
             &application_info.application.reward_account_id,
             &application_info.application.staking_account_id,
-            opening
-                .stake_policy
-                .as_ref()
-                .map_or(Zero::zero(), |sp| sp.leaving_unstaking_period),
+            opening.stake_policy.leaving_unstaking_period,
             opening.reward_per_block,
             Self::current_block(),
         );
@@ -1231,9 +1211,7 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
         WorkerById::<T, I>::remove(worker_id);
         Self::decrease_active_worker_counter();
 
-        if let Some(staking_account_id) = worker.staking_account_id.clone() {
-            T::StakingHandler::unlock(&staking_account_id);
-        }
+        T::StakingHandler::unlock(&worker.staking_account_id);
 
         Self::deposit_event(event);
     }
@@ -1388,10 +1366,8 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
             return true;
         }
 
-        if let Some(staking_account_id) = worker.staking_account_id.clone() {
-            if T::StakingHandler::current_stake(&staking_account_id) == Zero::zero() {
-                return true;
-            }
+        if T::StakingHandler::current_stake(&worker.staking_account_id) == Zero::zero() {
+            return true;
         }
 
         false

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -87,8 +87,7 @@ pub trait WeightInfo {
     fn update_reward_account() -> Weight;
     fn set_budget() -> Weight;
     fn add_opening(i: u32) -> Weight;
-    fn leave_role_immediatly() -> Weight;
-    fn leave_role_later() -> Weight;
+    fn leave_role(i: u32) -> Weight;
 }
 
 /// The _Group_ main _Trait_
@@ -601,8 +600,7 @@ decl_module! {
         /// - DB:
         ///    - O(1) doesn't depend on the state or parameters
         /// # </weight>
-        #[weight = WeightInfoWorkingGroup::<T, I>::leave_role_immediatly()
-            .max(WeightInfoWorkingGroup::<T, I>::leave_role_later())]
+        #[weight = Module::<T, I>::leave_role_weight(&rationale)]
         pub fn leave_role(
             origin,
             worker_id: WorkerId<T>,
@@ -1075,6 +1073,16 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
         .max(WeightInfoWorkingGroup::<T, I>::on_initialize_leaving(
             workers,
         ))
+    }
+
+    // Calculate weight for `leave_role`
+    fn leave_role_weight(rationale: &Option<Vec<u8>>) -> Weight {
+        WeightInfoWorkingGroup::<T, I>::leave_role(
+            rationale
+                .as_ref()
+                .map(|rationale| rationale.len().saturated_into())
+                .unwrap_or_default(),
+        )
     }
 
     // Calculate weights for terminate_role

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -620,17 +620,9 @@ decl_module! {
             // == MUTATION SAFE ==
             //
 
-            if Self::can_leave_immediately(&worker){
-                Self::remove_worker(
-                    &worker_id,
-                    &worker,
-                    RawEvent::WorkerLeft(worker_id, rationale)
-                );
-            } else{
-                WorkerById::<T, I>::mutate(worker_id, |worker| {
-                    worker.started_leaving_at = Some(Self::current_block())
-                });
-            }
+            WorkerById::<T, I>::mutate(worker_id, |worker| {
+                worker.started_leaving_at = Some(Self::current_block())
+            });
         }
 
         /// Terminate the active worker by the lead.
@@ -1370,19 +1362,6 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
 
         // Check whether current block is a reward block.
         current_block % reward_period.into() == Zero::zero()
-    }
-
-    // Defines whether the worker staking parameters allow to leave without unstaking period.
-    fn can_leave_immediately(worker: &Worker<T>) -> bool {
-        if worker.job_unstaking_period == Zero::zero() {
-            return true;
-        }
-
-        if T::StakingHandler::current_stake(&worker.staking_account_id) == Zero::zero() {
-            return true;
-        }
-
-        false
     }
 
     // Sets the working group budget.

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -259,7 +259,7 @@ impl ApplyOnOpeningFixture {
                 staking_account_id: self.stake_parameters.staking_account_id,
                 member_id: self.member_id,
                 description_hash: expected_hash.as_ref().to_vec(),
-                opening_id: 1,
+                opening_id: self.opening_id,
             };
 
             assert_eq!(actual_application, expected_application);

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -1,5 +1,6 @@
 #![cfg(test)]
 use frame_support::dispatch::{DispatchError, DispatchResult};
+use frame_support::traits::Currency;
 use frame_support::StorageMap;
 use frame_system::{EventRecord, Phase, RawOrigin};
 use sp_runtime::traits::Hash;
@@ -10,7 +11,7 @@ use super::mock::{Balances, LockId, System, Test, TestEvent, TestWorkingGroup};
 use crate::types::StakeParameters;
 use crate::{
     Application, ApplyOnOpeningParameters, DefaultInstance, Opening, OpeningType, RawEvent,
-    StakePolicy, Worker,
+    StakePolicy, Trait, Worker,
 };
 
 pub struct EventFixture;
@@ -50,7 +51,7 @@ pub struct AddOpeningFixture {
     pub description: Vec<u8>,
     pub opening_type: OpeningType,
     pub starting_block: u64,
-    pub stake_policy: Option<StakePolicy<u64, u64>>,
+    pub stake_policy: StakePolicy<u64, u64>,
     pub reward_per_block: Option<u64>,
 }
 
@@ -61,7 +62,10 @@ impl Default for AddOpeningFixture {
             description: b"human_text".to_vec(),
             opening_type: OpeningType::Regular,
             starting_block: 0,
-            stake_policy: None,
+            stake_policy: StakePolicy {
+                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get() + 1,
+            },
             reward_per_block: None,
         }
     }
@@ -129,7 +133,7 @@ impl AddOpeningFixture {
         }
     }
 
-    pub fn with_stake_policy(self, stake_policy: Option<StakePolicy<u64, u64>>) -> Self {
+    pub fn with_stake_policy(self, stake_policy: StakePolicy<u64, u64>) -> Self {
         Self {
             stake_policy,
             ..self
@@ -151,7 +155,8 @@ pub struct ApplyOnOpeningFixture {
     role_account_id: u64,
     reward_account_id: u64,
     description: Vec<u8>,
-    stake_parameters: Option<StakeParameters<u64, u64>>,
+    stake_parameters: StakeParameters<u64, u64>,
+    initial_balance: u64,
 }
 
 impl ApplyOnOpeningFixture {
@@ -162,33 +167,47 @@ impl ApplyOnOpeningFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>, member_id: u64) -> Self {
+    pub fn with_origin(self, origin: RawOrigin<u64>, id: u64) -> Self {
         Self {
             origin,
-            member_id,
+            stake_parameters: StakeParameters {
+                staking_account_id: id,
+                ..self.stake_parameters
+            },
+            member_id: id,
+            role_account_id: id,
+            reward_account_id: id,
             ..self
         }
     }
 
-    pub fn with_stake_parameters(
-        self,
-        stake_parameters: Option<StakeParameters<u64, u64>>,
-    ) -> Self {
+    pub fn with_stake_parameters(self, stake_parameters: StakeParameters<u64, u64>) -> Self {
         Self {
             stake_parameters,
             ..self
         }
     }
 
+    pub fn with_initial_balance(self, initial_balance: u64) -> Self {
+        Self {
+            initial_balance,
+            ..self
+        }
+    }
+
     pub fn default_for_opening_id(opening_id: u64) -> Self {
         Self {
-            origin: RawOrigin::Signed(1),
-            member_id: 1,
+            origin: RawOrigin::Signed(2),
+            member_id: 2,
             opening_id,
-            role_account_id: 1,
-            reward_account_id: 1,
+            role_account_id: 2,
+            reward_account_id: 2,
             description: b"human_text".to_vec(),
-            stake_parameters: None,
+            stake_parameters: StakeParameters {
+                stake: <Test as Trait>::MinimumStakeForOpening::get(),
+                staking_account_id: 2,
+            },
+            initial_balance: <Test as Trait>::MinimumStakeForOpening::get(),
         }
     }
 
@@ -204,6 +223,11 @@ impl ApplyOnOpeningFixture {
     }
 
     pub fn call(&self) -> Result<u64, DispatchError> {
+        balances::Module::<Test>::make_free_balance_be(
+            &self.stake_parameters.staking_account_id,
+            self.initial_balance,
+        );
+
         let saved_application_next_id = TestWorkingGroup::next_application_id();
         TestWorkingGroup::apply_on_opening(
             self.origin.clone().into(),
@@ -212,6 +236,7 @@ impl ApplyOnOpeningFixture {
 
         Ok(saved_application_next_id)
     }
+
     pub fn call_and_assert(&self, expected_result: DispatchResult) -> u64 {
         let saved_application_next_id = TestWorkingGroup::next_application_id();
 
@@ -231,12 +256,10 @@ impl ApplyOnOpeningFixture {
             let expected_application = Application::<Test> {
                 role_account_id: self.role_account_id,
                 reward_account_id: self.reward_account_id,
-                staking_account_id: self
-                    .stake_parameters
-                    .clone()
-                    .map(|sp| sp.staking_account_id),
+                staking_account_id: self.stake_parameters.staking_account_id,
                 member_id: self.member_id,
                 description_hash: expected_hash.as_ref().to_vec(),
+                opening_id: 1,
             };
 
             assert_eq!(actual_application, expected_application);
@@ -252,8 +275,8 @@ pub struct FillOpeningFixture {
     pub successful_application_ids: BTreeSet<u64>,
     role_account_id: u64,
     reward_account_id: u64,
-    staking_account_id: Option<u64>,
-    stake_policy: Option<StakePolicy<u64, u64>>,
+    staking_account_id: u64,
+    stake_policy: StakePolicy<u64, u64>,
     reward_per_block: Option<u64>,
     created_at: u64,
 }
@@ -266,10 +289,13 @@ impl FillOpeningFixture {
             origin: RawOrigin::Signed(1),
             opening_id,
             successful_application_ids: application_ids,
-            role_account_id: 1,
-            reward_account_id: 1,
-            staking_account_id: None,
-            stake_policy: None,
+            role_account_id: 2,
+            reward_account_id: 2,
+            staking_account_id: 2,
+            stake_policy: StakePolicy {
+                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get() + 1,
+            },
             reward_per_block: None,
             created_at: 0,
         }
@@ -283,14 +309,14 @@ impl FillOpeningFixture {
         Self { created_at, ..self }
     }
 
-    pub fn with_stake_policy(self, stake_policy: Option<StakePolicy<u64, u64>>) -> Self {
+    pub fn with_stake_policy(self, stake_policy: StakePolicy<u64, u64>) -> Self {
         Self {
             stake_policy,
             ..self
         }
     }
 
-    pub fn with_staking_account_id(self, staking_account_id: Option<u64>) -> Self {
+    pub fn with_staking_account_id(self, staking_account_id: u64) -> Self {
         Self {
             staking_account_id,
             ..self
@@ -336,15 +362,12 @@ impl FillOpeningFixture {
             }
 
             let expected_worker = Worker::<Test> {
-                member_id: 1,
+                member_id: 2,
                 role_account_id: self.role_account_id,
                 reward_account_id: self.reward_account_id,
                 staking_account_id: self.staking_account_id,
                 started_leaving_at: None,
-                job_unstaking_period: self
-                    .stake_policy
-                    .as_ref()
-                    .map_or(0, |sp| sp.leaving_unstaking_period),
+                job_unstaking_period: self.stake_policy.leaving_unstaking_period,
                 reward_per_block: self.reward_per_block,
                 missed_reward: None,
                 created_at: self.created_at,
@@ -369,20 +392,34 @@ impl FillOpeningFixture {
 
 pub struct HireLeadFixture {
     setup_environment: bool,
-    stake_policy: Option<StakePolicy<u64, u64>>,
+    stake_policy: StakePolicy<u64, u64>,
     reward_per_block: Option<u64>,
+    lead_id: u64,
+    initial_balance: u64,
 }
 
 impl Default for HireLeadFixture {
     fn default() -> Self {
         Self {
             setup_environment: true,
-            stake_policy: None,
+            stake_policy: StakePolicy {
+                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get() + 1,
+            },
             reward_per_block: None,
+            lead_id: 1,
+            initial_balance: <Test as Trait>::MinimumStakeForOpening::get() + 1,
         }
     }
 }
 impl HireLeadFixture {
+    pub fn with_initial_balance(self, initial_balance: u64) -> Self {
+        Self {
+            initial_balance,
+            ..self
+        }
+    }
+
     pub fn with_setup_environment(self, setup_environment: bool) -> Self {
         Self {
             setup_environment,
@@ -390,7 +427,7 @@ impl HireLeadFixture {
         }
     }
 
-    pub fn with_stake_policy(self, stake_policy: Option<StakePolicy<u64, u64>>) -> Self {
+    pub fn with_stake_policy(self, stake_policy: StakePolicy<u64, u64>) -> Self {
         Self {
             stake_policy,
             ..self
@@ -404,46 +441,59 @@ impl HireLeadFixture {
         }
     }
 
-    pub fn hire_lead(self) -> u64 {
+    fn get_hiring_workflow(self) -> HiringWorkflow {
         HiringWorkflow::default()
             .with_setup_environment(self.setup_environment)
             .with_opening_type(OpeningType::Leader)
             .with_stake_policy(self.stake_policy)
             .with_reward_per_block(self.reward_per_block)
-            .add_application(b"leader".to_vec())
-            .execute()
-            .unwrap()
+            .with_initial_balance(self.initial_balance)
+            .add_application_full(
+                b"leader".to_vec(),
+                RawOrigin::Signed(self.lead_id),
+                self.lead_id,
+                self.lead_id,
+            )
+    }
+
+    pub fn hire_lead(self) -> u64 {
+        self.get_hiring_workflow().execute().unwrap()
     }
 
     pub fn expect(self, error: DispatchError) {
-        HiringWorkflow::default()
-            .with_setup_environment(self.setup_environment)
-            .with_opening_type(OpeningType::Leader)
-            .with_stake_policy(self.stake_policy)
-            .with_reward_per_block(self.reward_per_block)
-            .add_application(b"leader".to_vec())
-            .expect(Err(error))
-            .execute();
+        self.get_hiring_workflow().expect(Err(error)).execute();
     }
 }
 
 pub struct HireRegularWorkerFixture {
     setup_environment: bool,
-    stake_policy: Option<StakePolicy<u64, u64>>,
+    stake_policy: StakePolicy<u64, u64>,
     reward_per_block: Option<u64>,
+    initial_balance: u64,
 }
 
 impl Default for HireRegularWorkerFixture {
     fn default() -> Self {
         Self {
             setup_environment: true,
-            stake_policy: None,
+            stake_policy: StakePolicy {
+                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get() + 1,
+            },
             reward_per_block: None,
+            initial_balance: <Test as Trait>::MinimumStakeForOpening::get(),
         }
     }
 }
 impl HireRegularWorkerFixture {
-    pub fn with_stake_policy(self, stake_policy: Option<StakePolicy<u64, u64>>) -> Self {
+    pub fn with_initial_balance(self, initial_balance: u64) -> Self {
+        Self {
+            initial_balance,
+            ..self
+        }
+    }
+
+    pub fn with_stake_policy(self, stake_policy: StakePolicy<u64, u64>) -> Self {
         Self {
             stake_policy,
             ..self
@@ -463,6 +513,7 @@ impl HireRegularWorkerFixture {
             .with_opening_type(OpeningType::Regular)
             .with_stake_policy(self.stake_policy)
             .with_reward_per_block(self.reward_per_block)
+            .with_initial_balance(self.initial_balance)
             .add_application(b"worker".to_vec())
             .execute()
             .unwrap()
@@ -506,26 +557,17 @@ impl UpdateWorkerRoleAccountFixture {
 pub(crate) struct LeaveWorkerRoleFixture {
     worker_id: u64,
     origin: RawOrigin<u64>,
-    stake_policy: Option<StakePolicy<u64, u64>>,
 }
 
 impl LeaveWorkerRoleFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
         Self {
             worker_id,
-            origin: RawOrigin::Signed(1),
-            stake_policy: None,
+            origin: RawOrigin::Signed(2),
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
         Self { origin, ..self }
-    }
-
-    pub fn with_stake_policy(self, stake_policy: Option<StakePolicy<u64, u64>>) -> Self {
-        Self {
-            stake_policy,
-            ..self
-        }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -534,16 +576,14 @@ impl LeaveWorkerRoleFixture {
         assert_eq!(actual_result, expected_result);
 
         if actual_result.is_ok() {
-            if self.stake_policy.is_some() {
-                let worker = TestWorkingGroup::worker_by_id(self.worker_id);
+            let worker = TestWorkingGroup::worker_by_id(self.worker_id);
 
-                if worker.job_unstaking_period > 0 {
-                    assert_eq!(
-                        worker.started_leaving_at,
-                        Some(<frame_system::Module<Test>>::block_number())
-                    );
-                    return;
-                }
+            if worker.job_unstaking_period > 0 {
+                assert_eq!(
+                    worker.started_leaving_at,
+                    Some(<frame_system::Module<Test>>::block_number())
+                );
+                return;
             }
 
             assert!(!<crate::WorkerById<Test, DefaultInstance>>::contains_key(
@@ -611,7 +651,7 @@ pub struct SlashWorkerStakeFixture {
 
 impl SlashWorkerStakeFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
-        let account_id = 1;
+        let account_id = 2;
 
         let lead_account_id = get_current_lead_account_id();
 
@@ -629,6 +669,10 @@ impl SlashWorkerStakeFixture {
 
     pub fn with_penalty(self, penalty: u64) -> Self {
         Self { penalty, ..self }
+    }
+
+    pub fn with_account_id(self, account_id: u64) -> Self {
+        Self { account_id, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -686,7 +730,7 @@ pub struct DecreaseWorkerStakeFixture {
 
 impl DecreaseWorkerStakeFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
-        let account_id = 1;
+        let account_id = 2;
 
         let lead_account_id = get_current_lead_account_id();
 
@@ -697,6 +741,11 @@ impl DecreaseWorkerStakeFixture {
             account_id,
         }
     }
+
+    pub fn with_account_id(self, account_id: u64) -> Self {
+        Self { account_id, ..self }
+    }
+
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
         Self { origin, ..self }
     }
@@ -718,7 +767,10 @@ impl DecreaseWorkerStakeFixture {
 
         if actual_result.is_ok() {
             // new stake was set
-            assert_eq!(self.balance, get_stake_balance(&self.account_id));
+            assert_eq!(
+                old_stake - self.balance,
+                get_stake_balance(&self.account_id)
+            );
 
             let new_balance = Balances::usable_balance(&self.account_id);
 
@@ -737,9 +789,9 @@ pub struct IncreaseWorkerStakeFixture {
 
 impl IncreaseWorkerStakeFixture {
     pub fn default_for_worker_id(worker_id: u64) -> Self {
-        let account_id = 1;
+        let account_id = 2;
         Self {
-            origin: RawOrigin::Signed(1),
+            origin: RawOrigin::Signed(account_id),
             worker_id,
             balance: 10,
             account_id,
@@ -747,6 +799,10 @@ impl IncreaseWorkerStakeFixture {
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
         Self { origin, ..self }
+    }
+
+    pub fn with_account_id(self, account_id: u64) -> Self {
+        Self { account_id, ..self }
     }
 
     pub fn with_balance(self, balance: u64) -> Self {
@@ -809,10 +865,10 @@ impl WithdrawApplicationFixture {
 
     pub fn default_for_application_id(application_id: u64) -> Self {
         Self {
-            origin: RawOrigin::Signed(1),
+            origin: RawOrigin::Signed(2),
             application_id,
             stake: false,
-            account_id: 1,
+            account_id: 2,
         }
     }
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -936,7 +992,7 @@ impl UpdateRewardAccountFixture {
         Self {
             worker_id,
             new_reward_account_id,
-            origin: RawOrigin::Signed(1),
+            origin: RawOrigin::Signed(2),
         }
     }
     pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -178,6 +178,7 @@ parameter_types! {
     pub const RewardPeriod: u32 = 2;
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const MinUnstakingPeriodLimit: u64 = 3;
+    pub const MinimumStakeForOpening: u64 = 50;
     pub const LockId: [u8; 8] = [1; 8];
 }
 
@@ -190,6 +191,7 @@ impl Trait for Test {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = RewardPeriod;
     type WeightInfo = ();
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl common::StakingAccountValidator<Test> for () {
@@ -295,7 +297,6 @@ pub type TestWorkingGroup = Module<Test, DefaultInstance>;
 
 pub const STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER: u64 = 222;
 pub const STAKING_ACCOUNT_ID_FOR_CONFLICTING_STAKES: u64 = 333;
-pub const STAKING_ACCOUNT_ID_FOR_ZERO_STAKE: u64 = 444;
 
 pub fn build_test_externalities() -> sp_io::TestExternalities {
     let t = frame_system::GenesisConfig::default()

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -264,10 +264,7 @@ impl crate::WeightInfo for () {
     fn add_opening(_: u32) -> Weight {
         0
     }
-    fn leave_role_immediatly() -> Weight {
-        0
-    }
-    fn leave_role_later() -> Weight {
+    fn leave_role(_: u32) -> Weight {
         0
     }
 }

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -13,11 +13,10 @@ use crate::tests::fixtures::{
 };
 use crate::tests::hiring_workflow::HiringWorkflow;
 use crate::tests::mock::{
-    STAKING_ACCOUNT_ID_FOR_CONFLICTING_STAKES, STAKING_ACCOUNT_ID_FOR_ZERO_STAKE,
-    STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER,
+    STAKING_ACCOUNT_ID_FOR_CONFLICTING_STAKES, STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER,
 };
 use crate::types::StakeParameters;
-use crate::{DefaultInstance, Error, OpeningType, RawEvent, StakePolicy, Worker};
+use crate::{DefaultInstance, Error, OpeningType, RawEvent, StakePolicy, Trait, Worker};
 use common::working_group::WorkingGroupAuthenticator;
 use fixtures::{
     increase_total_balance_issuance_using_account_id, AddOpeningFixture, ApplyOnOpeningFixture,
@@ -40,10 +39,10 @@ fn add_opening_succeeded() {
 
         let add_opening_fixture = AddOpeningFixture::default()
             .with_starting_block(starting_block)
-            .with_stake_policy(Some(StakePolicy {
-                stake_amount: 10,
+            .with_stake_policy(StakePolicy {
+                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
                 leaving_unstaking_period: 100,
-            }))
+            })
             .with_reward_per_block(Some(10));
 
         let opening_id = add_opening_fixture.call_and_assert(Ok(()));
@@ -74,14 +73,14 @@ fn add_opening_fails_with_zero_stake() {
     build_test_externalities().execute_with(|| {
         HireLeadFixture::default().hire_lead();
 
-        let add_opening_fixture =
-            AddOpeningFixture::default().with_stake_policy(Some(StakePolicy {
-                stake_amount: 0,
-                leaving_unstaking_period: 0,
-            }));
+        let add_opening_fixture = AddOpeningFixture::default().with_stake_policy(StakePolicy {
+            stake_amount: 0,
+            leaving_unstaking_period: 0,
+        });
 
-        add_opening_fixture
-            .call_and_assert(Err(Error::<Test, DefaultInstance>::CannotStakeZero.into()));
+        add_opening_fixture.call_and_assert(Err(
+            Error::<Test, DefaultInstance>::BelowMinimumStakes.into(),
+        ));
     });
 }
 
@@ -110,11 +109,10 @@ fn add_opening_fails_with_incorrect_unstaking_period() {
         increase_total_balance_issuance_using_account_id(account_id, total_balance);
 
         let invalid_unstaking_period = 3;
-        let add_opening_fixture =
-            AddOpeningFixture::default().with_stake_policy(Some(StakePolicy {
-                stake_amount: stake,
-                leaving_unstaking_period: invalid_unstaking_period,
-            }));
+        let add_opening_fixture = AddOpeningFixture::default().with_stake_policy(StakePolicy {
+            stake_amount: stake,
+            leaving_unstaking_period: invalid_unstaking_period,
+        });
 
         add_opening_fixture.call_and_assert(Err(
             Error::<Test, DefaultInstance>::UnstakingPeriodLessThanMinimum.into(),
@@ -144,7 +142,8 @@ fn apply_on_opening_succeeded() {
 
         let opening_id = add_opening_fixture.call().unwrap();
 
-        let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id);
+        let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
+            .with_initial_balance(<Test as Trait>::MinimumStakeForOpening::get());
 
         let application_id = apply_on_opening_fixture.call_and_assert(Ok(()));
 
@@ -252,7 +251,7 @@ fn fill_opening_succeeded_with_stake() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let account_id = 1;
+        let account_id = 2;
         let total_balance = 300;
         let stake = 200;
 
@@ -261,12 +260,10 @@ fn fill_opening_succeeded_with_stake() {
             staking_account_id: account_id,
         };
 
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
+        };
         let add_opening_fixture = AddOpeningFixture::default()
             .with_starting_block(starting_block)
             .with_stake_policy(stake_policy.clone());
@@ -274,14 +271,15 @@ fn fill_opening_succeeded_with_stake() {
         let opening_id = add_opening_fixture.call().unwrap();
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_stake_parameters(Some(stake_parameters));
+            .with_initial_balance(total_balance)
+            .with_stake_parameters(stake_parameters);
 
         let application_id = apply_on_opening_fixture.call().unwrap();
 
         let fill_opening_fixture =
             FillOpeningFixture::default_for_ids(opening_id, vec![application_id])
                 .with_stake_policy(stake_policy)
-                .with_staking_account_id(Some(account_id))
+                .with_staking_account_id(account_id)
                 .with_created_at(starting_block);
 
         let worker_id = fill_opening_fixture.call_and_assert(Ok(()));
@@ -328,18 +326,19 @@ fn fill_opening_fails_with_invalid_active_worker_number() {
         let opening_id = add_opening_fixture.call().unwrap();
 
         let application_id1 = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .call()
-            .unwrap();
-        let application_id2 = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
             .with_origin(RawOrigin::Signed(2), 2)
             .call()
             .unwrap();
-        let application_id3 = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
+        let application_id2 = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
             .with_origin(RawOrigin::Signed(3), 3)
             .call()
             .unwrap();
-        let application_id4 = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
+        let application_id3 = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
             .with_origin(RawOrigin::Signed(4), 4)
+            .call()
+            .unwrap();
+        let application_id4 = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
+            .with_origin(RawOrigin::Signed(5), 5)
             .call()
             .unwrap();
 
@@ -402,7 +401,7 @@ fn cannot_hire_a_lead_twice() {
         HireLeadFixture::default().hire_lead();
         HireLeadFixture::default()
             .with_setup_environment(false)
-            .expect(Error::<Test, DefaultInstance>::CannotHireLeaderWhenLeaderExists.into());
+            .expect(Error::<Test, DefaultInstance>::ConflictStakesOnAccount.into());
     });
 }
 
@@ -413,7 +412,7 @@ fn cannot_hire_muptiple_leaders() {
             .with_setup_environment(true)
             .with_opening_type(OpeningType::Leader)
             .add_default_application()
-            .add_application_full(b"leader2".to_vec(), RawOrigin::Signed(2), 2, Some(2))
+            .add_application_full(b"leader2".to_vec(), RawOrigin::Signed(3), 3, 3)
             .expect(Err(
                 Error::<Test, DefaultInstance>::CannotHireMultipleLeaders.into(),
             ))
@@ -474,26 +473,23 @@ fn update_worker_role_account_by_leader_succeeds() {
 #[test]
 fn update_worker_role_fails_with_leaving_worker() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
         let leaving_unstaking_period = 10;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy.clone())
             .hire();
 
         let new_account_id = 10;
 
-        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id)
-            .with_stake_policy(stake_policy);
+        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
         leave_worker_role_fixture.call_and_assert(Ok(()));
 
         let update_worker_account_fixture =
@@ -533,14 +529,17 @@ fn leave_worker_role_succeeds() {
 
         leave_worker_role_fixture.call_and_assert(Ok(()));
 
-        EventFixture::assert_last_crate_event(RawEvent::WorkerLeft(worker_id, None));
+        let worker = TestWorkingGroup::worker_by_id(worker_id);
+        run_to_block(1 + worker.job_unstaking_period);
+
+        EventFixture::assert_last_crate_event(RawEvent::WorkerExited(worker_id));
     });
 }
 
 #[test]
 fn leave_worker_role_succeeds_with_paying_missed_reward() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
+        let account_id = 2;
         let reward_per_block = 10;
 
         let worker_id = HireRegularWorkerFixture::default()
@@ -557,9 +556,12 @@ fn leave_worker_role_succeeds_with_paying_missed_reward() {
         let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
         leave_worker_role_fixture.call_and_assert(Ok(()));
 
+        let worker = TestWorkingGroup::worker_by_id(worker_id);
+        run_to_block(block_number + worker.job_unstaking_period);
+
         assert_eq!(
             Balances::usable_balance(&account_id),
-            block_number * reward_per_block
+            block_number * reward_per_block + <Test as Trait>::MinimumStakeForOpening::get()
         );
     });
 }
@@ -567,7 +569,7 @@ fn leave_worker_role_succeeds_with_paying_missed_reward() {
 #[test]
 fn leave_worker_role_succeeds_with_partial_payment_of_missed_reward() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
+        let account_id = 2;
         let reward_per_block = 10;
 
         let worker_id = HireRegularWorkerFixture::default()
@@ -585,7 +587,13 @@ fn leave_worker_role_succeeds_with_partial_payment_of_missed_reward() {
         let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
         leave_worker_role_fixture.call_and_assert(Ok(()));
 
-        assert_eq!(Balances::usable_balance(&account_id), budget);
+        let worker = TestWorkingGroup::worker_by_id(worker_id);
+        run_to_block(block_number + worker.job_unstaking_period);
+
+        assert_eq!(
+            Balances::usable_balance(&account_id),
+            budget + <Test as Trait>::MinimumStakeForOpening::get()
+        );
     });
 }
 
@@ -598,9 +606,16 @@ fn leave_worker_role_by_leader_succeeds() {
 
         assert!(TestWorkingGroup::current_lead().is_some());
 
-        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
+        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id)
+            .with_origin(RawOrigin::Signed(1));
 
         leave_worker_role_fixture.call_and_assert(Ok(()));
+
+        let current_lead = TestWorkingGroup::current_lead().unwrap();
+        let leader = TestWorkingGroup::worker_by_id(current_lead);
+        assert!(leader.started_leaving_at.is_some());
+
+        run_to_block(frame_system::Module::<Test>::block_number() + leader.job_unstaking_period);
 
         assert_eq!(TestWorkingGroup::current_lead(), None);
     });
@@ -622,7 +637,7 @@ fn leave_worker_role_fails_with_invalid_origin_signed_account() {
         let worker_id = HireRegularWorkerFixture::default().hire();
 
         let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id)
-            .with_origin(RawOrigin::Signed(2));
+            .with_origin(RawOrigin::Signed(3));
 
         leave_worker_role_fixture.call_and_assert(Err(
             Error::<Test, DefaultInstance>::SignerIsNotWorkerRoleAccount.into(),
@@ -633,23 +648,20 @@ fn leave_worker_role_fails_with_invalid_origin_signed_account() {
 #[test]
 fn leave_worker_role_fails_already_leaving_worker() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
 
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy.clone())
             .hire();
 
-        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id)
-            .with_stake_policy(stake_policy);
+        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
 
         leave_worker_role_fixture.call_and_assert(Ok(()));
         leave_worker_role_fixture
@@ -700,12 +712,13 @@ fn terminate_worker_role_succeeds() {
 #[test]
 fn terminate_worker_role_succeeds_with_paying_missed_reward() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
+        let account_id = 2;
         let reward_per_block = 10;
 
         let worker_id = HireRegularWorkerFixture::default()
             .with_reward_per_block(Some(reward_per_block))
             .hire();
+
         let block_number = 4;
 
         run_to_block(block_number);
@@ -721,7 +734,7 @@ fn terminate_worker_role_succeeds_with_paying_missed_reward() {
 
         assert_eq!(
             Balances::usable_balance(&account_id),
-            block_number * reward_per_block
+            block_number * reward_per_block + <Test as Trait>::MinimumStakeForOpening::get()
         );
     });
 }
@@ -777,7 +790,7 @@ fn terminate_worker_role_fails_with_invalid_origin() {
 
         let worker_id = HiringWorkflow::default()
             .with_setup_environment(false)
-            .add_application_full(b"worker_handle".to_vec(), RawOrigin::Signed(2), 2, Some(2))
+            .add_application_full(b"worker_handle".to_vec(), RawOrigin::Signed(2), 2, 2)
             .execute()
             .unwrap();
 
@@ -846,22 +859,21 @@ fn apply_on_opening_fails_with_stake_inconsistent_with_opening_stake() {
         HireLeadFixture::default().hire_lead();
 
         let account_id = 1;
-        increase_total_balance_issuance_using_account_id(account_id, 300);
 
         let stake_parameters = StakeParameters {
             stake: 100,
             staking_account_id: account_id,
         };
 
-        let add_opening_fixture =
-            AddOpeningFixture::default().with_stake_policy(Some(StakePolicy {
-                stake_amount: 200,
-                leaving_unstaking_period: 10,
-            }));
+        let add_opening_fixture = AddOpeningFixture::default().with_stake_policy(StakePolicy {
+            stake_amount: 200,
+            leaving_unstaking_period: 10,
+        });
         let opening_id = add_opening_fixture.call().unwrap();
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_stake_parameters(Some(stake_parameters));
+            .with_initial_balance(300)
+            .with_stake_parameters(stake_parameters);
 
         apply_on_opening_fixture.call_and_assert(Err(
             Error::<Test, DefaultInstance>::ApplicationStakeDoesntMatchOpening.into(),
@@ -874,28 +886,24 @@ fn apply_on_opening_locks_the_stake() {
     build_test_externalities().execute_with(|| {
         HireLeadFixture::default().hire_lead();
 
-        let account_id = 1;
-        let total_balance = 300;
-        let stake = 200;
+        let account_id = 2;
+        let total_balance = <Test as Trait>::MinimumStakeForOpening::get() + 100;
+        let stake = <Test as Trait>::MinimumStakeForOpening::get();
 
         let stake_parameters = StakeParameters {
             stake,
             staking_account_id: account_id,
         };
 
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let add_opening_fixture =
-            AddOpeningFixture::default().with_stake_policy(Some(StakePolicy {
-                stake_amount: stake,
-                leaving_unstaking_period: 10,
-            }));
+        let add_opening_fixture = AddOpeningFixture::default().with_stake_policy(StakePolicy {
+            stake_amount: stake,
+            leaving_unstaking_period: 10,
+        });
         let opening_id = add_opening_fixture.call().unwrap();
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_stake_parameters(Some(stake_parameters));
-
-        assert_eq!(Balances::usable_balance(&account_id), total_balance);
+            .with_stake_parameters(stake_parameters)
+            .with_initial_balance(total_balance);
 
         apply_on_opening_fixture.call_and_assert(Ok(()));
 
@@ -908,7 +916,7 @@ fn apply_on_opening_fails_stake_amount_check() {
     build_test_externalities().execute_with(|| {
         HireLeadFixture::default().hire_lead();
 
-        let account_id = 1;
+        let account_id = 2;
         let total_balance = 100;
         let stake = 200;
 
@@ -917,17 +925,15 @@ fn apply_on_opening_fails_stake_amount_check() {
             staking_account_id: account_id,
         };
 
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let add_opening_fixture =
-            AddOpeningFixture::default().with_stake_policy(Some(StakePolicy {
-                stake_amount: stake,
-                leaving_unstaking_period: 10,
-            }));
+        let add_opening_fixture = AddOpeningFixture::default().with_stake_policy(StakePolicy {
+            stake_amount: stake,
+            leaving_unstaking_period: 10,
+        });
         let opening_id = add_opening_fixture.call().unwrap();
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_stake_parameters(Some(stake_parameters));
+            .with_initial_balance(total_balance)
+            .with_stake_parameters(stake_parameters);
 
         apply_on_opening_fixture.call_and_assert(Err(
             Error::<Test, DefaultInstance>::InsufficientBalanceToCoverStake.into(),
@@ -940,11 +946,9 @@ fn apply_on_opening_fails_invalid_staking_check() {
     build_test_externalities().execute_with(|| {
         HireLeadFixture::default().hire_lead();
 
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
 
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
         increase_total_balance_issuance_using_account_id(
             STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER,
             total_balance,
@@ -955,15 +959,15 @@ fn apply_on_opening_fails_invalid_staking_check() {
             staking_account_id: STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER,
         };
 
-        let add_opening_fixture =
-            AddOpeningFixture::default().with_stake_policy(Some(StakePolicy {
-                stake_amount: stake,
-                leaving_unstaking_period: 10,
-            }));
+        let add_opening_fixture = AddOpeningFixture::default().with_stake_policy(StakePolicy {
+            stake_amount: stake,
+            leaving_unstaking_period: 10,
+        });
         let opening_id = add_opening_fixture.call().unwrap();
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_stake_parameters(Some(stake_parameters));
+            .with_initial_balance(total_balance)
+            .with_stake_parameters(stake_parameters);
 
         apply_on_opening_fixture.call_and_assert(Err(
             Error::<Test, DefaultInstance>::InvalidStakingAccountForMember.into(),
@@ -991,19 +995,19 @@ fn apply_on_opening_fails_with_conflicting_stakes() {
             total_balance,
         );
 
-        let add_opening_fixture =
-            AddOpeningFixture::default().with_stake_policy(Some(StakePolicy {
-                stake_amount: stake,
-                leaving_unstaking_period: 10,
-            }));
+        let add_opening_fixture = AddOpeningFixture::default().with_stake_policy(StakePolicy {
+            stake_amount: stake,
+            leaving_unstaking_period: 10,
+        });
         let opening_id = add_opening_fixture.call().unwrap();
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_stake_parameters(Some(stake_parameters.clone()));
+            .with_stake_parameters(stake_parameters.clone())
+            .with_initial_balance(stake_parameters.stake);
         apply_on_opening_fixture.call_and_assert(Ok(()));
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_stake_parameters(Some(stake_parameters));
+            .with_stake_parameters(stake_parameters);
 
         apply_on_opening_fixture.call_and_assert(Err(
             Error::<Test, DefaultInstance>::ConflictStakesOnAccount.into(),
@@ -1014,18 +1018,17 @@ fn apply_on_opening_fails_with_conflicting_stakes() {
 #[test]
 fn terminate_worker_unlocks_the_stake() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
+        let account_id = 2;
         let total_balance = 300;
         let stake = 200;
 
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire();
 
@@ -1043,27 +1046,25 @@ fn terminate_worker_unlocks_the_stake() {
 #[test]
 fn leave_worker_unlocks_the_stake() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
+        let account_id = 2;
         let total_balance = 300;
         let stake = 200;
 
         let leaving_unstaking_period = 10;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy.clone())
             .hire();
 
         assert_eq!(Balances::usable_balance(&account_id), total_balance - stake);
 
-        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id)
-            .with_stake_policy(stake_policy);
+        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
 
         leave_worker_role_fixture.call_and_assert(Ok(()));
 
@@ -1076,26 +1077,24 @@ fn leave_worker_unlocks_the_stake() {
 #[test]
 fn leave_worker_unlocks_the_stake_with_unstaking_period() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
+        let account_id = 2;
         let total_balance = 300;
         let stake = 200;
 
         let leaving_unstaking_period = 10;
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy.clone())
             .hire();
 
         assert_eq!(Balances::usable_balance(&account_id), total_balance - stake);
 
-        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id)
-            .with_stake_policy(stake_policy);
+        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
 
         leave_worker_role_fixture.call_and_assert(Ok(()));
 
@@ -1111,56 +1110,19 @@ fn leave_worker_unlocks_the_stake_with_unstaking_period() {
 }
 
 #[test]
-fn leave_worker_works_immediately_stake_is_zero() {
-    build_test_externalities().execute_with(|| {
-        let account_id = STAKING_ACCOUNT_ID_FOR_ZERO_STAKE;
-        let total_balance = 300;
-        let stake = 200;
-
-        let leaving_unstaking_period = 10;
-        let stake_policy = Some(StakePolicy {
-            stake_amount: stake,
-            leaving_unstaking_period,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let worker_id = HiringWorkflow::default()
-            .with_setup_environment(true)
-            .with_opening_type(OpeningType::Regular)
-            //    .with_stake_policy(stake_policy.clone())
-            .add_application_full(b"worker".to_vec(), RawOrigin::Signed(1), 1, None)
-            .execute()
-            .unwrap();
-
-        //        assert_eq!(Balances::usable_balance(&account_id), total_balance - stake);
-
-        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id)
-            .with_stake_policy(stake_policy);
-
-        leave_worker_role_fixture.call_and_assert(Ok(()));
-
-        assert!(!<crate::WorkerById<Test, DefaultInstance>>::contains_key(
-            worker_id
-        ));
-    });
-}
-
-#[test]
 fn terminate_worker_with_slashing_succeeds() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
+        let account_id = 2;
         let total_balance = 300;
         let stake = 200;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire();
 
@@ -1176,29 +1138,6 @@ fn terminate_worker_with_slashing_succeeds() {
 }
 
 #[test]
-fn terminate_worker_with_slashing_fails_with_no_staking_account() {
-    build_test_externalities().execute_with(|| {
-        let account_id = 1;
-        let total_balance = 300;
-        let stake = 200;
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let worker_id = HiringWorkflow::default()
-            .add_application_full(b"worker".to_vec(), RawOrigin::Signed(1), 1, None)
-            .execute()
-            .unwrap();
-
-        let terminate_worker_role_fixture =
-            TerminateWorkerRoleFixture::default_for_worker_id(worker_id).with_penalty(Some(stake));
-
-        terminate_worker_role_fixture.call_and_assert(Err(
-            Error::<Test, DefaultInstance>::CannotChangeStakeWithoutStakingAccount.into(),
-        ));
-    });
-}
-
-#[test]
 fn slash_worker_stake_succeeds() {
     build_test_externalities().execute_with(|| {
         /*
@@ -1208,19 +1147,17 @@ fn slash_worker_stake_succeeds() {
         */
         run_to_block(1);
 
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
         let penalty = 100;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire();
 
@@ -1236,29 +1173,6 @@ fn slash_worker_stake_succeeds() {
 }
 
 #[test]
-fn slash_worker_stake_fails_with_no_staking_account() {
-    build_test_externalities().execute_with(|| {
-        let account_id = 1;
-        let total_balance = 300;
-        let penalty = 100;
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let worker_id = HiringWorkflow::default()
-            .add_application_full(b"worker".to_vec(), RawOrigin::Signed(1), 1, None)
-            .execute()
-            .unwrap();
-
-        let slash_stake_fixture =
-            SlashWorkerStakeFixture::default_for_worker_id(worker_id).with_penalty(penalty);
-
-        slash_stake_fixture.call_and_assert(Err(
-            Error::<Test, DefaultInstance>::CannotChangeStakeWithoutStakingAccount.into(),
-        ));
-    });
-}
-
-#[test]
 fn slash_leader_stake_succeeds() {
     build_test_externalities().execute_with(|| {
         /*
@@ -1268,22 +1182,22 @@ fn slash_leader_stake_succeeds() {
         */
         run_to_block(1);
 
-        let account_id = 1;
         let total_balance = 300;
         let penalty = 200;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: penalty,
             leaving_unstaking_period: 10,
-        });
+        };
 
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
         let leader_worker_id = HireLeadFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire_lead();
 
         let slash_stake_fixture = SlashWorkerStakeFixture::default_for_worker_id(leader_worker_id)
             .with_penalty(penalty)
+            .with_account_id(1)
             .with_origin(RawOrigin::Root);
 
         slash_stake_fixture.call_and_assert(Ok(()));
@@ -1325,18 +1239,16 @@ fn slash_leader_stake_fails_with_invalid_origin() {
 #[test]
 fn slash_worker_stake_fails_with_zero_balance() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire();
 
@@ -1385,19 +1297,17 @@ fn decrease_worker_stake_succeeds() {
         */
         run_to_block(1);
 
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
         let new_stake_balance = 100;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire();
 
@@ -1414,48 +1324,24 @@ fn decrease_worker_stake_succeeds() {
 }
 
 #[test]
-fn decrease_worker_stake_fails_with_no_staking_account() {
-    build_test_externalities().execute_with(|| {
-        let account_id = 1;
-        let total_balance = 300;
-        let new_stake_balance = 100;
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let worker_id = HiringWorkflow::default()
-            .add_application_full(b"worker".to_vec(), RawOrigin::Signed(1), 1, None)
-            .execute()
-            .unwrap();
-
-        let decrease_stake_fixture = DecreaseWorkerStakeFixture::default_for_worker_id(worker_id)
-            .with_balance(new_stake_balance);
-
-        decrease_stake_fixture.call_and_assert(Err(
-            Error::<Test, DefaultInstance>::CannotChangeStakeWithoutStakingAccount.into(),
-        ));
-    });
-}
-
-#[test]
 fn decrease_worker_stake_succeeds_for_leader() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireLeadFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire_lead();
 
         let new_stake = 100;
         let decrease_stake_fixture = DecreaseWorkerStakeFixture::default_for_worker_id(worker_id)
+            .with_account_id(1)
             .with_origin(RawOrigin::Root)
             .with_balance(new_stake);
 
@@ -1490,19 +1376,17 @@ fn decrease_worker_stake_fails_with_invalid_origin_for_leader() {
 #[test]
 fn decrease_worker_stake_fails_with_zero_balance() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
             .with_stake_policy(stake_policy)
+            .with_initial_balance(total_balance)
             .hire();
 
         let decrease_stake_fixture =
@@ -1552,19 +1436,17 @@ fn increase_worker_stake_succeeds() {
         */
         run_to_block(1);
 
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
         let stake_balance_delta = 100;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire();
 
@@ -1583,23 +1465,23 @@ fn increase_worker_stake_succeeds() {
 #[test]
 fn increase_worker_stake_succeeds_for_leader() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 400;
         let stake = 200;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireLeadFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire_lead();
 
-        let increase_stake_fixture =
-            IncreaseWorkerStakeFixture::default_for_worker_id(worker_id).with_balance(stake);
+        let increase_stake_fixture = IncreaseWorkerStakeFixture::default_for_worker_id(worker_id)
+            .with_balance(stake)
+            .with_account_id(1)
+            .with_origin(RawOrigin::Signed(1));
 
         increase_stake_fixture.call_and_assert(Ok(()));
     });
@@ -1621,19 +1503,17 @@ fn increase_worker_stake_fails_with_invalid_origin() {
 #[test]
 fn increase_worker_stake_fails_with_zero_balance() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
             .with_stake_policy(stake_policy)
+            .with_initial_balance(total_balance)
             .hire();
 
         let increase_stake_fixture =
@@ -1641,27 +1521,6 @@ fn increase_worker_stake_fails_with_zero_balance() {
 
         increase_stake_fixture.call_and_assert(Err(
             Error::<Test, DefaultInstance>::StakeBalanceCannotBeZero.into(),
-        ));
-    });
-}
-
-#[test]
-fn increase_worker_stake_fails_with_no_staking_account() {
-    build_test_externalities().execute_with(|| {
-        let account_id = 1;
-        let total_balance = 300;
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
-        let worker_id = HiringWorkflow::default()
-            .add_application_full(b"worker".to_vec(), RawOrigin::Signed(1), 1, None)
-            .execute()
-            .unwrap();
-
-        let increase_stake_fixture = IncreaseWorkerStakeFixture::default_for_worker_id(worker_id);
-
-        increase_stake_fixture.call_and_assert(Err(
-            Error::<Test, DefaultInstance>::CannotChangeStakeWithoutStakingAccount.into(),
         ));
     });
 }
@@ -1685,18 +1544,16 @@ fn increase_worker_stake_fails_with_invalid_worker_id() {
 #[test]
 fn increase_worker_stake_fails_external_check() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy)
             .hire();
 
@@ -1721,7 +1578,7 @@ fn withdraw_application_succeeds() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let account_id = 1;
+        let account_id = 2;
         let total_balance = 300;
         let stake = 200;
 
@@ -1730,20 +1587,19 @@ fn withdraw_application_succeeds() {
             staking_account_id: account_id,
         };
 
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
-
         HireLeadFixture::default().hire_lead();
 
         let add_opening_fixture = AddOpeningFixture::default()
             .with_starting_block(starting_block)
-            .with_stake_policy(Some(StakePolicy {
+            .with_stake_policy(StakePolicy {
                 stake_amount: stake,
                 leaving_unstaking_period: 10,
-            }));
+            });
         let opening_id = add_opening_fixture.call_and_assert(Ok(()));
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_stake_parameters(Some(stake_parameters));
+            .with_initial_balance(total_balance)
+            .with_stake_parameters(stake_parameters);
         let application_id = apply_on_opening_fixture.call_and_assert(Ok(()));
 
         let withdraw_application_fixture =
@@ -1793,7 +1649,8 @@ fn withdraw_worker_application_fails_with_invalid_application_author() {
         let add_opening_fixture = AddOpeningFixture::default();
         let opening_id = add_opening_fixture.call_and_assert(Ok(()));
 
-        let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id);
+        let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
+            .with_initial_balance(<Test as Trait>::MinimumStakeForOpening::get() + 1);
         let application_id = apply_on_opening_fixture.call_and_assert(Ok(()));
 
         let invalid_author_account_id = 55;
@@ -1860,24 +1717,21 @@ fn cancel_opening_fails_invalid_opening_id() {
 #[test]
 fn decrease_worker_stake_fails_with_leaving_worker() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
         let new_stake_balance = 100;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
+            .with_initial_balance(total_balance)
             .with_stake_policy(stake_policy.clone())
             .hire();
 
-        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id)
-            .with_stake_policy(stake_policy);
+        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
 
         leave_worker_role_fixture.call_and_assert(Ok(()));
 
@@ -1892,24 +1746,21 @@ fn decrease_worker_stake_fails_with_leaving_worker() {
 #[test]
 fn increase_worker_stake_fails_with_leaving_worker() {
     build_test_externalities().execute_with(|| {
-        let account_id = 1;
         let total_balance = 300;
         let stake = 200;
         let new_stake_balance = 100;
 
-        let stake_policy = Some(StakePolicy {
+        let stake_policy = StakePolicy {
             stake_amount: stake,
             leaving_unstaking_period: 10,
-        });
-
-        increase_total_balance_issuance_using_account_id(account_id, total_balance);
+        };
 
         let worker_id = HireRegularWorkerFixture::default()
             .with_stake_policy(stake_policy.clone())
+            .with_initial_balance(total_balance)
             .hire();
 
-        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id)
-            .with_stake_policy(stake_policy);
+        let leave_worker_role_fixture = LeaveWorkerRoleFixture::default_for_worker_id(worker_id);
 
         leave_worker_role_fixture.call_and_assert(Ok(()));
 
@@ -2120,7 +1971,8 @@ fn update_reward_account_succeeds_for_leader() {
 
         let new_reward_account = 22;
         let update_account_fixture =
-            UpdateRewardAccountFixture::default_with_ids(worker_id, new_reward_account);
+            UpdateRewardAccountFixture::default_with_ids(worker_id, new_reward_account)
+                .with_origin(RawOrigin::Signed(1));
 
         update_account_fixture.call_and_assert(Ok(()));
     });
@@ -2387,7 +2239,7 @@ fn ensure_worker_origin_works_correctly() {
             Err(DispatchError::BadOrigin)
         );
 
-        let account_id = 1;
+        let account_id = 2;
         assert_eq!(
             TestWorkingGroup::ensure_worker_origin(
                 RawOrigin::Signed(account_id).into(),
@@ -2398,7 +2250,7 @@ fn ensure_worker_origin_works_correctly() {
 
         let worker_id = HireRegularWorkerFixture::default().hire();
 
-        let invalid_account = 2;
+        let invalid_account = 3;
         assert_eq!(
             TestWorkingGroup::ensure_worker_origin(
                 RawOrigin::Signed(invalid_account).into(),
@@ -2486,8 +2338,8 @@ fn is_leader_account_id_works_correctly() {
 #[test]
 fn is_worker_account_id_works_correctly() {
     build_test_externalities().execute_with(|| {
-        let invalid_account_id = 2u64;
-        let invalid_worker_id = 2u64;
+        let invalid_account_id = 3u64;
+        let invalid_worker_id = 3u64;
 
         // Not hired
         assert_eq!(
@@ -2502,7 +2354,7 @@ fn is_worker_account_id_works_correctly() {
             false
         );
 
-        let account_id = 1u64;
+        let account_id = 2u64;
         assert_eq!(
             TestWorkingGroup::is_worker_account_id(&account_id, &invalid_worker_id),
             false

--- a/runtime-modules/working-group/src/types.rs
+++ b/runtime-modules/working-group/src/types.rs
@@ -68,7 +68,7 @@ pub struct Opening<BlockNumber: Ord, Balance> {
     pub description_hash: Vec<u8>,
 
     /// Stake policy for the job opening.
-    pub stake_policy: Option<StakePolicy<BlockNumber, Balance>>,
+    pub stake_policy: StakePolicy<BlockNumber, Balance>,
 
     /// Reward per block for the job opening.
     pub reward_per_block: Option<Balance>,
@@ -104,13 +104,16 @@ pub struct JobApplication<AccountId, MemberId> {
     pub reward_account_id: AccountId,
 
     /// Account used to stake in this role.
-    pub staking_account_id: Option<AccountId>,
+    pub staking_account_id: AccountId,
 
     /// Member applying.
     pub member_id: MemberId,
 
     /// Hash of the application description.
     pub description_hash: Vec<u8>,
+
+    /// Opening ID for the application
+    pub opening_id: OpeningId,
 }
 
 impl<AccountId: Clone, MemberId: Clone> JobApplication<AccountId, MemberId> {
@@ -118,8 +121,9 @@ impl<AccountId: Clone, MemberId: Clone> JobApplication<AccountId, MemberId> {
     pub fn new(
         role_account_id: &AccountId,
         reward_account_id: &AccountId,
-        staking_account_id: &Option<AccountId>,
+        staking_account_id: &AccountId,
         member_id: &MemberId,
+        opening_id: OpeningId,
         description_hash: Vec<u8>,
     ) -> Self {
         JobApplication {
@@ -127,6 +131,7 @@ impl<AccountId: Clone, MemberId: Clone> JobApplication<AccountId, MemberId> {
             reward_account_id: reward_account_id.clone(),
             staking_account_id: staking_account_id.clone(),
             member_id: member_id.clone(),
+            opening_id,
             description_hash,
         }
     }
@@ -143,7 +148,7 @@ pub struct GroupWorker<AccountId, MemberId, BlockNumber, Balance> {
     pub role_account_id: AccountId,
 
     /// Account used to stake in this role.
-    pub staking_account_id: Option<AccountId>,
+    pub staking_account_id: AccountId,
 
     /// Reward account id.
     pub reward_account_id: AccountId,
@@ -152,6 +157,7 @@ pub struct GroupWorker<AccountId, MemberId, BlockNumber, Balance> {
     pub started_leaving_at: Option<BlockNumber>,
 
     /// Unstaking period when the worker chooses to leave the role.
+    ///
     /// It is defined by the job opening.
     pub job_unstaking_period: BlockNumber,
 
@@ -173,7 +179,7 @@ impl<AccountId: Clone, MemberId: Clone, BlockNumber, Balance>
         member_id: &MemberId,
         role_account_id: &AccountId,
         reward_account_id: &AccountId,
-        staking_account_id: &Option<AccountId>,
+        staking_account_id: &AccountId,
         job_unstaking_period: BlockNumber,
         reward_per_block: Option<Balance>,
         created_at: BlockNumber,
@@ -228,7 +234,7 @@ pub struct ApplyOnOpeningParams<MemberId, OpeningId, AccountId, Balance> {
     pub description: Vec<u8>,
 
     /// Stake information for the application.
-    pub stake_parameters: Option<StakeParameters<AccountId, Balance>>,
+    pub stake_parameters: StakeParameters<AccountId, Balance>,
 }
 
 /// Contains information for the stakes when applying for opening.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -700,7 +700,7 @@ parameter_types! {
     // This should be more costly than `add_opening` fee with the current configuration
     // the base cost of `add_opening` in tokens is 193. And has a very slight slope
     // with the lenght with the length of rationale, with 2000 stake we are probably safe.
-    pub const MinimumStakeForOpening: u32 = 2000;
+    pub const MinimumStakeForOpening: Balance = 2000;
 }
 
 // Staking managers type aliases.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -697,6 +697,7 @@ parameter_types! {
     pub const StorageWorkingGroupRewardPeriod: u32 = 14400 + 20;
     pub const ContentWorkingGroupRewardPeriod: u32 = 14400 + 30;
     pub const MembershipRewardPeriod: u32 = 14400 + 40;
+    pub const MinimumStakeForOpening: u32 = 100;
 }
 
 // Staking managers type aliases.
@@ -732,6 +733,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = ForumWorkingGroupRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::Trait<StorageWorkingGroupInstance> for Runtime {
@@ -743,6 +745,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = StorageWorkingGroupRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Runtime {
@@ -754,6 +757,7 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = ContentWorkingGroupRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Runtime {
@@ -765,6 +769,7 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = MembershipRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
+    type MinimumStakeForOpening = MinimumStakeForOpening;
 }
 
 impl service_discovery::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -697,7 +697,10 @@ parameter_types! {
     pub const StorageWorkingGroupRewardPeriod: u32 = 14400 + 20;
     pub const ContentWorkingGroupRewardPeriod: u32 = 14400 + 30;
     pub const MembershipRewardPeriod: u32 = 14400 + 40;
-    pub const MinimumStakeForOpening: u32 = 100;
+    // This should be more costly than `add_opening` fee with the current configuration
+    // the base cost of `add_opening` in tokens is 193. And has a very slight slope
+    // with the lenght with the length of rationale, with 2000 stake we are probably safe.
+    pub const MinimumStakeForOpening: u32 = 2000;
 }
 
 // Staking managers type aliases.

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -331,7 +331,6 @@ impl_runtime_apis! {
                     member_id: <Runtime as common::Trait>::MemberId,
                 ) -> <Runtime as common::Trait>::ActorId {
                     working_group::benchmarking::complete_opening::<Runtime, crate::MembershipWorkingGroupInstance>(
-                        working_group::benchmarking::StakingRole::WithStakes,
                         working_group::OpeningType::Leader,
                         opening_id,
                         None,

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -7,6 +7,7 @@ use common::working_group::WorkingGroup;
 use common::BalanceKind;
 use frame_system::RawOrigin;
 use proposals_codex::CreateOpeningParameters;
+use sp_std::convert::TryInto;
 use strum::IntoEnumIterator;
 use working_group::StakeParameters;
 
@@ -492,10 +493,15 @@ fn run_create_fill_working_group_leader_opening_proposal_execution_succeeds<
                     description: Vec::new(),
                     stake_parameters:
                         StakeParameters {
-                            stake: <Runtime as working_group::Trait<
-                                MembershipWorkingGroupInstance,
-                            >>::MinimumStakeForOpening::get()
-                            .into(),
+                            stake:
+                                T::Balance::from(
+                                    <Runtime as working_group::Trait<
+                                        MembershipWorkingGroupInstance,
+                                    >>::MinimumStakeForOpening::get(
+                                    )
+                                    .try_into()
+                                    .unwrap(),
+                                ),
                             staking_account_id: account_id.into(),
                         },
                 },

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -582,7 +582,7 @@ fn run_create_decrease_group_leader_stake_proposal_execution_succeeds<
         let member_id: MemberId = 14;
 
         let account_id: [u8; 32] = [member_id as u8; 32];
-        let stake_amount: Balance = 100;
+        let stake_amount: Balance = 10_000;
 
         increase_total_balance_issuance_using_account_id(account_id.into(), 1_500_000);
 
@@ -728,7 +728,7 @@ fn run_create_slash_group_leader_stake_proposal_execution_succeeds<
         let member_id: MemberId = 14;
 
         let account_id: [u8; 32] = [member_id as u8; 32];
-        let stake_amount: Balance = 100;
+        let stake_amount: Balance = 10_000;
 
         let stake_policy = working_group::StakePolicy {
             stake_amount,
@@ -1196,7 +1196,7 @@ fn run_create_terminate_group_leader_role_proposal_execution_succeeds<
         let member_id: MemberId = 14;
 
         let account_id: [u8; 32] = [member_id as u8; 32];
-        let stake_amount = 100_u128;
+        let stake_amount = 100_000_u128;
 
         let stake_policy = working_group::StakePolicy {
             stake_amount,
@@ -1334,7 +1334,7 @@ fn run_create_terminate_group_leader_role_proposal_with_slashing_execution_succe
         let member_id: MemberId = 14;
 
         let account_id: [u8; 32] = [member_id as u8; 32];
-        let stake_amount = 100_u128;
+        let stake_amount = 100_000_u128;
 
         let stake_policy = working_group::StakePolicy {
             stake_amount,
@@ -1343,15 +1343,10 @@ fn run_create_terminate_group_leader_role_proposal_with_slashing_execution_succe
 
         increase_total_balance_issuance_using_account_id(account_id.clone().into(), 1_500_000);
 
-        let stake_parameters =
-            StakeParameters {
-                stake: <Runtime as working_group::Trait<
-                    MembershipWorkingGroupInstance,
-                >>::MinimumStakeForOpening::get()
-                .into(),
-                staking_account_id: account_id.into(),
-            }
-        ;
+        let stake_parameters = StakeParameters {
+            stake: stake_amount.into(),
+            staking_account_id: account_id.into(),
+        };
 
         let opening_id = add_opening(member_id, account_id, stake_policy, 1, working_group);
 

--- a/runtime/src/weights/working_group.rs
+++ b/runtime/src/weights/working_group.rs
@@ -9,133 +9,129 @@ pub struct WeightInfo;
 impl working_group::WeightInfo for WeightInfo {
     fn on_initialize_leaving(i: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((744_041_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((496_301_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn on_initialize_rewarding_with_missing_reward(i: u32) -> Weight {
-        (2_692_227_000 as Weight)
-            .saturating_add((490_219_000 as Weight).saturating_mul(i as Weight))
+        (32_208_000 as Weight)
+            .saturating_add((361_542_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((2 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn on_initialize_rewarding_with_missing_reward_cant_pay(i: u32) -> Weight {
-        (106_702_000 as Weight)
-            .saturating_add((382_691_000 as Weight).saturating_mul(i as Weight))
+        (129_133_000 as Weight)
+            .saturating_add((233_951_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn on_initialize_rewarding_without_missing_reward(i: u32) -> Weight {
-        (946_654_000 as Weight)
-            .saturating_add((326_825_000 as Weight).saturating_mul(i as Weight))
+        (82_724_000 as Weight)
+            .saturating_add((222_551_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((2 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn apply_on_opening(i: u32) -> Weight {
-        (583_905_000 as Weight)
-            .saturating_add((2_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(5 as Weight))
+        (532_302_000 as Weight)
+            .saturating_add((144_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn fill_opening_lead() -> Weight {
-        (517_943_000 as Weight)
+        (441_600_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
     }
     fn fill_opening_worker(i: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((337_560_000 as Weight).saturating_mul(i as Weight))
+        (145_112_000 as Weight)
+            .saturating_add((257_669_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((2 as Weight).saturating_mul(i as Weight)))
     }
     fn update_role_account() -> Weight {
-        (405_699_000 as Weight)
+        (278_339_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn cancel_opening() -> Weight {
-        (284_090_000 as Weight)
+        (201_764_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn withdraw_application() -> Weight {
-        (412_772_000 as Weight)
+        (291_554_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn slash_stake(i: u32) -> Weight {
-        (827_597_000 as Weight)
-            .saturating_add((4_000 as Weight).saturating_mul(i as Weight))
+        (605_562_000 as Weight)
+            .saturating_add((122_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn terminate_role_worker(i: u32) -> Weight {
-        (1_268_966_000 as Weight)
-            .saturating_add((14_000 as Weight).saturating_mul(i as Weight))
+        (961_187_000 as Weight)
+            .saturating_add((249_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn terminate_role_lead(i: u32) -> Weight {
-        (1_266_771_000 as Weight)
-            .saturating_add((5_000 as Weight).saturating_mul(i as Weight))
+        (986_954_000 as Weight)
+            .saturating_add((255_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
     }
     fn increase_stake() -> Weight {
-        (783_675_000 as Weight)
+        (393_177_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn decrease_stake() -> Weight {
-        (895_623_000 as Weight)
+        (456_618_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn spend_from_budget() -> Weight {
-        (307_455_000 as Weight)
+        (227_722_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_reward_amount() -> Weight {
-        (420_916_000 as Weight)
+        (309_008_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_status_text(i: u32) -> Weight {
-        (238_830_000 as Weight)
-            .saturating_add((68_000 as Weight).saturating_mul(i as Weight))
+        (182_500_000 as Weight)
+            .saturating_add((127_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_reward_account() -> Weight {
-        (313_123_000 as Weight)
+        (240_377_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_budget() -> Weight {
-        (81_417_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        (66_927_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn add_opening(i: u32) -> Weight {
-        (290_743_000 as Weight)
-            .saturating_add((2_000 as Weight).saturating_mul(i as Weight))
+        (233_945_000 as Weight)
+            .saturating_add((127_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
-    fn leave_role_immediatly() -> Weight {
-        (544_861_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn leave_role_later() -> Weight {
-        (341_012_000 as Weight)
+    fn leave_role(i: u32) -> Weight {
+        (221_051_000 as Weight)
+            .saturating_add((28_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }


### PR DESCRIPTION
# Fix #2196 for `working_group` and  fix #2216 

In #2196 we decided to make the application for an opening require stake as an anti-spam mechanism for applications.

This PR includes:
* Make stake required for application in `working_group`
  * Fix tests and benchmarks
* Small fix for fee analysis to correctly calculate the minimum stake
* Store opening within application
  * When filling an opening verify the applications are consistent with the opening
  * Add tests for incorrect mapping between opening and application

**Note:** the corresponding handbook PR is Joystream/handbook#35

This also fixes Joystream/audits#14