### PR TITLE
Require stake for membership candidacy

### DIFF
--- a/runtime-modules/blog/src/mock.rs
+++ b/runtime-modules/blog/src/mock.rs
@@ -88,7 +88,9 @@ parameter_types! {
     pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const InviteMemberLockId: [u8; 8] = [9; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [10; 8];
     pub const MinimumPeriod: u64 = 5;
+    pub const CandidateStake: u64 = 100;
 }
 
 impl membership::Trait for Runtime {
@@ -98,6 +100,9 @@ impl membership::Trait for Runtime {
     type WorkingGroup = ();
     type WeightInfo = Weights;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InviteMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl pallet_timestamp::Trait for Runtime {

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -261,6 +261,8 @@ parameter_types! {
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const MinimumPeriod: u64 = 5;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
+    pub const CandidateStake: u64 = 100;
     pub const MaxWinnerTargetCount: u64 = 10;
 }
 
@@ -443,6 +445,9 @@ impl membership::Trait for Runtime {
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl common::working_group::WorkingGroupBudgetHandler<Runtime> for () {

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -103,7 +103,9 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId: [u8; 8] = [9; 8];
     pub const InviteMemberLockId: [u8; 8] = [9; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [10; 8];
     pub const MinimumStakeForOpening: u32 = 50;
+    pub const CandidateStake: u64 = 100;
 }
 
 // The forum working group instance alias.
@@ -304,6 +306,9 @@ impl membership::Trait for Runtime {
     type WorkingGroup = ();
     type WeightInfo = Weights;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InviteMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 parameter_types! {

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -86,6 +86,8 @@ parameter_types! {
     pub const ExistentialDeposit: u32 = 0;
     pub const DefaultMembershipPrice: u64 = 100;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
+    pub const CandidateStake: u64 = 100;
 }
 
 impl balances::Trait for Test {
@@ -301,6 +303,9 @@ impl Trait for Test {
     type WorkingGroup = ();
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
     type WeightInfo = ();
 }
 

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -777,6 +777,17 @@ fn add_staking_account_candidate_fails_with_duplicated_staking_account_id() {
 }
 
 #[test]
+fn add_staking_account_candidate_fails_with_insufficient_balance() {
+    let initial_members = [(ALICE_MEMBER_ID, ALICE_ACCOUNT_ID)];
+
+    build_test_externalities_with_initial_members(initial_members.to_vec()).execute_with(|| {
+        AddStakingAccountFixture::default()
+            .with_initial_balance(<Test as Trait>::CandidateStake::get() - 1)
+            .call_and_assert(Err(Error::<Test>::InsufficientBalanceToCoverStake.into()));
+    });
+}
+
+#[test]
 fn remove_staking_account_succeeds() {
     let initial_members = [(ALICE_MEMBER_ID, ALICE_ACCOUNT_ID)];
 

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -35,6 +35,8 @@ parameter_types! {
     pub const AvailableBlockRatio: Perbill = Perbill::one();
     pub const MinimumPeriod: u64 = 5;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
+    pub const CandidateStake: u64 = 100;
 }
 
 mod proposals_codex_mod {
@@ -140,6 +142,9 @@ impl membership::Trait for Test {
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl common::working_group::WorkingGroupBudgetHandler<Test> for () {

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -75,6 +75,8 @@ parameter_types! {
     pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
+    pub const CandidateStake: u64 = 100;
 }
 
 // Weights info stub
@@ -158,6 +160,9 @@ impl membership::Trait for Test {
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl LockComparator<<Test as balances::Trait>::Balance> for Test {

--- a/runtime-modules/proposals/engine/src/benchmarking.rs
+++ b/runtime-modules/proposals/engine/src/benchmarking.rs
@@ -141,7 +141,9 @@ fn create_proposal<T: Trait + membership::Trait>(
         approval_threshold_percentage: 1,
         slashing_quorum_percentage: 0,
         slashing_threshold_percentage: 1,
-        required_stake: Some(T::Balance::max_value()),
+        required_stake: Some(
+            T::Balance::max_value() - <T as membership::Trait>::CandidateStake::get(),
+        ),
         constitutionality,
     };
 
@@ -190,7 +192,7 @@ fn create_proposal<T: Trait + membership::Trait>(
 
     assert_eq!(
         <T as Trait>::StakingHandler::current_stake(&account_id),
-        T::Balance::max_value()
+        T::Balance::max_value() - <T as membership::Trait>::CandidateStake::get(),
     );
 
     (account_id, member_id, proposal_id)
@@ -422,7 +424,7 @@ benchmarks! {
 
         assert_eq!(
             Balances::<T>::usable_balance(account_id),
-            T::Balance::max_value() - T::CancellationFee::get(),
+            T::Balance::max_value() - T::CancellationFee::get() - T::CandidateStake::get(),
             "Balance not slashed"
         );
 
@@ -446,7 +448,7 @@ benchmarks! {
 
         assert_eq!(
             Balances::<T>::usable_balance(account_id),
-            T::Balance::max_value(),
+            T::Balance::max_value() - <T as membership::Trait>::CandidateStake::get(),
             "Vetoed proposals shouldn't be slashed"
         );
 
@@ -677,7 +679,7 @@ benchmarks! {
             );
 
             assert_eq!(
-                Balances::<T>::free_balance(&proposer_account_id),
+                Balances::<T>::usable_balance(&proposer_account_id),
                 Zero::zero(),
                 "Should've all balance slashed"
             );

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -181,6 +181,8 @@ parameter_types! {
     pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
+    pub const CandidateStake: u64 = 100;
 }
 
 impl common::Trait for Test {
@@ -254,6 +256,9 @@ impl membership::Trait for Test {
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl common::working_group::WorkingGroupBudgetHandler<Test> for () {

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -234,6 +234,8 @@ parameter_types! {
     pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
+    pub const CandidateStake: u64 = 100;
 }
 
 impl membership::Trait for Runtime {
@@ -243,6 +245,9 @@ impl membership::Trait for Runtime {
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl pallet_timestamp::Trait for Runtime {

--- a/runtime-modules/service-discovery/src/mock.rs
+++ b/runtime-modules/service-discovery/src/mock.rs
@@ -159,6 +159,9 @@ impl membership::Trait for Test {
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
@@ -213,7 +216,9 @@ parameter_types! {
     pub const MaxWorkerNumberLimit: u32 = 3;
     pub const LockId1: [u8; 8] = [1; 8];
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
     pub const MinimumStakeForOpening: u32 = 50;
+    pub const CandidateStake: u64 = 100;
 }
 
 pub struct WorkingGroupWeightInfo;

--- a/runtime-modules/storage/src/tests/mock.rs
+++ b/runtime-modules/storage/src/tests/mock.rs
@@ -157,7 +157,9 @@ parameter_types! {
     pub const DefaultMembershipPrice: u64 = 100;
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
     pub const MinimumStakeForOpening: u32 = 50;
+    pub const CandidateStake: u64 = 100;
 }
 
 pub struct WorkingGroupWeightInfo;
@@ -355,6 +357,9 @@ impl membership::Trait for Test {
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl common::working_group::WorkingGroupBudgetHandler<Test> for () {

--- a/runtime-modules/utility/src/tests/mocks.rs
+++ b/runtime-modules/utility/src/tests/mocks.rs
@@ -223,6 +223,8 @@ impl pallet_timestamp::Trait for Test {
 parameter_types! {
     pub const DefaultMembershipPrice: u64 = 100;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
+    pub const CandidateStake: u64 = 100;
 }
 
 impl membership::Trait for Test {
@@ -232,6 +234,9 @@ impl membership::Trait for Test {
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl common::working_group::WorkingGroupBudgetHandler<Test> for () {

--- a/runtime-modules/working-group/src/tests/mock.rs
+++ b/runtime-modules/working-group/src/tests/mock.rs
@@ -41,6 +41,8 @@ parameter_types! {
     pub const DefaultMembershipPrice: u64 = 0;
     pub const DefaultInitialInvitationBalance: u64 = 100;
     pub const InvitedMemberLockId: [u8; 8] = [2; 8];
+    pub const StakingCandidateLockId: [u8; 8] = [3; 8];
+    pub const CandidateStake: u64 = 100;
 }
 
 // Workaround for https://github.com/rust-lang/rust/issues/26925 - remove when sorted.
@@ -163,6 +165,9 @@ impl membership::Trait for Test {
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
+    type StakingCandidateStakingHandler =
+        staking_handler::StakingManager<Self, StakingCandidateLockId>;
+    type CandidateStake = CandidateStake;
 }
 
 impl LockComparator<<Test as balances::Trait>::Balance> for Test {

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -111,6 +111,7 @@ parameter_types! {
     pub const ForumGroupLockId: LockIdentifier = [8; 8];
     pub const MembershipWorkingGroupLockId: LockIdentifier = [9; 8];
     pub const InvitedMemberLockId: LockIdentifier = [10; 8];
+    pub const StakingCandidateLockId: LockIdentifier = [11; 8];
 }
 
 // Staking lock ID used by nomination and validation in the staking pallet.
@@ -131,6 +132,19 @@ lazy_static! {
             ContentWorkingGroupLockId::get(),
             StorageWorkingGroupLockId::get(),
             MembershipWorkingGroupLockId::get(),
+            StakingCandidateLockId::get(),
+        ].to_vec()),
+        (StakingCandidateLockId::get(), [
+            VotingLockId::get(),
+            CandidacyLockId::get(),
+            CouncilorLockId::get(),
+            STAKING_LOCK_ID,
+            ProposalsLockId::get(),
+            ForumGroupLockId::get(),
+            ContentWorkingGroupLockId::get(),
+            StorageWorkingGroupLockId::get(),
+            MembershipWorkingGroupLockId::get(),
+            InvitedMemberLockId::get(),
         ].to_vec()),
         (VotingLockId::get(), [
             InvitedMemberLockId::get(),
@@ -142,38 +156,46 @@ lazy_static! {
             ContentWorkingGroupLockId::get(),
             StorageWorkingGroupLockId::get(),
             MembershipWorkingGroupLockId::get(),
+            StakingCandidateLockId::get(),
         ].to_vec()),
         (CandidacyLockId::get(), [
             InvitedMemberLockId::get(),
             VotingLockId::get(),
             CouncilorLockId::get(),
+            StakingCandidateLockId::get(),
         ].to_vec()),
         (CouncilorLockId::get(), [
             InvitedMemberLockId::get(),
             VotingLockId::get(),
             CandidacyLockId::get(),
+            StakingCandidateLockId::get(),
         ].to_vec()),
         // Proposals
         (ProposalsLockId::get(), [
             InvitedMemberLockId::get(),
             VotingLockId::get(),
+            StakingCandidateLockId::get(),
         ].to_vec()),
         // Working Groups
         (ForumGroupLockId::get(), [
             InvitedMemberLockId::get(),
             VotingLockId::get(),
+            StakingCandidateLockId::get(),
         ].to_vec()),
         (ContentWorkingGroupLockId::get(), [
             InvitedMemberLockId::get(),
             VotingLockId::get(),
+            StakingCandidateLockId::get(),
         ].to_vec()),
         (StorageWorkingGroupLockId::get(), [
             InvitedMemberLockId::get(),
             VotingLockId::get(),
+            StakingCandidateLockId::get(),
         ].to_vec()),
         (MembershipWorkingGroupLockId::get(), [
             InvitedMemberLockId::get(),
             VotingLockId::get(),
+            StakingCandidateLockId::get(),
         ].to_vec()),
     ]
     .iter()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -604,6 +604,8 @@ impl memo::Trait for Runtime {
 parameter_types! {
     pub const MaxObjectsPerInjection: u32 = 100;
     pub const DefaultMembershipPrice: Balance = 100;
+    // The candidate stake should be more than the transaction fee which currently is 53
+    pub const CandidateStake: Balance = 200;
 }
 
 impl storage::data_object_type_registry::Trait for Runtime {
@@ -637,8 +639,10 @@ impl membership::Trait for Runtime {
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
     type InvitedMemberStakingHandler = InvitedMemberStakingManager;
+    type StakingCandidateStakingHandler = StakingCandidateStakingHandler;
     type WorkingGroup = MembershipWorkingGroup;
     type WeightInfo = weights::membership::WeightInfo;
+    type CandidateStake = CandidateStake;
 }
 
 parameter_types! {
@@ -721,6 +725,8 @@ pub type MembershipWorkingGroupStakingManager =
     staking_handler::StakingManager<Runtime, MembershipWorkingGroupLockId>;
 pub type InvitedMemberStakingManager =
     staking_handler::StakingManager<Runtime, InvitedMemberLockId>;
+pub type StakingCandidateStakingHandler =
+    staking_handler::StakingManager<Runtime, StakingCandidateLockId>;
 
 // The forum working group instance alias.
 pub type ForumWorkingGroupInstance = working_group::Instance1;

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -179,11 +179,28 @@ pub(crate) fn set_staking_account(
     staking_account_id: AccountId32,
     member_id: u64,
 ) {
+    let current_balance = pallet_balances::Module::<Runtime>::usable_balance(&staking_account_id);
+
+    let _ = pallet_balances::Module::<Runtime>::deposit_creating(
+        &staking_account_id,
+        <Runtime as membership::Trait>::CandidateStake::get(),
+    );
+
+    assert_eq!(
+        pallet_balances::Module::<Runtime>::usable_balance(&staking_account_id),
+        current_balance + <Runtime as membership::Trait>::CandidateStake::get()
+    );
+
     membership::Module::<Runtime>::add_staking_account_candidate(
         RawOrigin::Signed(staking_account_id.clone()).into(),
         member_id,
     )
     .unwrap();
+
+    assert_eq!(
+        pallet_balances::Module::<Runtime>::usable_balance(&staking_account_id),
+        current_balance
+    );
 
     membership::Module::<Runtime>::confirm_staking_account(
         RawOrigin::Signed(controller_account_id.clone()).into(),

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -613,7 +613,7 @@ fn run_create_decrease_group_leader_stake_proposal_execution_succeeds<
             staking_account_id: staking_account_id.into(),
         };
 
-        let old_balance = Balances::usable_balance(&account_id.into());
+        let old_balance = Balances::free_balance(&account_id.into());
 
         let apply_result = WorkingGroupInstance::<T, I>::apply_on_opening(
             RawOrigin::Signed(account_id.into()).into(),
@@ -1284,7 +1284,10 @@ fn run_create_terminate_group_leader_role_proposal_execution_succeeds<
         let new_stake: working_group::BalanceOf<T> = SM::current_stake(&account_id.into()).into();
 
         assert_eq!(new_stake, 0.into());
-        assert_eq!(new_balance, old_balance + stake_amount);
+        assert_eq!(
+            new_balance,
+            old_balance + stake_amount - <Runtime as membership::Trait>::CandidateStake::get()
+        );
     });
 }
 
@@ -1422,6 +1425,9 @@ fn run_create_terminate_group_leader_role_proposal_with_slashing_execution_succe
         let new_stake: working_group::BalanceOf<T> = SM::current_stake(&account_id.into()).into();
 
         assert_eq!(new_stake, 0.into());
-        assert_eq!(new_balance, old_balance);
+        assert_eq!(
+            new_balance,
+            old_balance - <Runtime as membership::Trait>::CandidateStake::get()
+        );
     });
 }


### PR DESCRIPTION
# Fixes `add_staking_account_candidate` in #2196 
Following [this comment](https://github.com/Joystream/joystream/issues/2196#issuecomment-799579423) we require each staking account candidate an stake to prevent filling up the storage very cheaply.

This also fixes Joystream/audits#11
The corresponding handbook PR: Joystream/handbook#37