### PR TITLE
Fix benchmarks in olympia after latest changes

### DIFF
--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -71,6 +71,19 @@ fn member_funded_account<T: Trait + membership::Trait>(
 
     let _ = Balances::<T>::make_free_balance_be(&account_id, T::Balance::max_value());
 
+    let member_id = T::MemberId::from(id.try_into().unwrap());
+    Membership::<T>::add_staking_account_candidate(
+        RawOrigin::Signed(account_id.clone()).into(),
+        member_id.clone(),
+    )
+    .unwrap();
+    Membership::<T>::confirm_staking_account(
+        RawOrigin::Signed(account_id.clone()).into(),
+        member_id.clone(),
+        account_id.clone(),
+    )
+    .unwrap();
+
     (account_id, T::MemberId::from(id.try_into().unwrap()))
 }
 

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -7,7 +7,6 @@ use frame_system::EventRecord;
 use frame_system::Module as System;
 use frame_system::RawOrigin;
 use sp_runtime::traits::Bounded;
-use sp_std::cmp::min;
 use sp_std::prelude::*;
 
 use crate::types::StakeParameters;
@@ -67,7 +66,7 @@ fn apply_on_opening_helper<T: Trait<I>, I: Instance>(
 ) -> ApplicationId {
     let stake_parameters = StakeParameters {
         // Due to mock implementation of StakingHandler we can't go over 1000
-        stake: min(BalanceOf::<T>::max_value(), BalanceOf::<T>::from(1000)),
+        stake: T::MinimumStakeForOpening::get(),
         staking_account_id: applicant_id.clone(),
     };
 

--- a/scripts/generate-weights.sh
+++ b/scripts/generate-weights.sh
@@ -7,23 +7,25 @@ SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 benchmark() {
   echo "Generating weights for $1..."
   start=`date +%s`
-  $SCRIPT_DIR/../target/release/joystream-node benchmark \
+  ERROR=$($SCRIPT_DIR/../target/release/joystream-node benchmark \
       --pallet=$1 \
       --extrinsic=* \
       --chain=dev \
       --steps=50 \
       --repeat=20 \
       --execution=wasm \
-      --output=.  > /dev/null
+      --output=. 2>&1 > /dev/null)
 
-  end=`date +%s`
 
-  if [ $? -eq 0 ]; then
+  if [[ $ERROR != *"Error"* ]]; then
+      end=`date +%s`
       mv $SCRIPT_DIR/../*.rs $SCRIPT_DIR/../runtime/src/weights/
       echo "Weights generated successfully for $1"
       echo "It took $((end-start)) seconds"
   else
-      echo "There was a problem generating the weights for $1, check the error above"
+      >&2 echo "$ERROR"
+      >&2 echo "There was a problem generating the weights for $1, check the error above"
+      exit 1
   fi
 }
 
@@ -36,7 +38,7 @@ benchmark() {
 # benchmark frame_system
 benchmark substrate_utility
 benchmark pallet_session
-# benchmark pallet_timestamp
+benchmark pallet_timestamp
 
 # This benchmark takes too long with 50 steps and 20 repeats in a normal laptop.
 # Will have it commented out until we test it in the reference machine. If there
@@ -55,3 +57,4 @@ benchmark referendum
 benchmark forum
 benchmark membership
 benchmark blog
+benchmark joystream_utility

--- a/scripts/generate-weights.sh
+++ b/scripts/generate-weights.sh
@@ -34,7 +34,7 @@ benchmark() {
 # So uncomment this when we move to a version that contains that PR.
 # See issue: #1979
 # benchmark frame_system
-benchmark pallet_utility
+benchmark substrate_utility
 benchmark pallet_session
 # benchmark pallet_timestamp
 


### PR DESCRIPTION
Some benchmarks broke with the latest changes when running them with the `scripts/generate_weights.sh`.

This PR fixes them.