### PR TITLE
Forum allow non-editable posts

### DIFF
--- a/node/src/chain_spec/forum_config.rs
+++ b/node/src/chain_spec/forum_config.rs
@@ -2,7 +2,7 @@ use codec::Decode;
 use node_runtime::{
     forum,
     forum::{Category, Post, Thread},
-    AccountId, Balance, ForumConfig, Moment, PostId, Runtime, ThreadId,
+    AccountId, Balance, BlockNumber, ForumConfig, Moment, PostId, Runtime, ThreadId,
 };
 use serde::Deserialize;
 use sp_core::H256;
@@ -12,18 +12,18 @@ type CategoryId = <Runtime as forum::Trait>::CategoryId;
 type ForumUserId = forum::ForumUserId<Runtime>;
 type ModeratorId = forum::ModeratorId<Runtime>;
 type Hash = H256;
-type PostOf = Post<ForumUserId, Hash>;
+type PostOf = Post<ForumUserId, ThreadId, H256, Balance, BlockNumber>;
 
 type ThreadOf = (
     CategoryId,
     ThreadId,
-    Thread<ForumUserId, CategoryId, Moment, Hash, PostId, PostOf, Balance>,
+    Thread<ForumUserId, CategoryId, Moment, Hash, Balance>,
 );
 
 #[derive(Decode)]
 struct ForumData {
-    categories: Vec<(CategoryId, Category<CategoryId, ThreadId, H256>)>,
-    posts: Vec<(ThreadId, PostId, Post<ForumUserId, H256>)>,
+    categories: Vec<(CategoryId, Category<CategoryId, ThreadId, Hash>)>,
+    posts: Vec<(ThreadId, PostId, PostOf)>,
     threads: Vec<ThreadOf>,
     category_by_moderator: Vec<(CategoryId, ModeratorId, ())>,
     data_migration_done: bool,
@@ -139,6 +139,7 @@ fn create(_forum_sudo: AccountId, forum_data: EncodedForumData) -> ForumConfig {
     ForumConfig {
         category_by_id: forum_data.categories,
         thread_by_id: forum_data.threads,
+        post_by_id: forum_data.posts,
         category_by_moderator: forum_data.category_by_moderator,
         next_category_id,
         next_thread_id,

--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -15,9 +15,8 @@ use frame_support::{
 use frame_system::ensure_signed;
 use sp_arithmetic::traits::{BaseArithmetic, One};
 pub use sp_io::storage::clear_prefix;
-use sp_runtime::traits::{AccountIdConversion, MaybeSerialize, Member, Saturating};
+use sp_runtime::traits::{AccountIdConversion, MaybeSerialize, Member};
 use sp_runtime::{ModuleId, SaturatedConversion};
-use sp_std::collections::btree_map::BTreeMap;
 use sp_std::fmt::Debug;
 use sp_std::prelude::*;
 
@@ -28,6 +27,9 @@ mod mock;
 mod tests;
 
 mod benchmarking;
+
+/// Type for keeping track of number of posts in a thread
+pub type NumberOfPosts = u64;
 
 /// Moderator ID alias for the actor of the system.
 pub type ModeratorId<T> = common::ActorId<T>;
@@ -45,8 +47,6 @@ pub type ThreadOf<T> = Thread<
     <T as Trait>::CategoryId,
     <T as pallet_timestamp::Trait>::Moment,
     <T as frame_system::Trait>::Hash,
-    <T as Trait>::PostId,
-    Post<ForumUserId<T>, <T as frame_system::Trait>::Hash>,
     BalanceOf<T>,
 >;
 
@@ -62,22 +62,22 @@ pub trait WeightInfo {
     fn update_category_archival_status_moderator(i: u32) -> Weight;
     fn delete_category_lead(i: u32) -> Weight;
     fn delete_category_moderator(i: u32) -> Weight;
-    fn create_thread(i: u32, j: u32, k: u32, z: u32) -> Weight;
+    fn create_thread(j: u32, k: u32, i: u32) -> Weight;
     fn edit_thread_title(i: u32, j: u32) -> Weight;
     fn update_thread_archival_status_lead(i: u32) -> Weight;
     fn update_thread_archival_status_moderator(i: u32) -> Weight;
-    fn delete_thread_lead(i: u32) -> Weight;
-    fn delete_thread_moderator(i: u32) -> Weight;
+    fn delete_thread(i: u32) -> Weight;
     fn move_thread_to_category_lead(i: u32) -> Weight;
     fn move_thread_to_category_moderator(i: u32) -> Weight;
     fn vote_on_poll(i: u32, j: u32) -> Weight;
-    fn moderate_thread_lead(i: u32, j: u32, k: u32) -> Weight;
+    fn moderate_thread_lead(i: u32, k: u32) -> Weight;
     fn moderate_thread_moderator(i: u32, j: u32, k: u32) -> Weight;
     fn add_post(i: u32, j: u32) -> Weight;
     fn react_post(i: u32) -> Weight;
     fn edit_post_text(i: u32, j: u32) -> Weight;
     fn moderate_post_lead(i: u32, j: u32) -> Weight;
     fn moderate_post_moderator(i: u32, j: u32) -> Weight;
+    fn delete_posts(i: u32, j: u32, k: u32) -> Weight;
     fn set_stickied_threads_lead(i: u32, j: u32) -> Weight;
     fn set_stickied_threads_moderator(i: u32, j: u32) -> Weight;
 }
@@ -141,6 +141,9 @@ pub trait Trait:
     /// Maximum depth for nested categories
     type MaxCategoryDepth: Get<u64>;
 
+    /// Maximum number of blocks before a post can be erased by anyone
+    type PostLifeTime: Get<Self::BlockNumber>;
+
     /// Type defining the limits for different Storage items in the forum pallet
     type MapLimits: StorageLimits;
 
@@ -174,7 +177,7 @@ pub trait StorageLimits {
     type MaxThreadsInCategory: Get<u64>;
 
     /// Maximum posts in a thread
-    type MaxPostsInThread: Get<u64>;
+    type MaxPostsInThread: Get<NumberOfPosts>;
 
     /// Maximum moderator count for a single category
     type MaxModeratorsForCategory: Get<u64>;
@@ -214,18 +217,27 @@ pub struct Poll<Timestamp, Hash> {
 /// Represents a thread post
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
-pub struct Post<ForumUserId, Hash> {
+pub struct Post<ForumUserId, ThreadId, Hash, Balance, BlockNumber> {
+    /// Id of thread to which this post corresponds.
+    pub thread_id: ThreadId,
+
     /// Hash of current text
     pub text_hash: Hash,
 
     /// Author of post.
     pub author_id: ForumUserId,
+
+    /// Cleanup pay off
+    pub cleanup_pay_off: Balance,
+
+    /// When it was created or last edited
+    pub last_edited: BlockNumber,
 }
 
 /// Represents a thread
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Debug, Eq)]
-pub struct Thread<ForumUserId, CategoryId, Moment, Hash, PostId: sp_std::cmp::Ord, Post, Balance> {
+pub struct Thread<ForumUserId, CategoryId, Moment, Hash, Balance> {
     /// Title hash
     pub title_hash: Hash,
 
@@ -241,11 +253,11 @@ pub struct Thread<ForumUserId, CategoryId, Moment, Hash, PostId: sp_std::cmp::Or
     /// poll description.
     pub poll: Option<Poll<Moment, Hash>>,
 
-    /// Post in thread
-    pub posts: BTreeMap<PostId, Post>,
-
     /// Pay off by deleting
     pub cleanup_pay_off: Balance,
+
+    /// Number of posts in the thread
+    pub number_of_posts: NumberOfPosts,
 }
 
 /// Represents a category
@@ -438,6 +450,17 @@ decl_storage! {
 
         /// If data migration is done, set as configible for unit test purpose
         pub DataMigrationDone get(fn data_migration_done) config(): bool;
+
+        /// Map post identifier to corresponding post.
+        pub PostById get(fn post_by_id) config(): double_map hasher(blake2_128_concat) T::ThreadId,
+            hasher(blake2_128_concat) T::PostId =>
+                                                Post<
+                                                    ForumUserId<T>,
+                                                    T::ThreadId,
+                                                    T::Hash,
+                                                    BalanceOf<T>,
+                                                    T::BlockNumber
+                                                >;
     }
 }
 
@@ -477,16 +500,19 @@ decl_event!(
         ThreadTitleUpdated(ThreadId, ForumUserId, CategoryId, Vec<u8>),
 
         /// A thread was deleted.
-        ThreadDeleted(ThreadId, PrivilegedActor, CategoryId),
+        ThreadDeleted(ThreadId, ForumUserId, CategoryId),
 
         /// A thread was moved to new category
         ThreadMoved(ThreadId, CategoryId, PrivilegedActor, CategoryId),
 
         /// Post with given id was created.
-        PostAdded(PostId, ForumUserId, CategoryId, ThreadId, Vec<u8>),
+        PostAdded(PostId, ForumUserId, CategoryId, ThreadId, Vec<u8>, bool),
 
         /// Post with givne id was moderated.
         PostModerated(PostId, Vec<u8>, PrivilegedActor, CategoryId, ThreadId),
+
+        /// Post with givne id was deleted.
+        PostDeleted(Vec<u8>, ForumUserId, Vec<(CategoryId, ThreadId, PostId)>),
 
         /// Post with given id had its text updated.
         /// The second argument reflects the number of total edits when the text update occurs.
@@ -725,12 +751,9 @@ decl_module! {
         ///    - O(W)
         /// # </weight>
         #[weight = WeightInfoForum::<T>::create_thread(
-            T::MaxCategoryDepth::get() as u32,
             title.len().saturated_into(),
             text.len().saturated_into(),
-            poll.as_ref()
-                .map(|poll| poll.poll_alternatives.len().saturated_into())
-                .unwrap_or_default(),
+            T::MaxCategoryDepth::get() as u32,
         )]
         fn create_thread(
             origin,
@@ -778,8 +801,8 @@ decl_module! {
                 author_id: forum_user_id,
                 archived: false,
                 poll: poll.clone(),
-                posts: BTreeMap::new(),
                 cleanup_pay_off: T::ThreadDeposit::get(),
+                number_of_posts: 0,
             };
 
             // Store thread
@@ -792,7 +815,8 @@ decl_module! {
                 new_thread_id,
                 category_id,
                 &text,
-                forum_user_id
+                forum_user_id,
+                true,
             );
 
             // Update next thread id
@@ -917,18 +941,19 @@ decl_module! {
         /// - DB:
         ///    - O(W)
         /// # </weight>
-        #[weight = WeightInfoForum::<T>::delete_thread_lead(
-            T::MaxCategoryDepth::get() as u32,
-        ).max(WeightInfoForum::<T>::delete_thread_moderator(
-            T::MaxCategoryDepth::get() as u32,
-        ))]
-        fn delete_thread(origin, actor: PrivilegedActor<T>, category_id: T::CategoryId, thread_id: T::ThreadId) -> DispatchResult {
+        #[weight = WeightInfoForum::<T>::delete_thread(T::MaxCategoryDepth::get() as u32)]
+        fn delete_thread(origin, forum_user_id: ForumUserId<T>, category_id: T::CategoryId, thread_id: T::ThreadId) -> DispatchResult {
             // Ensure data migration is done
             Self::ensure_data_migration_done()?;
 
             let account_id = ensure_signed(origin)?;
 
-            let thread = Self::ensure_can_moderate_thread(&account_id, &actor, &category_id, &thread_id)?;
+            let thread = Self::ensure_can_delete_thread(
+                &account_id,
+                &forum_user_id,
+                &category_id,
+                &thread_id
+            )?;
 
             //
             // == MUTATION SAFE ==
@@ -943,7 +968,7 @@ decl_module! {
             // Store the event
             Self::deposit_event(RawEvent::ThreadDeleted(
                     thread_id,
-                    actor,
+                    forum_user_id,
                     category_id
                 ));
 
@@ -1076,7 +1101,6 @@ decl_module! {
         /// # </weight>
         #[weight = WeightInfoForum::<T>::moderate_thread_lead(
             T::MaxCategoryDepth::get() as u32,
-            <T::MapLimits as StorageLimits>::MaxPostsInThread::get() as u32,
             rationale.len().saturated_into(),
         ).max(
             WeightInfoForum::<T>::moderate_thread_moderator(
@@ -1126,7 +1150,14 @@ decl_module! {
             T::MaxCategoryDepth::get() as u32,
             text.len().saturated_into(),
         )]
-        fn add_post(origin, forum_user_id: ForumUserId<T>, category_id: T::CategoryId, thread_id: T::ThreadId, text: Vec<u8>) -> DispatchResult {
+        fn add_post(
+            origin,
+            forum_user_id: ForumUserId<T>,
+            category_id: T::CategoryId,
+            thread_id: T::ThreadId,
+            text: Vec<u8>,
+            editable: bool,
+        ) -> DispatchResult {
             // Ensure data migration is done
             Self::ensure_data_migration_done()?;
 
@@ -1135,34 +1166,44 @@ decl_module! {
             // Make sure thread exists and is mutable
             let (_, thread) = Self::ensure_can_add_post(&account_id, &forum_user_id, &category_id, &thread_id)?;
 
+            if editable {
+                ensure!(
+                    Self::ensure_enough_balance(T::PostDeposit::get(), &account_id),
+                    Error::<T>::InsufficientBalanceForPost
+                );
+            }
+
             // Ensure map limits are not reached
             Self::ensure_map_limits::<<<T>::MapLimits as StorageLimits>::MaxPostsInThread>(
-                thread.posts.len().saturated_into(),
+                thread.number_of_posts,
             )?;
 
             //
             // == MUTATION SAFE ==
             //
 
-            // Shouldn't fail since we checked in `ensure_can_add_post` that the account
-            // has enough balance.
-            Self::transfer_to_state_cleanup_treasury_account(
-                T::PostDeposit::get(),
-                thread_id,
-                &account_id
-            )?;
+            if editable {
+                // Shouldn't fail since we checked in `ensure_can_add_post` that the account
+                // has enough balance.
+                Self::transfer_to_state_cleanup_treasury_account(
+                    T::PostDeposit::get(),
+                    thread_id,
+                    &account_id
+                )?;
+            }
 
             // Add new post
-            let (post_id, _) = Self::add_new_post(
+            let post_id = Self::add_new_post(
                     thread_id,
                     category_id,
                     text.as_slice(),
-                    forum_user_id
+                    forum_user_id,
+                    editable,
                 );
 
             // Generate event
             Self::deposit_event(
-                RawEvent::PostAdded(post_id, forum_user_id, category_id, thread_id, text)
+                RawEvent::PostAdded(post_id, forum_user_id, category_id, thread_id, text, editable)
             );
 
             Ok(())
@@ -1190,8 +1231,8 @@ decl_module! {
             // Check that account is forum member
             Self::ensure_is_forum_user(&account_id, &forum_user_id)?;
 
-            // Make sure there exists a mutable post with post id `post_id`
-            Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?;
+            // Make sure the thread exists and is mutable
+            Self::ensure_thread_is_mutable(&category_id, &thread_id)?;
 
             //
             // == MUTATION SAFE ==
@@ -1219,7 +1260,14 @@ decl_module! {
             T::MaxCategoryDepth::get() as u32,
             new_text.len().saturated_into(),
         )]
-        fn edit_post_text(origin, forum_user_id: ForumUserId<T>, category_id: T::CategoryId, thread_id: T::ThreadId, post_id: T::PostId, new_text: Vec<u8>) -> DispatchResult {
+        fn edit_post_text(
+            origin,
+            forum_user_id: ForumUserId<T>,
+            category_id: T::CategoryId,
+            thread_id: T::ThreadId,
+            post_id: T::PostId,
+            new_text: Vec<u8>
+        ) -> DispatchResult {
             // Ensure data migration is done
             Self::ensure_data_migration_done()?;
 
@@ -1241,10 +1289,9 @@ decl_module! {
             // Update post text
             let text_hash = T::calculate_hash(&new_text);
             post.text_hash = text_hash;
+            post.last_edited = frame_system::Module::<T>::block_number();
 
-            <ThreadById<T>>::mutate(category_id, thread_id,
-                |thread| thread.posts.insert(post_id, post)
-            );
+            <PostById<T>>::insert(thread_id, post_id, post);
 
             // Generate event
             Self::deposit_event(RawEvent::PostTextUpdated(
@@ -1282,18 +1329,76 @@ decl_module! {
 
             let account_id = ensure_signed(origin)?;
 
-            // Ensure actor is allowed to moderate post
-            Self::ensure_can_moderate_post(account_id, &actor, &category_id, &thread_id, &post_id)?;
+            // Ensure actor is allowed to moderate post and post is editable
+            let post = Self::ensure_can_moderate_post(
+                account_id,
+                &actor,
+                &category_id,
+                &thread_id,
+                &post_id
+            )?;
 
             //
             // == MUTATION SAFE ==
             //
+
+            Self::slash_thread_account(thread_id, post.cleanup_pay_off);
 
             Self::delete_post_inner(category_id, thread_id, post_id);
 
             // Generate event
             Self::deposit_event(
                 RawEvent::PostModerated(post_id, rationale, actor, category_id, thread_id)
+            );
+
+            Ok(())
+        }
+
+        #[weight = WeightInfoForum::<T>::delete_posts(
+            T::MaxCategoryDepth::get() as u32,
+            rationale.len().saturated_into(),
+            posts.len().saturated_into(),
+        )]
+        fn delete_posts(
+            origin,
+            forum_user_id: ForumUserId<T>,
+            posts: Vec<(T::CategoryId, T::ThreadId, T::PostId)>,
+            rationale: Vec<u8>
+        ) -> DispatchResult {
+
+            // Ensure data migration is done
+            Self::ensure_data_migration_done()?;
+
+            let account_id = ensure_signed(origin)?;
+
+            let mut deleting_posts = Vec::new();
+            for (category_id, thread_id, post_id) in &posts {
+                // Ensure actor is allowed to moderate post and post is editable
+                let post = Self::ensure_can_delete_post(
+                    &account_id,
+                    &forum_user_id,
+                    &category_id,
+                    &thread_id,
+                    &post_id
+                )?;
+
+                deleting_posts.push((category_id, thread_id, post_id, post));
+            }
+
+            //
+            // == MUTATION SAFE ==
+            //
+
+            for (category_id, thread_id, post_id, post) in deleting_posts {
+                // Pay off to thread deleter
+                Self::pay_off(*thread_id, post.cleanup_pay_off, &account_id)?;
+
+                Self::delete_post_inner(*category_id, *thread_id, *post_id);
+            }
+
+            // Generate event
+            Self::deposit_event(
+                RawEvent::PostDeleted(rationale, forum_user_id, posts)
             );
 
             Ok(())
@@ -1383,27 +1488,33 @@ impl<T: Trait> Module<T> {
         category_id: T::CategoryId,
         text: &[u8],
         author_id: ForumUserId<T>,
-    ) -> (T::PostId, Post<ForumUserId<T>, T::Hash>) {
+        editable: bool,
+    ) -> T::PostId {
         // Make and add initial post
         let new_post_id = <NextPostId<T>>::get();
-
-        // Build a post
-        let new_post = Post {
-            text_hash: T::calculate_hash(text),
-            author_id,
-        };
-
-        let mut thread = <ThreadById<T>>::get(category_id, thread_id);
-        thread.posts.insert(new_post_id, new_post.clone());
-
-        thread.cleanup_pay_off = thread.cleanup_pay_off.saturating_add(T::PostDeposit::get());
-
-        <ThreadById<T>>::insert(category_id, thread_id, thread);
 
         // Update next post id
         <NextPostId<T>>::mutate(|n| *n += One::one());
 
-        (new_post_id, new_post)
+        if editable {
+            // Build a post
+            let new_post = Post {
+                text_hash: T::calculate_hash(text),
+                thread_id,
+                author_id,
+                cleanup_pay_off: T::PostDeposit::get(),
+                last_edited: frame_system::Module::<T>::block_number(),
+            };
+
+            <PostById<T>>::insert(thread_id, new_post_id, new_post);
+        }
+
+        let mut thread = <ThreadById<T>>::get(category_id, thread_id);
+        thread.number_of_posts = thread.number_of_posts.saturating_add(1);
+
+        <ThreadById<T>>::mutate(category_id, thread_id, |value| *value = thread);
+
+        new_post_id
     }
 
     fn delete_thread_inner(category_id: T::CategoryId, thread_id: T::ThreadId) {
@@ -1415,10 +1526,14 @@ impl<T: Trait> Module<T> {
     }
 
     fn delete_post_inner(category_id: T::CategoryId, thread_id: T::ThreadId, post_id: T::PostId) {
-        // Decrease thread's post counter
-        <ThreadById<T>>::mutate(category_id, thread_id, |thread| {
-            thread.posts.remove(&post_id);
-        });
+        if <ThreadById<T>>::contains_key(category_id, thread_id) {
+            let mut thread = <ThreadById<T>>::get(category_id, thread_id);
+            thread.number_of_posts = thread.number_of_posts.saturating_sub(1);
+
+            <ThreadById<T>>::mutate(category_id, thread_id, |value| *value = thread);
+        }
+
+        <PostById<T>>::remove(thread_id, post_id);
     }
 
     // Ensure poll is valid
@@ -1451,8 +1566,9 @@ impl<T: Trait> Module<T> {
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
         post_id: &T::PostId,
-    ) -> Result<Post<ForumUserId<T>, T::Hash>, Error<T>> {
-        // Make sure post exists
+    ) -> Result<Post<ForumUserId<T>, T::ThreadId, T::Hash, BalanceOf<T>, T::BlockNumber>, Error<T>>
+    {
+        // If the post is stored then it's mutable
         let post = Self::ensure_post_exists(category_id, thread_id, post_id)?;
 
         // and make sure thread is mutable
@@ -1461,22 +1577,22 @@ impl<T: Trait> Module<T> {
         Ok(post)
     }
 
+    // TODO: change this name, since it's no longer descriptive
     fn ensure_post_exists(
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
         post_id: &T::PostId,
-    ) -> Result<Post<ForumUserId<T>, T::Hash>, Error<T>> {
+    ) -> Result<Post<ForumUserId<T>, T::ThreadId, T::Hash, BalanceOf<T>, T::BlockNumber>, Error<T>>
+    {
         if !<ThreadById<T>>::contains_key(category_id, thread_id) {
             return Err(Error::<T>::PostDoesNotExist);
         }
 
-        let thread = <ThreadById<T>>::get(category_id, thread_id);
+        if !<PostById<T>>::contains_key(thread_id, post_id) {
+            return Err(Error::<T>::PostDoesNotExist);
+        }
 
-        thread
-            .posts
-            .get(post_id)
-            .cloned()
-            .ok_or_else(|| Error::<T>::PostDoesNotExist)
+        Ok(<PostById<T>>::get(thread_id, post_id))
     }
 
     fn ensure_can_moderate_post(
@@ -1485,14 +1601,60 @@ impl<T: Trait> Module<T> {
         category_id: &T::CategoryId,
         thread_id: &T::ThreadId,
         post_id: &T::PostId,
-    ) -> Result<Post<ForumUserId<T>, T::Hash>, Error<T>> {
+    ) -> Result<Post<ForumUserId<T>, T::ThreadId, T::Hash, BalanceOf<T>, T::BlockNumber>, Error<T>>
+    {
         // Ensure the moderator can moderate the category
         Self::ensure_can_moderate_category(&account_id, &actor, &category_id)?;
 
         // Make sure post exists and is mutable
-        let post = Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?;
+        let post = if Self::thread_exists(category_id, thread_id) {
+            Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?
+        } else {
+            <PostById<T>>::get(thread_id, post_id)
+        };
 
         Ok(post)
+    }
+
+    fn ensure_can_delete_post(
+        account_id: &T::AccountId,
+        forum_user_id: &ForumUserId<T>,
+        category_id: &T::CategoryId,
+        thread_id: &T::ThreadId,
+        post_id: &T::PostId,
+    ) -> Result<Post<ForumUserId<T>, T::ThreadId, T::Hash, BalanceOf<T>, T::BlockNumber>, Error<T>>
+    {
+        // Make sure post exists and is mutable
+        let post = if Self::thread_exists(category_id, thread_id) {
+            Self::ensure_post_is_mutable(&category_id, &thread_id, &post_id)?
+        } else {
+            <PostById<T>>::get(thread_id, post_id)
+        };
+
+        // Check that account is forum member
+        Self::ensure_is_forum_user(&account_id, &forum_user_id)?;
+
+        // Signer does not match creator of post with identifier postId
+        ensure!(
+            post.author_id == *forum_user_id
+                || Self::anyone_can_delete_post(&post, &thread_id, &category_id),
+            Error::<T>::AccountDoesNotMatchPostAuthor
+        );
+
+        Ok(post)
+    }
+
+    fn anyone_can_delete_post(
+        post: &Post<ForumUserId<T>, T::ThreadId, T::Hash, BalanceOf<T>, T::BlockNumber>,
+        thread_id: &T::ThreadId,
+        category_id: &T::CategoryId,
+    ) -> bool {
+        frame_system::Module::<T>::block_number() >= T::PostLifeTime::get() + post.last_edited
+            && !Self::thread_exists(&category_id, &thread_id)
+    }
+
+    fn thread_exists(category_id: &T::CategoryId, thread_id: &T::ThreadId) -> bool {
+        <ThreadById<T>>::contains_key(category_id, thread_id)
     }
 
     fn ensure_thread_is_mutable(
@@ -1628,6 +1790,25 @@ impl<T: Trait> Module<T> {
         Self::ensure_can_moderate_category(account_id, actor, category_id)?;
 
         let thread = Self::ensure_thread_exists(category_id, thread_id)?;
+
+        Ok(thread)
+    }
+
+    // Ensure actor can manipulate thread.
+    fn ensure_can_delete_thread(
+        account_id: &T::AccountId,
+        forum_user_id: &ForumUserId<T>,
+        category_id: &T::CategoryId,
+        thread_id: &T::ThreadId,
+    ) -> Result<ThreadOf<T>, Error<T>> {
+        // Ensure thread exists and is mutable
+        let (_, thread) = Self::ensure_thread_is_mutable(category_id, thread_id)?;
+
+        // Check that account is forum member
+        Self::ensure_is_forum_user(&account_id, &forum_user_id)?;
+
+        // Ensure forum user is author of the thread
+        Self::ensure_is_thread_author(&thread, &forum_user_id)?;
 
         Ok(thread)
     }
@@ -1935,11 +2116,6 @@ impl<T: Trait> Module<T> {
     ) -> Result<(Category<T::CategoryId, T::ThreadId, T::Hash>, ThreadOf<T>), Error<T>> {
         // Check that account is forum member
         Self::ensure_is_forum_user(account_id, &forum_user_id)?;
-
-        ensure!(
-            Self::ensure_enough_balance(T::PostDeposit::get(), &account_id),
-            Error::<T>::InsufficientBalanceForPost
-        );
 
         let (category, thread) = Self::ensure_thread_is_mutable(category_id, thread_id)?;
 

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -728,6 +728,7 @@ pub fn delete_thread_mock(
     result: DispatchResult,
 ) {
     let initial_balance = balances::Module::<Runtime>::free_balance(&account_id);
+    let hide = false;
 
     let num_direct_threads = match <CategoryById<Runtime>>::contains_key(category_id) {
         true => <CategoryById<Runtime>>::get(category_id).num_direct_threads,
@@ -740,6 +741,7 @@ pub fn delete_thread_mock(
             forum_user_id,
             category_id,
             thread_id,
+            hide,
         ),
         result
     );
@@ -754,7 +756,8 @@ pub fn delete_thread_mock(
             TestEvent::forum_mod(RawEvent::ThreadDeleted(
                 thread_id,
                 forum_user_id,
-                category_id
+                category_id,
+                hide,
             ))
         );
 
@@ -778,10 +781,11 @@ pub fn delete_post_mock(
     thread_id: <Runtime as Trait>::ThreadId,
     post_id: <Runtime as Trait>::PostId,
     result: DispatchResult,
+    hide: bool,
 ) {
     let initial_balance = balances::Module::<Runtime>::free_balance(&account_id);
     let number_of_posts = <ThreadById<Runtime>>::get(category_id, thread_id).number_of_posts;
-    let deleted_posts = vec![(category_id, thread_id, post_id)];
+    let deleted_posts = vec![(category_id, thread_id, post_id, hide)];
 
     assert_eq!(
         TestForumModule::delete_posts(

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -311,8 +311,6 @@ parameter_types! {
     pub const PostLifeTime: u64 = 100;
 
     pub const MaxSubcategories: u64 = 20;
-    pub const MaxThreadsInCategory: u64 = 20;
-    pub const MaxPostsInThread: u64 = 20;
     pub const MaxModeratorsForCategory: u64 = 3;
     pub const MaxCategories: u64 = 40;
     pub const MaxPollAlternativesNumber: u64 = 20;
@@ -325,8 +323,6 @@ pub struct MapLimits;
 
 impl StorageLimits for MapLimits {
     type MaxSubcategories = MaxSubcategories;
-    type MaxThreadsInCategory = MaxThreadsInCategory;
-    type MaxPostsInThread = MaxPostsInThread;
     type MaxModeratorsForCategory = MaxModeratorsForCategory;
     type MaxCategories = MaxCategories;
     type MaxPollAlternativesNumber = MaxPollAlternativesNumber;

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -356,6 +356,7 @@ fn update_category_archival_status_lock_works() {
             category_id,
             thread_id,
             good_post_text(),
+            true,
             Ok(()),
         );
 
@@ -387,6 +388,7 @@ fn update_category_archival_status_lock_works() {
             category_id,
             thread_id,
             good_post_text(),
+            true,
             Err(Error::<Runtime>::AncestorCategoryImmutable.into()),
         );
 
@@ -1017,6 +1019,7 @@ fn update_thread_archival_status_lock_works() {
             category_id,
             thread_id,
             good_post_text(),
+            true,
             Ok(()),
         );
 
@@ -1037,6 +1040,7 @@ fn update_thread_archival_status_lock_works() {
             category_id,
             thread_id,
             good_post_text(),
+            true,
             Err(Error::<Runtime>::ThreadImmutable.into()),
         );
 
@@ -1064,24 +1068,17 @@ fn update_thread_archival_status_lock_works() {
 }
 
 #[test]
-// test if moderator can delete thread
+// test if thread creator can delete thread
 fn delete_thread() {
-    let moderators = [
-        FORUM_MODERATOR_ORIGIN_ID,
-        FORUM_MODERATOR_2_ORIGIN_ID,
-        NOT_FORUM_MODERATOR_ORIGIN_ID,
-    ];
-    let origins = [
-        FORUM_MODERATOR_ORIGIN,
-        FORUM_MODERATOR_2_ORIGIN,
-        NOT_FORUM_MODERATOR_ORIGIN,
-    ];
-
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
     let initial_balance = 10_000_000;
     with_test_externalities(|| {
         balances::Module::<Runtime>::make_free_balance_be(&forum_lead, initial_balance);
+        balances::Module::<Runtime>::make_free_balance_be(
+            &NOT_FORUM_LEAD_ORIGIN_ID,
+            initial_balance,
+        );
 
         let mut current_balance = initial_balance;
 
@@ -1099,9 +1096,9 @@ fn delete_thread() {
         );
 
         let thread_id = create_thread_mock(
-            origin.clone(),
-            forum_lead,
-            forum_lead,
+            NOT_FORUM_LEAD_ORIGIN.clone(),
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            NOT_FORUM_LEAD_ORIGIN_ID,
             category_id,
             good_thread_title(),
             good_thread_text(),
@@ -1113,30 +1110,31 @@ fn delete_thread() {
         current_balance -= <Runtime as Trait>::PostDeposit::get();
 
         assert_eq!(
-            balances::Module::<Runtime>::free_balance(&forum_lead),
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
             current_balance
         );
 
         let _ = create_post_mock(
-            origin.clone(),
-            forum_lead,
-            forum_lead,
+            NOT_FORUM_LEAD_ORIGIN.clone(),
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            NOT_FORUM_LEAD_ORIGIN_ID,
             category_id,
             thread_id,
             good_post_text(),
+            true,
             Ok(()),
         );
 
         current_balance -= <Runtime as Trait>::PostDeposit::get();
 
         assert_eq!(
-            balances::Module::<Runtime>::free_balance(&forum_lead),
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
             current_balance
         );
 
         update_category_membership_of_moderator_mock(
-            origin.clone(),
-            moderators[0],
+            FORUM_MODERATOR_ORIGIN.clone(),
+            FORUM_MODERATOR_ORIGIN_ID,
             category_id,
             true,
             Ok(()),
@@ -1150,32 +1148,69 @@ fn delete_thread() {
 
         // regular user will fail to delete the thread
         delete_thread_mock(
-            origins[2].clone(),
-            moderators[2],
-            moderators[2],
+            NOT_FORUM_MODERATOR_ORIGIN.clone(),
+            NOT_FORUM_MODERATOR_ORIGIN_ID,
+            NOT_FORUM_MODERATOR_ORIGIN_ID,
             category_id,
             thread_id,
-            Err(Error::<Runtime>::ModeratorIdNotMatchAccount.into()),
+            Err(Error::<Runtime>::ForumUserIdNotMatchAccount.into()),
         );
 
         // moderator not associated with thread will fail to delete it
         delete_thread_mock(
-            origins[1].clone(),
-            moderators[1],
-            moderators[1],
+            FORUM_MODERATOR_2_ORIGIN.clone(),
+            FORUM_MODERATOR_2_ORIGIN_ID,
+            FORUM_MODERATOR_2_ORIGIN_ID,
             category_id,
             thread_id,
-            Err(Error::<Runtime>::ModeratorCantUpdateCategory.into()),
+            Err(Error::<Runtime>::ForumUserIdNotMatchAccount.into()),
         );
 
-        // moderator will delete thread
+        // moderator will not delete thread
         delete_thread_mock(
-            origins[0].clone(),
-            moderators[0],
-            moderators[0],
+            FORUM_MODERATOR_ORIGIN.clone(),
+            FORUM_MODERATOR_ORIGIN_ID,
+            FORUM_MODERATOR_ORIGIN_ID,
+            category_id,
+            thread_id,
+            Err(Error::<Runtime>::ForumUserIdNotMatchAccount.into()),
+        );
+
+        // forum lead will not delete thread
+        delete_thread_mock(
+            origin.clone(),
+            forum_lead,
+            forum_lead,
+            category_id,
+            thread_id,
+            Err(Error::<Runtime>::AccountDoesNotMatchThreadAuthor.into()),
+        );
+
+        // another user will not delete thread
+        delete_thread_mock(
+            NOT_FORUM_LEAD_2_ORIGIN.clone(),
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            category_id,
+            thread_id,
+            Err(Error::<Runtime>::AccountDoesNotMatchThreadAuthor.into()),
+        );
+
+        // post creator will delete thread
+        delete_thread_mock(
+            NOT_FORUM_LEAD_ORIGIN.clone(),
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            NOT_FORUM_LEAD_ORIGIN_ID,
             category_id,
             thread_id,
             Ok(()),
+        );
+
+        current_balance += <Runtime as Trait>::ThreadDeposit::get();
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
+            current_balance
         );
 
         // check category's thread count was decreased
@@ -1588,6 +1623,7 @@ fn add_post_origin() {
                 category_id,
                 thread_id,
                 good_post_text(),
+                true,
                 results[index],
             );
         });
@@ -1595,7 +1631,7 @@ fn add_post_origin() {
 }
 
 #[test]
-// test if post can be created by user without enough balance
+// test that we can't add editable posst without enough balance but we can add a non-editable one.
 fn add_post_balance() {
     let forum_lead = FORUM_LEAD_ORIGIN_ID;
     let origin = OriginType::Signed(forum_lead);
@@ -1629,6 +1665,8 @@ fn add_post_balance() {
             &forum_lead,
             <Runtime as Trait>::PostDeposit::get() - 1,
         );
+
+        // Can't create an editable post without enough balance
         create_post_mock(
             FORUM_LEAD_ORIGIN,
             forum_lead,
@@ -1636,7 +1674,20 @@ fn add_post_balance() {
             category_id,
             thread_id,
             good_post_text(),
+            true,
             Err(Error::<Runtime>::InsufficientBalanceForPost.into()),
+        );
+
+        // No balance requirements for non-editable posts
+        create_post_mock(
+            FORUM_LEAD_ORIGIN,
+            forum_lead,
+            forum_lead,
+            category_id,
+            thread_id,
+            good_post_text(),
+            false,
+            Ok(()),
         );
     });
 }
@@ -1689,6 +1740,7 @@ fn edit_post_text() {
             category_id,
             thread_id,
             good_post_text(),
+            true,
             Ok(()),
         );
 
@@ -1712,6 +1764,64 @@ fn edit_post_text() {
             post_id,
             good_post_new_text(),
             Err(Error::<Runtime>::AccountDoesNotMatchPostAuthor.into()),
+        );
+    });
+}
+
+#[test]
+// can't edit non-editable post
+fn edit_non_editable_post_text() {
+    let forum_lead = FORUM_LEAD_ORIGIN_ID;
+    let origin = OriginType::Signed(forum_lead);
+
+    let initial_balance = 10_000_000;
+    with_test_externalities(|| {
+        balances::Module::<Runtime>::make_free_balance_be(&forum_lead, initial_balance);
+        balances::Module::<Runtime>::make_free_balance_be(
+            &NOT_FORUM_LEAD_ORIGIN_ID,
+            initial_balance,
+        );
+
+        // prepare category and thread
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
+        let thread_id = create_thread_mock(
+            origin.clone(),
+            forum_lead,
+            forum_lead,
+            category_id,
+            good_thread_title(),
+            good_thread_text(),
+            None,
+            Ok(()),
+        );
+
+        // create post by author
+        let post_id = create_post_mock(
+            origin.clone(),
+            forum_lead,
+            forum_lead,
+            category_id,
+            thread_id,
+            good_post_text(),
+            false,
+            Ok(()),
+        );
+
+        // check non-author is forbidden from editing text
+        edit_post_text_mock(
+            origin.clone(),
+            forum_lead,
+            category_id,
+            thread_id,
+            post_id,
+            good_post_new_text(),
+            Err(Error::<Runtime>::PostDoesNotExist.into()),
         );
     });
 }
@@ -1756,6 +1866,7 @@ fn react_post() {
                 category_id,
                 thread_id,
                 good_post_text(),
+                true,
                 Ok(()),
             );
             react_post_mock(
@@ -1823,6 +1934,7 @@ fn moderate_post_origin() {
                 category_id,
                 thread_id,
                 good_post_text(),
+                true,
                 Ok(()),
             );
             moderate_post_mock(
@@ -1836,6 +1948,287 @@ fn moderate_post_origin() {
             );
         });
     }
+}
+
+/*
+ * Delete post
+*/
+
+#[test]
+// Test that post creator can delete it
+fn delete_post_creator() {
+    let forum_lead = FORUM_LEAD_ORIGIN_ID;
+    let origin = OriginType::Signed(forum_lead);
+    let initial_balance = 10_000_000;
+    with_test_externalities(|| {
+        balances::Module::<Runtime>::make_free_balance_be(&forum_lead, initial_balance);
+        balances::Module::<Runtime>::make_free_balance_be(
+            &NOT_FORUM_LEAD_ORIGIN_ID,
+            initial_balance,
+        );
+
+        let mut current_balance = initial_balance;
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&forum_lead),
+            current_balance
+        );
+
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
+
+        let thread_id = create_thread_mock(
+            NOT_FORUM_LEAD_ORIGIN.clone(),
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            category_id,
+            good_thread_title(),
+            good_thread_text(),
+            None,
+            Ok(()),
+        );
+
+        current_balance -= <Runtime as Trait>::ThreadDeposit::get();
+        current_balance -= <Runtime as Trait>::PostDeposit::get();
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
+            current_balance
+        );
+
+        let post_id = create_post_mock(
+            NOT_FORUM_LEAD_ORIGIN.clone(),
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            category_id,
+            thread_id,
+            good_post_text(),
+            true,
+            Ok(()),
+        );
+
+        current_balance -= <Runtime as Trait>::PostDeposit::get();
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
+            current_balance
+        );
+
+        update_category_membership_of_moderator_mock(
+            FORUM_MODERATOR_ORIGIN.clone(),
+            FORUM_MODERATOR_ORIGIN_ID,
+            category_id,
+            true,
+            Ok(()),
+        );
+
+        // regular user will fail to delete the thread
+        delete_post_mock(
+            NOT_FORUM_MODERATOR_ORIGIN.clone(),
+            NOT_FORUM_MODERATOR_ORIGIN_ID,
+            NOT_FORUM_MODERATOR_ORIGIN_ID,
+            category_id,
+            thread_id,
+            post_id,
+            Err(Error::<Runtime>::ForumUserIdNotMatchAccount.into()),
+        );
+
+        // moderator not associated with thread will fail to delete it
+        delete_post_mock(
+            FORUM_MODERATOR_2_ORIGIN.clone(),
+            FORUM_MODERATOR_2_ORIGIN_ID,
+            FORUM_MODERATOR_2_ORIGIN_ID,
+            category_id,
+            thread_id,
+            post_id,
+            Err(Error::<Runtime>::ForumUserIdNotMatchAccount.into()),
+        );
+
+        // moderator will not delete thread
+        delete_post_mock(
+            FORUM_MODERATOR_ORIGIN.clone(),
+            FORUM_MODERATOR_ORIGIN_ID,
+            FORUM_MODERATOR_ORIGIN_ID,
+            category_id,
+            thread_id,
+            post_id,
+            Err(Error::<Runtime>::ForumUserIdNotMatchAccount.into()),
+        );
+
+        // forum lead will not delete thread
+        delete_post_mock(
+            origin.clone(),
+            forum_lead,
+            forum_lead,
+            category_id,
+            thread_id,
+            post_id,
+            Err(Error::<Runtime>::AccountDoesNotMatchPostAuthor.into()),
+        );
+
+        // another user will not delete thread
+        delete_post_mock(
+            NOT_FORUM_LEAD_2_ORIGIN.clone(),
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            category_id,
+            thread_id,
+            post_id,
+            Err(Error::<Runtime>::AccountDoesNotMatchPostAuthor.into()),
+        );
+
+        // post creator will delete thread
+        delete_post_mock(
+            NOT_FORUM_LEAD_ORIGIN.clone(),
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            category_id,
+            thread_id,
+            post_id,
+            Ok(()),
+        );
+
+        current_balance += <Runtime as Trait>::PostDeposit::get();
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
+            current_balance
+        );
+    });
+}
+
+#[test]
+// Test that not creator of a post can delete it after N blocks
+fn delete_post_not_creator() {
+    let forum_lead = FORUM_LEAD_ORIGIN_ID;
+    let origin = OriginType::Signed(forum_lead);
+    let initial_balance = 10_000_000;
+    with_test_externalities(|| {
+        balances::Module::<Runtime>::make_free_balance_be(&forum_lead, initial_balance);
+        balances::Module::<Runtime>::make_free_balance_be(
+            &NOT_FORUM_LEAD_ORIGIN_ID,
+            initial_balance,
+        );
+
+        let mut current_balance = initial_balance;
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&forum_lead),
+            current_balance
+        );
+
+        let category_id = create_category_mock(
+            origin.clone(),
+            None,
+            good_category_title(),
+            good_category_description(),
+            Ok(()),
+        );
+
+        let thread_id = create_thread_mock(
+            NOT_FORUM_LEAD_ORIGIN.clone(),
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            category_id,
+            good_thread_title(),
+            good_thread_text(),
+            None,
+            Ok(()),
+        );
+
+        current_balance -= <Runtime as Trait>::ThreadDeposit::get();
+        current_balance -= <Runtime as Trait>::PostDeposit::get();
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
+            current_balance
+        );
+
+        let post_id = create_post_mock(
+            NOT_FORUM_LEAD_ORIGIN.clone(),
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            category_id,
+            thread_id,
+            good_post_text(),
+            true,
+            Ok(()),
+        );
+
+        current_balance -= <Runtime as Trait>::PostDeposit::get();
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
+            current_balance
+        );
+
+        update_category_membership_of_moderator_mock(
+            FORUM_MODERATOR_ORIGIN.clone(),
+            FORUM_MODERATOR_ORIGIN_ID,
+            category_id,
+            true,
+            Ok(()),
+        );
+
+        delete_thread_mock(
+            NOT_FORUM_LEAD_ORIGIN.clone(),
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            NOT_FORUM_LEAD_ORIGIN_ID,
+            category_id,
+            thread_id,
+            Ok(()),
+        );
+
+        // post creator will not delete thread now
+        delete_post_mock(
+            NOT_FORUM_LEAD_2_ORIGIN.clone(),
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            category_id,
+            thread_id,
+            post_id,
+            Err(Error::<Runtime>::AccountDoesNotMatchPostAuthor.into()),
+        );
+
+        current_balance += <Runtime as Trait>::ThreadDeposit::get();
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
+            current_balance
+        );
+
+        let current_block = System::block_number();
+        run_to_block(current_block + <Runtime as Trait>::PostLifeTime::get());
+
+        let not_creator_balance =
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_2_ORIGIN_ID);
+
+        // post creator will not delete thread now
+        delete_post_mock(
+            NOT_FORUM_LEAD_2_ORIGIN.clone(),
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            category_id,
+            thread_id,
+            post_id,
+            Ok(()),
+        );
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_ORIGIN_ID),
+            current_balance
+        );
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_2_ORIGIN_ID),
+            not_creator_balance + <Runtime as Trait>::PostDeposit::get()
+        );
+    });
 }
 
 #[test]
@@ -1997,6 +2390,7 @@ fn test_migration_not_done() {
                 category_id,
                 thread_id,
                 good_post_text(),
+                true,
             ),
             Error::<Runtime>::DataMigrationNotDone,
         );
@@ -2112,6 +2506,7 @@ fn storage_limit_checks() {
                 category_id,
                 thread_id,
                 good_post_text(),
+                true,
                 match i {
                     _ if i == max => Err(Error::<Runtime>::MapSizeLimit.into()),
                     _ => Ok(()),

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -1196,7 +1196,7 @@ fn delete_thread() {
             Err(Error::<Runtime>::AccountDoesNotMatchThreadAuthor.into()),
         );
 
-        // post creator will delete thread
+        // thread creator will delete thread
         delete_thread_mock(
             NOT_FORUM_LEAD_ORIGIN.clone(),
             NOT_FORUM_LEAD_ORIGIN_ID,
@@ -2036,6 +2036,7 @@ fn delete_post_creator() {
             thread_id,
             post_id,
             Err(Error::<Runtime>::ForumUserIdNotMatchAccount.into()),
+            false,
         );
 
         // moderator not associated with thread will fail to delete it
@@ -2047,6 +2048,7 @@ fn delete_post_creator() {
             thread_id,
             post_id,
             Err(Error::<Runtime>::ForumUserIdNotMatchAccount.into()),
+            false,
         );
 
         // moderator will not delete thread
@@ -2058,6 +2060,7 @@ fn delete_post_creator() {
             thread_id,
             post_id,
             Err(Error::<Runtime>::ForumUserIdNotMatchAccount.into()),
+            false,
         );
 
         // forum lead will not delete thread
@@ -2069,6 +2072,7 @@ fn delete_post_creator() {
             thread_id,
             post_id,
             Err(Error::<Runtime>::AccountDoesNotMatchPostAuthor.into()),
+            false,
         );
 
         // another user will not delete thread
@@ -2080,6 +2084,7 @@ fn delete_post_creator() {
             thread_id,
             post_id,
             Err(Error::<Runtime>::AccountDoesNotMatchPostAuthor.into()),
+            false,
         );
 
         // post creator will delete thread
@@ -2091,6 +2096,7 @@ fn delete_post_creator() {
             thread_id,
             post_id,
             Ok(()),
+            true,
         );
 
         current_balance += <Runtime as Trait>::PostDeposit::get();
@@ -2193,6 +2199,7 @@ fn delete_post_not_creator() {
             thread_id,
             post_id,
             Err(Error::<Runtime>::AccountDoesNotMatchPostAuthor.into()),
+            false,
         );
 
         current_balance += <Runtime as Trait>::ThreadDeposit::get();
@@ -2208,7 +2215,19 @@ fn delete_post_not_creator() {
         let not_creator_balance =
             balances::Module::<Runtime>::free_balance(&NOT_FORUM_LEAD_2_ORIGIN_ID);
 
-        // post creator will not delete thread now
+        // not post creator wil not be able to delete hiding the post
+        delete_post_mock(
+            NOT_FORUM_LEAD_2_ORIGIN.clone(),
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            NOT_FORUM_LEAD_2_ORIGIN_ID,
+            category_id,
+            thread_id,
+            post_id,
+            Err(Error::<Runtime>::AccountDoesNotMatchPostAuthor.into()),
+            true,
+        );
+
+        // not post creator will delete thread now
         delete_post_mock(
             NOT_FORUM_LEAD_2_ORIGIN.clone(),
             NOT_FORUM_LEAD_2_ORIGIN_ID,
@@ -2217,6 +2236,7 @@ fn delete_post_not_creator() {
             thread_id,
             post_id,
             Ok(()),
+            false,
         );
 
         assert_eq!(
@@ -2264,7 +2284,40 @@ fn set_stickied_threads_ok() {
             None,
             Ok(()),
         );
-        set_stickied_threads_mock(origin, moderator_id, category_id, vec![thread_id], Ok(()));
+        set_stickied_threads_mock(
+            origin.clone(),
+            moderator_id,
+            category_id,
+            vec![thread_id],
+            Ok(()),
+        );
+
+        let thread_id_deleted = create_thread_mock(
+            origin.clone(),
+            forum_lead,
+            forum_lead,
+            category_id,
+            good_thread_title(),
+            good_thread_text(),
+            None,
+            Ok(()),
+        );
+        moderate_thread_mock(
+            origin.clone(),
+            moderator_id,
+            category_id,
+            thread_id_deleted,
+            good_moderation_rationale(),
+            Ok(()),
+        );
+        // Can sticky deleted thread
+        set_stickied_threads_mock(
+            origin,
+            moderator_id,
+            category_id,
+            vec![thread_id, thread_id_deleted],
+            Ok(()),
+        );
     });
 }
 

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -2453,66 +2453,6 @@ fn storage_limit_checks() {
                 },
             );
         }
-
-        // test max threads in category
-        let max = <<<Runtime as Trait>::MapLimits as StorageLimits>::MaxThreadsInCategory>::get();
-        for i in 0..max {
-            create_thread_mock(
-                origin.clone(),
-                forum_lead,
-                forum_lead,
-                category_id,
-                good_thread_title(),
-                good_thread_text(),
-                None,
-                match i {
-                    _ if i == max => Err(Error::<Runtime>::MapSizeLimit.into()),
-                    _ => Ok(()),
-                },
-            );
-        }
-    });
-
-    // test MaxPostsInThread
-    with_test_externalities(|| {
-        balances::Module::<Runtime>::make_free_balance_be(&forum_lead, initial_balance);
-
-        let category_id = create_category_mock(
-            origin.clone(),
-            None,
-            good_category_title(),
-            good_category_description(),
-            Ok(()),
-        );
-        let thread_id = create_thread_mock(
-            origin.clone(),
-            forum_lead,
-            forum_lead,
-            category_id,
-            good_thread_title(),
-            good_thread_text(),
-            None,
-            Ok(()),
-        );
-
-        // test max posts in thread
-        let max = <<<Runtime as Trait>::MapLimits as StorageLimits>::MaxPostsInThread>::get();
-        // starting from 1 because create_thread_mock creates one post by itself
-        for i in 1..max {
-            create_post_mock(
-                origin.clone(),
-                forum_lead,
-                forum_lead,
-                category_id,
-                thread_id,
-                good_post_text(),
-                true,
-                match i {
-                    _ if i == max => Err(Error::<Runtime>::MapSizeLimit.into()),
-                    _ => Ok(()),
-                },
-            );
-        }
     });
 
     // test MaxModeratorsForCategory
@@ -2546,7 +2486,7 @@ fn storage_limit_checks() {
     // test MaxCategories
     with_test_externalities(|| {
         let max: usize =
-            <<<Runtime as Trait>::MapLimits as StorageLimits>::MaxPostsInThread>::get() as usize;
+            <<<Runtime as Trait>::MapLimits as StorageLimits>::MaxCategories>::get() as usize;
         for i in 0..max {
             create_category_mock(
                 origin.clone(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -653,6 +653,7 @@ parameter_types! {
     pub const ThreadDeposit: u64 = 30;
     pub const PostDeposit: u64 = 10;
     pub const ForumModuleId: ModuleId = ModuleId(*b"mo:forum"); // module : forum
+    pub const PostLifeTime: BlockNumber = 3600;
 }
 
 pub struct MapLimits;
@@ -687,6 +688,7 @@ impl forum::Trait for Runtime {
 
     type WorkingGroup = ForumWorkingGroup;
     type MemberOriginValidator = Members;
+    type PostLifeTime = PostLifeTime;
 }
 
 impl LockComparator<<Runtime as pallet_balances::Trait>::Balance> for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -660,8 +660,6 @@ pub struct MapLimits;
 
 impl forum::StorageLimits for MapLimits {
     type MaxSubcategories = MaxSubcategories;
-    type MaxThreadsInCategory = MaxThreadsInCategory;
-    type MaxPostsInThread = MaxPostsInThread;
     type MaxModeratorsForCategory = MaxModeratorsForCategory;
     type MaxCategories = MaxCategories;
     type MaxPollAlternativesNumber = MaxPollAlternativesNumber;

--- a/runtime/src/weights/forum.rs
+++ b/runtime/src/weights/forum.rs
@@ -9,188 +9,191 @@ pub struct WeightInfo;
 impl forum::WeightInfo for WeightInfo {
     fn create_category(i: u32, j: u32, k: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((536_866_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((206_000 as Weight).saturating_mul(j as Weight))
-            .saturating_add((58_000 as Weight).saturating_mul(k as Weight))
+            .saturating_add((214_529_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((98_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((134_000 as Weight).saturating_mul(k as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn update_category_membership_of_moderator_new() -> Weight {
-        (769_077_000 as Weight)
+        (297_135_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_category_membership_of_moderator_old() -> Weight {
-        (844_050_000 as Weight)
+        (315_520_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_category_archival_status_lead(i: u32) -> Weight {
-        (579_518_000 as Weight)
-            .saturating_add((148_741_000 as Weight).saturating_mul(i as Weight))
+        (177_097_000 as Weight)
+            .saturating_add((57_774_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_category_archival_status_moderator(i: u32) -> Weight {
-        (695_186_000 as Weight)
-            .saturating_add((90_362_000 as Weight).saturating_mul(i as Weight))
+        (195_602_000 as Weight)
+            .saturating_add((57_023_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn delete_category_lead(i: u32) -> Weight {
-        (475_589_000 as Weight)
-            .saturating_add((137_382_000 as Weight).saturating_mul(i as Weight))
+        (142_929_000 as Weight)
+            .saturating_add((68_133_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn delete_category_moderator(i: u32) -> Weight {
-        (491_714_000 as Weight)
-            .saturating_add((143_917_000 as Weight).saturating_mul(i as Weight))
+        (184_678_000 as Weight)
+            .saturating_add((63_220_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
-    fn create_thread(i: u32, j: u32, k: u32, z: u32) -> Weight {
-        (657_005_000 as Weight)
-            .saturating_add((95_246_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((78_000 as Weight).saturating_mul(j as Weight))
-            .saturating_add((80_000 as Weight).saturating_mul(k as Weight))
-            .saturating_add((9_492_000 as Weight).saturating_mul(z as Weight))
+    // WARNING! Some components were not used: ["z"]
+    fn create_thread(j: u32, k: u32, i: u32) -> Weight {
+        (1_763_250_000 as Weight)
+            .saturating_add((122_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((171_000 as Weight).saturating_mul(k as Weight))
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
+            .saturating_add(DbWeight::get().writes(7 as Weight))
     }
     fn edit_thread_title(i: u32, j: u32) -> Weight {
-        (379_562_000 as Weight)
-            .saturating_add((210_957_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((83_000 as Weight).saturating_mul(j as Weight))
+        (161_572_000 as Weight)
+            .saturating_add((72_014_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((127_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_thread_archival_status_lead(i: u32) -> Weight {
-        (532_961_000 as Weight)
-            .saturating_add((233_514_000 as Weight).saturating_mul(i as Weight))
+        (212_838_000 as Weight)
+            .saturating_add((116_257_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_thread_archival_status_moderator(i: u32) -> Weight {
-        (688_504_000 as Weight)
-            .saturating_add((197_194_000 as Weight).saturating_mul(i as Weight))
+        (237_385_000 as Weight)
+            .saturating_add((114_127_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
-    fn delete_thread_lead(i: u32) -> Weight {
-        (1_030_000_000 as Weight)
-            .saturating_add((148_165_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
+    fn delete_thread(i: u32) -> Weight {
+        (592_486_000 as Weight)
+            .saturating_add((57_770_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(22 as Weight))
-    }
-    fn delete_thread_moderator(i: u32) -> Weight {
-        (1_260_738_000 as Weight)
-            .saturating_add((122_231_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(22 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn move_thread_to_category_lead(i: u32) -> Weight {
-        (977_047_000 as Weight)
-            .saturating_add((205_129_000 as Weight).saturating_mul(i as Weight))
+        (365_000_000 as Weight)
+            .saturating_add((100_941_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn move_thread_to_category_moderator(i: u32) -> Weight {
-        (931_744_000 as Weight)
-            .saturating_add((206_882_000 as Weight).saturating_mul(i as Weight))
+        (400_012_000 as Weight)
+            .saturating_add((101_980_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn vote_on_poll(i: u32, j: u32) -> Weight {
-        (933_414_000 as Weight)
-            .saturating_add((169_101_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((33_456_000 as Weight).saturating_mul(j as Weight))
+        (311_689_000 as Weight)
+            .saturating_add((57_977_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((18_453_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
-    fn moderate_thread_lead(i: u32, j: u32, k: u32) -> Weight {
-        (1_339_536_000 as Weight)
-            .saturating_add((157_127_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((5_014_000 as Weight).saturating_mul(j as Weight))
-            .saturating_add((339_000 as Weight).saturating_mul(k as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
-    }
-    fn moderate_thread_moderator(k: u32, i: u32, j: u32) -> Weight {
-        (6_048_919_000 as Weight)
-            .saturating_add((270_000 as Weight).saturating_mul(k as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
-    }
-    fn add_post(i: u32, j: u32) -> Weight {
-        (544_287_000 as Weight)
-            .saturating_add((84_358_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((83_000 as Weight).saturating_mul(j as Weight))
+    // WARNING! Some components were not used: ["j"]
+    fn moderate_thread_lead(i: u32, k: u32) -> Weight {
+        (533_448_000 as Weight)
+            .saturating_add((57_859_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((129_000 as Weight).saturating_mul(k as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
+    fn moderate_thread_moderator(i: u32, j: u32, k: u32) -> Weight {
+        (343_909_000 as Weight)
+            .saturating_add((63_466_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((6_334_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((131_000 as Weight).saturating_mul(k as Weight))
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
+    fn add_post(i: u32, j: u32) -> Weight {
+        (584_267_000 as Weight)
+            .saturating_add((54_076_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((128_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
+    }
     fn react_post(i: u32) -> Weight {
-        (624_679_000 as Weight)
-            .saturating_add((90_554_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
+        (299_480_000 as Weight)
+            .saturating_add((57_223_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
     }
     fn edit_post_text(i: u32, j: u32) -> Weight {
-        (623_715_000 as Weight)
-            .saturating_add((110_140_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((83_000 as Weight).saturating_mul(j as Weight))
+        (387_494_000 as Weight)
+            .saturating_add((70_340_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((126_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn moderate_post_lead(i: u32, j: u32) -> Weight {
-        (1_265_038_000 as Weight)
-            .saturating_add((179_219_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((240_000 as Weight).saturating_mul(j as Weight))
-            .saturating_add(DbWeight::get().reads(5 as Weight))
+        (1_094_423_000 as Weight)
+            .saturating_add((103_781_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((121_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn moderate_post_moderator(i: u32, j: u32) -> Weight {
-        (1_156_880_000 as Weight)
-            .saturating_add((193_169_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((243_000 as Weight).saturating_mul(j as Weight))
+        (863_056_000 as Weight)
+            .saturating_add((134_282_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((126_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
+    fn delete_posts(i: u32, j: u32, k: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((1_007_340_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((113_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((1_418_940_000 as Weight).saturating_mul(k as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(k as Weight)))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(k as Weight)))
     }
     fn set_stickied_threads_lead(i: u32, j: u32) -> Weight {
-        (647_830_000 as Weight)
-            .saturating_add((53_426_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((356_269_000 as Weight).saturating_mul(j as Weight))
+        (219_049_000 as Weight)
+            .saturating_add((59_817_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((204_099_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_stickied_threads_moderator(i: u32, j: u32) -> Weight {
-        (479_755_000 as Weight)
-            .saturating_add((78_709_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((354_352_000 as Weight).saturating_mul(j as Weight))
+        (281_825_000 as Weight)
+            .saturating_add((47_851_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((203_487_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))


### PR DESCRIPTION
# Fix forum state bloat in #2196
In this PR I implement what we decided to do to solve the problem of state bloat in the forum pallet [here](https://github.com/Joystream/joystream/issues/2196#issuecomment-802111952).

Originally, we've solved the problem of state bloat in the forum pallet, by requiring a deposit for thread and post creation. Furthermore, the thread stored within its structure all the posts, using this, to delete a thread it was constant in time and when a thread was deleted all the deposit from all posts was given to the thread deleter(normally the thread creator).

However, this had the problem of making the structure of a thread to big which we would need to deal with in the weight functions, see: #2234 

To solve this we wanted to return each post to its own storage. The problem if we make the thread deletion as a side effect delete all its posts, it'd be too costly, on the other side, if we require the creator of the post to delete each of their posts that would generate too much traffic.

To solve the last problem we decided that we can have both editable and non-editable posts. Editable posts work as the posts have always worked, non-editable don't need to occupy storage, so there is no deletion after a thread is deleted. We expect most posts to be non-editable and that would mean that this would greatly reduce traffic and dependence on each user deleting their posts.

Furthermore, we allow users who are not the posters to delete other users posts given this 2 conditions:
* The thread has been deleted
* It has passed `PostLifeTime` since the post was last edited

In this way we make sure that a post will be delted by other users opportunistically.

To motivate a user to delete their post, now deleting a post recover its original deposit. And the thread only recover its original deposit(not from all posts).

## Included in this PR

To introduce the changes I described above I needed to include the following:
* Change `delete_thread` to only be used by thread creator instead of only the moderator/lead as to prevent a moderator/lead from deleting a thread just to recover its deposit(also to allow the correct functioning for a user to recover their deposit by deleting it). If a moderator/lead wants to remove a thread they need to use `moderate_thread` which slash the deposit instead of giving it to any one account.
* Add `delete_posts` which allows deletion of posts by the user(allowing multiple post deletion at the same time to reduce the cost of doing so and reducing traffic)
* Remove any verification for reactions to valid posts, that is left for query nodes.

Furthermore, we removed the storage limits for threads and posts since that is dealt with by the deposits.

Companion handbook PR: Joystream/handbook#38