### PR TITLE
Verify that staking account is valid for member when creating a proposal

### DIFF
--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -486,6 +486,7 @@ decl_module! {
                 &general_proposal_parameters.description,
                 general_proposal_parameters.staking_account_id.clone(),
                 general_proposal_parameters.exact_execution_block,
+                general_proposal_parameters.member_id,
             )?;
 
             let initial_thread_mode = ThreadMode::Open;

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -222,6 +222,15 @@ impl proposals_engine::Trait for Test {
     type DispatchableCallCode = crate::Call<Test>;
     type ProposalObserver = crate::Module<Test>;
     type WeightInfo = MockProposalsEngineWeight;
+    type StakingAccountValidator = ();
+}
+
+pub const STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER: u64 = 222;
+
+impl common::StakingAccountValidator<Test> for () {
+    fn is_member_staking_account(_: &u64, account_id: &u64) -> bool {
+        *account_id != STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER
+    }
 }
 
 impl proposals_engine::WeightInfo for MockProposalsEngineWeight {
@@ -353,7 +362,7 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
     type Event = TestEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
     type StakingHandler = StakingManager<Self, LockId1>;
-    type StakingAccountValidator = membership::Module<Test>;
+    type StakingAccountValidator = ();
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
@@ -436,7 +445,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type Event = TestEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
     type StakingHandler = StakingManager<Self, LockId2>;
-    type StakingAccountValidator = membership::Module<Test>;
+    type StakingAccountValidator = ();
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
@@ -447,7 +456,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Test {
     type Event = TestEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
     type StakingHandler = staking_handler::StakingManager<Self, LockId2>;
-    type StakingAccountValidator = membership::Module<Test>;
+    type StakingAccountValidator = ();
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
@@ -458,7 +467,7 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type Event = TestEvent;
     type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
     type StakingHandler = StakingManager<Self, LockId2>;
-    type StakingAccountValidator = membership::Module<Test>;
+    type StakingAccountValidator = ();
     type MemberOriginValidator = ();
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
@@ -618,12 +627,6 @@ impl council::Trait for Test {
     fn new_council_elected(_: &[council::CouncilMemberOf<Self>]) {}
 
     type MemberOriginValidator = ();
-}
-
-impl common::StakingAccountValidator<Test> for () {
-    fn is_member_staking_account(_: &u64, _: &u64) -> bool {
-        true
-    }
 }
 
 pub struct CouncilWeightInfo;

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -309,6 +309,15 @@ impl crate::Trait for Test {
     type DispatchableCallCode = proposals::Call<Test>;
     type ProposalObserver = ();
     type WeightInfo = ();
+    type StakingAccountValidator = ();
+}
+
+pub const STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER: u64 = 222;
+
+impl common::StakingAccountValidator<Test> for () {
+    fn is_member_staking_account(_: &u64, account_id: &u64) -> bool {
+        *account_id != STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER
+    }
 }
 
 impl crate::WeightInfo for () {

--- a/runtime-modules/proposals/engine/src/tests/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mod.rs
@@ -344,6 +344,19 @@ fn create_dummy_proposal_succeeds() {
 }
 
 #[test]
+fn create_dummy_proposal_fails_with_incorrect_staking_account() {
+    initial_test_ext().execute_with(|| {
+        let parameters_fixture = ProposalParametersFixture::default().with_required_stake(100);
+        let dummy_proposal = DummyProposalFixture::default()
+            .with_stake(STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER)
+            .with_parameters(parameters_fixture.params());
+
+        dummy_proposal
+            .create_proposal_and_assert(Err(Error::<Test>::InvalidStakingAccountForMember.into()));
+    });
+}
+
+#[test]
 fn vote_succeeds() {
     initial_test_ext().execute_with(|| {
         let dummy_proposal = DummyProposalFixture::default();

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -794,6 +794,7 @@ impl proposals_engine::Trait for Runtime {
     type DispatchableCallCode = Call;
     type ProposalObserver = ProposalsCodex;
     type WeightInfo = weights::proposals_engine::WeightInfo;
+    type StakingAccountValidator = Members;
 }
 
 impl Default for Call {

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -73,6 +73,12 @@ fn add_opening(
             1_500_000,
         );
 
+        set_staking_account(
+            account_id.clone().into(),
+            staking_account_id.clone().into(),
+            member_id,
+        );
+
         let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
             member_id: member_id.into(),
             title: b"title".to_vec(),


### PR DESCRIPTION
# Fix #2005 

This PR:
* Ensures that a valid member id is associated with the staking account when calling `create_proposal`
* Update tests accordingly and add tests for verification