### PR TITLE
query node - license deletion

### DIFF
--- a/query-node/mappings/src/content/utils.ts
+++ b/query-node/mappings/src/content/utils.ts
@@ -639,6 +639,11 @@ async function prepareLicense(licenseProtobuf: LicenseMetadata.AsObject | undefi
     return undefined
   }
 
+  // license is meant to be deleted
+  if (isLicenseEmpty(licenseProtobuf)) {
+    return new License({})
+  }
+
   // crete new license
   const license = new License({
     ...licenseProtobuf,
@@ -649,6 +654,19 @@ async function prepareLicense(licenseProtobuf: LicenseMetadata.AsObject | undefi
 
   return license
 }
+
+/*
+  Checks if protobof contains license with some fields filled or is empty object (`{}` or `{someKey: undefined, ...}`).
+  Empty object means deletion is requested.
+*/
+function isLicenseEmpty(licenseObject) {
+    let somePropertySet = Object.entries(licenseObject).reduce((acc, [key, value]) => {
+        return acc || value !== undefined
+    }, false)
+
+    return somePropertySet
+}
+
 
 function prepareVideoMetadata(videoProtobuf: VideoMetadata.AsObject, videoSize: number | undefined, blockNumber: number): RawVideoMetadata {
   const rawMeta = {

--- a/query-node/mappings/src/content/utils.ts
+++ b/query-node/mappings/src/content/utils.ts
@@ -659,12 +659,12 @@ async function prepareLicense(licenseProtobuf: LicenseMetadata.AsObject | undefi
   Checks if protobof contains license with some fields filled or is empty object (`{}` or `{someKey: undefined, ...}`).
   Empty object means deletion is requested.
 */
-function isLicenseEmpty(licenseObject) {
+function isLicenseEmpty(licenseObject: LicenseMetadata.AsObject): boolean {
     let somePropertySet = Object.entries(licenseObject).reduce((acc, [key, value]) => {
         return acc || value !== undefined
     }, false)
 
-    return somePropertySet
+    return !somePropertySet
 }
 
 


### PR DESCRIPTION
This PR adds support for License deletion. If protobuf's license is `{}` or `{anyKey: undefined, anyOtherKey: undefined, ...}`, the existing license will be deleted (if any exists).

Solves https://github.com/Joystream/joystream/issues/2413