### PR TITLE
Fix wrong volta package.json location in colossus

### DIFF
--- a/storage-node/packages/colossus/package.json
+++ b/storage-node/packages/colossus/package.json
@@ -32,7 +32,7 @@
     "node": ">=12.18.0"
   },
   "volta": {
-    "extends": "../package.json"
+    "extends": "../../package.json"
   },
   "scripts": {
     "test": "mocha 'test/**/*.js'",


### PR DESCRIPTION
The parent folder doesn't have any package.json I think it should be the root of the **storage-node** folder instead of the **packages** folder