### PR TITLE
Fix blog state bloat

### DIFF
--- a/runtime-modules/blog/Cargo.toml
+++ b/runtime-modules/blog/Cargo.toml
@@ -12,23 +12,22 @@ frame-system = { package = 'frame-system', default-features = false, git = 'http
 codec = { package = 'parity-scale-codec', version = '1.0.0', default-features = false, features = ['derive'] }
 sp-arithmetic = { package = 'sp-arithmetic', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 common = { package = 'pallet-common', default-features = false, path = '../common'}
+balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 
 #Benchmark dependencies
 frame-benchmarking = { package = 'frame-benchmarking', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
 membership = { package = 'pallet-membership', default-features = false, path = '../membership', optional = true}
-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca', optional = true}
 
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 membership = { package = 'pallet-membership', default-features = false, path = '../membership' }
 staking-handler = { package = 'pallet-staking-handler', default-features = false, path = '../staking-handler' }
 pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = 'a200cdb93c6af5763b9c7bf313fa708764ac88ca'}
 
 [features]
 default = ['std']
-runtime-benchmarks = ['frame-benchmarking', 'membership', 'balances']
+runtime-benchmarks = ['frame-benchmarking', 'membership']
 std = [
 	'codec/std',
 	'sp-std/std',

--- a/runtime-modules/blog/Cargo.toml
+++ b/runtime-modules/blog/Cargo.toml
@@ -35,5 +35,6 @@ std = [
 	'sp-runtime/std',
 	'frame-system/std',
     'common/std',
-    'sp-arithmetic/std'
+    'sp-arithmetic/std',
+    'balances/std'
 ]

--- a/runtime-modules/blog/src/benchmarking.rs
+++ b/runtime-modules/blog/src/benchmarking.rs
@@ -310,17 +310,18 @@ benchmarks_instance! {
         let post_id = generate_post::<T, I>();
         let (account_id, participant_id) = member_funded_account::<T, I>("caller", 0);
         let mut replies = Vec::new();
+        let hide = false;
 
         for _ in 0..=i {
             let reply_id =
                 generate_reply::<T, I>(account_id.clone(), participant_id, post_id.clone());
-            replies.push((post_id, reply_id, false));
+            replies.push(ReplyToDelete {post_id, reply_id, hide});
         }
 
         let origin = RawOrigin::Signed(account_id);
     }: _(origin.clone(), participant_id, replies.clone())
     verify {
-        for (post_id, reply_id, hide) in replies {
+        for ReplyToDelete {post_id, reply_id, hide} in replies {
             assert!(!<ReplyById<T, I>>::contains_key(post_id, reply_id));
 
             assert_in_events::<T, I>(RawEvent::ReplyDeleted(

--- a/runtime-modules/blog/src/benchmarking.rs
+++ b/runtime-modules/blog/src/benchmarking.rs
@@ -294,6 +294,22 @@ benchmarks_instance! {
                 updated_text
             ).into());
     }
+
+    delete_reply {
+        let post_id = generate_post::<T, I>();
+        let (account_id, participant_id) = member_funded_account::<T, I>("caller", 0);
+        let reply_id = generate_reply::<T, I>(account_id.clone(), participant_id, post_id.clone());
+        let origin = RawOrigin::Signed(account_id);
+    }: _(origin.clone(), participant_id, post_id, reply_id)
+    verify {
+        assert!(!<ReplyById<T, I>>::contains_key(post_id, reply_id));
+
+        assert_last_event::<T, I>(RawEvent::ReplyDeleted(
+                participant_id,
+                post_id,
+                reply_id,
+            ).into());
+    }
 }
 
 #[cfg(test)]
@@ -348,6 +364,13 @@ mod tests {
     fn test_edit_reply() {
         ExtBuilder::default().build().execute_with(|| {
             assert_ok!(test_benchmark_edit_reply::<Runtime>());
+        })
+    }
+
+    #[test]
+    fn test_delete_reply() {
+        ExtBuilder::default().build().execute_with(|| {
+            assert_ok!(test_benchmark_delete_reply::<Runtime>());
         })
     }
 }

--- a/runtime-modules/blog/src/benchmarking.rs
+++ b/runtime-modules/blog/src/benchmarking.rs
@@ -113,12 +113,18 @@ fn generate_reply<T: Trait<I>, I: Instance>(
         post_id,
         None,
         vec![0u8],
+        true,
     )
     .unwrap();
 
     assert_eq!(
         Blog::<T, I>::reply_by_id(post_id, T::ReplyId::zero()),
-        Reply::<T, I>::new(vec![0u8], participant_id, ParentId::Post(post_id))
+        Reply::<T, I>::new(
+            vec![0u8],
+            participant_id,
+            ParentId::Post(post_id),
+            T::ReplyDeposit::get()
+        )
     );
 
     T::ReplyId::zero()
@@ -194,7 +200,7 @@ benchmarks_instance! {
         let (account_id, participant_id) = member_funded_account::<T, I>("caller", 0);
         let origin = RawOrigin::Signed(account_id);
         let text = vec![0u8; t.try_into().unwrap()];
-    }: create_reply(origin.clone(), participant_id, post_id, None, text.clone())
+    }: create_reply(origin.clone(), participant_id, post_id, None, text.clone(), true)
     verify {
         let mut expected_post = Post::<T, I>::new(&vec![0u8], &vec![0u8]);
         expected_post.increment_replies_counter();
@@ -204,7 +210,8 @@ benchmarks_instance! {
             Reply::<T, I>::new(
                 text.clone(),
                 participant_id,
-                ParentId::Post(post_id)
+                ParentId::Post(post_id),
+                T::ReplyDeposit::get(),
             )
         );
 
@@ -213,7 +220,8 @@ benchmarks_instance! {
                 participant_id,
                 post_id,
                 Zero::zero(),
-                text
+                text,
+                true
             ).into()
         );
     }
@@ -229,7 +237,7 @@ benchmarks_instance! {
         expected_post.increment_replies_counter();
         assert_eq!(Blog::<T, I>::post_by_id(post_id), expected_post);
         let text = vec![0u8; t.try_into().unwrap()];
-    }: create_reply(origin.clone(), participant_id, post_id, Some(reply_id), text.clone())
+    }: create_reply(origin.clone(), participant_id, post_id, Some(reply_id), text.clone(), true)
     verify {
         expected_post.increment_replies_counter();
         assert_eq!(Blog::<T, I>::post_by_id(post_id), expected_post);
@@ -238,7 +246,8 @@ benchmarks_instance! {
             Reply::<T, I>::new(
                 text.clone(),
                 participant_id,
-                ParentId::Reply(reply_id)
+                ParentId::Reply(reply_id),
+                T::ReplyDeposit::get(),
             )
         );
 
@@ -248,7 +257,8 @@ benchmarks_instance! {
                 post_id,
                 reply_id,
                 One::one(),
-                text
+                text,
+                true,
             ).into()
         );
     }
@@ -272,7 +282,8 @@ benchmarks_instance! {
             Reply::<T, I>::new(
                 updated_text.clone(),
                 participant_id,
-                ParentId::Post(post_id)
+                ParentId::Post(post_id),
+                T::ReplyDeposit::get(),
             )
         );
 

--- a/runtime-modules/blog/src/benchmarking.rs
+++ b/runtime-modules/blog/src/benchmarking.rs
@@ -300,7 +300,7 @@ benchmarks_instance! {
         let (account_id, participant_id) = member_funded_account::<T, I>("caller", 0);
         let reply_id = generate_reply::<T, I>(account_id.clone(), participant_id, post_id.clone());
         let origin = RawOrigin::Signed(account_id);
-    }: _(origin.clone(), participant_id, post_id, reply_id)
+    }: _(origin.clone(), participant_id, post_id, reply_id, true)
     verify {
         assert!(!<ReplyById<T, I>>::contains_key(post_id, reply_id));
 
@@ -308,6 +308,7 @@ benchmarks_instance! {
                 participant_id,
                 post_id,
                 reply_id,
+                true,
             ).into());
     }
 }

--- a/runtime-modules/blog/src/errors.rs
+++ b/runtime-modules/blog/src/errors.rs
@@ -29,6 +29,10 @@ decl_error! {
         InvalidReactionIndex,
 
         /// Insuficient balance for reply creation
-        InsufficientBalanceForReply
+        InsufficientBalanceForReply,
+
+        /// This error represent the invalid state where there is not enough funds in a post
+        /// account to pay off its delete
+        InsufficientBalanceInPostAccount,
     }
 }

--- a/runtime-modules/blog/src/errors.rs
+++ b/runtime-modules/blog/src/errors.rs
@@ -25,10 +25,10 @@ decl_error! {
         /// Number of posts exceeds limits.
         PostLimitReached,
 
-        /// Number of maximum replies reached
-        RepliesLimitReached,
-
         /// Reaction doesn't exists
         InvalidReactionIndex,
+
+        /// Insuficient balance for reply creation
+        InsufficientBalanceForReply
     }
 }

--- a/runtime-modules/blog/src/lib.rs
+++ b/runtime-modules/blog/src/lib.rs
@@ -653,7 +653,8 @@ decl_module! {
         /// <weight>
         ///
         /// ## Weight
-        /// `O (1)` doesn't depend on the state or parameters
+        /// `O (R)` where
+        /// - R is the number of replies to be deleted
         /// - DB:
         ///    - O(1) doesn't depend on the state or parameters
         /// # </weight>

--- a/runtime-modules/blog/src/lib.rs
+++ b/runtime-modules/blog/src/lib.rs
@@ -38,13 +38,17 @@ use codec::{Codec, Decode, Encode};
 use common::membership::MemberOriginValidator;
 use errors::Error;
 pub use frame_support::dispatch::{DispatchError, DispatchResult};
+use frame_support::traits::{Currency, ExistenceRequirement};
 use frame_support::weights::Weight;
 use frame_support::{
     decl_event, decl_module, decl_storage, ensure, traits::Get, Parameter, StorageDoubleMap,
 };
 use sp_arithmetic::traits::{BaseArithmetic, One};
-use sp_runtime::traits::{Hash, MaybeSerialize, Member};
 use sp_runtime::SaturatedConversion;
+use sp_runtime::{
+    traits::{AccountIdConversion, Hash, MaybeSerialize, Member},
+    ModuleId,
+};
 use sp_std::prelude::*;
 
 mod benchmarking;
@@ -61,6 +65,11 @@ pub type PostId = u64;
 /// Blogger participant ID alias for the member of the system.
 pub type ParticipantId<T> = common::MemberId<T>;
 
+/// Balance alias for `balances` module.
+pub type BalanceOf<T> = <T as balances::Trait>::Balance;
+
+type Balances<T> = balances::Module<T>;
+
 /// blog WeightInfo.
 /// Note: This was auto generated through the benchmark CLI using the `--weight-trait` flag
 pub trait WeightInfo {
@@ -73,9 +82,11 @@ pub trait WeightInfo {
     fn edit_reply(t: u32) -> Weight;
 }
 
+type BlogWeightInfo<T, I> = <T as Trait<I>>::WeightInfo;
+
 // The pallet's configuration trait.
 pub trait Trait<I: Instance = DefaultInstance>:
-    frame_system::Trait + common::membership::Trait
+    frame_system::Trait + common::membership::Trait + balances::Trait
 {
     /// Origin from which participant must come.
     type ParticipantEnsureOrigin: MemberOriginValidator<
@@ -89,9 +100,6 @@ pub trait Trait<I: Instance = DefaultInstance>:
 
     /// The maximum number of posts in a blog.
     type PostsMaxNumber: Get<MaxNumber>;
-
-    /// The maximum number of replies to a post.
-    type RepliesMaxNumber: Get<MaxNumber>;
 
     /// Type of identifier for replies.
     type ReplyId: Parameter
@@ -107,6 +115,12 @@ pub trait Trait<I: Instance = DefaultInstance>:
 
     /// Weight information for extrinsics in this pallet.
     type WeightInfo: WeightInfo;
+
+    /// Deposit needed to create a reply
+    type ReplyDeposit: Get<Self::Balance>;
+
+    /// The forum module Id, used to derive the account Id to hold the thread bounty
+    type ModuleId: Get<ModuleId>;
 }
 
 /// Type, representing blog related post structure
@@ -233,6 +247,8 @@ pub struct Reply<T: Trait<I>, I: Instance> {
     owner: ParticipantId<T>,
     /// Reply`s parent id
     parent_id: ParentId<T::ReplyId, PostId>,
+    /// Pay off by deleting post
+    cleanup_pay_off: T::Balance,
 }
 
 // Note: we derive it by hand because the derive isn't working because of a Rust problem
@@ -270,6 +286,7 @@ impl<T: Trait<I>, I: Instance> Default for Reply<T, I> {
             text_hash: Default::default(),
             owner: Default::default(),
             parent_id: Default::default(),
+            cleanup_pay_off: Default::default(),
         }
     }
 }
@@ -280,11 +297,13 @@ impl<T: Trait<I>, I: Instance> Reply<T, I> {
         text: Vec<u8>,
         owner: ParticipantId<T>,
         parent_id: ParentId<T::ReplyId, PostId>,
+        cleanup_pay_off: T::Balance,
     ) -> Self {
         Self {
             text_hash: T::Hashing::hash(&text),
             owner,
             parent_id,
+            cleanup_pay_off,
         }
     }
 
@@ -338,7 +357,7 @@ decl_module! {
         /// - DB:
         ///    - O(1) doesn't depend on the state or parameters
         /// # </weight>
-        #[weight = T::WeightInfo::create_post(
+        #[weight = BlogWeightInfo::<T, I>::create_post(
                 title.len().saturated_into(),
                 body.len().saturated_into()
             )]
@@ -377,7 +396,7 @@ decl_module! {
         /// - DB:
         ///    - O(1) doesn't depend on the state or parameters
         /// # </weight>
-        #[weight = T::WeightInfo::lock_post()]
+        #[weight = BlogWeightInfo::<T, I>::lock_post()]
         pub fn lock_post(origin, post_id: PostId) -> DispatchResult {
 
             // Ensure blog -> owner relation exists
@@ -408,7 +427,7 @@ decl_module! {
         /// - DB:
         ///    - O(1) doesn't depend on the state or parameters
         /// # </weight>
-        #[weight = T::WeightInfo::unlock_post()]
+        #[weight = BlogWeightInfo::<T, I>::unlock_post()]
         pub fn unlock_post(origin, post_id: PostId) -> DispatchResult {
 
             // Ensure blog -> owner relation exists
@@ -486,9 +505,10 @@ decl_module! {
             participant_id: ParticipantId<T>,
             post_id: PostId,
             reply_id: Option<T::ReplyId>,
-            text: Vec<u8>
+            text: Vec<u8>,
+            editable: bool,
         ) -> DispatchResult {
-            Self::ensure_valid_participant(origin, participant_id)?;
+            let account_id = Self::ensure_valid_participant(origin, participant_id)?;
 
             // Ensure post with given id exists
             let post = Self::ensure_post_exists(post_id)?;
@@ -496,35 +516,62 @@ decl_module! {
             // Ensure post unlocked, so mutations can be performed
             Self::ensure_post_unlocked(&post)?;
 
-            // Ensure root replies limit not reached
-            Self::ensure_replies_limit_not_reached(&post)?;
-
-            // New reply creation
-            let reply = if let Some(reply_id) = reply_id {
+            if let Some(reply_id) = reply_id {
                 // Check parent reply existance in case of direct reply
                 Self::ensure_reply_exists(post_id, reply_id)?;
-                Reply::<T, I>::new(text.clone(), participant_id, ParentId::Reply(reply_id))
-            } else {
-                Reply::<T, I>::new(text.clone(), participant_id, ParentId::Post(post_id))
-            };
+            }
+
+            if editable {
+
+                ensure!(
+                    Balances::<T>::usable_balance(&account_id) >= T::ReplyDeposit::get(),
+                    Error::<T, I>::InsufficientBalanceForReply
+                );
+            }
 
             //
             // == MUTATION SAFE ==
             //
 
+            if editable {
+                Self::transfer_to_state_cleanup_treasury_account(
+                    T::ReplyDeposit::get(),
+                    post_id,
+                    &account_id
+                )?;
+            }
+
             // Update runtime storage with new reply
             let post_replies_count = post.replies_count();
-            <ReplyById<T, I>>::insert(post_id, post_replies_count, reply);
 
             // Increment replies counter, associated with given post
             <PostById<T, I>>::mutate(post_id, |inner_post| inner_post.increment_replies_counter());
 
+            if editable {
+                let parent_id = if let Some(reply_id) = reply_id {
+                    Self::ensure_reply_exists(post_id, reply_id)?;
+                    ParentId::Reply(reply_id)
+                } else {
+                    ParentId::Post(post_id)
+                };
+
+
+                let reply = Reply::<T, I>::new(
+                    text.clone(),
+                    participant_id,
+                    parent_id,
+                    T::ReplyDeposit::get()
+                );
+
+                <ReplyById<T, I>>::insert(post_id, post_replies_count, reply);
+            }
+
             if let Some(reply_id) = reply_id {
                 // Trigger event
-                Self::deposit_event(RawEvent::DirectReplyCreated(participant_id, post_id, reply_id, post_replies_count, text));
+                Self::deposit_event(RawEvent::DirectReplyCreated(participant_id, post_id, reply_id, post_replies_count, text, editable));
             } else {
                 // Trigger event
-                Self::deposit_event(RawEvent::ReplyCreated(participant_id, post_id, post_replies_count, text));
+                Self::deposit_event(RawEvent::ReplyCreated(participant_id, post_id, post_replies_count, text, editable));
             }
             Ok(())
         }
@@ -540,7 +587,7 @@ decl_module! {
         /// - DB:
         ///    - O(1) doesn't depend on the state or parameters
         /// # </weight>
-        #[weight = T::WeightInfo::edit_reply(new_text.len().saturated_into())]
+        #[weight = BlogWeightInfo::<T, I>::edit_reply(new_text.len().saturated_into())]
         pub fn edit_reply(
             origin,
             participant_id: ParticipantId<T>,
@@ -578,36 +625,93 @@ decl_module! {
             Ok(())
         }
 
+        #[weight = 1_000_000] // TODO: Adjust weight
+        pub fn delete_reply(
+            origin,
+            participant_id: ParticipantId<T>,
+            post_id: PostId,
+            reply_id: T::ReplyId,
+        ) -> DispatchResult {
+            let account_id = Self::ensure_valid_participant(origin, participant_id)?;
+
+            if let Ok(post) = Self::ensure_post_exists(post_id) {
+                // Ensure post unlocked, so mutations can be performed
+                Self::ensure_post_unlocked(&post)?;
+            }
+
+            // Ensure reply with given id exists
+            let reply = Self::ensure_reply_exists(post_id, reply_id)?;
+
+            // Ensure reply -> owner relation exists
+            Self::ensure_reply_ownership(&reply, &participant_id)?;
+
+            //
+            // == MUTATION SAFE ==
+            //
+
+            Self::pay_off(post_id, reply.cleanup_pay_off, &account_id)?;
+
+            // Update reply with new text
+            <ReplyById<T, I>>::remove(post_id, reply_id);
+
+            // Trigger event
+            Self::deposit_event(RawEvent::ReplyDeleted(participant_id, post_id, reply_id));
+            Ok(())
+        }
+
     }
 }
 
 impl<T: Trait<I>, I: Instance> Module<T, I> {
+    fn pay_off(post_id: PostId, amount: BalanceOf<T>, account_id: &T::AccountId) -> DispatchResult {
+        let state_cleanup_treasury_account = T::ModuleId::get().into_sub_account(post_id);
+        <Balances<T> as Currency<T::AccountId>>::transfer(
+            &state_cleanup_treasury_account,
+            account_id,
+            amount,
+            ExistenceRequirement::AllowDeath,
+        )
+    }
+
+    fn transfer_to_state_cleanup_treasury_account(
+        amount: BalanceOf<T>,
+        post_id: PostId,
+        account_id: &T::AccountId,
+    ) -> DispatchResult {
+        let state_cleanup_treasury_account = T::ModuleId::get().into_sub_account(post_id);
+        <Balances<T> as Currency<T::AccountId>>::transfer(
+            account_id,
+            &state_cleanup_treasury_account,
+            amount,
+            ExistenceRequirement::AllowDeath,
+        )
+    }
     // edit_post_weight
     fn edit_post_weight(title: &Option<Vec<u8>>, body: &Option<Vec<u8>>) -> Weight {
         let title_len: u32 = title.as_ref().map_or(0, |t| t.len().saturated_into());
         let body_len: u32 = body.as_ref().map_or(0, |b| b.len().saturated_into());
 
-        T::WeightInfo::edit_post(title_len, body_len)
+        BlogWeightInfo::<T, I>::edit_post(title_len, body_len)
     }
 
     // calculate create_reply weight
     fn create_reply_weight(text_len: usize) -> Weight {
         let text_len: u32 = text_len.saturated_into();
-        T::WeightInfo::create_reply_to_post(text_len)
-            .max(T::WeightInfo::create_reply_to_reply(text_len))
+        BlogWeightInfo::<T, I>::create_reply_to_post(text_len)
+            .max(BlogWeightInfo::<T, I>::create_reply_to_reply(text_len))
     }
 
     // Get participant id from origin
     fn ensure_valid_participant(
         origin: T::Origin,
         participant_id: ParticipantId<T>,
-    ) -> Result<(), DispatchError> {
+    ) -> Result<T::AccountId, DispatchError> {
         let account_id = frame_system::ensure_signed(origin)?;
         ensure!(
             T::ParticipantEnsureOrigin::is_member_controller_account(&participant_id, &account_id),
             Error::<T, I>::MembershipError
         );
-        Ok(())
+        Ok(account_id)
     }
 
     fn ensure_post_exists(post_id: PostId) -> Result<Post<T, I>, DispatchError> {
@@ -665,18 +769,6 @@ impl<T: Trait<I>, I: Instance> Module<T, I> {
 
         Ok(posts_count)
     }
-
-    fn ensure_replies_limit_not_reached(post: &Post<T, I>) -> Result<(), DispatchError> {
-        // Get replies count, associated with given post
-        let root_replies_count = post.replies_count();
-
-        ensure!(
-            root_replies_count < T::RepliesMaxNumber::get().into(),
-            Error::<T, I>::RepliesLimitReached
-        );
-
-        Ok(())
-    }
 }
 
 decl_event!(
@@ -703,10 +795,13 @@ decl_event!(
         PostEdited(PostId, UpdatedTitle, UpdatedBody),
 
         /// A reply to a post was created
-        ReplyCreated(ParticipantId, PostId, ReplyId, Text),
+        ReplyCreated(ParticipantId, PostId, ReplyId, Text, bool),
 
         /// A reply to a reply was created
-        DirectReplyCreated(ParticipantId, PostId, ReplyId, ReplyId, Text),
+        DirectReplyCreated(ParticipantId, PostId, ReplyId, ReplyId, Text, bool),
+
+        /// A reply was deleted from storage
+        ReplyDeleted(ParticipantId, PostId, ReplyId),
 
         /// A reply was edited
         ReplyEdited(ParticipantId, PostId, ReplyId, Text),

--- a/runtime-modules/blog/src/lib.rs
+++ b/runtime-modules/blog/src/lib.rs
@@ -652,6 +652,7 @@ decl_module! {
             participant_id: ParticipantId<T>,
             post_id: PostId,
             reply_id: T::ReplyId,
+            hide: bool,
         ) -> DispatchResult {
             let account_id = Self::ensure_valid_participant(origin, participant_id)?;
             // Ensure post with given id exists
@@ -680,7 +681,7 @@ decl_module! {
             <ReplyById<T, I>>::remove(post_id, reply_id);
 
             // Trigger event
-            Self::deposit_event(RawEvent::ReplyDeleted(participant_id, post_id, reply_id));
+            Self::deposit_event(RawEvent::ReplyDeleted(participant_id, post_id, reply_id, hide));
             Ok(())
         }
 
@@ -826,7 +827,7 @@ decl_event!(
         DirectReplyCreated(ParticipantId, PostId, ReplyId, ReplyId, Text, bool),
 
         /// A reply was deleted from storage
-        ReplyDeleted(ParticipantId, PostId, ReplyId),
+        ReplyDeleted(ParticipantId, PostId, ReplyId, bool),
 
         /// A reply was edited
         ReplyEdited(ParticipantId, PostId, ReplyId, Text),

--- a/runtime-modules/blog/src/mock.rs
+++ b/runtime-modules/blog/src/mock.rs
@@ -12,9 +12,9 @@ use sp_runtime::{
     DispatchResult, Perbill,
 };
 
-pub(crate) const FIRST_OWNER_ORIGIN: u64 = 0;
+pub(crate) const FIRST_OWNER_ORIGIN: u128 = 0;
 pub(crate) const FIRST_OWNER_PARTICIPANT_ID: u64 = 0;
-pub(crate) const SECOND_OWNER_ORIGIN: u64 = 2;
+pub(crate) const SECOND_OWNER_ORIGIN: u128 = 2;
 pub(crate) const SECOND_OWNER_PARTICIPANT_ID: u64 = 2;
 pub(crate) const BAD_MEMBER_ID: u64 = 100000;
 
@@ -55,7 +55,7 @@ impl frame_system::Trait for Runtime {
     type BlockNumber = u64;
     type Hash = H256;
     type Hashing = BlakeTwo256;
-    type AccountId = u64;
+    type AccountId = u128;
     type Lookup = IdentityLookup<Self::AccountId>;
     type Header = Header;
     type Event = TestEvent;
@@ -262,7 +262,7 @@ impl WeightInfo for () {
     fn edit_reply(_: u32) -> Weight {
         unimplemented!()
     }
-    fn delete_reply() -> Weight {
+    fn delete_replies(_: u32) -> Weight {
         unimplemented!()
     }
 }
@@ -406,7 +406,7 @@ pub fn get_reply_text() -> Vec<u8> {
 }
 
 pub fn get_reply(
-    owner: <Runtime as frame_system::Trait>::AccountId,
+    owner: ParticipantId<Runtime>,
     parent_id: ParentId<<Runtime as Trait>::ReplyId, PostId>,
 ) -> Reply<Runtime, DefaultInstance> {
     let reply_text = get_reply_text();
@@ -419,7 +419,7 @@ pub fn get_reply(
 }
 
 pub fn create_reply(
-    origin_id: u64,
+    origin_id: u128,
     participant_id: u64,
     post_id: PostId,
     reply_id: Option<<Runtime as Trait>::ReplyId>,
@@ -437,7 +437,7 @@ pub fn create_reply(
 }
 
 pub fn delete_reply(
-    origin_id: u64,
+    origin_id: u128,
     participant_id: u64,
     post_id: PostId,
     reply_id: <Runtime as Trait>::ReplyId,
@@ -445,12 +445,16 @@ pub fn delete_reply(
     TestBlogModule::delete_replies(
         Origin::signed(origin_id),
         participant_id,
-        vec![(post_id, reply_id, false)],
+        vec![ReplyToDelete {
+            post_id,
+            reply_id,
+            hide: false,
+        }],
     )
 }
 
 pub fn edit_reply(
-    origin_id: u64,
+    origin_id: u128,
     participant_id: u64,
     post_id: PostId,
     reply_id: <Runtime as Trait>::ReplyId,

--- a/runtime-modules/blog/src/mock.rs
+++ b/runtime-modules/blog/src/mock.rs
@@ -442,12 +442,10 @@ pub fn delete_reply(
     post_id: PostId,
     reply_id: <Runtime as Trait>::ReplyId,
 ) -> DispatchResult {
-    TestBlogModule::delete_reply(
+    TestBlogModule::delete_replies(
         Origin::signed(origin_id),
         participant_id,
-        post_id,
-        reply_id,
-        true,
+        vec![(post_id, reply_id, false)],
     )
 }
 

--- a/runtime-modules/blog/src/mock.rs
+++ b/runtime-modules/blog/src/mock.rs
@@ -222,17 +222,20 @@ impl membership::WeightInfo for Weights {
 parameter_types! {
     pub const PostsMaxNumber: u64 = 20;
     pub const RepliesMaxNumber: u64 = 100;
+    pub const ReplyDeposit: u64 = 500;
+    pub const BlogModuleId: ModuleId = ModuleId(*b"m00:blog"); // module : blog
 }
 
 impl Trait for Runtime {
     type Event = TestEvent;
 
     type PostsMaxNumber = PostsMaxNumber;
-    type RepliesMaxNumber = RepliesMaxNumber;
     type ParticipantEnsureOrigin = MockEnsureParticipant;
     type WeightInfo = ();
 
     type ReplyId = u64;
+    type ReplyDeposit = ReplyDeposit;
+    type ModuleId = BlogModuleId;
 }
 
 impl WeightInfo for () {
@@ -402,7 +405,12 @@ pub fn get_reply(
     parent_id: ParentId<<Runtime as Trait>::ReplyId, PostId>,
 ) -> Reply<Runtime, DefaultInstance> {
     let reply_text = get_reply_text();
-    Reply::new(reply_text, owner, parent_id)
+    Reply::new(
+        reply_text,
+        owner,
+        parent_id,
+        <Runtime as Trait>::ReplyDeposit::get(),
+    )
 }
 
 pub fn create_reply(
@@ -418,6 +426,7 @@ pub fn create_reply(
         post_id,
         reply_id,
         reply,
+        true,
     )
 }
 

--- a/runtime-modules/blog/src/mock.rs
+++ b/runtime-modules/blog/src/mock.rs
@@ -442,7 +442,13 @@ pub fn delete_reply(
     post_id: PostId,
     reply_id: <Runtime as Trait>::ReplyId,
 ) -> DispatchResult {
-    TestBlogModule::delete_reply(Origin::signed(origin_id), participant_id, post_id, reply_id)
+    TestBlogModule::delete_reply(
+        Origin::signed(origin_id),
+        participant_id,
+        post_id,
+        reply_id,
+        true,
+    )
 }
 
 pub fn edit_reply(

--- a/runtime-modules/blog/src/tests.rs
+++ b/runtime-modules/blog/src/tests.rs
@@ -1090,7 +1090,7 @@ fn reply_delete_success() {
             FIRST_OWNER_PARTICIPANT_ID,
             FIRST_ID,
             FIRST_ID,
-            true,
+            false,
         ));
 
         assert_event_success(reply_created_event, number_of_events_before_call + 2)
@@ -1238,7 +1238,7 @@ fn reply_delete_success_with_other_participant() {
             SECOND_OWNER_PARTICIPANT_ID,
             FIRST_ID,
             FIRST_ID,
-            true,
+            false,
         ));
 
         assert_event_success(reply_created_event, number_of_events_before_call + 4)

--- a/runtime-modules/blog/src/tests.rs
+++ b/runtime-modules/blog/src/tests.rs
@@ -415,6 +415,11 @@ fn editable_reply_creation_success() {
             <Runtime as Trait>::ReplyDeposit::get(),
         );
 
+        assert_eq!(
+            Balances::<Runtime>::usable_balance(&SECOND_OWNER_ORIGIN),
+            <Runtime as Trait>::ReplyDeposit::get()
+        );
+
         let reply_owner_id = ensure_signed(Origin::signed(SECOND_OWNER_ORIGIN)).unwrap();
 
         // Events number before tested call
@@ -427,6 +432,8 @@ fn editable_reply_creation_success() {
             None,
             true
         ));
+
+        assert_eq!(Balances::<Runtime>::usable_balance(&SECOND_OWNER_ORIGIN), 0);
 
         // Check reply related state after extrinsic performed
 
@@ -1027,6 +1034,11 @@ fn reply_delete_success() {
             <Runtime as Trait>::ReplyDeposit::get(),
         );
 
+        assert_eq!(
+            Balances::<Runtime>::usable_balance(&FIRST_OWNER_ORIGIN),
+            <Runtime as Trait>::ReplyDeposit::get()
+        );
+
         assert_ok!(create_reply(
             FIRST_OWNER_ORIGIN,
             FIRST_OWNER_PARTICIPANT_ID,
@@ -1034,6 +1046,8 @@ fn reply_delete_success() {
             None,
             true,
         ));
+
+        assert_eq!(Balances::<Runtime>::usable_balance(&FIRST_OWNER_ORIGIN), 0);
 
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
@@ -1058,6 +1072,11 @@ fn reply_delete_success() {
             FIRST_ID,
             FIRST_ID,
         ));
+
+        assert_eq!(
+            Balances::<Runtime>::usable_balance(&FIRST_OWNER_ORIGIN),
+            <Runtime as Trait>::ReplyDeposit::get()
+        );
 
         // Overall post replies count
         assert_eq!(post.replies_count(), 1);
@@ -1156,6 +1175,11 @@ fn reply_delete_success_with_other_participant() {
             <Runtime as Trait>::ReplyDeposit::get(),
         );
 
+        assert_eq!(
+            Balances::<Runtime>::usable_balance(&FIRST_OWNER_ORIGIN),
+            <Runtime as Trait>::ReplyDeposit::get()
+        );
+
         assert_ok!(create_reply(
             FIRST_OWNER_ORIGIN,
             FIRST_OWNER_PARTICIPANT_ID,
@@ -1163,6 +1187,8 @@ fn reply_delete_success_with_other_participant() {
             None,
             true,
         ));
+
+        assert_eq!(Balances::<Runtime>::usable_balance(&FIRST_OWNER_ORIGIN), 0);
 
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
@@ -1186,12 +1212,19 @@ fn reply_delete_success_with_other_participant() {
                 + <Runtime as Trait>::ReplyLifetime::get(),
         );
 
+        assert_eq!(Balances::<Runtime>::usable_balance(&SECOND_OWNER_ORIGIN), 0);
+
         assert_ok!(delete_reply(
             SECOND_OWNER_ORIGIN,
             SECOND_OWNER_PARTICIPANT_ID,
             FIRST_ID,
             FIRST_ID,
         ));
+
+        assert_eq!(
+            Balances::<Runtime>::usable_balance(&SECOND_OWNER_ORIGIN),
+            <Runtime as Trait>::ReplyDeposit::get()
+        );
 
         // Overall post replies count
         assert_eq!(post.replies_count(), 1);

--- a/runtime-modules/blog/src/tests.rs
+++ b/runtime-modules/blog/src/tests.rs
@@ -1071,6 +1071,7 @@ fn reply_delete_success() {
             FIRST_OWNER_PARTICIPANT_ID,
             FIRST_ID,
             FIRST_ID,
+            true,
         ));
 
         assert_event_success(reply_created_event, number_of_events_before_call + 2)
@@ -1204,6 +1205,7 @@ fn reply_delete_success_with_other_participant() {
             SECOND_OWNER_PARTICIPANT_ID,
             FIRST_ID,
             FIRST_ID,
+            true,
         ));
 
         assert_event_success(reply_created_event, number_of_events_before_call + 4)

--- a/runtime-modules/blog/src/tests.rs
+++ b/runtime-modules/blog/src/tests.rs
@@ -410,6 +410,11 @@ fn reply_creation_success() {
         // Create post for future replies
         create_post(Origin::root()).unwrap();
 
+        Balances::<Runtime>::make_free_balance_be(
+            &SECOND_OWNER_ORIGIN,
+            <Runtime as Trait>::ReplyDeposit::get(),
+        );
+
         let reply_owner_id = ensure_signed(Origin::signed(SECOND_OWNER_ORIGIN)).unwrap();
 
         // Events number before tested call
@@ -443,8 +448,9 @@ fn reply_creation_success() {
             FIRST_ID,
             FIRST_ID,
             get_reply_text(),
+            true,
         ));
-        assert_event_success(reply_created_event, number_of_events_before_call + 1)
+        assert_event_success(reply_created_event, number_of_events_before_call + 4)
     })
 }
 
@@ -453,6 +459,17 @@ fn direct_reply_creation_success() {
     ExtBuilder::default().build().execute_with(|| {
         // Create post for future replies
         create_post(Origin::root()).unwrap();
+
+        Balances::<Runtime>::make_free_balance_be(
+            &FIRST_OWNER_ORIGIN,
+            <Runtime as Trait>::ReplyDeposit::get(),
+        );
+
+        Balances::<Runtime>::make_free_balance_be(
+            &SECOND_OWNER_ORIGIN,
+            <Runtime as Trait>::ReplyDeposit::get(),
+        );
+
         let direct_reply_owner_id = ensure_signed(Origin::signed(SECOND_OWNER_ORIGIN)).unwrap();
 
         assert_ok!(create_reply(
@@ -490,8 +507,10 @@ fn direct_reply_creation_success() {
             FIRST_ID,
             SECOND_ID,
             get_reply_text(),
+            true,
         ));
-        assert_event_success(reply_created_event, number_of_events_before_call + 1)
+
+        assert_event_success(reply_created_event, number_of_events_before_call + 2)
     })
 }
 
@@ -551,41 +570,15 @@ fn reply_creation_post_not_found() {
 }
 
 #[test]
-fn reply_creation_limit_reached() {
-    ExtBuilder::default().build().execute_with(|| {
-        // Create post for future replies
-        create_post(Origin::root()).unwrap();
-        loop {
-            // Events number before tested call
-            let number_of_events_before_call = System::events().len();
-            if let Err(create_reply_err) = create_reply(
-                FIRST_OWNER_ORIGIN,
-                FIRST_OWNER_PARTICIPANT_ID,
-                FIRST_ID,
-                None,
-            ) {
-                let post = post_by_id(FIRST_ID).unwrap();
-
-                // Root post replies counter & reply root max number contraint equality checked
-                assert_eq!(post.replies_count(), RepliesMaxNumber::get());
-
-                // Last reply creation, before limit reached, failure checked
-                assert_failure(
-                    Err(create_reply_err),
-                    Error::RepliesLimitReached,
-                    number_of_events_before_call,
-                );
-                break;
-            }
-        }
-    })
-}
-
-#[test]
 fn direct_reply_creation_reply_not_found() {
     ExtBuilder::default().build().execute_with(|| {
         // Create post for future replies
         create_post(Origin::root()).unwrap();
+
+        Balances::<Runtime>::make_free_balance_be(
+            &SECOND_OWNER_ORIGIN,
+            <Runtime as Trait>::ReplyDeposit::get(),
+        );
 
         // Events number before tested call
         let number_of_events_before_call = System::events().len();
@@ -617,6 +610,11 @@ fn reply_editing_success() {
         create_post(Origin::root()).unwrap();
 
         let reply_owner_id = ensure_signed(Origin::signed(SECOND_OWNER_ORIGIN)).unwrap();
+
+        Balances::<Runtime>::make_free_balance_be(
+            &SECOND_OWNER_ORIGIN,
+            <Runtime as Trait>::ReplyDeposit::get(),
+        );
 
         create_reply(
             SECOND_OWNER_ORIGIN,
@@ -660,6 +658,11 @@ fn reply_editing_post_locked_error() {
         create_post(Origin::root()).unwrap();
 
         let reply_owner_id = ensure_signed(Origin::signed(SECOND_OWNER_ORIGIN)).unwrap();
+
+        Balances::<Runtime>::make_free_balance_be(
+            &SECOND_OWNER_ORIGIN,
+            <Runtime as Trait>::ReplyDeposit::get(),
+        );
 
         create_reply(
             SECOND_OWNER_ORIGIN,
@@ -728,6 +731,11 @@ fn reply_editing_ownership_error() {
         // Create post for future replies
         create_post(Origin::root()).unwrap();
 
+        Balances::<Runtime>::make_free_balance_be(
+            &SECOND_OWNER_ORIGIN,
+            <Runtime as Trait>::ReplyDeposit::get(),
+        );
+
         let reply_owner_id = ensure_signed(Origin::signed(SECOND_OWNER_ORIGIN)).unwrap();
 
         create_reply(
@@ -789,6 +797,11 @@ fn reply_editing_participant_error() {
         create_post(Origin::root()).unwrap();
 
         let reply_owner_id = ensure_signed(Origin::signed(SECOND_OWNER_ORIGIN)).unwrap();
+
+        Balances::<Runtime>::make_free_balance_be(
+            &SECOND_OWNER_ORIGIN,
+            <Runtime as Trait>::ReplyDeposit::get(),
+        );
 
         create_reply(
             SECOND_OWNER_ORIGIN,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -945,6 +945,9 @@ impl bounty::Trait for Runtime {
 parameter_types! {
     pub const PostsMaxNumber: u64 = 20;
     pub const RepliesMaxNumber: u64 = 100;
+    pub const ReplyDeposit: Balance = 2000;
+    pub const BlogModuleId: ModuleId = ModuleId(*b"mod:blog"); // module : forum
+    pub const ReplyLifetime: BlockNumber = 43_200;
 }
 
 pub type BlogInstance = blog::Instance1;
@@ -952,11 +955,13 @@ impl blog::Trait<BlogInstance> for Runtime {
     type Event = Event;
 
     type PostsMaxNumber = PostsMaxNumber;
-    type RepliesMaxNumber = RepliesMaxNumber;
     type ParticipantEnsureOrigin = Members;
     type WeightInfo = weights::blog::WeightInfo;
 
     type ReplyId = u64;
+    type ReplyDeposit = ReplyDeposit;
+    type ModuleId = BlogModuleId;
+    type ReplyLifetime = ReplyLifetime;
 }
 
 /// Forum identifier for category

--- a/runtime/src/weights/blog.rs
+++ b/runtime/src/weights/blog.rs
@@ -8,51 +8,52 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl blog::WeightInfo for WeightInfo {
     fn create_post(t: u32, b: u32) -> Weight {
-        (317_873_000 as Weight)
-            .saturating_add((92_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((129_000 as Weight).saturating_mul(b as Weight))
+        (496_105_000 as Weight)
+            .saturating_add((88_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((150_000 as Weight).saturating_mul(b as Weight))
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn lock_post() -> Weight {
-        (160_756_000 as Weight)
+        (169_763_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn unlock_post() -> Weight {
-        (158_932_000 as Weight)
+        (169_042_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn edit_post(t: u32, b: u32) -> Weight {
-        (384_273_000 as Weight)
-            .saturating_add((95_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((131_000 as Weight).saturating_mul(b as Weight))
+        (561_965_000 as Weight)
+            .saturating_add((94_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((134_000 as Weight).saturating_mul(b as Weight))
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn create_reply_to_post(t: u32) -> Weight {
-        (591_784_000 as Weight)
-            .saturating_add((161_000 as Weight).saturating_mul(t as Weight))
+        (581_402_000 as Weight)
+            .saturating_add((189_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn create_reply_to_reply(t: u32) -> Weight {
-        (508_330_000 as Weight)
-            .saturating_add((160_000 as Weight).saturating_mul(t as Weight))
+        (532_869_000 as Weight)
+            .saturating_add((187_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn edit_reply(t: u32) -> Weight {
-        (281_077_000 as Weight)
-            .saturating_add((160_000 as Weight).saturating_mul(t as Weight))
+        (327_078_000 as Weight)
+            .saturating_add((192_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn delete_replies(i: u32) -> Weight {
-        (492_001_000 as Weight)
-            .saturating_add((352_154_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+        (93_653_000 as Weight)
+            .saturating_add((446_908_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(1 as Weight))
+            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes((2 as Weight).saturating_mul(i as Weight)))
     }
 }

--- a/runtime/src/weights/blog.rs
+++ b/runtime/src/weights/blog.rs
@@ -8,49 +8,50 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl blog::WeightInfo for WeightInfo {
     fn create_post(t: u32, b: u32) -> Weight {
-        (291_037_000 as Weight)
-            .saturating_add((101_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((139_000 as Weight).saturating_mul(b as Weight))
+        (317_873_000 as Weight)
+            .saturating_add((92_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((129_000 as Weight).saturating_mul(b as Weight))
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn lock_post() -> Weight {
-        (166_327_000 as Weight)
+        (160_756_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn unlock_post() -> Weight {
-        (164_654_000 as Weight)
+        (158_932_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn edit_post(t: u32, b: u32) -> Weight {
-        (464_651_000 as Weight)
-            .saturating_add((99_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((134_000 as Weight).saturating_mul(b as Weight))
+        (384_273_000 as Weight)
+            .saturating_add((95_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((131_000 as Weight).saturating_mul(b as Weight))
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn create_reply_to_post(t: u32) -> Weight {
-        (594_751_000 as Weight)
-            .saturating_add((174_000 as Weight).saturating_mul(t as Weight))
+        (591_784_000 as Weight)
+            .saturating_add((161_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn create_reply_to_reply(t: u32) -> Weight {
-        (561_603_000 as Weight)
-            .saturating_add((169_000 as Weight).saturating_mul(t as Weight))
+        (508_330_000 as Weight)
+            .saturating_add((160_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn edit_reply(t: u32) -> Weight {
-        (302_109_000 as Weight)
-            .saturating_add((170_000 as Weight).saturating_mul(t as Weight))
+        (281_077_000 as Weight)
+            .saturating_add((160_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
-    fn delete_reply() -> Weight {
-        (501_946_000 as Weight)
+    fn delete_replies(i: u32) -> Weight {
+        (492_001_000 as Weight)
+            .saturating_add((352_154_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }

--- a/runtime/src/weights/blog.rs
+++ b/runtime/src/weights/blog.rs
@@ -8,45 +8,50 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl blog::WeightInfo for WeightInfo {
     fn create_post(t: u32, b: u32) -> Weight {
-        (355_638_000 as Weight)
-            .saturating_add((151_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((189_000 as Weight).saturating_mul(b as Weight))
+        (291_037_000 as Weight)
+            .saturating_add((101_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((139_000 as Weight).saturating_mul(b as Weight))
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn lock_post() -> Weight {
-        (205_726_000 as Weight)
+        (166_327_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn unlock_post() -> Weight {
-        (200_216_000 as Weight)
+        (164_654_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn edit_post(t: u32, b: u32) -> Weight {
-        (497_924_000 as Weight)
-            .saturating_add((142_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add((197_000 as Weight).saturating_mul(b as Weight))
+        (464_651_000 as Weight)
+            .saturating_add((99_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((134_000 as Weight).saturating_mul(b as Weight))
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn create_reply_to_post(t: u32) -> Weight {
-        (354_299_000 as Weight)
-            .saturating_add((245_000 as Weight).saturating_mul(t as Weight))
-            .saturating_add(DbWeight::get().reads(2 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+        (594_751_000 as Weight)
+            .saturating_add((174_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn create_reply_to_reply(t: u32) -> Weight {
-        (407_973_000 as Weight)
-            .saturating_add((245_000 as Weight).saturating_mul(t as Weight))
+        (561_603_000 as Weight)
+            .saturating_add((169_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn edit_reply(t: u32) -> Weight {
-        (317_997_000 as Weight)
-            .saturating_add((252_000 as Weight).saturating_mul(t as Weight))
+        (302_109_000 as Weight)
+            .saturating_add((170_000 as Weight).saturating_mul(t as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn delete_reply() -> Weight {
+        (501_946_000 as Weight)
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(2 as Weight))
     }
 }


### PR DESCRIPTION
# Fix blog pallet for #2196

Fixes the state bloat problem for the blog in a similar manner to what we did for [`proposal_discussions` and `forum`](https://github.com/Joystream/joystream/issues/2196#issuecomment-802111952).

The way it works in the case of the blog is the following:
* Replies to post can be editable/non-editable.
* Editable replies take space in storage and a fee, this is not the case for non-editable replies.
* Editable replies can be deleted only by the author until the `ReplyLifetime` has gone by.
* If a reply has been editable for more than `ReplyLifetime` it can be erased by anyone.
* A reply to a reply only requires that the parent reply has been created at some point not that it's present in storage.

Companion handbook PR: Joystream/handbook#41