### PR TITLE
Official rust docker image for multi-arch support

### DIFF
--- a/joystream-node.Dockerfile
+++ b/joystream-node.Dockerfile
@@ -1,11 +1,13 @@
-FROM liuchong/rustup:nightly AS rustup
-RUN rustup install nightly-2021-03-24
+FROM rust:1.52.1-buster AS rust
+RUN rustup self update
+RUN rustup install nightly-2021-03-24 --force
 RUN rustup default nightly-2021-03-24
 RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2021-03-24
+RUN rustup component add --toolchain nightly-2021-03-24 clippy
 RUN apt-get update && \
   apt-get install -y curl git gcc xz-utils sudo pkg-config unzip clang llvm libc6-dev
 
-FROM rustup AS builder
+FROM rust AS builder
 LABEL description="Compiles all workspace artifacts"
 WORKDIR /joystream
 COPY . /joystream
@@ -17,7 +19,7 @@ RUN BUILD_DUMMY_WASM_BINARY=1 cargo clippy --release --all -- -D warnings && \
     cargo test --release --all && \
     cargo build --release
 
-FROM debian:buster
+FROM rust:1.52.1-slim-buster
 LABEL description="Joystream node"
 WORKDIR /joystream
 COPY --from=builder /joystream/target/release/joystream-node /joystream/node

--- a/joystream-node.Dockerfile
+++ b/joystream-node.Dockerfile
@@ -19,7 +19,7 @@ RUN BUILD_DUMMY_WASM_BINARY=1 cargo clippy --release --all -- -D warnings && \
     cargo test --release --all && \
     cargo build --release
 
-FROM rust:1.52.1-slim-buster
+FROM ubuntu:21.04
 LABEL description="Joystream node"
 WORKDIR /joystream
 COPY --from=builder /joystream/target/release/joystream-node /joystream/node

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,8 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     brew update
     brew install coreutils gnu-tar jq curl
     echo "It is recommended to setup Docker desktop from: https://www.docker.com/products/docker-desktop"
+    echo "It is also recommended to install qemu emulators with following command:"
+    echo "docker run --privileged --rm tonistiigi/binfmt --install all"
 fi
 
 # If OS is supported will install build tools for rust and substrate.


### PR DESCRIPTION
Updated the image to build joystream/node docker image using official rust images.
Build can now succeed on Macs with M1 processors.

### Mac users
If you don't need to build, you can pull images built for amd64 and run them with qemu emulation.
Requirements latest version of docker desktop and latest update to OSX, BigSur v11.4 

Configure qemu emulation with latest emulators for best results:
```
# Make sure to update to latest image (older versions had issues)
docker pull tonistiigi/binfmt
docker run --rm --privileged tonistiigi/binfmt --uninstall qemu-*
docker run --privileged --rm tonistiigi/binfmt --install all
```