### PR TITLE
Upgrade chain spec to v2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ yarn*
 
 # eslint cache
 **/.eslintcache
+
+# test data for local node tests
+test-data/
+tmp.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "chain-spec-builder"
+version = "3.1.0"
+dependencies = [
+ "ansi_term 0.12.1",
+ "enum-utils",
+ "joystream-node",
+ "rand 0.7.3",
+ "sc-chain-spec",
+ "sc-keystore",
+ "sc-telemetry",
+ "sp-core",
+ "structopt",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,6 +1158,30 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "enum-utils"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed327f716d0d351d86c9fd3398d20ee39ad8f681873cc081da2ca1c10fed398a"
+dependencies = [
+ "enum-utils-from-str",
+ "failure",
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "enum-utils-from-str"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49be08bad6e4ca87b2b8e74146987d4e5cb3b7512efa50ef505b51a22227ee1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "env_logger"
@@ -6480,6 +6519,17 @@ name = "serde_derive"
 version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 	"runtime-modules/working-group",
 	"runtime-modules/content-directory",
 	"node",
-	#"utils/chain-spec-builder/"
+	"utils/chain-spec-builder/"
 ]
 
 [profile.release]

--- a/tests/network-tests/run-local-node-test.sh
+++ b/tests/network-tests/run-local-node-test.sh
@@ -1,0 +1,64 @@
+# Location that will be mounted as the /data volume in containers
+# This is how we access the initial members and balances files from
+# the containers and where generated chainspec files will be located.
+DATA_PATH="test-data"
+
+# Initial account balance for Alice
+# Alice is the source of funds for all new accounts that are created in the tests.
+ALICE_INITIAL_BALANCE=100000000
+
+rm -Rf ${DATA_PATH}
+mkdir -p ${DATA_PATH}
+
+echo "{
+  \"balances\":[
+    [\"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY\", ${ALICE_INITIAL_BALANCE}]
+  ]
+}" > ${DATA_PATH}/initial-balances.json
+
+# Make Alice a member
+echo '
+  [{
+    "member_id": 0,
+    "root_account": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    "controller_account": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    "handle":"alice_with_a_long_handle",
+    "avatar_uri":"https://alice.com/avatar.png",
+    "about":"Alice",
+    "name": "Alice",
+    "registered_at_time": 0
+  },
+  {
+    "member_id": 1,
+    "root_account": "5FUeDYFzvvizNhhHyidsuchG7jnToKj7zfimbWBpWKzT9Fqe",
+    "controller_account": "5FUeDYFzvvizNhhHyidsuchG7jnToKj7zfimbWBpWKzT9Fqe",
+    "handle":"bob_with_a_long_handle",
+    "avatar_uri":"https://bob.com/avatar.png",
+    "about":"Bob",
+    "name": "Bob",
+    "registered_at_time": 0
+  }
+]
+' > ${DATA_PATH}/initial-members.json
+
+# Create a chain spec file
+./target/release/chain-spec-builder generate -a 2 -e 2 -k ${DATA_PATH} --chain-spec-path ${DATA_PATH}/chain-spec.json --initial-balances-path ${DATA_PATH}/initial-balances.json --initial-members-path ${DATA_PATH}/initial-members.json --deployment live > ${DATA_PATH}/seeds
+
+jq -c '.id = "js_babylon_test"' ${DATA_PATH}/chain-spec.json > tmp.$$.json && mv tmp.$$.json ${DATA_PATH}/chain-spec.json
+jq -c '.protocolId = "js/babylon/test"' ${DATA_PATH}/chain-spec.json > tmp.$$.json && mv tmp.$$.json ${DATA_PATH}/chain-spec.json
+
+timeout 3s ./target/release/joystream-node --base-path ${DATA_PATH}/alice3  --validator --chain ${DATA_PATH}/chain-spec.json
+
+
+timeout 3s ./target/release/joystream-node --base-path ${DATA_PATH}/bob4  --validator --port 30334 --ws-port 9945 --chain ${DATA_PATH}/chain-spec.json
+
+
+mv  ${DATA_PATH}/auth-0/* ${DATA_PATH}/alice3/chains/js_babylon_test/keystore
+mv  ${DATA_PATH}/auth-1/* ${DATA_PATH}/bob4/chains/js_babylon_test/keystore
+
+rm -Rf ${DATA_PATH}/alice3/chains/js_babylon_test/db
+rm -Rf ${DATA_PATH}/bob4/chains/js_babylon_test/db
+
+# RUN
+#./target/release/joystream-node --base-path test-data/alice3  --validator --chain test-data/chain-spec.json --pruning=archive --log runtime,txpool,transaction-pool
+#./target/release/joystream-node --base-path test-data/bob4 --validator --port 30334 --ws-port 9945 --chain test-data/chain-spec.json --pruning=archive --log runtime,txpool,transaction-pool

--- a/utils/chain-spec-builder/Cargo.toml
+++ b/utils/chain-spec-builder/Cargo.toml
@@ -9,10 +9,10 @@ version = '3.1.0'
 ansi_term = "0.12.1"
 rand = "0.7.2"
 structopt = "0.3.8"
-sc-keystore = { git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4' }
-sc-telemetry = { git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4' }
-sc-chain-spec = { git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4' }
-sp-core = { git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4' }
+sc-keystore = { git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca' }
+sc-telemetry = { git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca' }
+sc-chain-spec = { git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca' }
+sp-core = { git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca' }
 joystream-node = { path = "../../node" }
 
 enum-utils = "0.1.2"


### PR DESCRIPTION
To test this changes:
`cargo build --release && cd utils/chain-spec-builder && cargo build --release && cd ../..`

`./tests/network-tests/run-local-node-test.sh`

In two separate consoles:

`./target/release/joystream-node --base-path test-data/alice3  --validator --chain test-data/chain-spec.json --pruning=archive --log runtime,txpool,transaction-pool`

`./target/release/joystream-node --base-path test-data/bob4 --validator --port 30334 --ws-port 9945 --chain test-data/chain-spec.json --pruning=archive --log runtime,txpool,transaction-pool`


**Note:** You might need to install `jq`