### PR TITLE
Fix cli upload of large files

### DIFF
--- a/cli/src/base/UploadCommandBase.ts
+++ b/cli/src/base/UploadCommandBase.ts
@@ -205,6 +205,7 @@ export default abstract class UploadCommandBase extends ContentDirectoryCommandB
           'Content-Type': '', // https://github.com/Joystream/storage-node-joystream/issues/16
           'Content-Length': fileSize.toString(),
         },
+        maxBodyLength: fileSize,
       }
       await axios.put(uploadUrl, fileStream, config)
     } catch (e) {


### PR DESCRIPTION
`maxBodyLength` was missing in request header to allow axios to upload larger content.