### PR TITLE
Antioch stack overflow fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,7 +950,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils 0.8.3",
  "lazy_static",
- "memoffset 0.6.2",
+ "memoffset 0.6.3",
  "scopeguard 1.1.0",
 ]
 
@@ -1668,7 +1668,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot 0.9.0",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "serde",
  "serde_json",
 ]
@@ -1788,7 +1788,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures 0.3.13",
  "memchr",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
 ]
 
 [[package]]
@@ -2463,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2687,9 +2687,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
 name = "libloading"
@@ -2741,7 +2741,7 @@ dependencies = [
  "multihash",
  "parity-multiaddr",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "smallvec 1.6.1",
  "wasm-timer",
 ]
@@ -2766,7 +2766,7 @@ dependencies = [
  "multistream-select",
  "parity-multiaddr",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2999,7 +2999,7 @@ checksum = "96b3c2d5d26a9500e959a0e19743897239a6c4be78dadf99b70414301a70c006"
 dependencies = [
  "futures 0.3.13",
  "log",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "rand 0.7.3",
  "salsa20",
  "sha3",
@@ -3201,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
 dependencies = [
  "scopeguard 1.1.0",
 ]
@@ -3299,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14fc54a812b4472b4113facc3e44d099fbc0ea2ce0551fa5c703f8edfbfd38"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -4615,7 +4615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api 0.4.2",
+ "lock_api 0.4.3",
  "parking_lot_core 0.8.3",
 ]
 
@@ -4741,11 +4741,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.28",
 ]
 
 [[package]]
@@ -4759,9 +4759,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4937,9 +4937,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -5509,7 +5509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
  "futures 0.3.13",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "static_assertions",
 ]
 
@@ -5950,7 +5950,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-client-api",
@@ -6079,7 +6079,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -6262,7 +6262,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "rand 0.7.3",
  "sc-block-builder",
  "sc-chain-spec",
@@ -6366,7 +6366,7 @@ dependencies = [
  "libp2p",
  "log",
  "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "rand 0.7.3",
  "serde",
  "slog",
@@ -6673,9 +6673,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa894ef3fade0ee7243422f4fbbd6c2b48e6de767e621d37ef65f2310f53cea"
+checksum = "ef33d6d0cd06e0840fba9985aab098c147e67e05cee14d412d3345ed14ff30ac"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -7737,9 +7737,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.65"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
+checksum = "3ce15dd3ed8aa2f8eeac4716d6ef5ab58b6b9256db41d7e1a0224c2788e8fd87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8520,9 +8520,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -8530,9 +8530,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -8545,9 +8545,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73157efb9af26fb564bb59a009afd1c7c334a44db171d280690d0c3faaec3468"
+checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -8557,9 +8557,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8567,9 +8567,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8580,9 +8580,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "wasm-timer"
@@ -8624,9 +8624,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can also run your our own joystream-node:
 
 ```sh
 git checkout master
-WASM_BUILD_TOOLCHAIN=nightly-2021-02-20 cargo build --release
+WASM_BUILD_TOOLCHAIN=nightly-2021-03-24 cargo build --release
 ./target/release/joystream-node -- --pruning archive --chain testnets/joy-testnet-4.json
 ```
 

--- a/devops/git-hooks/pre-push
+++ b/devops/git-hooks/pre-push
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-export WASM_BUILD_TOOLCHAIN=nightly-2021-02-20
+export WASM_BUILD_TOOLCHAIN=nightly-2021-03-24
 
 echo 'running clippy (rust linter)'
 # When custom build.rs triggers wasm-build-runner-impl to build we get error:

--- a/joystream-node.Dockerfile
+++ b/joystream-node.Dockerfile
@@ -1,5 +1,4 @@
 FROM liuchong/rustup:nightly AS rustup
-RUN rustup component add rustfmt clippy
 RUN rustup install nightly-2021-03-24
 RUN rustup default nightly-2021-03-24
 RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2021-03-24

--- a/joystream-node.Dockerfile
+++ b/joystream-node.Dockerfile
@@ -1,7 +1,8 @@
-FROM liuchong/rustup:1.51.0 AS rustup
+FROM liuchong/rustup:nightly AS rustup
 RUN rustup component add rustfmt clippy
-RUN rustup install nightly-2021-02-20 --force
-RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2021-02-20
+RUN rustup install nightly-2021-03-24
+RUN rustup default nightly-2021-03-24
+RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2021-03-24
 RUN apt-get update && \
   apt-get install -y curl git gcc xz-utils sudo pkg-config unzip clang llvm libc6-dev
 
@@ -12,7 +13,7 @@ COPY . /joystream
 
 # Build all cargo crates
 # Ensure our tests and linter pass before actual build
-ENV WASM_BUILD_TOOLCHAIN=nightly-2021-02-20
+ENV WASM_BUILD_TOOLCHAIN=nightly-2021-03-24
 RUN BUILD_DUMMY_WASM_BINARY=1 cargo clippy --release --all -- -D warnings && \
     cargo test --release --all && \
     cargo build --release

--- a/node/README.md
+++ b/node/README.md
@@ -26,7 +26,7 @@ cd joystream/
 Compile the node and runtime:
 
 ```bash
-WASM_BUILD_TOOLCHAIN=nightly-2021-02-20 cargo build --release
+WASM_BUILD_TOOLCHAIN=nightly-2021-03-24 cargo build --release
 ```
 
 This produces the binary in `./target/release/joystream-node`
@@ -79,7 +79,7 @@ If you are building a tagged release from `master` branch and want to install th
 This will install the executable `joystream-node` to your `~/.cargo/bin` folder, which you would normally have in your `$PATH` environment.
 
 ```bash
-WASM_BUILD_TOOLCHAIN=nightly-2021-02-20 cargo install joystream-node --path node/ --locked
+WASM_BUILD_TOOLCHAIN=nightly-2021-03-24 cargo install joystream-node --path node/ --locked
 ```
 
 Now you can run and connect to the testnet:

--- a/runtime-modules/content-directory/src/operations.rs
+++ b/runtime-modules/content-directory/src/operations.rs
@@ -70,7 +70,17 @@ pub enum OperationType<T: Trait> {
 
 impl<T: Trait> core::fmt::Debug for OperationType<T> {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(formatter, "OperationType {:?}", self)
+        match self {
+            OperationType::CreateEntity(_) => {
+                write!(formatter, "OperationType::CreateEntity")
+            }
+            OperationType::AddSchemaSupportToEntity(_) => {
+                write!(formatter, "OperationType::AddSchemaSupportToEntity")
+            }
+            OperationType::UpdatePropertyValues(_) => {
+                write!(formatter, "OperationType::UpdatePropertyValues")
+            }
+        }
     }
 }
 

--- a/runtime-modules/content-directory/src/schema/input.rs
+++ b/runtime-modules/content-directory/src/schema/input.rs
@@ -42,13 +42,9 @@ impl<T: Trait> InputPropertyValue<T> {
     /// Retrieve all involved `entity_id`'s, if current `InputPropertyValue` is reference
     pub fn get_involved_entities(&self) -> Option<Vec<T::EntityId>> {
         match self {
-            InputPropertyValue::Single(single_property_value) => {
-                if let Some(entity_id) = single_property_value.get_involved_entity() {
-                    Some(vec![entity_id])
-                } else {
-                    None
-                }
-            }
+            InputPropertyValue::Single(single_property_value) => single_property_value
+                .get_involved_entity()
+                .map(|entity_id| vec![entity_id]),
             InputPropertyValue::Vector(vector_property_value) => {
                 vector_property_value.get_involved_entities()
             }

--- a/runtime-modules/content-directory/src/schema/input.rs
+++ b/runtime-modules/content-directory/src/schema/input.rs
@@ -10,7 +10,7 @@ pub enum InputPropertyValue<T: Trait> {
 
 impl<T: Trait> core::fmt::Debug for InputPropertyValue<T> {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(formatter, "InputPropertyValue {:?}", self)
+        write!(formatter, "InputPropertyValue")
     }
 }
 
@@ -81,7 +81,7 @@ pub enum InputValue<T: Trait> {
 
 impl<T: Trait> core::fmt::Debug for InputValue<T> {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> sp_std::fmt::Result {
-        write!(formatter, "InputValue {:?}", self)
+        write!(formatter, "InputValue")
     }
 }
 

--- a/runtime-modules/content-directory/src/schema/output.rs
+++ b/runtime-modules/content-directory/src/schema/output.rs
@@ -64,13 +64,9 @@ impl<
     /// Retrieve all involved `entity_id`'s, if current `StoredPropertyValue` is reference
     pub fn get_involved_entities(&self) -> Option<Vec<EntityId>> {
         match self {
-            StoredPropertyValue::Single(single_property_value) => {
-                if let Some(entity_id) = single_property_value.get_involved_entity() {
-                    Some(vec![entity_id])
-                } else {
-                    None
-                }
-            }
+            StoredPropertyValue::Single(single_property_value) => single_property_value
+                .get_involved_entity()
+                .map(|entity_id| vec![entity_id]),
             StoredPropertyValue::Vector(vector_property_value) => vector_property_value
                 .get_vec_value_ref()
                 .get_involved_entities(),

--- a/runtime-modules/hiring/src/lib.rs
+++ b/runtime-modules/hiring/src/lib.rs
@@ -1257,14 +1257,9 @@ impl<T: Trait> Module<T> {
         opt_imbalance: Option<NegativeImbalance<T>>,
         application_id: &T::ApplicationId,
     ) -> Option<T::StakeId> {
-        if let Some(imbalance) = opt_imbalance {
-            Some(Self::infallible_stake_initiation_on_application(
-                imbalance,
-                application_id,
-            ))
-        } else {
-            None
-        }
+        opt_imbalance.map(|imbalance| {
+            Self::infallible_stake_initiation_on_application(imbalance, application_id)
+        })
     }
 
     fn infallible_stake_initiation_on_application(
@@ -1399,11 +1394,9 @@ impl<T: Trait> Module<T> {
     pub(crate) fn create_stake_balance(
         opt_stake_imbalance: &Option<NegativeImbalance<T>>,
     ) -> Option<BalanceOf<T>> {
-        if let Some(ref imbalance) = opt_stake_imbalance {
-            Some(imbalance.peek())
-        } else {
-            None
-        }
+        opt_stake_imbalance
+            .as_ref()
+            .map(|imbalance| imbalance.peek())
     }
 
     /// Performs all necessary check before adding an opening

--- a/runtime-modules/working-group/src/lib.rs
+++ b/runtime-modules/working-group/src/lib.rs
@@ -1577,17 +1577,15 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
                     hiring::ApplicationById::<T>::get(successful_application.hiring_application_id);
 
                 // Staking profile for worker
-                let stake_profile = if let Some(ref stake_id) = application.active_role_staking_id {
-                    Some(RoleStakeProfile::new(
+                let stake_profile = application.active_role_staking_id.as_ref().map(|stake_id| {
+                    RoleStakeProfile::new(
                         stake_id,
                         &opening
                             .policy_commitment
                             .terminate_role_stake_unstaking_period,
                         &opening.policy_commitment.exit_role_stake_unstaking_period,
-                    ))
-                } else {
-                    None
-                };
+                    )
+                });
 
                 // Get worker id
                 let new_worker_id = <NextWorkerId<T, I>>::get();

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '9.0.0'
+version = '9.0.1'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -89,7 +89,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 9,
     spec_version: 0,
-    impl_version: 0,
+    impl_version: 1,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,
 };

--- a/scripts/cargo-build.sh
+++ b/scripts/cargo-build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-export WASM_BUILD_TOOLCHAIN=nightly-2021-02-20
+export WASM_BUILD_TOOLCHAIN=nightly-2021-03-24
 
 cargo build --release

--- a/scripts/cargo-tests-with-networking.sh
+++ b/scripts/cargo-tests-with-networking.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+export WASM_BUILD_TOOLCHAIN=nightly-2021-03-24
+
+echo 'running all cargo tests'
+cargo test --release --all -- --ignored

--- a/scripts/raspberry-cross-build.sh
+++ b/scripts/raspberry-cross-build.sh
@@ -9,7 +9,7 @@
 export WORKSPACE_ROOT=`cargo metadata --offline --no-deps --format-version 1 | jq .workspace_root -r`
 
 docker run \
-    -e WASM_BUILD_TOOLCHAIN=nightly-2021-02-20 \
+    -e WASM_BUILD_TOOLCHAIN=nightly-2021-03-24 \
     --volume ${WORKSPACE_ROOT}/:/home/cross/project \
     --volume ${HOME}/.cargo/registry:/home/cross/.cargo/registry \
     joystream/rust-raspberry \

--- a/scripts/run-dev-chain.sh
+++ b/scripts/run-dev-chain.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export WASM_BUILD_TOOLCHAIN=nightly-2021-02-20
+export WASM_BUILD_TOOLCHAIN=nightly-2021-03-24
 
 # Build release binary
 cargo build --release

--- a/setup.sh
+++ b/setup.sh
@@ -25,11 +25,10 @@ curl https://getsubstrate.io -sSf | bash -s -- --fast
 
 source ~/.cargo/env
 
-rustup install nightly-2021-02-20
-rustup target add wasm32-unknown-unknown --toolchain nightly-2021-02-20
+rustup install nightly-2021-03-24
+rustup target add wasm32-unknown-unknown --toolchain nightly-2021-03-24
 
-rustup install 1.51.0
-rustup default 1.51.0
+rustup default nightly-2021-03-24
 
 rustup component add rustfmt clippy
 


### PR DESCRIPTION
Fix for the stack overflow encountered while testing, resulting from infinite recursion in impl of `core::fmt::Debug` trait for some types in content-directory https://github.com/Joystream/joystream/pull/2320/commits/8d0aed31399d3183d1ee8a300222f233de9281cc, and bumped runtime impl version.

Misc improvements:
Linter fixes to build with latest rust nightly.
Bumping cargo crates.
Update build scripts to use latest rust `nightly-2021-03-24`

Some thoughts,,

There are three types in the content directory that implement the Debug trait with infinite recursion.
One example:
https://github.com/Joystream/joystream/blob/656fa3412da81029650672051b28d25980a08d3f/runtime-modules/content-directory/src/operations.rs#L71

```rust
use sp_std::prelude::*; // where write! macro comes from

// This trait implementation is required by substrate because OperationType is a paramter type
// in a dispatchable call 'transaction' which we use to batch Operations.
impl<T: Trait> core::fmt::Debug for OperationType<T> {
    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
        write!(formatter, "OperationType {:?}", self)
    }
}
```

node log on crash when a block being imported had some transactions from content directory:
```
Apr 01 18:44:55 localhost joystream-node[2530]: thread 'tokio-runtime-worker' has overflowed its stack
Apr 01 18:44:55 localhost joystream-node[2530]: fatal runtime error: stack overflow
Apr 01 18:44:55 localhost systemd[1]: joystream-node.service: Main process exited, code=killed, status=6/ABRT
```

Output from valgrind 
```
thread 'tokio-runtime-worker' has overflowed its stack
fatal runtime error: stack overflow
==17173==
==17173== Process terminating with default action of signal 6 (SIGABRT)
==17173==    at 0x5DE6FB7: raise (raise.c:51)
==17173==    by 0x5DE8920: abort (abort.c:79)
==17173==    by 0x1D41099: std::sys::unix::abort_internal (mod.rs:237)
==17173==    by 0x1D3AA14: std::sys_common::util::abort (util.rs:19)
==17173==    by 0x1D404BF: std::sys::unix::stack_overflow::imp::signal_handler (stack_overflow.rs:106)
==17173==    by 0x55F997F: ??? (in /lib/x86_64-linux-gnu/libpthread-2.27.so)
==17173==    by 0x1D5AC04: core::fmt::write (mod.rs:1075)
```
The `mod.rs` is in the rust std lib which implements the `write!` macro.

What was unusual about this bug which was hard to track down is that it manifests only under the following conditions.
1 - Node is using native execution for block syncing (and the node should be syncing of course)
when running node with `--execution-syncing Wasm` the stack doesn't overflow or the code path is not executed.
2 - When node log level is set to info, debug or trace
when node was run with `--log warn` the stack doesn't overflow or the code path is not executed.

Its not clear why our previous network with older version of substrate we didn't suffer from this dormant bug. Why did this code path never get executed?

fmt::Debug implementation as far as I can tell is primarily used to "serialize" the object to a string for the purpose of a comparison/assertions in unit tests. So they are not adequately implemented for this purpose. I didn't have the stamina to do it, and I don't think the implementation has any affect on stored state. Please confirm this @shamil-gadelshin ?
