### PR TITLE
Require stake for add opening

### DIFF
--- a/runtime-modules/forum/src/benchmarking.rs
+++ b/runtime-modules/forum/src/benchmarking.rs
@@ -182,7 +182,7 @@ fn add_opening_helper<T: Trait + working_group::Trait<ForumWorkingGroupInstance>
         *job_opening_type,
         StakePolicy {
             stake_amount:
-                <T as working_group::Trait<ForumWorkingGroupInstance>>::MinimumStakeForOpening::get(
+                <T as working_group::Trait<ForumWorkingGroupInstance>>::MinimumApplicationStake::get(
                 ),
             leaving_unstaking_period: <T as
                 working_group::Trait<ForumWorkingGroupInstance>>::MinUnstakingPeriodLimit::get() + One::one(),
@@ -215,7 +215,7 @@ fn apply_on_opening_helper<T: Trait + working_group::Trait<ForumWorkingGroupInst
             reward_account_id: applicant_id.clone(),
             description: vec![],
             stake_parameters: StakeParameters {
-                stake: <T as working_group::Trait<ForumWorkingGroupInstance>>::MinimumStakeForOpening::get(),
+                stake: <T as working_group::Trait<ForumWorkingGroupInstance>>::MinimumApplicationStake::get(),
                 staking_account_id: applicant_id.clone()
             },
         },

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -106,6 +106,7 @@ parameter_types! {
     pub const StakingCandidateLockId: [u8; 8] = [10; 8];
     pub const MinimumStakeForOpening: u32 = 50;
     pub const CandidateStake: u64 = 100;
+    pub const OpeningStake: u32 = 20;
 }
 
 // The forum working group instance alias.
@@ -121,6 +122,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Runtime {
     type RewardPeriod = ();
     type WeightInfo = Weights;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl LockComparator<<Runtime as balances::Trait>::Balance> for Runtime {

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -104,9 +104,9 @@ parameter_types! {
     pub const LockId: [u8; 8] = [9; 8];
     pub const InviteMemberLockId: [u8; 8] = [9; 8];
     pub const StakingCandidateLockId: [u8; 8] = [10; 8];
-    pub const MinimumStakeForOpening: u32 = 50;
     pub const CandidateStake: u64 = 100;
-    pub const OpeningStake: u32 = 20;
+    pub const MinimumApplicationStake: u32 = 50;
+    pub const LeaderOpeningStake: u32 = 20;
 }
 
 // The forum working group instance alias.
@@ -121,8 +121,8 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = Weights;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl LockComparator<<Runtime as balances::Trait>::Balance> for Runtime {

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -110,6 +110,7 @@ parameter_types! {
     pub const LockId: LockIdentifier = [9; 8];
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const MinimumStakeForOpening: u32 = 50;
+    pub const OpeningStake: u32 = 20;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -122,6 +123,7 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = Weights;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl LockComparator<u64> for Test {

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -109,8 +109,8 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: LockIdentifier = [9; 8];
     pub const DefaultInitialInvitationBalance: u64 = 100;
-    pub const MinimumStakeForOpening: u32 = 50;
-    pub const OpeningStake: u32 = 20;
+    pub const MinimumApplicationStake: u32 = 50;
+    pub const LeaderOpeningStake: u32 = 20;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -122,8 +122,8 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = Weights;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl LockComparator<u64> for Test {

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -326,7 +326,7 @@ benchmarks! {
                 stake_policy: working_group::StakePolicy {
                     stake_amount:
                         <T as working_group::Trait<working_group::Instance1>>
-                            ::MinimumStakeForOpening::get(),
+                            ::MinimumApplicationStake::get(),
                     leaving_unstaking_period: Zero::zero(),
                 },
                 reward_per_block: None,

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -361,6 +361,7 @@ parameter_types! {
     pub const LockId1: [u8; 8] = [1; 8];
     pub const LockId2: [u8; 8] = [2; 8];
     pub const MinimumStakeForOpening: u32 = 50;
+    pub const OpeningStake: u32 = 20;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -374,6 +375,7 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {
@@ -455,6 +457,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::Trait<ForumWorkingGroupInstance> for Test {
@@ -467,6 +470,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -479,6 +483,7 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 pallet_staking_reward_curve::build! {

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -360,8 +360,8 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 100;
     pub const LockId1: [u8; 8] = [1; 8];
     pub const LockId2: [u8; 8] = [2; 8];
-    pub const MinimumStakeForOpening: u32 = 50;
-    pub const OpeningStake: u32 = 20;
+    pub const MinimumApplicationStake: u32 = 50;
+    pub const LeaderOpeningStake: u32 = 20;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -374,8 +374,8 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {
@@ -456,8 +456,8 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::Trait<ForumWorkingGroupInstance> for Test {
@@ -469,8 +469,8 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -482,8 +482,8 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 pallet_staking_reward_curve::build! {

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -722,7 +722,7 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(gr
         let add_opening_parameters = CreateOpeningParameters {
             description: b"some text".to_vec(),
             stake_policy: StakePolicy {
-                stake_amount: <Test as working_group::Trait<working_group::Instance1>>::MinimumStakeForOpening::get() as
+                stake_amount: <Test as working_group::Trait<working_group::Instance1>>::MinimumApplicationStake::get() as
                     u64,
                 leaving_unstaking_period: 0 as u64,
             },

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -217,9 +217,9 @@ parameter_types! {
     pub const LockId1: [u8; 8] = [1; 8];
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
     pub const StakingCandidateLockId: [u8; 8] = [3; 8];
-    pub const MinimumStakeForOpening: u32 = 50;
     pub const CandidateStake: u64 = 100;
-    pub const OpeningStake: u32 = 20;
+    pub const MinimumApplicationStake: u32 = 50;
+    pub const LeaderOpeningStake: u32 = 20;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -232,8 +232,8 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -219,6 +219,7 @@ parameter_types! {
     pub const StakingCandidateLockId: [u8; 8] = [3; 8];
     pub const MinimumStakeForOpening: u32 = 50;
     pub const CandidateStake: u64 = 100;
+    pub const OpeningStake: u32 = 20;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -232,6 +233,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -160,6 +160,7 @@ parameter_types! {
     pub const StakingCandidateLockId: [u8; 8] = [3; 8];
     pub const MinimumStakeForOpening: u32 = 50;
     pub const CandidateStake: u64 = 100;
+    pub const OpeningStake: u64 = 20;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -173,6 +174,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -158,9 +158,9 @@ parameter_types! {
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
     pub const StakingCandidateLockId: [u8; 8] = [3; 8];
-    pub const MinimumStakeForOpening: u32 = 50;
     pub const CandidateStake: u64 = 100;
-    pub const OpeningStake: u64 = 20;
+    pub const MinimumApplicationStake: u32 = 50;
+    pub const LeaderOpeningStake: u64 = 20;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -173,8 +173,8 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {

--- a/runtime-modules/utility/src/tests/mocks.rs
+++ b/runtime-modules/utility/src/tests/mocks.rs
@@ -339,8 +339,8 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 100;
     pub const LockId1: [u8; 8] = [1; 8];
     pub const LockId2: [u8; 8] = [2; 8];
-    pub const MinimumStakeForOpening: u32 = 50;
-    pub const OpeningStake: u32 = 20;
+    pub const MinimumApplicationStake: u32 = 50;
+    pub const LeaderOpeningStake: u32 = 20;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -353,8 +353,8 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {
@@ -435,8 +435,8 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::Trait<ForumWorkingGroupInstance> for Test {
@@ -448,8 +448,8 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -461,8 +461,8 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type MinUnstakingPeriodLimit = ();
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 parameter_types! {

--- a/runtime-modules/utility/src/tests/mocks.rs
+++ b/runtime-modules/utility/src/tests/mocks.rs
@@ -340,6 +340,7 @@ parameter_types! {
     pub const LockId1: [u8; 8] = [1; 8];
     pub const LockId2: [u8; 8] = [2; 8];
     pub const MinimumStakeForOpening: u32 = 50;
+    pub const OpeningStake: u32 = 20;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -353,6 +354,7 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::WeightInfo for WorkingGroupWeightInfo {
@@ -434,6 +436,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::Trait<ForumWorkingGroupInstance> for Test {
@@ -446,6 +449,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
@@ -458,6 +462,7 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
     type RewardPeriod = ();
     type WeightInfo = WorkingGroupWeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 parameter_types! {

--- a/runtime-modules/working-group/src/benchmarking.rs
+++ b/runtime-modules/working-group/src/benchmarking.rs
@@ -35,7 +35,7 @@ fn add_opening_helper<T: Trait<I>, I: Instance>(
     job_opening_type: &OpeningType,
 ) -> OpeningId {
     let staking_policy = StakePolicy {
-        stake_amount: T::MinimumStakeForOpening::get(),
+        stake_amount: T::MinimumApplicationStake::get(),
         leaving_unstaking_period: T::MinUnstakingPeriodLimit::get() + One::one(),
     };
 
@@ -66,7 +66,7 @@ fn apply_on_opening_helper<T: Trait<I>, I: Instance>(
 ) -> ApplicationId {
     let stake_parameters = StakeParameters {
         // Due to mock implementation of StakingHandler we can't go over 1000
-        stake: T::MinimumStakeForOpening::get(),
+        stake: T::MinimumApplicationStake::get(),
         staking_account_id: applicant_id.clone(),
     };
 
@@ -524,7 +524,7 @@ benchmarks_instance! {
             description: vec![0u8; i.try_into().unwrap()],
             stake_parameters:
                 StakeParameters {
-                    stake: T::MinimumStakeForOpening::get(),
+                    stake: T::MinimumApplicationStake::get(),
                     staking_account_id: lead_account_id.clone(),
                 }
         };

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -408,7 +408,9 @@ impl Default for HireLeadFixture {
             },
             reward_per_block: None,
             lead_id: 1,
-            initial_balance: <Test as Trait>::MinimumStakeForOpening::get() + 1,
+            initial_balance: <Test as Trait>::MinimumStakeForOpening::get()
+                + <Test as Trait>::OpeningStake::get()
+                + 1,
         }
     }
 }

--- a/runtime-modules/working-group/src/tests/fixtures.rs
+++ b/runtime-modules/working-group/src/tests/fixtures.rs
@@ -63,7 +63,7 @@ impl Default for AddOpeningFixture {
             opening_type: OpeningType::Regular,
             starting_block: 0,
             stake_policy: StakePolicy {
-                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                stake_amount: <Test as Trait>::MinimumApplicationStake::get(),
                 leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get() + 1,
             },
             reward_per_block: None,
@@ -94,6 +94,11 @@ impl AddOpeningFixture {
                 opening_type: self.opening_type,
                 stake_policy: self.stake_policy.clone(),
                 reward_per_block: self.reward_per_block.clone(),
+                creation_stake: if self.opening_type == OpeningType::Regular {
+                    <Test as Trait>::LeaderOpeningStake::get()
+                } else {
+                    0
+                },
             };
 
             assert_eq!(actual_opening, expected_opening);
@@ -204,10 +209,10 @@ impl ApplyOnOpeningFixture {
             reward_account_id: 2,
             description: b"human_text".to_vec(),
             stake_parameters: StakeParameters {
-                stake: <Test as Trait>::MinimumStakeForOpening::get(),
+                stake: <Test as Trait>::MinimumApplicationStake::get(),
                 staking_account_id: 2,
             },
-            initial_balance: <Test as Trait>::MinimumStakeForOpening::get(),
+            initial_balance: <Test as Trait>::MinimumApplicationStake::get(),
         }
     }
 
@@ -293,7 +298,7 @@ impl FillOpeningFixture {
             reward_account_id: 2,
             staking_account_id: 2,
             stake_policy: StakePolicy {
-                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                stake_amount: <Test as Trait>::MinimumApplicationStake::get(),
                 leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get() + 1,
             },
             reward_per_block: None,
@@ -403,13 +408,13 @@ impl Default for HireLeadFixture {
         Self {
             setup_environment: true,
             stake_policy: StakePolicy {
-                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                stake_amount: <Test as Trait>::MinimumApplicationStake::get(),
                 leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get() + 1,
             },
             reward_per_block: None,
             lead_id: 1,
-            initial_balance: <Test as Trait>::MinimumStakeForOpening::get()
-                + <Test as Trait>::OpeningStake::get()
+            initial_balance: <Test as Trait>::MinimumApplicationStake::get()
+                + <Test as Trait>::LeaderOpeningStake::get()
                 + 1,
         }
     }
@@ -479,11 +484,11 @@ impl Default for HireRegularWorkerFixture {
         Self {
             setup_environment: true,
             stake_policy: StakePolicy {
-                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                stake_amount: <Test as Trait>::MinimumApplicationStake::get(),
                 leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get() + 1,
             },
             reward_per_block: None,
-            initial_balance: <Test as Trait>::MinimumStakeForOpening::get(),
+            initial_balance: <Test as Trait>::MinimumApplicationStake::get(),
         }
     }
 }

--- a/runtime-modules/working-group/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-group/src/tests/hiring_workflow.rs
@@ -33,13 +33,13 @@ impl Default for HiringWorkflow {
             opening_type: OpeningType::Regular,
             expected_result: Ok(()),
             stake_policy: StakePolicy {
-                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                stake_amount: <Test as Trait>::MinimumApplicationStake::get(),
                 leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get() + 1,
             },
             reward_per_block: None,
             applications: Vec::new(),
             setup_environment: true,
-            initial_balance: <Test as Trait>::MinimumStakeForOpening::get() + 1,
+            initial_balance: <Test as Trait>::MinimumApplicationStake::get() + 1,
         }
     }
 }
@@ -129,8 +129,8 @@ impl HiringWorkflow {
         } else {
             balances::Module::<Test>::make_free_balance_be(
                 &1,
-                <Test as Trait>::MinimumStakeForOpening::get()
-                    + <Test as Trait>::OpeningStake::get()
+                <Test as Trait>::MinimumApplicationStake::get()
+                    + <Test as Trait>::LeaderOpeningStake::get()
                     + 1,
             );
             //         setup_members(6);

--- a/runtime-modules/working-group/src/tests/hiring_workflow.rs
+++ b/runtime-modules/working-group/src/tests/hiring_workflow.rs
@@ -129,7 +129,9 @@ impl HiringWorkflow {
         } else {
             balances::Module::<Test>::make_free_balance_be(
                 &1,
-                <Test as Trait>::MinimumStakeForOpening::get() + 1,
+                <Test as Trait>::MinimumStakeForOpening::get()
+                    + <Test as Trait>::OpeningStake::get()
+                    + 1,
             );
             //         setup_members(6);
         }
@@ -137,7 +139,7 @@ impl HiringWorkflow {
 
     pub fn execute(&self) -> Option<u64> {
         if self.setup_environment {
-            self.setup_environment()
+            self.setup_environment();
         }
 
         let result = self.fill_worker_position();

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -183,9 +183,9 @@ parameter_types! {
     pub const RewardPeriod: u32 = 2;
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const MinUnstakingPeriodLimit: u64 = 3;
-    pub const MinimumStakeForOpening: u64 = 50;
+    pub const MinimumApplicationStake: u64 = 50;
     pub const LockId: [u8; 8] = [1; 8];
-    pub const OpeningStake: u64 = 20;
+    pub const LeaderOpeningStake: u64 = 20;
 }
 
 impl Trait for Test {
@@ -197,8 +197,8 @@ impl Trait for Test {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = RewardPeriod;
     type WeightInfo = ();
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl common::StakingAccountValidator<Test> for () {

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -185,6 +185,7 @@ parameter_types! {
     pub const MinUnstakingPeriodLimit: u64 = 3;
     pub const MinimumStakeForOpening: u64 = 50;
     pub const LockId: [u8; 8] = [1; 8];
+    pub const OpeningStake: u64 = 20;
 }
 
 impl Trait for Test {
@@ -197,6 +198,7 @@ impl Trait for Test {
     type RewardPeriod = RewardPeriod;
     type WeightInfo = ();
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl common::StakingAccountValidator<Test> for () {

--- a/runtime-modules/working-group/src/tests/mod.rs
+++ b/runtime-modules/working-group/src/tests/mod.rs
@@ -41,7 +41,7 @@ fn add_opening_succeeded() {
         let add_opening_fixture = AddOpeningFixture::default()
             .with_starting_block(starting_block)
             .with_stake_policy(StakePolicy {
-                stake_amount: <Test as Trait>::MinimumStakeForOpening::get(),
+                stake_amount: <Test as Trait>::MinimumApplicationStake::get(),
                 leaving_unstaking_period: 100,
             })
             .with_reward_per_block(Some(10));
@@ -84,7 +84,7 @@ fn add_opening_fails_with_less_than_minimum_stake() {
         ));
 
         let add_opening_fixture = AddOpeningFixture::default().with_stake_policy(StakePolicy {
-            stake_amount: <Test as Trait>::MinimumStakeForOpening::get() - 1,
+            stake_amount: <Test as Trait>::MinimumApplicationStake::get() - 1,
             leaving_unstaking_period: <Test as Trait>::MinUnstakingPeriodLimit::get(),
         });
 
@@ -111,7 +111,7 @@ fn add_opening_fails_with_zero_reward() {
 fn add_opening_fails_with_insufficient_balance() {
     build_test_externalities().execute_with(|| {
         HireLeadFixture::default()
-            .with_initial_balance(<Test as Trait>::MinimumStakeForOpening::get() + 1)
+            .with_initial_balance(<Test as Trait>::MinimumApplicationStake::get() + 1)
             .hire_lead();
 
         let add_opening_fixture = AddOpeningFixture::default();
@@ -168,7 +168,7 @@ fn apply_on_opening_succeeded() {
         let opening_id = add_opening_fixture.call().unwrap();
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_initial_balance(<Test as Trait>::MinimumStakeForOpening::get());
+            .with_initial_balance(<Test as Trait>::MinimumApplicationStake::get());
 
         let application_id = apply_on_opening_fixture.call_and_assert(Ok(()));
 
@@ -261,7 +261,7 @@ fn fill_opening_succeeded() {
 
         assert_eq!(
             Balances::usable_balance(&1),
-            initial_balance + <Test as Trait>::OpeningStake::get()
+            initial_balance + <Test as Trait>::LeaderOpeningStake::get()
         );
 
         let mut result_map = BTreeMap::new();
@@ -353,8 +353,8 @@ fn fill_opening_fails_with_application_for_other_opening() {
     build_test_externalities().execute_with(|| {
         HireLeadFixture::default()
             .with_initial_balance(
-                <Test as Trait>::MinimumStakeForOpening::get()
-                    + 3 * <Test as Trait>::OpeningStake::get()
+                <Test as Trait>::MinimumApplicationStake::get()
+                    + 3 * <Test as Trait>::LeaderOpeningStake::get()
                     + 1,
             )
             .hire_lead();
@@ -624,7 +624,7 @@ fn leave_worker_role_succeeds_with_paying_missed_reward() {
 
         assert_eq!(
             Balances::usable_balance(&account_id),
-            block_number * reward_per_block + <Test as Trait>::MinimumStakeForOpening::get()
+            block_number * reward_per_block + <Test as Trait>::MinimumApplicationStake::get()
         );
     });
 }
@@ -655,7 +655,7 @@ fn leave_worker_role_succeeds_with_partial_payment_of_missed_reward() {
 
         assert_eq!(
             Balances::usable_balance(&account_id),
-            budget + <Test as Trait>::MinimumStakeForOpening::get()
+            budget + <Test as Trait>::MinimumApplicationStake::get()
         );
     });
 }
@@ -797,7 +797,7 @@ fn terminate_worker_role_succeeds_with_paying_missed_reward() {
 
         assert_eq!(
             Balances::usable_balance(&account_id),
-            block_number * reward_per_block + <Test as Trait>::MinimumStakeForOpening::get()
+            block_number * reward_per_block + <Test as Trait>::MinimumApplicationStake::get()
         );
     });
 }
@@ -950,8 +950,8 @@ fn apply_on_opening_locks_the_stake() {
         HireLeadFixture::default().hire_lead();
 
         let account_id = 2;
-        let total_balance = <Test as Trait>::MinimumStakeForOpening::get() + 100;
-        let stake = <Test as Trait>::MinimumStakeForOpening::get();
+        let total_balance = <Test as Trait>::MinimumApplicationStake::get() + 100;
+        let stake = <Test as Trait>::MinimumApplicationStake::get();
 
         let stake_parameters = StakeParameters {
             stake,
@@ -1713,7 +1713,7 @@ fn withdraw_worker_application_fails_with_invalid_application_author() {
         let opening_id = add_opening_fixture.call_and_assert(Ok(()));
 
         let apply_on_opening_fixture = ApplyOnOpeningFixture::default_for_opening_id(opening_id)
-            .with_initial_balance(<Test as Trait>::MinimumStakeForOpening::get() + 1);
+            .with_initial_balance(<Test as Trait>::MinimumApplicationStake::get() + 1);
         let application_id = apply_on_opening_fixture.call_and_assert(Ok(()));
 
         let invalid_author_account_id = 55;
@@ -1749,7 +1749,7 @@ fn cancel_opening_succeeds() {
 
         assert_eq!(
             Balances::usable_balance(&1),
-            initial_balance + <Test as Trait>::OpeningStake::get()
+            initial_balance + <Test as Trait>::LeaderOpeningStake::get()
         );
 
         EventFixture::assert_last_crate_event(RawEvent::OpeningCanceled(opening_id));

--- a/runtime-modules/working-group/src/types.rs
+++ b/runtime-modules/working-group/src/types.rs
@@ -72,6 +72,9 @@ pub struct Opening<BlockNumber: Ord, Balance> {
 
     /// Reward per block for the job opening.
     pub reward_per_block: Option<Balance>,
+
+    /// Stake used to create the opening.
+    pub creation_stake: Balance,
 }
 
 /// Defines type of the opening: regular working group fellow or group leader.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -711,11 +711,11 @@ parameter_types! {
     // This should be more costly than `apply_on_opening` fee with the current configuration
     // the base cost of `apply_on_opening` in tokens is 193. And has a very slight slope
     // with the lenght with the length of rationale, with 2000 stake we are probably safe.
-    pub const MinimumStakeForOpening: Balance = 2000;
+    pub const MinimumApplicationStake: Balance = 2000;
     // This should be more costly than `add_opening` fee with the current configuration
     // the base cost of `add_opening` in tokens is 81. And has a very slight slope
     // with the lenght with the length of rationale, with 2000 stake we are probably safe.
-    pub const OpeningStake: Balance = 2000;
+    pub const LeaderOpeningStake: Balance = 2000;
 }
 
 // Staking managers type aliases.
@@ -753,8 +753,8 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = ForumWorkingGroupRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::Trait<StorageWorkingGroupInstance> for Runtime {
@@ -766,8 +766,8 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = StorageWorkingGroupRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Runtime {
@@ -779,8 +779,8 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = ContentWorkingGroupRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Runtime {
@@ -792,8 +792,8 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Runtime {
     type MinUnstakingPeriodLimit = MinUnstakingPeriodLimit;
     type RewardPeriod = MembershipRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
-    type MinimumStakeForOpening = MinimumStakeForOpening;
-    type OpeningStake = OpeningStake;
+    type MinimumApplicationStake = MinimumApplicationStake;
+    type LeaderOpeningStake = LeaderOpeningStake;
 }
 
 impl service_discovery::Trait for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -708,10 +708,14 @@ parameter_types! {
     pub const StorageWorkingGroupRewardPeriod: u32 = 14400 + 20;
     pub const ContentWorkingGroupRewardPeriod: u32 = 14400 + 30;
     pub const MembershipRewardPeriod: u32 = 14400 + 40;
-    // This should be more costly than `add_opening` fee with the current configuration
-    // the base cost of `add_opening` in tokens is 193. And has a very slight slope
+    // This should be more costly than `apply_on_opening` fee with the current configuration
+    // the base cost of `apply_on_opening` in tokens is 193. And has a very slight slope
     // with the lenght with the length of rationale, with 2000 stake we are probably safe.
     pub const MinimumStakeForOpening: Balance = 2000;
+    // This should be more costly than `add_opening` fee with the current configuration
+    // the base cost of `add_opening` in tokens is 81. And has a very slight slope
+    // with the lenght with the length of rationale, with 2000 stake we are probably safe.
+    pub const OpeningStake: Balance = 2000;
 }
 
 // Staking managers type aliases.
@@ -750,6 +754,7 @@ impl working_group::Trait<ForumWorkingGroupInstance> for Runtime {
     type RewardPeriod = ForumWorkingGroupRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::Trait<StorageWorkingGroupInstance> for Runtime {
@@ -762,6 +767,7 @@ impl working_group::Trait<StorageWorkingGroupInstance> for Runtime {
     type RewardPeriod = StorageWorkingGroupRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Runtime {
@@ -774,6 +780,7 @@ impl working_group::Trait<ContentDirectoryWorkingGroupInstance> for Runtime {
     type RewardPeriod = ContentWorkingGroupRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl working_group::Trait<MembershipWorkingGroupInstance> for Runtime {
@@ -786,6 +793,7 @@ impl working_group::Trait<MembershipWorkingGroupInstance> for Runtime {
     type RewardPeriod = MembershipRewardPeriod;
     type WeightInfo = weights::working_group::WeightInfo;
     type MinimumStakeForOpening = MinimumStakeForOpening;
+    type OpeningStake = OpeningStake;
 }
 
 impl service_discovery::Trait for Runtime {

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -470,7 +470,7 @@ fn set_membership_leader(lead_account_id: AccountId32, lead_id: u64) {
         working_group::OpeningType::Leader,
         StakePolicy {
             stake_amount:
-                <Runtime as working_group::Trait<MembershipWorkingGroupInstance>>::MinimumStakeForOpening::get(
+                <Runtime as working_group::Trait<MembershipWorkingGroupInstance>>::MinimumApplicationStake::get(
                 ) as u128,
             leaving_unstaking_period: 1000000,
         },
@@ -485,7 +485,7 @@ fn set_membership_leader(lead_account_id: AccountId32, lead_id: u64) {
         reward_account_id: lead_account_id.clone(),
         description: vec![0u8],
         stake_parameters: StakeParameters {
-            stake: <Runtime as working_group::Trait<MembershipWorkingGroupInstance>>::MinimumStakeForOpening::get() as
+            stake: <Runtime as working_group::Trait<MembershipWorkingGroupInstance>>::MinimumApplicationStake::get() as
                 u128,
             staking_account_id: lead_account_id.clone(),
         },

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -409,7 +409,7 @@ fn run_create_add_working_group_leader_opening_proposal_execution_succeeds<
                 StakePolicy {
                     stake_amount: <Runtime as working_group::Trait<
                         MembershipWorkingGroupInstance,
-                    >>::MinimumStakeForOpening::get() as u128,
+                    >>::MinimumApplicationStake::get() as u128,
                     leaving_unstaking_period: 1_000_000,
                 },
                 1,
@@ -481,7 +481,7 @@ fn run_create_fill_working_group_leader_opening_proposal_execution_succeeds<
                 StakePolicy {
                     stake_amount: <Runtime as working_group::Trait<
                         MembershipWorkingGroupInstance,
-                    >>::MinimumStakeForOpening::get() as u128,
+                    >>::MinimumApplicationStake::get() as u128,
                     leaving_unstaking_period: 1_000_000,
                 },
                 1,
@@ -503,7 +503,7 @@ fn run_create_fill_working_group_leader_opening_proposal_execution_succeeds<
                                 T::Balance::from(
                                     <Runtime as working_group::Trait<
                                         MembershipWorkingGroupInstance,
-                                    >>::MinimumStakeForOpening::get(
+                                    >>::MinimumApplicationStake::get(
                                     )
                                     .try_into()
                                     .unwrap(),
@@ -931,7 +931,7 @@ fn run_create_syphon_working_group_mint_capacity_proposal_execution_succeeds<
                 StakePolicy {
                     stake_amount: <Runtime as working_group::Trait<
                         MembershipWorkingGroupInstance,
-                    >>::MinimumStakeForOpening::get() as u128,
+                    >>::MinimumApplicationStake::get() as u128,
                     leaving_unstaking_period: 1_000_000,
                 },
                 1,
@@ -942,7 +942,7 @@ fn run_create_syphon_working_group_mint_capacity_proposal_execution_succeeds<
             StakeParameters {
                 stake: <Runtime as working_group::Trait<
                     MembershipWorkingGroupInstance,
-                >>::MinimumStakeForOpening::get()
+                >>::MinimumApplicationStake::get()
                 .into(),
                 staking_account_id: account_id.into(),
             }
@@ -1073,7 +1073,7 @@ fn run_create_set_group_leader_reward_proposal_execution_succeeds<
             StakeParameters {
                 stake: <Runtime as working_group::Trait<
                     MembershipWorkingGroupInstance,
-                >>::MinimumStakeForOpening::get()
+                >>::MinimumApplicationStake::get()
                 .into(),
                 staking_account_id: account_id.into(),
             }
@@ -1086,7 +1086,7 @@ fn run_create_set_group_leader_reward_proposal_execution_succeeds<
                 StakePolicy {
                     stake_amount: <Runtime as working_group::Trait<
                         MembershipWorkingGroupInstance,
-                    >>::MinimumStakeForOpening::get() as u128,
+                    >>::MinimumApplicationStake::get() as u128,
                     leaving_unstaking_period: 1_000_000,
                 },
                 1,


### PR DESCRIPTION
# Regarding #2196 for `add_opening`

In [this comment](https://github.com/Joystream/joystream/issues/2196#issuecomment-799579423) we decided that the best way to deal with a lead creating a lot of openings to fill the storage is to have it require an additional stake, which additionally to prevent an attack filling the storage also motivates the lead to cleanup any lingering opening.

Fix Joystream/audits#12