### PR TITLE
cli - chalk color change

### DIFF
--- a/cli/src/base/ApiCommandBase.ts
+++ b/cli/src/base/ApiCommandBase.ts
@@ -125,7 +125,7 @@ export default abstract class ApiCommandBase extends StateAwareCommandBase {
     return (
       '{\n' +
       Object.keys(obj)
-        .map((prop) => `  ${prop}${chalk.white(':' + obj[prop])}`)
+        .map((prop) => `  ${prop}${chalk.magentaBright(':' + obj[prop])}`)
         .join('\n') +
       '\n}'
     )
@@ -425,7 +425,7 @@ export default abstract class ApiCommandBase extends StateAwareCommandBase {
     params: CodecArg[],
     warnOnly = false
   ): Promise<boolean> {
-    this.log(chalk.white(`\nSending ${module}.${method} extrinsic...`))
+    this.log(chalk.magentaBright(`\nSending ${module}.${method} extrinsic...`))
     const tx = await this.getOriginalApi().tx[module][method](...params)
     return await this.sendAndFollowTx(account, tx, warnOnly)
   }

--- a/cli/src/base/DefaultCommandBase.ts
+++ b/cli/src/base/DefaultCommandBase.ts
@@ -53,7 +53,7 @@ export default abstract class DefaultCommandBase extends Command {
   }
 
   private jsonPrettyKeyVal(key: string, val: any): string {
-    return this.jsonPrettyIndented(chalk.white(`${key}: ${this.jsonPrettyAny(val)}`))
+    return this.jsonPrettyIndented(chalk.magentaBright(`${key}: ${this.jsonPrettyAny(val)}`))
   }
 
   private jsonPrettyObj(obj: { [key: string]: any }): string {

--- a/cli/src/base/UploadCommandBase.ts
+++ b/cli/src/base/UploadCommandBase.ts
@@ -263,7 +263,9 @@ export default abstract class UploadCommandBase extends ContentDirectoryCommandB
     )
     if (rejectedAssetsOutput.length) {
       this.warn(
-        `Some assets were not uploaded succesfully. Try reuploading them with ${chalk.magentaBright('content:reuploadAssets')}!`
+        `Some assets were not uploaded succesfully. Try reuploading them with ${chalk.magentaBright(
+          'content:reuploadAssets'
+        )}!`
       )
       console.log(rejectedAssetsOutput)
       const outputPath = inputFilePath.replace('.json', `${outputFilePostfix}.json`)

--- a/cli/src/base/UploadCommandBase.ts
+++ b/cli/src/base/UploadCommandBase.ts
@@ -263,13 +263,13 @@ export default abstract class UploadCommandBase extends ContentDirectoryCommandB
     )
     if (rejectedAssetsOutput.length) {
       this.warn(
-        `Some assets were not uploaded succesfully. Try reuploading them with ${chalk.white('content:reuploadAssets')}!`
+        `Some assets were not uploaded succesfully. Try reuploading them with ${chalk.magentaBright('content:reuploadAssets')}!`
       )
       console.log(rejectedAssetsOutput)
       const outputPath = inputFilePath.replace('.json', `${outputFilePostfix}.json`)
       try {
         fs.writeFileSync(outputPath, JSON.stringify(rejectedAssetsOutput, null, 4))
-        this.log(`Rejected content ids succesfully saved to: ${chalk.white(outputPath)}!`)
+        this.log(`Rejected content ids succesfully saved to: ${chalk.magentaBright(outputPath)}!`)
       } catch (e) {
         console.error(e)
         this.warn(

--- a/cli/src/base/WorkingGroupsCommandBase.ts
+++ b/cli/src/base/WorkingGroupsCommandBase.ts
@@ -194,6 +194,6 @@ export default abstract class WorkingGroupsCommandBase extends RolesCommandBase 
     if (flags.group) {
       this.group = flags.group
     }
-    this.log(chalk.white('Current Group: ' + this.group))
+    this.log(chalk.magentaBright('Current Group: ' + this.group))
   }
 }

--- a/cli/src/commands/account/choose.ts
+++ b/cli/src/commands/account/choose.ts
@@ -24,7 +24,7 @@ export default class AccountChoose extends AccountsCommandBase {
     const accounts: NamedKeyringPair[] = this.fetchAccounts(!!address || showSpecial)
     const selectedAccount: NamedKeyringPair | null = this.getSelectedAccount()
 
-    this.log(chalk.white(`Found ${accounts.length} existing accounts...\n`))
+    this.log(chalk.magentaBright(`Found ${accounts.length} existing accounts...\n`))
 
     if (accounts.length === 0) {
       this.warn('No account to choose from. Add accont using account:import or account:create.')
@@ -43,6 +43,6 @@ export default class AccountChoose extends AccountsCommandBase {
     }
 
     await this.setSelectedAccount(choosenAccount)
-    this.log(chalk.greenBright(`\nAccount switched to ${chalk.white(choosenAccount.address)}!`))
+    this.log(chalk.greenBright(`\nAccount switched to ${chalk.magentaBright(choosenAccount.address)}!`))
   }
 }

--- a/cli/src/commands/account/create.ts
+++ b/cli/src/commands/account/create.ts
@@ -41,7 +41,7 @@ export default class AccountCreate extends AccountsCommandBase {
     this.saveAccount(keys, password)
 
     this.log(chalk.greenBright(`\nAccount succesfully created!`))
-    this.log(chalk.white(`${chalk.bold('Name:    ')}${args.name}`))
-    this.log(chalk.white(`${chalk.bold('Address: ')}${keys.address}`))
+    this.log(chalk.magentaBright(`${chalk.bold('Name:    ')}${args.name}`))
+    this.log(chalk.magentaBright(`${chalk.bold('Address: ')}${keys.address}`))
   }
 }

--- a/cli/src/commands/account/export.ts
+++ b/cli/src/commands/account/export.ts
@@ -59,7 +59,7 @@ export default class AccountExport extends AccountsCommandBase {
         this.error(`Failed to create the export folder (${destPath})`, { exit: ExitCodes.FsOperationFailed })
       }
       for (const account of accounts) this.exportAccount(account, destPath)
-      this.log(chalk.greenBright(`All accounts succesfully exported succesfully to: ${chalk.white(destPath)}!`))
+      this.log(chalk.greenBright(`All accounts succesfully exported succesfully to: ${chalk.magentaBright(destPath)}!`))
     } else {
       const destPath: string = args.path
       const choosenAccount: NamedKeyringPair = await this.promptForAccount(
@@ -68,7 +68,7 @@ export default class AccountExport extends AccountsCommandBase {
         'Select an account to export'
       )
       const exportedFilePath: string = this.exportAccount(choosenAccount, destPath)
-      this.log(chalk.greenBright(`Account succesfully exported to: ${chalk.white(exportedFilePath)}`))
+      this.log(chalk.greenBright(`Account succesfully exported to: ${chalk.magentaBright(exportedFilePath)}`))
     }
   }
 }

--- a/cli/src/commands/account/import.ts
+++ b/cli/src/commands/account/import.ts
@@ -38,7 +38,7 @@ export default class AccountImport extends AccountsCommandBase {
     }
 
     this.log(chalk.bold.greenBright(`ACCOUNT IMPORTED SUCCESFULLY!`))
-    this.log(chalk.bold.white(`NAME:    `), accountName)
-    this.log(chalk.bold.white(`ADDRESS: `), accountAddress)
+    this.log(chalk.bold.magentaBright(`NAME:    `), accountName)
+    this.log(chalk.bold.magentaBright(`ADDRESS: `), accountAddress)
   }
 }

--- a/cli/src/commands/account/transferTokens.ts
+++ b/cli/src/commands/account/transferTokens.ts
@@ -40,7 +40,7 @@ export default class AccountTransferTokens extends AccountsCommandBase {
 
     await this.requestAccountDecoding(selectedAccount)
 
-    this.log(chalk.white('Estimating fee...'))
+    this.log(chalk.magentaBright('Estimating fee...'))
     const tx = await this.getApi().createTransferTx(args.recipient, amountBN)
     let estimatedFee: BN
     try {
@@ -49,8 +49,8 @@ export default class AccountTransferTokens extends AccountsCommandBase {
       this.error('Could not estimate the fee.', { exit: ExitCodes.UnexpectedException })
     }
     const totalAmount: BN = amountBN.add(estimatedFee)
-    this.log(chalk.white('Estimated fee:', formatBalance(estimatedFee)))
-    this.log(chalk.white('Total transfer amount:', formatBalance(totalAmount)))
+    this.log(chalk.magentaBright('Estimated fee:', formatBalance(estimatedFee)))
+    this.log(chalk.magentaBright('Total transfer amount:', formatBalance(totalAmount)))
 
     checkBalance(accBalances, totalAmount)
 
@@ -59,7 +59,7 @@ export default class AccountTransferTokens extends AccountsCommandBase {
     try {
       const txHash: Hash = await tx.signAndSend(selectedAccount)
       this.log(chalk.greenBright('Transaction succesfully sent!'))
-      this.log(chalk.white('Hash:', txHash.toString()))
+      this.log(chalk.magentaBright('Hash:', txHash.toString()))
     } catch (e) {
       this.error('Could not send the transaction.', { exit: ExitCodes.UnexpectedException })
     }

--- a/cli/src/commands/api/inspect.ts
+++ b/cli/src/commands/api/inspect.ts
@@ -155,7 +155,7 @@ export default class ApiInspect extends ApiCommandBase {
   async requestParamsValues(paramTypes: string[]): Promise<ApiMethodArg[]> {
     const result: ApiMethodArg[] = []
     for (const [key, paramType] of Object.entries(paramTypes)) {
-      this.log(chalk.bold.white(`Parameter no. ${parseInt(key) + 1} (${paramType}):`))
+      this.log(chalk.bold.magentaBright(`Parameter no. ${parseInt(key) + 1} (${paramType}):`))
       const paramValue = await this.promptForParam(paramType)
       result.push(paramValue)
     }
@@ -192,7 +192,7 @@ export default class ApiInspect extends ApiCommandBase {
     }
     // Describing a method
     else if (apiType && apiModule && apiMethod) {
-      this.log(chalk.bold.white(`${apiType}.${apiModule}.${apiMethod}`))
+      this.log(chalk.bold.magentaBright(`${apiType}.${apiModule}.${apiMethod}`))
       const description: string = this.getMethodDescription(apiType, apiModule, apiMethod)
       this.log(`\n${description}\n`)
       const typesRows: NameValueObj[] = []
@@ -215,17 +215,17 @@ export default class ApiInspect extends ApiCommandBase {
     }
     // Displaying all available modules
     else if (apiType) {
-      this.log(chalk.bold.white('Available modules:'))
+      this.log(chalk.bold.magentaBright('Available modules:'))
       this.log(
         Object.keys(api[apiType])
-          .map((key) => chalk.white(key))
+          .map((key) => chalk.magentaBright(key))
           .join('\n')
       )
     }
     // Displaying all available types
     else {
-      this.log(chalk.bold.white('Available types:'))
-      this.log(availableTypes.map((type) => chalk.white(type)).join('\n'))
+      this.log(chalk.bold.magentaBright('Available types:'))
+      this.log(availableTypes.map((type) => chalk.magentaBright(type)).join('\n'))
     }
   }
 }

--- a/cli/src/commands/api/setUri.ts
+++ b/cli/src/commands/api/setUri.ts
@@ -32,6 +32,6 @@ export default class ApiSetUri extends ApiCommandBase {
     } else {
       newUri = await this.promptForApiUri()
     }
-    this.log(chalk.greenBright('Api uri successfuly changed! New uri: ') + chalk.white(newUri))
+    this.log(chalk.greenBright('Api uri successfuly changed! New uri: ') + chalk.magentaBright(newUri))
   }
 }

--- a/cli/src/commands/content/addCuratorToGroup.ts
+++ b/cli/src/commands/content/addCuratorToGroup.ts
@@ -37,6 +37,10 @@ export default class AddCuratorToGroupCommand extends ContentDirectoryCommandBas
     await this.requestAccountDecoding(account)
     await this.sendAndFollowNamedTx(account, 'content', 'addCuratorToGroup', [groupId, curatorId])
 
-    console.log(chalk.green(`Curator ${chalk.magentaBright(curatorId)} succesfully added to group ${chalk.magentaBright(groupId)}!`))
+    console.log(
+      chalk.green(
+        `Curator ${chalk.magentaBright(curatorId)} succesfully added to group ${chalk.magentaBright(groupId)}!`
+      )
+    )
   }
 }

--- a/cli/src/commands/content/addCuratorToGroup.ts
+++ b/cli/src/commands/content/addCuratorToGroup.ts
@@ -37,6 +37,6 @@ export default class AddCuratorToGroupCommand extends ContentDirectoryCommandBas
     await this.requestAccountDecoding(account)
     await this.sendAndFollowNamedTx(account, 'content', 'addCuratorToGroup', [groupId, curatorId])
 
-    console.log(chalk.green(`Curator ${chalk.white(curatorId)} succesfully added to group ${chalk.white(groupId)}!`))
+    console.log(chalk.green(`Curator ${chalk.magentaBright(curatorId)} succesfully added to group ${chalk.magentaBright(groupId)}!`))
   }
 }

--- a/cli/src/commands/content/createCuratorGroup.ts
+++ b/cli/src/commands/content/createCuratorGroup.ts
@@ -13,6 +13,6 @@ export default class CreateCuratorGroupCommand extends ContentDirectoryCommandBa
     await this.buildAndSendExtrinsic(account, 'content', 'createCuratorGroup')
 
     const newGroupId = (await this.getApi().nextCuratorGroupId()) - 1
-    console.log(chalk.green(`New group succesfully created! (ID: ${chalk.white(newGroupId)})`))
+    console.log(chalk.green(`New group succesfully created! (ID: ${chalk.magentaBright(newGroupId)})`))
   }
 }

--- a/cli/src/commands/content/curatorGroup.ts
+++ b/cli/src/commands/content/curatorGroup.ts
@@ -27,7 +27,7 @@ export default class CuratorGroupCommand extends ContentDirectoryCommandBase {
     displayHeader(`Group Members (${members.length})`)
     this.log(
       members
-        .map((curator) => chalk.white(`${curator.profile.handle} (WorkerID: ${curator.workerId.toString()})`))
+        .map((curator) => chalk.magentaBright(`${curator.profile.handle} (WorkerID: ${curator.workerId.toString()})`))
         .join(', ')
     )
   }

--- a/cli/src/commands/content/removeCuratorFromGroup.ts
+++ b/cli/src/commands/content/removeCuratorFromGroup.ts
@@ -33,7 +33,7 @@ export default class RemoveCuratorFromGroupCommand extends ContentDirectoryComma
       curatorId = await this.promptForCurator('Choose a Curator to remove', groupCuratorIds)
     } else {
       if (!groupCuratorIds.includes(parseInt(curatorId))) {
-        this.error(`Curator ${chalk.white(curatorId)} is not part of group ${chalk.white(groupId)}`)
+        this.error(`Curator ${chalk.magentaBright(curatorId)} is not part of group ${chalk.magentaBright(groupId)}`)
       }
       await this.getCurator(curatorId)
     }
@@ -41,6 +41,6 @@ export default class RemoveCuratorFromGroupCommand extends ContentDirectoryComma
     await this.requestAccountDecoding(account)
     await this.sendAndFollowNamedTx(account, 'content', 'removeCuratorFromGroup', [groupId, curatorId])
 
-    this.log(chalk.green(`Curator ${chalk.white(curatorId)} successfully removed from group ${chalk.white(groupId)}!`))
+    this.log(chalk.green(`Curator ${chalk.magentaBright(curatorId)} successfully removed from group ${chalk.magentaBright(groupId)}!`))
   }
 }

--- a/cli/src/commands/content/removeCuratorFromGroup.ts
+++ b/cli/src/commands/content/removeCuratorFromGroup.ts
@@ -41,6 +41,10 @@ export default class RemoveCuratorFromGroupCommand extends ContentDirectoryComma
     await this.requestAccountDecoding(account)
     await this.sendAndFollowNamedTx(account, 'content', 'removeCuratorFromGroup', [groupId, curatorId])
 
-    this.log(chalk.green(`Curator ${chalk.magentaBright(curatorId)} successfully removed from group ${chalk.magentaBright(groupId)}!`))
+    this.log(
+      chalk.green(
+        `Curator ${chalk.magentaBright(curatorId)} successfully removed from group ${chalk.magentaBright(groupId)}!`
+      )
+    )
   }
 }

--- a/cli/src/commands/content/setCuratorGroupStatus.ts
+++ b/cli/src/commands/content/setCuratorGroupStatus.ts
@@ -52,7 +52,7 @@ export default class SetCuratorGroupStatusCommand extends ContentDirectoryComman
 
     console.log(
       chalk.green(
-        `Curator Group ${chalk.white(id)} status succesfully changed to: ${chalk.white(
+        `Curator Group ${chalk.magentaBright(id)} status succesfully changed to: ${chalk.magentaBright(
           status ? 'Active' : 'Inactive'
         )}!`
       )

--- a/cli/src/commands/content/updateChannelCensorshipStatus.ts
+++ b/cli/src/commands/content/updateChannelCensorshipStatus.ts
@@ -70,7 +70,7 @@ export default class UpdateChannelCensorshipStatusCommand extends ContentDirecto
 
     console.log(
       chalk.green(
-        `Channel ${chalk.white(id)} censorship status succesfully changed to: ${chalk.white(
+        `Channel ${chalk.magentaBright(id)} censorship status succesfully changed to: ${chalk.magentaBright(
           status ? 'Censored' : 'Not censored'
         )}!`
       )

--- a/cli/src/commands/content/updateVideoCensorshipStatus.ts
+++ b/cli/src/commands/content/updateVideoCensorshipStatus.ts
@@ -71,7 +71,7 @@ export default class UpdateVideoCensorshipStatusCommand extends ContentDirectory
 
     console.log(
       chalk.green(
-        `Video ${chalk.white(id)} censorship status succesfully changed to: ${chalk.white(
+        `Video ${chalk.magentaBright(id)} censorship status succesfully changed to: ${chalk.magentaBright(
           status ? 'Censored' : 'Not censored'
         )}!`
       )

--- a/cli/src/commands/working-groups/createOpening.ts
+++ b/cli/src/commands/working-groups/createOpening.ts
@@ -198,7 +198,7 @@ export default class WorkingGroupsCreateOpening extends WorkingGroupsCommandBase
       if (output) {
         try {
           saveOutputJsonToFile(output, rememberedInput)
-          this.log(chalk.green(`Output succesfully saved in: ${chalk.white(output)}!`))
+          this.log(chalk.green(`Output succesfully saved in: ${chalk.magentaBright(output)}!`))
         } catch (e) {
           this.warn(`Could not save output to ${output}!`)
         }
@@ -209,7 +209,7 @@ export default class WorkingGroupsCreateOpening extends WorkingGroupsCommandBase
       }
 
       // Send the tx
-      this.log(chalk.white('Sending the extrinsic...'))
+      this.log(chalk.magentaBright('Sending the extrinsic...'))
       const txSuccess = await this.sendAndFollowTx(
         account,
         this.getOriginalApi().tx[apiModuleByGroup[this.group]].addOpening(...txParams),

--- a/cli/src/commands/working-groups/decreaseWorkerStake.ts
+++ b/cli/src/commands/working-groups/decreaseWorkerStake.ts
@@ -33,7 +33,7 @@ export default class WorkingGroupsDecreaseWorkerStake extends WorkingGroupsComma
     const workerId = parseInt(args.workerId)
     const groupMember = await this.getWorkerWithStakeForLeadAction(workerId)
 
-    this.log(chalk.white('Current worker stake: ', formatBalance(groupMember.stake)))
+    this.log(chalk.magentaBright('Current worker stake: ', formatBalance(groupMember.stake)))
     const balanceValidator = minMaxInt(1, groupMember.stake.toNumber())
     const balance = (await this.promptForParam(
       'Balance',
@@ -46,8 +46,8 @@ export default class WorkingGroupsDecreaseWorkerStake extends WorkingGroupsComma
 
     this.log(
       chalk.green(
-        `${chalk.white(formatBalance(balance))} from worker ${chalk.white(workerId)} stake ` +
-          `has been returned to worker's role account (${chalk.white(groupMember.roleAccount.toString())})!`
+        `${chalk.magentaBright(formatBalance(balance))} from worker ${chalk.magentaBright(workerId)} stake ` +
+          `has been returned to worker's role account (${chalk.magentaBright(groupMember.roleAccount.toString())})!`
       )
     )
   }

--- a/cli/src/commands/working-groups/evictWorker.ts
+++ b/cli/src/commands/working-groups/evictWorker.ts
@@ -47,9 +47,9 @@ export default class WorkingGroupsEvictWorker extends WorkingGroupsCommandBase {
       shouldSlash,
     ])
 
-    this.log(chalk.green(`Worker ${chalk.white(workerId)} has been evicted!`))
+    this.log(chalk.green(`Worker ${chalk.magentaBright(workerId)} has been evicted!`))
     if (shouldSlash) {
-      this.log(chalk.green(`Worker stake totalling ${chalk.white(formatBalance(groupMember.stake))} has been slashed!`))
+      this.log(chalk.green(`Worker stake totalling ${chalk.magentaBright(formatBalance(groupMember.stake))} has been slashed!`))
     }
   }
 }

--- a/cli/src/commands/working-groups/evictWorker.ts
+++ b/cli/src/commands/working-groups/evictWorker.ts
@@ -49,7 +49,9 @@ export default class WorkingGroupsEvictWorker extends WorkingGroupsCommandBase {
 
     this.log(chalk.green(`Worker ${chalk.magentaBright(workerId)} has been evicted!`))
     if (shouldSlash) {
-      this.log(chalk.green(`Worker stake totalling ${chalk.magentaBright(formatBalance(groupMember.stake))} has been slashed!`))
+      this.log(
+        chalk.green(`Worker stake totalling ${chalk.magentaBright(formatBalance(groupMember.stake))} has been slashed!`)
+      )
     }
   }
 }

--- a/cli/src/commands/working-groups/fillOpening.ts
+++ b/cli/src/commands/working-groups/fillOpening.ts
@@ -39,10 +39,10 @@ export default class WorkingGroupsFillOpening extends WorkingGroupsCommandBase {
       rewardPolicyOpt,
     ])
 
-    this.log(chalk.green(`Opening ${chalk.white(openingId)} succesfully filled!`))
+    this.log(chalk.green(`Opening ${chalk.magentaBright(openingId)} succesfully filled!`))
     this.log(
       chalk.green('Accepted working group application IDs: ') +
-        chalk.white(applicationIds.length ? applicationIds.join(chalk.green(', ')) : 'NONE')
+        chalk.magentaBright(applicationIds.length ? applicationIds.join(chalk.green(', ')) : 'NONE')
     )
   }
 }

--- a/cli/src/commands/working-groups/increaseStake.ts
+++ b/cli/src/commands/working-groups/increaseStake.ts
@@ -22,7 +22,7 @@ export default class WorkingGroupsIncreaseStake extends WorkingGroupsCommandBase
       this.error('Cannot increase stake. No associated role stake profile found!', { exit: ExitCodes.InvalidInput })
     }
 
-    this.log(chalk.white('Current stake: ', formatBalance(worker.stake)))
+    this.log(chalk.magentaBright('Current stake: ', formatBalance(worker.stake)))
     const balance = (await this.promptForParam(
       'Balance',
       createParamOptions('amount', undefined, positiveInt())
@@ -34,7 +34,7 @@ export default class WorkingGroupsIncreaseStake extends WorkingGroupsCommandBase
 
     this.log(
       chalk.green(
-        `Worker ${chalk.white(worker.workerId.toNumber())} stake has been increased by ${chalk.white(
+        `Worker ${chalk.magentaBright(worker.workerId.toNumber())} stake has been increased by ${chalk.magentaBright(
           formatBalance(balance)
         )}`
       )

--- a/cli/src/commands/working-groups/leaveRole.ts
+++ b/cli/src/commands/working-groups/leaveRole.ts
@@ -23,6 +23,6 @@ export default class WorkingGroupsLeaveRole extends WorkingGroupsCommandBase {
 
     await this.sendAndFollowNamedTx(account, apiModuleByGroup[this.group], 'leaveRole', [worker.workerId, rationale])
 
-    this.log(chalk.green(`Succesfully left the role! (worker id: ${chalk.white(worker.workerId.toNumber())})`))
+    this.log(chalk.green(`Succesfully left the role! (worker id: ${chalk.magentaBright(worker.workerId.toNumber())})`))
   }
 }

--- a/cli/src/commands/working-groups/setDefaultGroup.ts
+++ b/cli/src/commands/working-groups/setDefaultGroup.ts
@@ -17,6 +17,6 @@ export default class SetDefaultGroupCommand extends WorkingGroupsCommandBase {
 
     await this.setPreservedState({ defaultWorkingGroup: group })
 
-    this.log(chalk.green(`${chalk.white(group)} succesfully set as default working group context`))
+    this.log(chalk.green(`${chalk.magentaBright(group)} succesfully set as default working group context`))
   }
 }

--- a/cli/src/commands/working-groups/slashWorker.ts
+++ b/cli/src/commands/working-groups/slashWorker.ts
@@ -30,7 +30,7 @@ export default class WorkingGroupsSlashWorker extends WorkingGroupsCommandBase {
     const workerId = parseInt(args.workerId)
     const groupMember = await this.getWorkerWithStakeForLeadAction(workerId)
 
-    this.log(chalk.white('Current worker stake: ', formatBalance(groupMember.stake)))
+    this.log(chalk.magentaBright('Current worker stake: ', formatBalance(groupMember.stake)))
     const balanceValidator = minMaxInt(1, groupMember.stake.toNumber())
     const balance = (await this.promptForParam(
       'Balance',
@@ -43,7 +43,7 @@ export default class WorkingGroupsSlashWorker extends WorkingGroupsCommandBase {
 
     this.log(
       chalk.green(
-        `${chalk.white(formatBalance(balance))} from worker ${chalk.white(
+        `${chalk.magentaBright(formatBalance(balance))} from worker ${chalk.magentaBright(
           workerId
         )} stake has been succesfully slashed!`
       )

--- a/cli/src/commands/working-groups/startAcceptingApplications.ts
+++ b/cli/src/commands/working-groups/startAcceptingApplications.ts
@@ -32,7 +32,7 @@ export default class WorkingGroupsStartAcceptingApplications extends WorkingGrou
     await this.sendAndFollowNamedTx(account, apiModuleByGroup[this.group], 'acceptApplications', [openingId])
 
     this.log(
-      chalk.green(`Opening ${chalk.white(openingId)} status changed to: ${chalk.white('Accepting Applications')}`)
+      chalk.green(`Opening ${chalk.magentaBright(openingId)} status changed to: ${chalk.magentaBright('Accepting Applications')}`)
     )
   }
 }

--- a/cli/src/commands/working-groups/startAcceptingApplications.ts
+++ b/cli/src/commands/working-groups/startAcceptingApplications.ts
@@ -32,7 +32,9 @@ export default class WorkingGroupsStartAcceptingApplications extends WorkingGrou
     await this.sendAndFollowNamedTx(account, apiModuleByGroup[this.group], 'acceptApplications', [openingId])
 
     this.log(
-      chalk.green(`Opening ${chalk.magentaBright(openingId)} status changed to: ${chalk.magentaBright('Accepting Applications')}`)
+      chalk.green(
+        `Opening ${chalk.magentaBright(openingId)} status changed to: ${chalk.magentaBright('Accepting Applications')}`
+      )
     )
   }
 }

--- a/cli/src/commands/working-groups/startReviewPeriod.ts
+++ b/cli/src/commands/working-groups/startReviewPeriod.ts
@@ -31,6 +31,8 @@ export default class WorkingGroupsStartReviewPeriod extends WorkingGroupsCommand
 
     await this.sendAndFollowNamedTx(account, apiModuleByGroup[this.group], 'beginApplicantReview', [openingId])
 
-    this.log(chalk.green(`Opening ${chalk.magentaBright(openingId)} status changed to: ${chalk.magentaBright('In Review')}`))
+    this.log(
+      chalk.green(`Opening ${chalk.magentaBright(openingId)} status changed to: ${chalk.magentaBright('In Review')}`)
+    )
   }
 }

--- a/cli/src/commands/working-groups/startReviewPeriod.ts
+++ b/cli/src/commands/working-groups/startReviewPeriod.ts
@@ -31,6 +31,6 @@ export default class WorkingGroupsStartReviewPeriod extends WorkingGroupsCommand
 
     await this.sendAndFollowNamedTx(account, apiModuleByGroup[this.group], 'beginApplicantReview', [openingId])
 
-    this.log(chalk.green(`Opening ${chalk.white(openingId)} status changed to: ${chalk.white('In Review')}`))
+    this.log(chalk.green(`Opening ${chalk.magentaBright(openingId)} status changed to: ${chalk.magentaBright('In Review')}`))
   }
 }

--- a/cli/src/commands/working-groups/terminateApplication.ts
+++ b/cli/src/commands/working-groups/terminateApplication.ts
@@ -32,6 +32,6 @@ export default class WorkingGroupsTerminateApplication extends WorkingGroupsComm
 
     await this.sendAndFollowNamedTx(account, apiModuleByGroup[this.group], 'terminateApplication', [applicationId])
 
-    this.log(chalk.green(`Application ${chalk.white(applicationId)} has been succesfully terminated!`))
+    this.log(chalk.green(`Application ${chalk.magentaBright(applicationId)} has been succesfully terminated!`))
   }
 }

--- a/cli/src/commands/working-groups/updateRewardAccount.ts
+++ b/cli/src/commands/working-groups/updateRewardAccount.ts
@@ -43,6 +43,6 @@ export default class WorkingGroupsUpdateRewardAccount extends WorkingGroupsComma
       newRewardAccount,
     ])
 
-    this.log(chalk.green(`Succesfully updated the reward account to: ${chalk.white(newRewardAccount)})`))
+    this.log(chalk.green(`Succesfully updated the reward account to: ${chalk.magentaBright(newRewardAccount)})`))
   }
 }

--- a/cli/src/commands/working-groups/updateRoleAccount.ts
+++ b/cli/src/commands/working-groups/updateRoleAccount.ts
@@ -37,7 +37,7 @@ export default class WorkingGroupsUpdateRoleAccount extends WorkingGroupsCommand
       newRoleAccount,
     ])
 
-    this.log(chalk.green(`Succesfully updated the role account to: ${chalk.white(newRoleAccount)})`))
+    this.log(chalk.green(`Succesfully updated the role account to: ${chalk.magentaBright(newRoleAccount)})`))
 
     const matchingAccount = cliAccounts.find((account) => account.address === newRoleAccount)
     if (matchingAccount) {
@@ -50,7 +50,7 @@ export default class WorkingGroupsUpdateRoleAccount extends WorkingGroupsCommand
         await this.setSelectedAccount(matchingAccount)
         this.log(
           chalk.green('Account switched to: ') +
-            chalk.white(`${matchingAccount.meta.name} (${matchingAccount.address})`)
+            chalk.magentaBright(`${matchingAccount.meta.name} (${matchingAccount.address})`)
         )
       }
     }

--- a/cli/src/commands/working-groups/updateRoleStorage.ts
+++ b/cli/src/commands/working-groups/updateRoleStorage.ts
@@ -31,6 +31,6 @@ export default class WorkingGroupsUpdateRoleStorage extends WorkingGroupsCommand
       storage,
     ])
 
-    this.log(chalk.green(`Succesfully updated the associated worker storage to: ${chalk.white(storage)})`))
+    this.log(chalk.green(`Succesfully updated the associated worker storage to: ${chalk.magentaBright(storage)})`))
   }
 }

--- a/cli/src/commands/working-groups/updateWorkerReward.ts
+++ b/cli/src/commands/working-groups/updateWorkerReward.ts
@@ -46,7 +46,7 @@ export default class WorkingGroupsUpdateWorkerReward extends WorkingGroupsComman
       this.error('There is no reward relationship associated with this worker!', { exit: ExitCodes.InvalidInput })
     }
 
-    console.log(chalk.white(`Current worker reward: ${this.formatReward(reward)}`))
+    console.log(chalk.magentaBright(`Current worker reward: ${this.formatReward(reward)}`))
 
     const newRewardValue = await this.promptForParam(
       'BalanceOfMint',
@@ -61,7 +61,7 @@ export default class WorkingGroupsUpdateWorkerReward extends WorkingGroupsComman
     ])
 
     const updatedGroupMember = await this.getApi().groupMember(this.group, workerId)
-    this.log(chalk.green(`Worker ${chalk.white(workerId)} reward has been updated!`))
-    this.log(chalk.green(`New worker reward: ${chalk.white(this.formatReward(updatedGroupMember.reward))}`))
+    this.log(chalk.green(`Worker ${chalk.magentaBright(workerId)} reward has been updated!`))
+    this.log(chalk.green(`New worker reward: ${chalk.magentaBright(this.formatReward(updatedGroupMember.reward))}`))
   }
 }

--- a/cli/src/helpers/InputOutput.ts
+++ b/cli/src/helpers/InputOutput.ts
@@ -60,7 +60,7 @@ export function saveOutputJson(outputPath: string | undefined, fileName: string,
     }
     saveOutputJsonToFile(outputFilePath, data)
 
-    console.log(`${chalk.green('Output succesfully saved to:')} ${chalk.white(outputFilePath)}`)
+    console.log(`${chalk.green('Output succesfully saved to:')} ${chalk.magentaBright(outputFilePath)}`)
   }
 }
 

--- a/cli/src/helpers/display.ts
+++ b/cli/src/helpers/display.ts
@@ -17,8 +17,8 @@ export function displayNameValueTable(rows: NameValueObj[]) {
   cli.table(
     rows,
     {
-      name: { minWidth: 30, get: (row) => chalk.bold.white(row.name) },
-      value: { get: (row) => chalk.white(row.value) },
+      name: { minWidth: 30, get: (row) => chalk.bold.magentaBright(row.name) },
+      value: { get: (row) => chalk.magentaBright(row.value) },
     },
     { 'no-header': true }
   )
@@ -49,7 +49,7 @@ export function displayTable(rows: { [k: string]: string | number }[], cellHoriz
     }, columnName.length)
   const columnDef = (columnName: string) => ({
     header: columnName,
-    get: (row: typeof rows[number]) => chalk.white(`${row[columnName]}`),
+    get: (row: typeof rows[number]) => chalk.magentaBright(`${row[columnName]}`),
     minWidth: maxLength(columnName) + cellHorizontalPadding,
   })
   const columns: Table.table.Columns<{ [k: string]: string }> = {}


### PR DESCRIPTION
CLI used `white` color for some command line outputs. White text is barely readable in consoles with white background. This PR changes it to `magentaBright` that was previously not used anywhere.