### PR TITLE
Use single metadata field for membership

### DIFF
--- a/runtime-modules/blog/src/benchmarking.rs
+++ b/runtime-modules/blog/src/benchmarking.rs
@@ -44,7 +44,7 @@ fn member_funded_account<T: Trait<I> + membership::Trait + balances::Trait, I: I
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/blog/src/benchmarking.rs
+++ b/runtime-modules/blog/src/benchmarking.rs
@@ -43,10 +43,8 @@ fn member_funded_account<T: Trait<I> + membership::Trait + balances::Trait, I: I
     let params = membership::BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/blog/src/mock.rs
+++ b/runtime-modules/blog/src/mock.rs
@@ -156,10 +156,10 @@ impl common::working_group::WorkingGroupAuthenticator<Runtime> for () {
 
 pub struct Weights;
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -183,7 +183,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/council/src/benchmarking.rs
+++ b/runtime-modules/council/src/benchmarking.rs
@@ -151,7 +151,7 @@ where
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/council/src/benchmarking.rs
+++ b/runtime-modules/council/src/benchmarking.rs
@@ -150,10 +150,8 @@ where
     let params = membership::BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -370,10 +370,10 @@ impl referendum::WeightInfo for Weights {
 }
 
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -397,7 +397,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/forum/src/benchmarking.rs
+++ b/runtime-modules/forum/src/benchmarking.rs
@@ -76,10 +76,8 @@ where
     let params = membership::BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/forum/src/benchmarking.rs
+++ b/runtime-modules/forum/src/benchmarking.rs
@@ -77,7 +77,7 @@ where
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -223,10 +223,10 @@ impl working_group::WeightInfo for Weights {
 }
 
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -250,7 +250,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/membership/src/benchmarking.rs
+++ b/runtime-modules/membership/src/benchmarking.rs
@@ -53,7 +53,7 @@ fn member_funded_account<T: Trait + balances::Trait>(
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 
@@ -107,14 +107,14 @@ benchmarks! {
 
         let fee = Module::<T>::membership_price();
 
-        let meta_data = vec![0u8].repeat(j as usize);
+        let metadata = vec![0u8].repeat(j as usize);
 
         let params = BuyMembershipParameters {
             root_account: account_id.clone(),
             controller_account: account_id.clone(),
             handle: Some(handle.clone()),
             referrer_id: None,
-            meta_data,
+            metadata,
         };
 
     }: buy_membership(RawOrigin::Signed(account_id.clone()), params.clone())
@@ -157,7 +157,7 @@ benchmarks! {
 
         let _ = Balances::<T>::make_free_balance_be(&account_id, BalanceOf::<T>::max_value());
 
-        let meta_data = vec![0u8].repeat(j as usize);
+        let metadata = vec![0u8].repeat(j as usize);
 
         let fee = Module::<T>::membership_price();
 
@@ -165,7 +165,7 @@ benchmarks! {
             root_account: account_id.clone(),
             controller_account: account_id.clone(),
             handle: Some(handle.clone()),
-            meta_data,
+            metadata,
             referrer_id: None,
         };
 
@@ -231,7 +231,7 @@ benchmarks! {
             root_account: account_id.clone(),
             controller_account: account_id.clone(),
             handle: Some(handle.clone()),
-            meta_data: Vec::new(),
+            metadata: Vec::new(),
             referrer_id: None,
         };
 
@@ -448,14 +448,14 @@ benchmarks! {
 
         let handle = handle_from_id::<T>(i);
 
-        let meta_data = vec![0u8].repeat(j as usize);
+        let metadata = vec![0u8].repeat(j as usize);
 
         let invite_params = InviteMembershipParameters {
             inviting_member_id: member_id,
             root_account: account_id.clone(),
             controller_account: account_id.clone(),
             handle: Some(handle.clone()),
-            meta_data,
+            metadata,
         };
 
         let default_invitation_balance = T::DefaultInitialInvitationBalance::get();

--- a/runtime-modules/membership/src/benchmarking.rs
+++ b/runtime-modules/membership/src/benchmarking.rs
@@ -52,10 +52,8 @@ fn member_funded_account<T: Trait + balances::Trait>(
     let params = BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 
@@ -95,10 +93,6 @@ benchmarks! {
 
         let j in 0 .. MAX_BYTES;
 
-        let k in 0 .. MAX_BYTES;
-
-        let z in 0 .. MAX_BYTES;
-
         let member_id = 0;
 
         let account_id = account::<T::AccountId>("member", member_id, SEED);
@@ -113,20 +107,14 @@ benchmarks! {
 
         let fee = Module::<T>::membership_price();
 
-        let name = Some(vec![0u8].repeat(j as usize));
-
-        let avatar_uri = Some(vec![0u8].repeat(k as usize));
-
-        let about = Some(vec![0u8].repeat(z as usize));
+        let meta_data = vec![0u8].repeat(j as usize);
 
         let params = BuyMembershipParameters {
             root_account: account_id.clone(),
             controller_account: account_id.clone(),
-            name,
             handle: Some(handle.clone()),
-            avatar_uri,
-            about,
             referrer_id: None,
+            meta_data,
         };
 
     }: buy_membership(RawOrigin::Signed(account_id.clone()), params.clone())
@@ -161,10 +149,6 @@ benchmarks! {
 
         let j in 0 .. MAX_BYTES;
 
-        let k in 0 .. MAX_BYTES;
-
-        let z in 0 .. MAX_BYTES;
-
         let member_id = 0;
 
         let account_id = account::<T::AccountId>("member", member_id, SEED);
@@ -173,21 +157,15 @@ benchmarks! {
 
         let _ = Balances::<T>::make_free_balance_be(&account_id, BalanceOf::<T>::max_value());
 
-        let name = Some(vec![0u8].repeat(j as usize));
-
-        let avatar_uri = Some(vec![0u8].repeat(k as usize));
-
-        let about = Some(vec![0u8].repeat(z as usize));
+        let meta_data = vec![0u8].repeat(j as usize);
 
         let fee = Module::<T>::membership_price();
 
         let mut params = BuyMembershipParameters {
             root_account: account_id.clone(),
             controller_account: account_id.clone(),
-            name,
             handle: Some(handle.clone()),
-            avatar_uri,
-            about,
+            meta_data,
             referrer_id: None,
         };
 
@@ -252,10 +230,8 @@ benchmarks! {
         let params = BuyMembershipParameters {
             root_account: account_id.clone(),
             controller_account: account_id.clone(),
-            name: None,
             handle: Some(handle.clone()),
-            avatar_uri: None,
-            about: None,
+            meta_data: Vec::new(),
             referrer_id: None,
         };
 
@@ -263,7 +239,7 @@ benchmarks! {
 
         let handle_updated = handle_from_id::<T>(i + 1);
 
-    }: _ (RawOrigin::Signed(account_id.clone()), member_id, None, Some(handle_updated.clone()), None, None)
+    }: _ (RawOrigin::Signed(account_id.clone()), member_id, Some(handle_updated.clone()), None)
     verify {
 
         // Ensure membership profile is successfully updated
@@ -275,9 +251,7 @@ benchmarks! {
 
         assert_last_event::<T>(RawEvent::MemberProfileUpdated(
                 member_id,
-                None,
                 Some(handle_updated),
-                None,
                 None,
             ).into()
         );
@@ -468,30 +442,20 @@ benchmarks! {
 
         let j in 0 .. MAX_BYTES;
 
-        let k in 0 .. MAX_BYTES;
-
-        let z in 0 .. MAX_BYTES;
-
         let member_id = 0;
 
         let (account_id, member_id) = member_funded_account::<T>("member", member_id);
 
         let handle = handle_from_id::<T>(i);
 
-        let name = Some(vec![0u8].repeat(j as usize));
-
-        let avatar_uri = Some(vec![0u8].repeat(k as usize));
-
-        let about = Some(vec![0u8].repeat(z as usize));
+        let meta_data = vec![0u8].repeat(j as usize);
 
         let invite_params = InviteMembershipParameters {
             inviting_member_id: member_id,
             root_account: account_id.clone(),
             controller_account: account_id.clone(),
-            name,
             handle: Some(handle.clone()),
-            avatar_uri,
-            about,
+            meta_data,
         };
 
         let default_invitation_balance = T::DefaultInitialInvitationBalance::get();

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -173,8 +173,8 @@ pub struct BuyMembershipParameters<AccountId, MemberId> {
     /// New member handle.
     pub handle: Option<Vec<u8>>,
 
-    /// Meta data concerning new member.
-    pub meta_data: Vec<u8>,
+    /// Metadata concerning new member.
+    pub metadata: Vec<u8>,
 
     /// Referrer member id.
     pub referrer_id: Option<MemberId>,
@@ -195,8 +195,8 @@ pub struct InviteMembershipParameters<AccountId, MemberId> {
     /// New member handle.
     pub handle: Option<Vec<u8>>,
 
-    /// Meta data concerning new member.
-    pub meta_data: Vec<u8>,
+    /// Metadata concerning new member.
+    pub metadata: Vec<u8>,
 }
 
 decl_error! {
@@ -438,10 +438,10 @@ decl_module! {
             origin,
             member_id: T::MemberId,
             handle: Option<Vec<u8>>,
-            meta: Option<Vec<u8>>,
+            metadata: Option<Vec<u8>>,
         ) {
             // No effect if no changes.
-            if handle.is_none() && meta.is_none() {
+            if handle.is_none() && metadata.is_none() {
                 return Ok(())
             }
 
@@ -470,7 +470,7 @@ decl_module! {
                 Self::deposit_event(RawEvent::MemberProfileUpdated(
                         member_id,
                         handle,
-                        meta,
+                        metadata,
                     ));
             }
         }
@@ -641,7 +641,7 @@ decl_module! {
         // TODO: adjust weight
         #[weight = WeightInfoMembership::<T>::invite_member(
             Module::<T>::text_length_unwrap_or_default(&params.handle),
-            params.meta_data.len().saturated_into(),
+            params.metadata.len().saturated_into(),
         )]
         pub fn invite_member(
             origin,
@@ -930,12 +930,12 @@ impl<T: Trait> Module<T> {
         if params.referrer_id.is_some() {
             WeightInfoMembership::<T>::buy_membership_with_referrer(
                 Self::text_length_unwrap_or_default(&params.handle),
-                params.meta_data.len().saturated_into(),
+                params.metadata.len().saturated_into(),
             )
         } else {
             WeightInfoMembership::<T>::buy_membership_without_referrer(
                 Self::text_length_unwrap_or_default(&params.handle),
-                params.meta_data.len().saturated_into(),
+                params.metadata.len().saturated_into(),
             )
         }
     }

--- a/runtime-modules/membership/src/tests/fixtures.rs
+++ b/runtime-modules/membership/src/tests/fixtures.rs
@@ -54,7 +54,7 @@ pub fn assert_dispatch_error_message(result: DispatchResult, expected_result: Di
 pub struct TestUserInfo {
     pub handle: Option<Vec<u8>>,
     pub handle_hash: Option<Vec<u8>>,
-    pub meta_data: Vec<u8>,
+    pub metadata: Vec<u8>,
 }
 
 pub fn get_alice_info() -> TestUserInfo {
@@ -62,7 +62,7 @@ pub fn get_alice_info() -> TestUserInfo {
     let hashed = <Test as frame_system::Trait>::Hashing::hash(&handle);
     let hash = hashed.as_ref().to_vec();
 
-    let meta_data = b"
+    let metadata = b"
     {
         'name': 'Alice',
         'avatar_uri': 'http://avatar-url.com/alice',
@@ -74,7 +74,7 @@ pub fn get_alice_info() -> TestUserInfo {
     TestUserInfo {
         handle: Some(handle),
         handle_hash: Some(hash),
-        meta_data,
+        metadata,
     }
 }
 
@@ -83,7 +83,7 @@ pub fn get_bob_info() -> TestUserInfo {
     let hashed = <Test as frame_system::Trait>::Hashing::hash(&handle);
     let hash = hashed.as_ref().to_vec();
 
-    let meta_data = b"
+    let metadata = b"
     {
         'name': 'Bob',
         'avatar_uri': 'http://avatar-url.com/bob',
@@ -95,7 +95,7 @@ pub fn get_bob_info() -> TestUserInfo {
     TestUserInfo {
         handle: Some(handle),
         handle_hash: Some(hash),
-        meta_data,
+        metadata,
     }
 }
 
@@ -112,7 +112,7 @@ pub fn get_alice_membership_parameters() -> BuyMembershipParameters<u64, u64> {
         controller_account: ALICE_ACCOUNT_ID,
         handle: info.handle,
         referrer_id: None,
-        meta_data: info.meta_data,
+        metadata: info.metadata,
     }
 }
 
@@ -178,7 +178,7 @@ pub struct BuyMembershipFixture {
     pub root_account: u64,
     pub controller_account: u64,
     pub handle: Option<Vec<u8>>,
-    pub meta_data: Vec<u8>,
+    pub metadata: Vec<u8>,
     pub referrer_id: Option<u64>,
 }
 
@@ -190,7 +190,7 @@ impl Default for BuyMembershipFixture {
             root_account: ALICE_ACCOUNT_ID,
             controller_account: ALICE_ACCOUNT_ID,
             handle: alice.handle,
-            meta_data: alice.meta_data,
+            metadata: alice.metadata,
             referrer_id: None,
         }
     }
@@ -202,7 +202,7 @@ impl BuyMembershipFixture {
             root_account: self.root_account.clone(),
             controller_account: self.controller_account.clone(),
             handle: self.handle.clone(),
-            meta_data: self.meta_data.clone(),
+            metadata: self.metadata.clone(),
             referrer_id: self.referrer_id.clone(),
         };
 
@@ -337,7 +337,7 @@ pub struct InviteMembershipFixture {
     pub root_account: u64,
     pub controller_account: u64,
     pub handle: Option<Vec<u8>>,
-    pub meta_data: Vec<u8>,
+    pub metadata: Vec<u8>,
 }
 
 impl Default for InviteMembershipFixture {
@@ -349,7 +349,7 @@ impl Default for InviteMembershipFixture {
             root_account: BOB_ACCOUNT_ID,
             controller_account: BOB_ACCOUNT_ID,
             handle: bob.handle,
-            meta_data: bob.meta_data,
+            metadata: bob.metadata,
         }
     }
 }
@@ -361,7 +361,7 @@ impl InviteMembershipFixture {
             root_account: self.root_account.clone(),
             controller_account: self.controller_account.clone(),
             handle: self.handle.clone(),
-            meta_data: self.meta_data.clone(),
+            metadata: self.metadata.clone(),
         }
     }
 

--- a/runtime-modules/membership/src/tests/fixtures.rs
+++ b/runtime-modules/membership/src/tests/fixtures.rs
@@ -52,11 +52,9 @@ pub fn assert_dispatch_error_message(result: DispatchResult, expected_result: Di
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TestUserInfo {
-    pub name: Option<Vec<u8>>,
     pub handle: Option<Vec<u8>>,
     pub handle_hash: Option<Vec<u8>>,
-    pub avatar_uri: Option<Vec<u8>>,
-    pub about: Option<Vec<u8>>,
+    pub meta_data: Vec<u8>,
 }
 
 pub fn get_alice_info() -> TestUserInfo {
@@ -64,12 +62,19 @@ pub fn get_alice_info() -> TestUserInfo {
     let hashed = <Test as frame_system::Trait>::Hashing::hash(&handle);
     let hash = hashed.as_ref().to_vec();
 
+    let meta_data = b"
+    {
+        'name': 'Alice',
+        'avatar_uri': 'http://avatar-url.com/alice',
+        'about': 'my name is alice',
+    }
+    "
+    .to_vec();
+
     TestUserInfo {
-        name: Some(b"Alice".to_vec()),
         handle: Some(handle),
         handle_hash: Some(hash),
-        avatar_uri: Some(b"http://avatar-url.com/alice".to_vec()),
-        about: Some(b"my name is alice".to_vec()),
+        meta_data,
     }
 }
 
@@ -78,12 +83,19 @@ pub fn get_bob_info() -> TestUserInfo {
     let hashed = <Test as frame_system::Trait>::Hashing::hash(&handle);
     let hash = hashed.as_ref().to_vec();
 
+    let meta_data = b"
+    {
+        'name': 'Bob',
+        'avatar_uri': 'http://avatar-url.com/bob',
+        'about': 'my name is bob',
+    }
+    "
+    .to_vec();
+
     TestUserInfo {
-        name: Some(b"Bob".to_vec()),
         handle: Some(handle),
         handle_hash: Some(hash),
-        avatar_uri: Some(b"http://avatar-url.com/bob".to_vec()),
-        about: Some(b"my name is bob".to_vec()),
+        meta_data,
     }
 }
 
@@ -98,11 +110,9 @@ pub fn get_alice_membership_parameters() -> BuyMembershipParameters<u64, u64> {
     BuyMembershipParameters {
         root_account: ALICE_ACCOUNT_ID,
         controller_account: ALICE_ACCOUNT_ID,
-        name: info.name,
         handle: info.handle,
-        avatar_uri: info.avatar_uri,
-        about: info.about,
         referrer_id: None,
+        meta_data: info.meta_data,
     }
 }
 
@@ -167,10 +177,8 @@ pub struct BuyMembershipFixture {
     pub origin: RawOrigin<u64>,
     pub root_account: u64,
     pub controller_account: u64,
-    pub name: Option<Vec<u8>>,
     pub handle: Option<Vec<u8>>,
-    pub avatar_uri: Option<Vec<u8>>,
-    pub about: Option<Vec<u8>>,
+    pub meta_data: Vec<u8>,
     pub referrer_id: Option<u64>,
 }
 
@@ -181,10 +189,8 @@ impl Default for BuyMembershipFixture {
             origin: RawOrigin::Signed(ALICE_ACCOUNT_ID),
             root_account: ALICE_ACCOUNT_ID,
             controller_account: ALICE_ACCOUNT_ID,
-            name: alice.name,
             handle: alice.handle,
-            avatar_uri: alice.avatar_uri,
-            about: alice.about,
+            meta_data: alice.meta_data,
             referrer_id: None,
         }
     }
@@ -195,10 +201,8 @@ impl BuyMembershipFixture {
         let params = BuyMembershipParameters {
             root_account: self.root_account.clone(),
             controller_account: self.controller_account.clone(),
-            name: self.name.clone(),
             handle: self.handle.clone(),
-            avatar_uri: self.avatar_uri.clone(),
-            about: self.about.clone(),
+            meta_data: self.meta_data.clone(),
             referrer_id: self.referrer_id.clone(),
         };
 
@@ -332,10 +336,8 @@ pub struct InviteMembershipFixture {
     pub origin: RawOrigin<u64>,
     pub root_account: u64,
     pub controller_account: u64,
-    pub name: Option<Vec<u8>>,
     pub handle: Option<Vec<u8>>,
-    pub avatar_uri: Option<Vec<u8>>,
-    pub about: Option<Vec<u8>>,
+    pub meta_data: Vec<u8>,
 }
 
 impl Default for InviteMembershipFixture {
@@ -346,10 +348,8 @@ impl Default for InviteMembershipFixture {
             origin: RawOrigin::Signed(ALICE_ACCOUNT_ID),
             root_account: BOB_ACCOUNT_ID,
             controller_account: BOB_ACCOUNT_ID,
-            name: bob.name,
             handle: bob.handle,
-            avatar_uri: bob.avatar_uri,
-            about: bob.about,
+            meta_data: bob.meta_data,
         }
     }
 }
@@ -360,10 +360,8 @@ impl InviteMembershipFixture {
             inviting_member_id: self.member_id.clone(),
             root_account: self.root_account.clone(),
             controller_account: self.controller_account.clone(),
-            name: self.name.clone(),
             handle: self.handle.clone(),
-            avatar_uri: self.avatar_uri.clone(),
-            about: self.about.clone(),
+            meta_data: self.meta_data.clone(),
         }
     }
 

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -224,10 +224,10 @@ impl working_group::WeightInfo for Weights {
 }
 
 impl WeightInfo for () {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         0
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         0
     }
     fn update_profile(_: u32) -> Weight {
@@ -251,7 +251,7 @@ impl WeightInfo for () {
     fn transfer_invites() -> Weight {
         0
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         0
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -107,10 +107,8 @@ fn update_profile_succeeds() {
         assert_ok!(Membership::update_profile(
             Origin::signed(ALICE_ACCOUNT_ID),
             next_member_id,
-            info.name.clone(),
             info.handle.clone(),
-            info.avatar_uri.clone(),
-            info.about.clone(),
+            Some(info.meta_data.clone()),
         ));
 
         let profile = get_membership_by_id(next_member_id);
@@ -123,10 +121,8 @@ fn update_profile_succeeds() {
 
         EventFixture::assert_last_crate_event(Event::<Test>::MemberProfileUpdated(
             next_member_id,
-            info.name,
             info.handle,
-            info.avatar_uri,
-            info.about,
+            Some(info.meta_data),
         ));
     });
 }
@@ -143,8 +139,6 @@ fn update_profile_has_no_effect_on_empty_parameters() {
         assert_ok!(Membership::update_profile(
             Origin::signed(ALICE_ACCOUNT_ID),
             next_member_id,
-            None,
-            None,
             None,
             None,
         ));

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -108,7 +108,7 @@ fn update_profile_succeeds() {
             Origin::signed(ALICE_ACCOUNT_ID),
             next_member_id,
             info.handle.clone(),
-            Some(info.meta_data.clone()),
+            Some(info.metadata.clone()),
         ));
 
         let profile = get_membership_by_id(next_member_id);
@@ -122,7 +122,7 @@ fn update_profile_succeeds() {
         EventFixture::assert_last_crate_event(Event::<Test>::MemberProfileUpdated(
             next_member_id,
             info.handle,
-            Some(info.meta_data),
+            Some(info.metadata),
         ));
     });
 }

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -60,10 +60,8 @@ fn member_funded_account<T: Trait + membership::Trait>(
     let params = membership::BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -61,7 +61,7 @@ fn member_funded_account<T: Trait + membership::Trait>(
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -77,10 +77,10 @@ impl common::Trait for Test {
 // Weights info stub
 pub struct Weights;
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -104,7 +104,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/proposals/discussion/src/benchmarking.rs
+++ b/runtime-modules/proposals/discussion/src/benchmarking.rs
@@ -88,10 +88,8 @@ fn member_account<T: common::Trait + balances::Trait + membership::Trait>(
     let params = membership::BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/proposals/discussion/src/benchmarking.rs
+++ b/runtime-modules/proposals/discussion/src/benchmarking.rs
@@ -89,7 +89,7 @@ fn member_account<T: common::Trait + balances::Trait + membership::Trait>(
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -80,10 +80,10 @@ parameter_types! {
 // Weights info stub
 pub struct Weights;
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -107,7 +107,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/proposals/engine/src/benchmarking.rs
+++ b/runtime-modules/proposals/engine/src/benchmarking.rs
@@ -87,7 +87,7 @@ fn member_funded_account<T: Trait + membership::Trait>(
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/proposals/engine/src/benchmarking.rs
+++ b/runtime-modules/proposals/engine/src/benchmarking.rs
@@ -86,10 +86,8 @@ fn member_funded_account<T: Trait + membership::Trait>(
     let params = membership::BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -191,10 +191,10 @@ impl common::Trait for Test {
 // Weights info stub
 pub struct Weights;
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -218,7 +218,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/referendum/src/benchmarking.rs
+++ b/runtime-modules/referendum/src/benchmarking.rs
@@ -221,7 +221,7 @@ fn member_funded_account<T: Trait<I> + membership::Trait, I: Instance>(
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/referendum/src/benchmarking.rs
+++ b/runtime-modules/referendum/src/benchmarking.rs
@@ -220,10 +220,8 @@ fn member_funded_account<T: Trait<I> + membership::Trait, I: Instance>(
     let params = membership::BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -174,10 +174,10 @@ impl WeightInfo for () {
 // Weights info stub
 pub struct Weights;
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -201,7 +201,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -96,10 +96,10 @@ impl common::Trait for Test {
 // Weights info stub
 pub struct Weights;
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -123,7 +123,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -245,10 +245,10 @@ impl working_group::WeightInfo for WorkingGroupWeightInfo {
 // Weights info stub
 pub struct Weights;
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -272,7 +272,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/utility/src/tests/mocks.rs
+++ b/runtime-modules/utility/src/tests/mocks.rs
@@ -274,10 +274,10 @@ impl common::working_group::WorkingGroupAuthenticator<Test> for () {
 
 pub struct Weights;
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -301,7 +301,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -165,7 +165,7 @@ fn member_funded_account<T: Trait<I> + membership::Trait, I: Instance>(
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -164,10 +164,8 @@ fn member_funded_account<T: Trait<I> + membership::Trait, I: Instance>(
     let params = membership::BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -100,10 +100,10 @@ impl common::Trait for Test {
 // Weights info stub
 pub struct Weights;
 impl membership::WeightInfo for Weights {
-    fn buy_membership_without_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
-    fn buy_membership_with_referrer(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn update_profile(_: u32) -> Weight {
@@ -127,7 +127,7 @@ impl membership::WeightInfo for Weights {
     fn transfer_invites() -> Weight {
         unimplemented!()
     }
-    fn invite_member(_: u32, _: u32, _: u32, _: u32) -> Weight {
+    fn invite_member(_: u32, _: u32) -> Weight {
         unimplemented!()
     }
     fn set_membership_price() -> Weight {

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -165,7 +165,7 @@ pub(crate) fn insert_member(account_id: AccountId32) {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
         handle: Some(handle.to_vec()),
-        meta_data: Vec::new(),
+        metadata: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -164,10 +164,8 @@ pub(crate) fn insert_member(account_id: AccountId32) {
     let params = membership::BuyMembershipParameters {
         root_account: account_id.clone(),
         controller_account: account_id.clone(),
-        name: None,
         handle: Some(handle.to_vec()),
-        avatar_uri: None,
-        about: None,
+        meta_data: Vec::new(),
         referrer_id: None,
     };
 

--- a/runtime/src/weights/membership.rs
+++ b/runtime/src/weights/membership.rs
@@ -7,96 +7,90 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 pub struct WeightInfo;
 impl membership::WeightInfo for WeightInfo {
-    fn buy_membership_without_referrer(i: u32, j: u32, k: u32, z: u32) -> Weight {
-        (245_545_000 as Weight)
-            .saturating_add((3_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(j as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(k as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(z as Weight))
+    fn buy_membership_without_referrer(i: u32, j: u32) -> Weight {
+        (580_636_000 as Weight)
+            .saturating_add((95_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((131_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
-    fn buy_membership_with_referrer(i: u32, j: u32, k: u32, z: u32) -> Weight {
-        (439_284_000 as Weight)
-            .saturating_add((2_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(j as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(k as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(z as Weight))
+    fn buy_membership_with_referrer(i: u32, j: u32) -> Weight {
+        (741_433_000 as Weight)
+            .saturating_add((92_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((131_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn update_profile(i: u32) -> Weight {
-        (356_978_000 as Weight)
-            .saturating_add((55_000 as Weight).saturating_mul(i as Weight))
+        (327_665_000 as Weight)
+            .saturating_add((173_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn update_accounts_none() -> Weight {
-        (9_314_000 as Weight)
+        (8_025_000 as Weight)
     }
     fn update_accounts_root() -> Weight {
-        (180_791_000 as Weight)
+        (172_444_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_accounts_controller() -> Weight {
-        (180_942_000 as Weight)
+        (172_544_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_accounts_both() -> Weight {
-        (181_642_000 as Weight)
+        (172_614_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_referral_cut() -> Weight {
-        (63_916_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        (65_363_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn transfer_invites() -> Weight {
-        (415_109_000 as Weight)
+        (364_596_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
-    fn invite_member(i: u32, j: u32, k: u32, z: u32) -> Weight {
-        (550_755_000 as Weight)
-            .saturating_add((3_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(j as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(k as Weight))
-            .saturating_add((1_000 as Weight).saturating_mul(z as Weight))
+    fn invite_member(i: u32, j: u32) -> Weight {
+        (800_719_000 as Weight)
+            .saturating_add((97_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((131_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
     }
     fn set_membership_price() -> Weight {
-        (67_277_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        (66_976_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_profile_verification() -> Weight {
-        (315_084_000 as Weight)
+        (274_927_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_leader_invitation_quota() -> Weight {
-        (291_926_000 as Weight)
+        (187_743_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_initial_invitation_balance() -> Weight {
-        (67_445_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        (65_533_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_initial_invitation_count() -> Weight {
-        (59_675_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
+        (60_294_000 as Weight).saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn add_staking_account_candidate() -> Weight {
-        (183_576_000 as Weight)
+        (164_369_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn confirm_staking_account() -> Weight {
-        (267_844_000 as Weight)
+        (242_797_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn remove_staking_account() -> Weight {
-        (206_082_000 as Weight)
+        (185_459_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }


### PR DESCRIPTION
# Fix #2244

This PR unifies all metadata fields into `metadata`. (They already weren't stored so no change was needed for that)

Companion handbook PR: Joystream/handbook#36