### PR TITLE
DevOps - Make RPC node accessible over TLS endpoint

### DIFF
--- a/devops/infrastructure/deploy-infra.sh
+++ b/devops/infrastructure/deploy-infra.sh
@@ -45,6 +45,9 @@ aws cloudformation deploy \
 
 # If the deploy succeeded, get the IP, create inventory and configure the created instances
 if [ $? -eq 0 ]; then
+  # Install additional Ansible roles from requirements
+  ansible-galaxy install -r requirements.yml
+
   VALIDATORS=$(aws cloudformation list-exports \
     --profile $CLI_PROFILE \
     --query "Exports[?starts_with(Name,'${NEW_STACK_NAME}PublicIp')].Value" \

--- a/devops/infrastructure/main.yml
+++ b/devops/infrastructure/main.yml
@@ -52,6 +52,14 @@ Resources:
           ToPort: 9944
           CidrIp: 0.0.0.0/0
         - IpProtocol: tcp
+          FromPort: 30333
+          ToPort: 30333
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
           CidrIp: 0.0.0.0/0

--- a/devops/infrastructure/requirements.yml
+++ b/devops/infrastructure/requirements.yml
@@ -1,0 +1,3 @@
+---
+roles:
+- caddy_ansible.caddy_ansible

--- a/devops/infrastructure/roles/rpc/tasks/main.yml
+++ b/devops/infrastructure/roles/rpc/tasks/main.yml
@@ -20,3 +20,17 @@
     name: joystream-node
     state: started
   become: yes
+
+- name: Install and configure Caddy
+  include_role:
+    name: caddy_ansible.caddy_ansible
+    apply:
+      become: yes
+  vars:
+    caddy_config: "{{ lookup('template', 'templates/Caddyfile.j2') }}"
+    caddy_systemd_capabilities_enabled: true
+    public_ip: "{{ inventory_hostname }}"
+
+- name: Print RPC node DNS
+  debug:
+    msg: "RPC Node DNS is: https://{{ inventory_hostname }}.nip.io"

--- a/devops/infrastructure/roles/rpc/tasks/main.yml
+++ b/devops/infrastructure/roles/rpc/tasks/main.yml
@@ -29,8 +29,9 @@
   vars:
     caddy_config: "{{ lookup('template', 'templates/Caddyfile.j2') }}"
     caddy_systemd_capabilities_enabled: true
-    public_ip: "{{ inventory_hostname }}"
+    ws_rpc: "{{ inventory_hostname }}.nip.io/ws-rpc"
+    http_rpc: "{{ inventory_hostname }}.nip.io/http-rpc"
 
 - name: Print RPC node DNS
   debug:
-    msg: "RPC Node DNS is: https://{{ inventory_hostname }}.nip.io"
+    msg: "RPC Endpoint: wss://{{ inventory_hostname }}.nip.io/ws-rpc"

--- a/devops/infrastructure/roles/rpc/templates/Caddyfile.j2
+++ b/devops/infrastructure/roles/rpc/templates/Caddyfile.j2
@@ -1,0 +1,3 @@
+{{ public_ip }}.nip.io
+
+reverse_proxy localhost:9944

--- a/devops/infrastructure/roles/rpc/templates/Caddyfile.j2
+++ b/devops/infrastructure/roles/rpc/templates/Caddyfile.j2
@@ -1,3 +1,7 @@
-{{ public_ip }}.nip.io
+{{ ws_rpc }} {
+    reverse_proxy localhost:9944
+}
 
-reverse_proxy localhost:9944
+{{ http_rpc }} {
+    reverse_proxy localhost:9933
+}


### PR DESCRIPTION
Adds TLS support to RPC node using [Caddy](https://caddyserver.com/) and [nip.io](https://nip.io/)

One step closer to #2406

<details>
<summary>Manual Testing</summary>

![Screenshot 2021-06-02 at 11 21 42 PM](https://user-images.githubusercontent.com/7795956/120528864-87599480-c3f9-11eb-9cd9-7b33135a24e9.png)


![Screenshot 2021-06-02 at 11 21 46 PM](https://user-images.githubusercontent.com/7795956/120528881-8aed1b80-c3f9-11eb-8f3d-5569ba58acb4.png)



</details>
