### PR TITLE
Ugrade chain-spec-builder substrate to v2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "chain-spec-builder"
+version = "3.1.0"
+dependencies = [
+ "ansi_term 0.12.1",
+ "enum-utils",
+ "joystream-node",
+ "rand 0.7.3",
+ "sc-chain-spec",
+ "sc-keystore",
+ "sc-telemetry",
+ "sp-core",
+ "structopt",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1202,30 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "enum-utils"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed327f716d0d351d86c9fd3398d20ee39ad8f681873cc081da2ca1c10fed398a"
+dependencies = [
+ "enum-utils-from-str",
+ "failure",
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "enum-utils-from-str"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49be08bad6e4ca87b2b8e74146987d4e5cb3b7512efa50ef505b51a22227ee1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "env_logger"
@@ -6527,6 +6566,17 @@ name = "serde_derive"
 version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 	"runtime-modules/working-group",
 	"runtime-modules/content-directory",
 	"node",
-	#"utils/chain-spec-builder/"
+	"utils/chain-spec-builder/"
 ]
 
 [profile.release]

--- a/utils/chain-spec-builder/Cargo.toml
+++ b/utils/chain-spec-builder/Cargo.toml
@@ -9,10 +9,10 @@ version = '3.1.0'
 ansi_term = "0.12.1"
 rand = "0.7.2"
 structopt = "0.3.8"
-sc-keystore = { git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca' }
-sc-telemetry = { git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca' }
-sc-chain-spec = { git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca' }
-sp-core = { git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca' }
+sc-keystore = { git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62' }
+sc-telemetry = { git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62' }
+sc-chain-spec = { git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62' }
+sp-core = { git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62' }
 joystream-node = { path = "../../node" }
 
 enum-utils = "0.1.2"

--- a/utils/chain-spec-builder/src/main.rs
+++ b/utils/chain-spec-builder/src/main.rs
@@ -48,6 +48,7 @@ enum ChainDeployment {
     live,
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<ChainType> for ChainDeployment {
     fn into(self) -> ChainType {
         match self {


### PR DESCRIPTION
To test this changes:
`cargo build --release && cd utils/chain-spec-builder && cargo build --release && cd ../..`

`./tests/network-tests/run-local-node-test.sh`

In two separate consoles:

`./target/release/joystream-node --base-path test-data/alice3  --validator --chain test-data/chain-spec.json --pruning=archive --log runtime,txpool,transaction-pool`

`./target/release/joystream-node --base-path test-data/bob4 --validator --port 30334 --ws-port 9945 --chain test-data/chain-spec.json --pruning=archive --log runtime,txpool,transaction-pool`