### PR TITLE
Multiple forum fixes

### DIFF
--- a/runtime-modules/forum/Cargo.toml
+++ b/runtime-modules/forum/Cargo.toml
@@ -15,6 +15,7 @@ sp-std = { package = 'sp-std', default-features = false, git = 'https://github.c
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 common = { package = 'pallet-common', default-features = false, path = '../common'}
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
+balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 
 # Benchmarking dependencies
 frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
@@ -22,20 +23,17 @@ membership = { package = 'pallet-membership', default-features = false, path = '
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group', optional = true}
 staking-handler = { package = 'pallet-staking-handler', default-features = false, path = '../staking-handler', optional = true}
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
 
 [dev-dependencies]
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 membership = { package = 'pallet-membership', default-features = false, path = '../membership'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group'}
 staking-handler = { package = 'pallet-staking-handler', default-features = false, path = '../staking-handler'}
-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 
 [features]
 default = ['std']
 runtime-benchmarks = [
     'frame-benchmarking',
-    'balances',
 	'membership',
 	'working-group',
 	'staking-handler',

--- a/runtime-modules/forum/src/benchmarking.rs
+++ b/runtime-modules/forum/src/benchmarking.rs
@@ -15,10 +15,6 @@ use working_group::{
     StakeParameters, StakePolicy, WorkerById,
 };
 
-type CurrencyBalance<T> = <<T as Trait>::Currency as frame_support::traits::Currency<
-    <T as frame_system::Trait>::AccountId,
->>::Balance;
-
 // We create this trait because we need to be compatible with the runtime
 // in the mock for tests. In that case we need to be able to have `membership_id == account_id`
 // We can't create an account from an `u32` or from a memberhsip_dd,
@@ -737,13 +733,13 @@ benchmarks! {
 
         let next_thread_id = Module::<T>::next_thread_id();
         let next_post_id = Module::<T>::next_post_id();
-        let initial_balance = T::Currency::free_balance(&caller_id);
+        let initial_balance = Balances::<T>::usable_balance(&caller_id);
 
     }: _ (RawOrigin::Signed(caller_id.clone()), forum_user_id.saturated_into(), category_id, title.clone(), text.clone(), poll.clone())
     verify {
 
         assert_eq!(
-            T::Currency::free_balance(&caller_id),
+            Balances::<T>::usable_balance(&caller_id),
             initial_balance - T::ThreadDeposit::get() - T::PostDeposit::get(),
         );
 
@@ -935,16 +931,16 @@ benchmarks! {
             add_thread_post::<T>(caller_id.clone(), forum_user_id.saturated_into(), category_id, thread_id, text.clone());
         }
 
-        let initial_balance = T::Currency::free_balance(&caller_id);
+        let initial_balance = Balances::<T>::usable_balance(&caller_id);
     }: delete_thread(RawOrigin::Signed(caller_id.clone()), PrivilegedActor::Lead, category_id, thread_id)
     verify {
 
         // Ensure that balance is paid off
         assert_eq!(
-            T::Currency::free_balance(&caller_id),
+            Balances::<T>::usable_balance(&caller_id),
             initial_balance +
             T::ThreadDeposit::get() +
-            CurrencyBalance::<T>::from(
+            BalanceOf::<T>::from(
                 max_posts_in_thread.try_into().unwrap()
             ) * T::PostDeposit::get()
         );
@@ -1003,16 +999,16 @@ benchmarks! {
             add_thread_post::<T>(caller_id.clone(), forum_user_id.saturated_into(), category_id, thread_id, text.clone());
         }
 
-        let initial_balance = T::Currency::free_balance(&caller_id);
+        let initial_balance = Balances::<T>::usable_balance(&caller_id);
 
     }: delete_thread(RawOrigin::Signed(caller_id.clone()), PrivilegedActor::Moderator(moderator_id), category_id, thread_id)
     verify {
         // Ensure that balance is paid off
         assert_eq!(
-            T::Currency::free_balance(&caller_id),
+            Balances::<T>::usable_balance(&caller_id),
             initial_balance +
             T::ThreadDeposit::get() +
-            CurrencyBalance::<T>::from(max_posts_in_thread.try_into().unwrap()) *
+            BalanceOf::<T>::from(max_posts_in_thread.try_into().unwrap()) *
             T::PostDeposit::get()
         );
 
@@ -1389,11 +1385,11 @@ benchmarks! {
         let mut thread = Module::<T>::thread_by_id(category_id, thread_id);
         let post_id = Module::<T>::next_post_id();
 
-        let initial_balance = T::Currency::free_balance(&caller_id);
+        let initial_balance = Balances::<T>::usable_balance(&caller_id);
     }: _ (RawOrigin::Signed(caller_id.clone()), forum_user_id.saturated_into(), category_id, thread_id, text.clone())
     verify {
         assert_eq!(
-            T::Currency::free_balance(&caller_id),
+            Balances::<T>::usable_balance(&caller_id),
             initial_balance - T::PostDeposit::get()
         );
 

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -346,7 +346,6 @@ impl Trait for Runtime {
     type PostDeposit = PostDeposit;
 
     type ModuleId = ForumModuleId;
-    type Currency = Balances;
 
     fn calculate_hash(text: &[u8]) -> Self::Hash {
         Self::Hashing::hash(text)
@@ -1266,4 +1265,3 @@ pub type Timestamp = pallet_timestamp::Module<Runtime>;
 
 /// Export forum module on a test runtime
 pub type TestForumModule = Module<Runtime>;
-pub type Balances = balances::Module<Runtime>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -687,8 +687,6 @@ impl forum::Trait for Runtime {
 
     type WorkingGroup = ForumWorkingGroup;
     type MemberOriginValidator = Members;
-
-    type Currency = Balances;
 }
 
 impl LockComparator<<Runtime as pallet_balances::Trait>::Balance> for Runtime {


### PR DESCRIPTION
This PR contains the following fixes for the forum:
* Use `usable_balance` instead of `free_balance` to check for available funds for deposit
  * Depend on `pallet_balances` instead of `Currency` to make this possible
* Let `transfer` errors surface in case it happens.
* Use `AllowDeath` instead of `KeepAlive` to transfer fund from account