### PR TITLE
Runtime: Fix Balance type alias for the council pallet.

### DIFF
--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -300,7 +300,7 @@ decl_storage! {
 
         /// Map of all candidates that ever candidated and haven't unstake yet.
         pub Candidates get(fn candidates) config(): map hasher(blake2_128_concat)
-            T::MemberId => Candidate<T::AccountId, Balance::<T>, T::Hash, VotePowerOf::<T>>;
+            T::MemberId => Candidate<T::AccountId, Balance<T>, T::Hash, VotePowerOf::<T>>;
 
         /// Index of the current candidacy period. It is incremented everytime announcement period
         /// starts.
@@ -316,17 +316,17 @@ decl_storage! {
         pub NextBudgetRefill get(fn next_budget_refill) config(): T::BlockNumber;
 
         /// Amount of balance to be refilled every budget period
-        pub BudgetIncrement get(fn budget_increment) config(): Balance::<T>;
+        pub BudgetIncrement get(fn budget_increment) config(): Balance<T>;
 
         /// Councilor reward per block
-        pub CouncilorReward get(fn councilor_reward) config(): Balance::<T>;
+        pub CouncilorReward get(fn councilor_reward) config(): Balance<T>;
     }
 }
 
 decl_event! {
     pub enum Event<T>
     where
-        Balance = Balance::<T>,
+        Balance = Balance<T>,
         <T as frame_system::Trait>::BlockNumber,
         <T as common::Trait>::MemberId,
         <T as frame_system::Trait>::AccountId,
@@ -708,7 +708,7 @@ decl_module! {
         ///    - `O(1)` doesn't depend on the state or parameters
         /// # </weight>
         #[weight = CouncilWeightInfo::<T>::set_budget_increment()]
-        pub fn set_budget_increment(origin, budget_increment: Balance::<T>) -> Result<(), Error<T>> {
+        pub fn set_budget_increment(origin, budget_increment: Balance<T>) -> Result<(), Error<T>> {
             // ensure action can be started
             EnsureChecks::<T>::can_set_budget_increment(origin)?;
 
@@ -737,7 +737,7 @@ decl_module! {
         ///    - `O(1)` doesn't depend on the state or parameters
         /// # </weight>
         #[weight = CouncilWeightInfo::<T>::set_councilor_reward()]
-        pub fn set_councilor_reward(origin, councilor_reward: Balance::<T>) -> Result<(), Error<T>> {
+        pub fn set_councilor_reward(origin, councilor_reward: Balance<T>) -> Result<(), Error<T>> {
             // ensure action can be started
             EnsureChecks::<T>::can_set_councilor_reward(origin)?;
 


### PR DESCRIPTION
#### Problem
`decl_storage` macro creates different types for two identical rust type aliases during the metadata generation for the `council` pallet storage.

From the rust perspective, `Balance<T>` and `Balance::<T>` are identical types. However, Substrate generates different metadata for them.

The solution is to change all `Balance::<T>` entries to `Balance<T>`