### PR TITLE
single instance of ApiPromise

### DIFF
--- a/storage-node/packages/cli/src/commands/dev.ts
+++ b/storage-node/packages/cli/src/commands/dev.ts
@@ -147,7 +147,7 @@ const init = async (api: RuntimeApi): Promise<any> => {
 // Using sudo to create initial storage lead and worker with given keys taken from env variables.
 // Used to quickly setup a storage provider on a new chain before a council is ready.
 const makeMemberInitialLeadAndStorageProvider = async (api: RuntimeApi): Promise<any> => {
-  if (api.workers.getLeadRoleAccount()) {
+  if (await api.workers.getLeadRoleAccount()) {
     throw new Error('The Storage Lead is already set!')
   }
 

--- a/storage-node/packages/runtime-api/index.js
+++ b/storage-node/packages/runtime-api/index.js
@@ -55,6 +55,8 @@ class RuntimeApi {
     options = options || {}
 
     const provider = new WsProvider(options.provider_url || 'ws://localhost:9944')
+    this.api = new ApiPromise({ provider, types })
+
     let attempts = 0
     // Create the API instrance
     while (true) {
@@ -65,11 +67,10 @@ class RuntimeApi {
       }
 
       try {
-        this.api = new ApiPromise({ provider, types })
         await this.api.isReadyOrError
         break
       } catch (err) {
-        debug('Connecting to node failed, will retry..')
+        // failed to connect to node
       }
       await sleep(5000)
     }

--- a/tests/network-tests/src/Api.ts
+++ b/tests/network-tests/src/Api.ts
@@ -56,12 +56,11 @@ export class ApiFactory {
   ): Promise<ApiFactory> {
     const debug = extendDebug('api-factory')
     let connectAttempts = 0
+    const api = new ApiPromise({ provider, types })
     while (true) {
       connectAttempts++
       debug(`Connecting to chain, attempt ${connectAttempts}..`)
       try {
-        const api = new ApiPromise({ provider, types })
-
         // Wait for api to be connected and ready
         await api.isReadyOrError
 

--- a/utils/api-scripts/src/dev-set-runtime-code.ts
+++ b/utils/api-scripts/src/dev-set-runtime-code.ts
@@ -27,12 +27,11 @@ async function main() {
   console.log('WASM bytes:', wasm.byteLength)
 
   const provider = new WsProvider('ws://127.0.0.1:9944')
+  const api = new ApiPromise({ provider, types })
 
-  let api: ApiPromise
   let retry = 6
   while (true) {
     try {
-      api = new ApiPromise({ provider, types })
       await api.isReadyOrError
       break
     } catch (err) {

--- a/utils/api-scripts/src/status.ts
+++ b/utils/api-scripts/src/status.ts
@@ -11,16 +11,14 @@ async function main() {
   const provider = new WsProvider('ws://127.0.0.1:9944')
 
   // Create the API and wait until ready
-  let api: ApiPromise
+  const api = new ApiPromise({ provider, types })
   let retry = 6
   while (true) {
     try {
-      api = new ApiPromise({ provider, types })
       await api.isReadyOrError
       break
     } catch (err) {
       // failed to connect to node
-      console.error('Caught Error', err)
     }
 
     if (retry-- === 0) {


### PR DESCRIPTION
We only need a single instance of ApiPromise when retrying connections.