### PR TITLE
Add helper script to make sudo the screening authority

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -30,6 +30,9 @@ docker-compose up -d colossus
 # Create a new content directory lead
 yarn workspace api-scripts initialize-content-lead
 
+# Set sudo as the membership screening authority
+yarn workspace api-scripts set-sudo-as-screening-auth
+
 ## Query Node Infrastructure
 # Initialize a new database for the query node infrastructure
 docker-compose up -d db

--- a/utils/api-scripts/package.json
+++ b/utils/api-scripts/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "status": "ts-node src/status",
     "initialize-content-lead": "ts-node src/initialize-content-lead",
+    "set-sudo-as-screening-auth": "yarn script set-sudo-as-screening-auth",
     "script": "ts-node src/script",
     "tsnode-strict": "node -r ts-node/register --unhandled-rejections=strict"
   },

--- a/utils/api-scripts/scripts/set-sudo-as-screening-auth.js
+++ b/utils/api-scripts/scripts/set-sudo-as-screening-auth.js
@@ -1,0 +1,38 @@
+/* global api, hashing, keyring, types, util, joy, window */
+
+// run this script with:
+// yarn workspace api-scripts script set-sudo-as-screening-auth
+//
+// or copy and paste the code into the pioneer javascript toolbox at:
+// https://testnet.joystream.org/#/js
+//
+// requires nicaea release+
+
+const script = async ({ api, keyring }) => {
+  const sudoAddress = (await api.query.sudo.key()).toString()
+  let sudo
+  if (typeof window === 'undefined') {
+    // In node, get the keyPair if the keyring was provided
+    sudo = keyring.getPair(sudoAddress)
+  } else {
+    // Pioneer: let the UI Signer handle it
+    sudo = sudoAddress
+  }
+
+  const tx = api.tx.members.setScreeningAuthority(sudoAddress)
+
+  const nonce = (await api.query.system.account(sudoAddress)).nonce
+  const sudoTx = api.tx.sudo.sudo(tx)
+  const signed = sudoTx.sign(sudo, { nonce })
+  await signed.send()
+
+  console.log(`sent tx with nonce: ${nonce.toNumber()}, tx hash: ${signed.hash}`)
+}
+
+if (typeof module === 'undefined') {
+  // Pioneer js-toolbox
+  script({ api, hashing, keyring, types, util, joy })
+} else {
+  // Node
+  module.exports = script
+}


### PR DESCRIPTION
Useful script for local dev setup to have sudo be the screening authority, so default configuration of the membership faucet works without need for configuration. https://github.com/Joystream/membership-faucet/pull/1