### PR TITLE
More generous initial data directory voucher limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "5.4.0"
+version = "5.5.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "9.6.0"
+version = "9.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '5.4.0'
+version = '5.5.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/runtime-modules/storage/src/data_directory.rs
+++ b/runtime-modules/storage/src/data_directory.rs
@@ -40,13 +40,13 @@ use crate::data_object_type_registry::IsActiveDataObjectType;
 use crate::*;
 
 /// The default maximum storage size (bytes) that lead can set on the voucher of an owner
-pub const DEFAULT_VOUCHER_SIZE_LIMIT_UPPER_BOUND: u64 = 54_000_000_000;
+pub const DEFAULT_VOUCHER_SIZE_LIMIT_UPPER_BOUND: u64 = 540_000_000_000;
 /// The default maximum number of objects that lead can set on the voucher of an owner
-pub const DEFAULT_VOUCHER_OBJECTS_LIMIT_UPPER_BOUND: u64 = 10_000;
+pub const DEFAULT_VOUCHER_OBJECTS_LIMIT_UPPER_BOUND: u64 = 50_000;
 /// The default frame_system global storage limits
-pub const DEFAULT_GLOBAL_VOUCHER: Voucher = Voucher::new(1_100_000_000_000, 1_000_000);
+pub const DEFAULT_GLOBAL_VOUCHER: Voucher = Voucher::new(110_000_000_000_000, 100_000_000);
 /// The default initial owner voucher
-pub const DEFAULT_VOUCHER: Voucher = Voucher::new(5_400_000_000, 1_000);
+pub const DEFAULT_VOUCHER: Voucher = Voucher::new(110_000_000_000, 10_000);
 /// The default starting upload blocked status
 pub const DEFAULT_UPLOADING_BLOCKED_STATUS: bool = false;
 

--- a/runtime-modules/storage/src/data_directory.rs
+++ b/runtime-modules/storage/src/data_directory.rs
@@ -42,11 +42,11 @@ use crate::*;
 /// The default maximum storage size (bytes) that lead can set on the voucher of an owner
 pub const DEFAULT_VOUCHER_SIZE_LIMIT_UPPER_BOUND: u64 = 540_000_000_000;
 /// The default maximum number of objects that lead can set on the voucher of an owner
-pub const DEFAULT_VOUCHER_OBJECTS_LIMIT_UPPER_BOUND: u64 = 50_000;
+pub const DEFAULT_VOUCHER_OBJECTS_LIMIT_UPPER_BOUND: u64 = 15_000;
 /// The default frame_system global storage limits
-pub const DEFAULT_GLOBAL_VOUCHER: Voucher = Voucher::new(110_000_000_000_000, 100_000_000);
+pub const DEFAULT_GLOBAL_VOUCHER: Voucher = Voucher::new(110_000_000_000_000, 10_000_000);
 /// The default initial owner voucher
-pub const DEFAULT_VOUCHER: Voucher = Voucher::new(110_000_000_000, 10_000);
+pub const DEFAULT_VOUCHER: Voucher = Voucher::new(110_000_000_000, 5_000);
 /// The default starting upload blocked status
 pub const DEFAULT_UPLOADING_BLOCKED_STATUS: bool = false;
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '9.6.0'
+version = '9.7.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -85,7 +85,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 9,
-    spec_version: 6,
+    spec_version: 7,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Addresses some issues raised in https://github.com/Joystream/joystream/issues/2414

Increased initial voucher limits both size and objects.
