### PR TITLE
Pioneer - Sumer glitch fixes

### DIFF
--- a/pioneer/packages/joy-proposals/src/forms/GenericWorkingGroupProposalForm.tsx
+++ b/pioneer/packages/joy-proposals/src/forms/GenericWorkingGroupProposalForm.tsx
@@ -43,6 +43,10 @@ type ExportComponentProps = ProposalFormExportProps<FormAdditionalProps, FormVal
 type FormContainerProps = ProposalFormContainerProps<ExportComponentProps>;
 export type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 
+const availableGroupsOptions = Object.keys(WorkingGroupDef)
+  .filter((wgKey) => wgKey !== 'Gateway') // Gateway group not yet supported!
+  .map((wgKey) => ({ text: wgKey + ' Working Group', value: wgKey }))
+
 export const GenericWorkingGroupProposalForm: React.FunctionComponent<FormInnerProps> = (props) => {
   const {
     handleChange,
@@ -81,7 +85,7 @@ export const GenericWorkingGroupProposalForm: React.FunctionComponent<FormInnerP
           name='workingGroup'
           placeholder='Select the working group'
           selection
-          options={Object.keys(WorkingGroupDef).map((wgKey) => ({ text: wgKey + ' Working Group', value: wgKey }))}
+          options={availableGroupsOptions}
           value={values.workingGroup}
           onChange={ handleChange }
         />

--- a/pioneer/packages/joy-proposals/src/forms/GenericWorkingGroupProposalForm.tsx
+++ b/pioneer/packages/joy-proposals/src/forms/GenericWorkingGroupProposalForm.tsx
@@ -45,7 +45,7 @@ export type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValu
 
 const availableGroupsOptions = Object.keys(WorkingGroupDef)
   .filter((wgKey) => wgKey !== 'Gateway') // Gateway group not yet supported!
-  .map((wgKey) => ({ text: wgKey + ' Working Group', value: wgKey }))
+  .map((wgKey) => ({ text: wgKey + ' Working Group', value: wgKey }));
 
 export const GenericWorkingGroupProposalForm: React.FunctionComponent<FormInnerProps> = (props) => {
   const {

--- a/pioneer/packages/joy-roles/src/elements.tsx
+++ b/pioneer/packages/joy-roles/src/elements.tsx
@@ -69,7 +69,7 @@ export function GroupLeadView (props: GroupMember) {
         <Card.Header><HandleView profile={props.profile} /></Card.Header>
         <Card.Meta>{props.title}</Card.Meta>
         <Card.Meta>
-          { props.workerId && (
+          { (props.workerId !== undefined) && (
             <Label>{ 'Worker ID: ' + props.workerId.toString() }</Label>
           ) }
         </Card.Meta>

--- a/pioneer/packages/joy-roles/src/transport.substrate.ts
+++ b/pioneer/packages/joy-roles/src/transport.substrate.ts
@@ -183,7 +183,7 @@ export class Transport extends BaseTransport implements ITransport {
       const leadWorker = await this.queryCachedByGroup(group).workerById(leadId) as Worker;
 
       return {
-        lead: await this.groupMember(group, leadId, leadWorker),
+        lead: { ...await this.groupMember(group, leadId, leadWorker), title: _.startCase(group) + ' Lead' },
         loaded: true
       };
     } else {
@@ -201,7 +201,7 @@ export class Transport extends BaseTransport implements ITransport {
     const workers = (await this.entriesByIds<WorkerId, Worker>(
       this.queryByGroup(group).workerById
     ))
-      .filter(([id, worker]) => worker.is_active && (!leadStatus.lead?.workerId || !id.eq(leadStatus.lead.workerId)));
+      .filter(([id, worker]) => worker.is_active && (typeof leadStatus.lead?.workerId === 'undefined' || !id.eq(leadStatus.lead.workerId)));
 
     return {
       leadStatus,
@@ -498,7 +498,7 @@ export class Transport extends BaseTransport implements ITransport {
 
           return {
             workerId: id,
-            name: (groupLead?.workerId && groupLead.workerId === id.toNumber())
+            name: ((groupLead?.workerId !== undefined) && groupLead.workerId === id.toNumber())
               ? _.startCase(group) + ' Lead'
               : workerRoleNameByGroup[group],
             reward: earnedValue,


### PR DESCRIPTION
Fixes point `1` and `2` from issue: https://github.com/Joystream/joystream/issues/2419

The "lead appearing twice" bug was caused by incorrect handling of `lead.workerId === 0` in some parts of the Pioneer code (which resulted in lead beeing treated simultaneously as both lead and worker)