### PR TITLE
runtime: proposals: Fix insufficient balance bug.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "3.7.2"
+version = "3.7.3"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "7.16.0"
+version = "7.17.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-proposals-engine"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '3.7.2'
+version = '3.7.3'
 default-run = "joystream-node"
 
 [[bin]]

--- a/runtime-modules/proposals/codex/src/lib.rs
+++ b/runtime-modules/proposals/codex/src/lib.rs
@@ -822,6 +822,7 @@ impl<T: Trait> Module<T> {
             &params.title,
             &params.description,
             params.stake_balance,
+            &account_id,
         )?;
 
         <proposals_discussion::Module<T>>::ensure_can_create_thread(

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -72,9 +72,16 @@ where
         );
     }
 
+    fn check_for_insufficient_balance(&self) {
+        assert_eq!(
+            (self.successful_call)(),
+            Err(proposals_engine::Error::<Test>::InsufficientBalance.into())
+        );
+    }
+
     fn check_for_successful_call(&self) {
         let account_id = 1;
-        let _imbalance = <Test as stake::Trait>::Currency::deposit_creating(&account_id, 150000);
+        let _imbalance = <Test as stake::Trait>::Currency::deposit_creating(&account_id, 5_000_000);
 
         assert_eq!((self.successful_call)(), Ok(()));
 
@@ -95,6 +102,7 @@ where
     pub fn check_all(&self) {
         self.check_call_for_insufficient_rights();
         self.check_for_invalid_stakes();
+        self.check_for_insufficient_balance();
         self.check_for_successful_call();
     }
 }
@@ -102,8 +110,6 @@ where
 #[test]
 fn create_text_proposal_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
-        increase_total_balance_issuance(500000);
-
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_text_proposal(
@@ -187,8 +193,6 @@ fn create_text_proposal_codex_call_fails_with_incorrect_text_size() {
 #[test]
 fn create_runtime_upgrade_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
-        increase_total_balance_issuance_using_account_id(1, 10000000);
-
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_runtime_upgrade_proposal(
@@ -272,8 +276,6 @@ fn create_upgrade_runtime_proposal_codex_call_fails_with_incorrect_wasm_size() {
 #[test]
 fn create_set_election_parameters_proposal_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
-        increase_total_balance_issuance_using_account_id(1, 2000000);
-
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_set_election_parameters_proposal(
@@ -566,8 +568,6 @@ fn create_spending_proposal_call_fails_with_incorrect_balance() {
 #[test]
 fn create_set_validator_count_proposal_common_checks_succeed() {
     initial_test_ext().execute_with(|| {
-        increase_total_balance_issuance_using_account_id(1, 1000000);
-
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_set_validator_count_proposal(
@@ -783,8 +783,6 @@ fn run_create_add_working_group_leader_opening_proposal_common_checks_succeed(
             working_group,
         };
 
-        increase_total_balance_issuance_using_account_id(1, 500000);
-
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
                 ProposalCodex::create_add_working_group_leader_opening_proposal(
@@ -850,8 +848,6 @@ fn run_create_begin_review_working_group_leader_applications_proposal_common_che
 ) {
     initial_test_ext().execute_with(|| {
         let opening_id = 1; // random opening id.
-
-        increase_total_balance_issuance_using_account_id(1, 500000);
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {
@@ -928,8 +924,6 @@ fn run_create_fill_working_group_leader_opening_proposal_common_checks_succeed(
             reward_policy: None,
             working_group,
         };
-
-        increase_total_balance_issuance_using_account_id(1, 500000);
 
         let proposal_fixture = ProposalTestFixture {
             insufficient_rights_call: || {

--- a/runtime-modules/proposals/engine/Cargo.toml
+++ b/runtime-modules/proposals/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'pallet-proposals-engine'
-version = '3.0.0'
+version = '3.0.1'
 authors = ['Joystream contributors']
 edition = '2018'
 
@@ -16,12 +16,12 @@ sp-runtime = { package = 'sp-runtime', default-features = false, git = 'https://
 membership = { package = 'pallet-membership', default-features = false, path = '../../membership'}
 stake = { package = 'pallet-stake', default-features = false, path = '../../stake'}
 common = { package = 'pallet-common', default-features = false, path = '../../common'}
+balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
 
 [dev-dependencies]
 mockall = "0.7.1"
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
-balances = { package = 'pallet-balances', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '00768a1f21a579c478fe5d4f51e1fa71f7db9fd4'}
 
 [features]
 default = ['std']
@@ -37,4 +37,5 @@ std = [
     'membership/std',
     'stake/std',
     'common/std',
+    'balances/std',
 ]

--- a/runtime-modules/proposals/engine/src/lib.rs
+++ b/runtime-modules/proposals/engine/src/lib.rs
@@ -87,7 +87,8 @@
 //!                 &parameters,
 //!                 &title,
 //!                 &description,
-//!                 None
+//!                 None,
+//!                 &account_id,
 //!             )?;
 //!             <engine::Module<T>>::create_proposal(
 //!                 account_id,
@@ -134,7 +135,7 @@ use frame_support::traits::{Currency, Get};
 use frame_support::{
     decl_error, decl_event, decl_module, decl_storage, ensure, print, Parameter, StorageDoubleMap,
 };
-use sp_arithmetic::traits::Zero;
+use sp_arithmetic::traits::{SaturatedConversion, Zero};
 use sp_std::vec::Vec;
 use system::{ensure_root, RawOrigin};
 
@@ -144,7 +145,7 @@ type MemberId<T> = <T as membership::Trait>::MemberId;
 
 /// Proposals engine trait.
 pub trait Trait:
-    system::Trait + pallet_timestamp::Trait + stake::Trait + membership::Trait
+    system::Trait + pallet_timestamp::Trait + stake::Trait + membership::Trait + balances::Trait
 {
     /// Engine event type.
     type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
@@ -265,6 +266,9 @@ decl_error! {
 
         /// Require root origin in extrinsics
         RequireRootOrigin,
+
+        /// Insufficient balance for operation.
+        InsufficientBalance,
     }
 }
 
@@ -434,6 +438,7 @@ impl<T: Trait> Module<T> {
             &title,
             &description,
             stake_balance,
+            &account_id,
         )?;
 
         // checks passed
@@ -492,6 +497,7 @@ impl<T: Trait> Module<T> {
         title: &[u8],
         description: &[u8],
         stake_balance: Option<types::BalanceOf<T>>,
+        stake_account_id: &T::AccountId,
     ) -> DispatchResult {
         ensure!(!title.is_empty(), Error::<T>::EmptyTitleProvided);
         ensure!(
@@ -533,6 +539,12 @@ impl<T: Trait> Module<T> {
             } else {
                 return Err(Error::<T>::EmptyStake.into());
             }
+
+            ensure!(
+                types::Balances::<T>::usable_balance(stake_account_id).saturated_into::<u128>()
+                    >= required_stake.saturated_into::<u128>(),
+                Error::<T>::InsufficientBalance
+            );
         }
 
         if stake_balance.is_some() && parameters.required_stake.is_none() {

--- a/runtime-modules/proposals/engine/src/tests/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mod.rs
@@ -1091,7 +1091,7 @@ fn create_dummy_proposal_fail_with_stake_on_empty_account() {
             .with_account_id(account_id)
             .with_stake(required_stake);
 
-        dummy_proposal.create_proposal_and_assert(Err(DispatchError::Other("InsufficientBalance")));
+        dummy_proposal.create_proposal_and_assert(Err(Error::<Test>::InsufficientBalance.into()));
     });
 }
 
@@ -1296,6 +1296,8 @@ fn finalize_proposal_using_stake_mocks_succeeds() {
 
             let account_id = 1;
 
+            increase_total_balance_issuance_using_account_id(account_id, 1000000);
+
             let stake_amount = 200;
             let parameters_fixture =
                 ProposalParametersFixture::default().with_required_stake(stake_amount);
@@ -1379,6 +1381,8 @@ fn finalize_proposal_using_stake_mocks_failed() {
             set_stake_handler_impl(mock.clone());
 
             let account_id = 1;
+
+            increase_total_balance_issuance_using_account_id(account_id, 1000000);
 
             let stake_amount = 200;
             let parameters_fixture =

--- a/runtime-modules/proposals/engine/src/types/mod.rs
+++ b/runtime-modules/proposals/engine/src/types/mod.rs
@@ -29,6 +29,8 @@ pub(crate) use stakes::DefaultStakeHandler;
 #[cfg(test)]
 pub(crate) use stakes::MockStakeHandler;
 
+pub(crate) type Balances<T> = balances::Module<T>;
+
 /// Vote kind for the proposal. Sum of all votes defines proposal status.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug)]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '7.16.0'
+version = '7.17.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -71,7 +71,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 7,
-    spec_version: 16,
+    spec_version: 17,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
#### Bug description
In case of the insufficient balance for proposal stake, we get an error on the proposal creation, but the runtime creates a proposal discussion thread.

This happens because the runtime does not validate account balance before the thread or proposal creation (in the `ensure_create_proposal_parameters_are_valid`). The first check (and error) happen on creating the proposal stake.

#### Solution
Add additional check to the `ensure_create_proposal_parameters_are_valid`: ensure account balance is enough for stake.

#### Comments
 - `Olympia` release branch has a different staking approach and such a check is already implemented.

[Original issue](https://github.com/Joystream/joystream/issues/2377)