### PR TITLE
Update mappings to hydra 3.1.0-alpha.0 - interfaces support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
     command: ["yarn", "workspace", "query-node-root", "processor:start"]
 
   indexer:
-    image: joystream/hydra-indexer:3.0.0-beta.6
+    image: joystream/hydra-indexer:3.0.0
     restart: unless-stopped
     env_file:
       # relative to working directory where docker-compose was run from
@@ -146,7 +146,7 @@ services:
       sh -c "yarn db:bootstrap && yarn start:prod"
 
   indexer-api-gateway:
-    image: joystream/hydra-indexer-gateway:3.0.0-beta.6
+    image: joystream/hydra-indexer-gateway:3.0.0
     restart: unless-stopped
     env_file:
       # relative to working directory where docker-compose was run from

--- a/query-node/codegen/package.json
+++ b/query-node/codegen/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@dzlzv/hydra-cli": "3.0.0-beta.6",
-    "@dzlzv/hydra-typegen": "3.0.0-beta.6"
+    "@dzlzv/hydra-cli": "3.1.0-alpha.0",
+    "@dzlzv/hydra-typegen": "3.1.0-alpha.0"
   }
 }

--- a/query-node/codegen/yarn.lock
+++ b/query-node/codegen/yarn.lock
@@ -76,10 +76,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@dzlzv/hydra-cli@3.0.0-beta.6":
-  version "3.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-cli/-/hydra-cli-3.0.0-beta.6.tgz#b85504ed9f4ec939b7108094fd7969d60a9b1f45"
-  integrity sha512-3ENzap6vq2DKOV8gA5Qq9ZX9xDJvP6WXpRvp+Aedf2yTms/gWB9vbhkp2oCZGnjqZqGZ9d2jIBBFJOwiRWpqsA==
+"@dzlzv/hydra-cli@3.1.0-alpha.0":
+  version "3.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-cli/-/hydra-cli-3.1.0-alpha.0.tgz#2f8bb0e4e8978da15bcf26bf39ac3c813af0a1ca"
+  integrity sha512-M/zeWTPHwFYCMI2gKHtSKevHFMaFQFX63yP2JVpMEOjIBt1+x+pjGYHChEojo8XjdDKv1noSJd3ZkhdmL4x0LQ==
   dependencies:
     "@inquirer/input" "^0.0.13-alpha.0"
     "@inquirer/password" "^0.0.12-alpha.0"
@@ -111,10 +111,10 @@
     tslib "1.11.2"
     warthog "https://github.com/metmirr/warthog/releases/download/v2.30.0/warthog-v2.30.0.tgz"
 
-"@dzlzv/hydra-typegen@3.0.0-beta.6":
-  version "3.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-typegen/-/hydra-typegen-3.0.0-beta.6.tgz#665364fdde787a293df58196f81abd517847e976"
-  integrity sha512-mYDh3G8tHjPIy6lUhXS2lNNOs27SxW580ODd3Ib87sR/scHv3Xmdv2Tgcu3lDj367MeKfhQ0hRfFDdLZnxaHeA==
+"@dzlzv/hydra-typegen@3.1.0-alpha.0":
+  version "3.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-typegen/-/hydra-typegen-3.1.0-alpha.0.tgz#6b725c4d8b15ca1f773a1db555e26c3f7a9fb733"
+  integrity sha512-a0Ev1s3VYoB6F4jZ/tKY5TByiCvDZbicaQ85xbBpxUqWGIquHgfkXmkubeFZV/Q42qKNIy8CcXQO2EgtXnlarg==
   dependencies:
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1"

--- a/query-node/mappings/common.ts
+++ b/query-node/mappings/common.ts
@@ -2,10 +2,11 @@ import { SubstrateEvent } from '@dzlzv/hydra-common'
 import { Network } from 'query-node/dist/src/modules/enums/enums'
 import { Event } from 'query-node/dist/src/modules/event/event.model'
 import { Bytes } from '@polkadot/types'
+import { BaseModel } from 'warthog'
 
 export const CURRENT_NETWORK = Network.OLYMPIA
 
-export function genericEventFields(substrateEvent: SubstrateEvent): Partial<Event> {
+export function genericEventFields(substrateEvent: SubstrateEvent): Partial<BaseModel & Event> {
   const { blockNumber, indexInBlock, extrinsic, blockTimestamp } = substrateEvent
   const eventTime = new Date(blockTimestamp)
   return {

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -10,8 +10,8 @@
     "clean": "rm -rf lib"
   },
   "dependencies": {
-    "@dzlzv/hydra-common": "3.0.0-beta.6",
-    "@dzlzv/hydra-db-utils": "3.0.0-beta.6",
+    "@dzlzv/hydra-common": "3.1.0-alpha.0",
+    "@dzlzv/hydra-db-utils": "3.1.0-alpha.0",
     "@joystream/types": "^0.15.0",
     "warthog": "https://github.com/metmirr/warthog/releases/download/v2.30.0/warthog-v2.30.0.tgz"
   },

--- a/query-node/mappings/workingGroups.ts
+++ b/query-node/mappings/workingGroups.ts
@@ -750,7 +750,7 @@ export async function workingGroups_RewardPaid({ store, event }: EventContext & 
     worker,
     amount,
     rewardAccount: rewardAccountId.toString(),
-    type: rewardPaymentType.isRegularReward ? RewardPaymentType.REGULAR : RewardPaymentType.MISSED,
+    paymentType: rewardPaymentType.isRegularReward ? RewardPaymentType.REGULAR : RewardPaymentType.MISSED,
   })
 
   await store.save<RewardPaidEvent>(rewardPaidEvent)
@@ -809,7 +809,7 @@ export async function workingGroups_WorkerExited({ store, event }: EventContext 
 }
 
 export async function workingGroups_LeaderUnset({ store, event }: EventContext & StoreContext): Promise<void> {
-  const group = await getWorkingGroup(store, event)
+  const group = await getWorkingGroup(store, event, ['leader'])
   const eventTime = new Date(event.blockTimestamp)
 
   const leaderUnsetEvent = new LeaderUnsetEvent({

--- a/query-node/package.json
+++ b/query-node/package.json
@@ -42,7 +42,7 @@
     "tslib": "^2.0.0",
     "@types/bn.js": "^4.11.6",
     "bn.js": "^5.1.2",
-    "@dzlzv/hydra-processor": "3.0.0-beta.6",
+    "@dzlzv/hydra-processor": "3.1.0-alpha.0",
     "envsub": "4.0.7"
   },
   "volta": {

--- a/query-node/schemas/membershipEvents.graphql
+++ b/query-node/schemas/membershipEvents.graphql
@@ -1,4 +1,4 @@
-type MembershipBoughtEvent @entity {
+type MembershipBoughtEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -37,7 +37,7 @@ type MembershipBoughtEvent @entity {
   referrer: Membership
 }
 
-type MemberInvitedEvent @entity {
+type MemberInvitedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -76,7 +76,7 @@ type MemberInvitedEvent @entity {
   metadata: MemberMetadata!
 }
 
-type MemberProfileUpdatedEvent @entity {
+type MemberProfileUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -106,7 +106,7 @@ type MemberProfileUpdatedEvent @entity {
   newMetadata: MemberMetadata!
 }
 
-type MemberAccountsUpdatedEvent @entity {
+type MemberAccountsUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -136,7 +136,7 @@ type MemberAccountsUpdatedEvent @entity {
   newControllerAccount: String
 }
 
-type MemberVerificationStatusUpdatedEvent @entity {
+type MemberVerificationStatusUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -166,7 +166,7 @@ type MemberVerificationStatusUpdatedEvent @entity {
   isVerified: Boolean!
 }
 
-type ReferralCutUpdatedEvent @entity {
+type ReferralCutUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -190,7 +190,7 @@ type ReferralCutUpdatedEvent @entity {
   newValue: Int!
 }
 
-type InvitesTransferredEvent @entity {
+type InvitesTransferredEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -220,7 +220,7 @@ type InvitesTransferredEvent @entity {
   numberOfInvites: Int!
 }
 
-type MembershipPriceUpdatedEvent @entity {
+type MembershipPriceUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -244,7 +244,7 @@ type MembershipPriceUpdatedEvent @entity {
   newPrice: BigInt!
 }
 
-type InitialInvitationBalanceUpdatedEvent @entity {
+type InitialInvitationBalanceUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -268,7 +268,7 @@ type InitialInvitationBalanceUpdatedEvent @entity {
   newInitialBalance: BigInt!
 }
 
-type LeaderInvitationQuotaUpdatedEvent @entity {
+type LeaderInvitationQuotaUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -292,7 +292,7 @@ type LeaderInvitationQuotaUpdatedEvent @entity {
   newInvitationQuota: Int!
 }
 
-type InitialInvitationCountUpdatedEvent @entity {
+type InitialInvitationCountUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -316,7 +316,7 @@ type InitialInvitationCountUpdatedEvent @entity {
   newInitialInvitationCount: Int!
 }
 
-type StakingAccountAddedEvent @entity {
+type StakingAccountAddedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -343,7 +343,7 @@ type StakingAccountAddedEvent @entity {
   account: String!
 }
 
-type StakingAccountConfirmedEvent @entity {
+type StakingAccountConfirmedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -370,7 +370,7 @@ type StakingAccountConfirmedEvent @entity {
   account: String!
 }
 
-type StakingAccountRemovedEvent @entity {
+type StakingAccountRemovedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"

--- a/query-node/schemas/workingGroupsEvents.graphql
+++ b/query-node/schemas/workingGroupsEvents.graphql
@@ -1,4 +1,4 @@
-type OpeningAddedEvent @entity {
+type OpeningAddedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -27,7 +27,7 @@ type OpeningAddedEvent @entity {
   # Other opening data like: metadata, type, staking policy, reward etc. is immutable, so can be read directly from Opening entity
 }
 
-type AppliedOnOpeningEvent @entity {
+type AppliedOnOpeningEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -59,7 +59,7 @@ type AppliedOnOpeningEvent @entity {
   # Same as with opening - application parameters are immutable and can be fetched from Application entity
 }
 
-type OpeningFilledEvent @entity {
+type OpeningFilledEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -89,7 +89,7 @@ type OpeningFilledEvent @entity {
   workersHired: [Worker!] @derivedFrom(field: "entry")
 }
 
-type LeaderSetEvent @entity {
+type LeaderSetEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -117,7 +117,7 @@ type LeaderSetEvent @entity {
   worker: Worker
 }
 
-type WorkerRoleAccountUpdatedEvent @entity {
+type WorkerRoleAccountUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -147,7 +147,7 @@ type WorkerRoleAccountUpdatedEvent @entity {
   newRoleAccount: String!
 }
 
-type LeaderUnsetEvent @entity {
+type LeaderUnsetEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -174,7 +174,7 @@ type LeaderUnsetEvent @entity {
   leader: Worker!
 }
 
-type WorkerExitedEvent @entity {
+type WorkerExitedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -201,40 +201,7 @@ type WorkerExitedEvent @entity {
   worker: Worker!
 }
 
-type TerminatedWorkerEvent @entity {
-  ### GENERIC DATA ###
-
-  "(network}-{blockNumber}-{indexInBlock}"
-  id: ID!
-
-  "Hash of the extrinsic which caused the event to be emitted"
-  inExtrinsic: String
-
-  "Blocknumber of the block in which the event was emitted."
-  inBlock: Int!
-
-  "Network the block was produced in"
-  network: Network!
-
-  "Index of event in block from which it was emitted."
-  indexInBlock: Int!
-
-  ### SPECIFIC DATA ###
-
-  "Related group"
-  group: WorkingGroup!
-
-  "Related worker"
-  worker: Worker!
-
-  "Slash amount (if any)"
-  penalty: BigInt
-
-  "Optional rationale"
-  rationale: String
-}
-
-type TerminatedLeaderEvent @entity {
+type TerminatedWorkerEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -267,7 +234,40 @@ type TerminatedLeaderEvent @entity {
   rationale: String
 }
 
-type WorkerStartedLeavingEvent @entity {
+type TerminatedLeaderEvent implements Event @entity {
+  ### GENERIC DATA ###
+
+  "(network}-{blockNumber}-{indexInBlock}"
+  id: ID!
+
+  "Hash of the extrinsic which caused the event to be emitted"
+  inExtrinsic: String
+
+  "Blocknumber of the block in which the event was emitted."
+  inBlock: Int!
+
+  "Network the block was produced in"
+  network: Network!
+
+  "Index of event in block from which it was emitted."
+  indexInBlock: Int!
+
+  ### SPECIFIC DATA ###
+
+  "Related group"
+  group: WorkingGroup!
+
+  "Related worker"
+  worker: Worker!
+
+  "Slash amount (if any)"
+  penalty: BigInt
+
+  "Optional rationale"
+  rationale: String
+}
+
+type WorkerStartedLeavingEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -297,7 +297,7 @@ type WorkerStartedLeavingEvent @entity {
   rationale: String
 }
 
-type StakeSlashedEvent @entity {
+type StakeSlashedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -333,7 +333,7 @@ type StakeSlashedEvent @entity {
   rationale: String
 }
 
-type StakeDecreasedEvent @entity {
+type StakeDecreasedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -363,7 +363,7 @@ type StakeDecreasedEvent @entity {
   amount: BigInt!
 }
 
-type StakeIncreasedEvent @entity {
+type StakeIncreasedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -393,7 +393,7 @@ type StakeIncreasedEvent @entity {
   amount: BigInt!
 }
 
-type ApplicationWithdrawnEvent @entity {
+type ApplicationWithdrawnEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -420,7 +420,7 @@ type ApplicationWithdrawnEvent @entity {
   application: WorkingGroupApplication!
 }
 
-type OpeningCanceledEvent @entity {
+type OpeningCanceledEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -447,7 +447,7 @@ type OpeningCanceledEvent @entity {
   opening: WorkingGroupOpening!
 }
 
-type BudgetSetEvent @entity {
+type BudgetSetEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -474,7 +474,7 @@ type BudgetSetEvent @entity {
   newBudget: BigInt!
 }
 
-type WorkerRewardAccountUpdatedEvent @entity {
+type WorkerRewardAccountUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -504,7 +504,7 @@ type WorkerRewardAccountUpdatedEvent @entity {
   newRewardAccount: String!
 }
 
-type WorkerRewardAmountUpdatedEvent @entity {
+type WorkerRewardAmountUpdatedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -558,7 +558,7 @@ union WorkingGroupMetadataActionResult =
   | WorkingGroupMetadataSet
   | InvalidActionMetadata
 
-type StatusTextChangedEvent @entity {
+type StatusTextChangedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -588,7 +588,7 @@ type StatusTextChangedEvent @entity {
   result: WorkingGroupMetadataActionResult!
 }
 
-type BudgetSpendingEvent @entity {
+type BudgetSpendingEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -628,7 +628,7 @@ enum RewardPaymentType {
   MISSED
 }
 
-type RewardPaidEvent @entity {
+type RewardPaidEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"
@@ -661,10 +661,10 @@ type RewardPaidEvent @entity {
   amount: BigInt!
 
   "Type of the payment (REGULAR/MISSED)"
-  type: RewardPaymentType!
+  paymentType: RewardPaymentType!
 }
 
-type NewMissedRewardLevelReachedEvent @entity {
+type NewMissedRewardLevelReachedEvent implements Event @entity {
   ### GENERIC DATA ###
 
   "(network}-{blockNumber}-{indexInBlock}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1564,26 +1564,19 @@
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-"@dzlzv/hydra-common@3.0.0-beta.6":
-  version "3.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-common/-/hydra-common-3.0.0-beta.6.tgz#7d6e3cb13a1a6487faa4a5975b77003c27c7e8ca"
-  integrity sha512-VFtp9JEJ4PEheACHo2AMLcFW0sudFlo9DWZ3ZPLKFm880QWqxvORLCpog5HoNMyK2BqucC8FDDkcpFo16ueMAA==
+"@dzlzv/hydra-common@3.1.0-alpha.0", "@dzlzv/hydra-common@^3.1.0-alpha.0":
+  version "3.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-common/-/hydra-common-3.1.0-alpha.0.tgz#6e37f2ee3a1675fddac110503e2c3d3e70f7d18c"
+  integrity sha512-Vm3L6gb4+flev0VuQWSPS9d0UtLMgY5eMqLP7D1nc2QpO5rZhq9oVN+jCUQ6wIfc1pMecV8J+Njpt2yd6C3wKA==
   dependencies:
     bn.js "^5.1.3"
 
-"@dzlzv/hydra-common@^3.0.0-beta.6", "@dzlzv/hydra-common@^3.0.0-hydra-v3.0":
-  version "3.0.0-hydra-v3.0"
-  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-common/-/hydra-common-3.0.0-hydra-v3.0.tgz#e7ca2a578e8a607317600945cdd7ea4eed2d0dae"
-  integrity sha512-WLEQ22U+j/3RmmZFKz4/CbJ3tgbGlNqfMTh67fJhx/UAuXKQx6YukLvfFIjd1onDDqgAXbf8c5+i0damjrkO3w==
+"@dzlzv/hydra-db-utils@3.1.0-alpha.0", "@dzlzv/hydra-db-utils@^3.1.0-alpha.0":
+  version "3.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-db-utils/-/hydra-db-utils-3.1.0-alpha.0.tgz#2c61c25025c9cf5f415b7ebde647894c3ed506a5"
+  integrity sha512-j6FqXRzOHdztgiqtnKhfzkgYkfoCP4QIzNYHEDt+BbfQmpQH+71N/3wFeRlVxH8S47EVUkrL7Jd9UUXDCDWSFw==
   dependencies:
-    bn.js "^5.1.3"
-
-"@dzlzv/hydra-db-utils@3.0.0-beta.6":
-  version "3.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-db-utils/-/hydra-db-utils-3.0.0-beta.6.tgz#b221a24bef89a2493e42ef520fe1abbdb8d83298"
-  integrity sha512-zxH9LialjFu4mxH+0EJhHPRSewy2tbaxqr992w2gJ2hULp2kJAGRLY1kpHFG/EEE1QWvCTmcJnFw9LyC61Q8Wg==
-  dependencies:
-    "@dzlzv/hydra-common" "^3.0.0-beta.6"
+    "@dzlzv/hydra-common" "^3.1.0-alpha.0"
     "@types/ioredis" "^4.17.4"
     bn.js "^5.1.3"
     ioredis "^4.17.3"
@@ -1591,26 +1584,13 @@
     shortid "^2.2.16"
     typeorm "^0.2.25"
 
-"@dzlzv/hydra-db-utils@^3.0.0-beta.6":
-  version "3.0.0-hydra-v3.0"
-  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-db-utils/-/hydra-db-utils-3.0.0-hydra-v3.0.tgz#c61ff2b6cd8f2229d2377c5c0a09770faead8d14"
-  integrity sha512-qryrvseTrxFeJnJwXqCnKhcM7HmwqIXWdkN0kPK8+HLDg5kFXL88a3mxgyC1XL56SWQKXuCbdj3MTeJeglj4Fw==
+"@dzlzv/hydra-processor@3.1.0-alpha.0":
+  version "3.1.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-processor/-/hydra-processor-3.1.0-alpha.0.tgz#28d87dca2afefb1fa600f9e3fd4cb5cdf38761c9"
+  integrity sha512-JM39MlFpI/IsYai714RMOWW/sJoDtbL2A+NumL4WsaXLQL0Nf7MVyKrfitLNHful2MI1bqvL/B3lwCj1KeWxNQ==
   dependencies:
-    "@dzlzv/hydra-common" "^3.0.0-hydra-v3.0"
-    "@types/ioredis" "^4.17.4"
-    bn.js "^5.1.3"
-    ioredis "^4.17.3"
-    lodash "^4.17.20"
-    shortid "^2.2.16"
-    typeorm "^0.2.25"
-
-"@dzlzv/hydra-processor@3.0.0-beta.6":
-  version "3.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@dzlzv/hydra-processor/-/hydra-processor-3.0.0-beta.6.tgz#2a79ef2df8288216886881ec3b0adba6f209437e"
-  integrity sha512-J4Vj11jpIC443ffV95xjwiqJIKllA5X0q3q47cvmf38pRZ8BZx5UhHHykxzZpR4MqjrxAze5c/QZTaoWGptNcg==
-  dependencies:
-    "@dzlzv/hydra-common" "^3.0.0-beta.6"
-    "@dzlzv/hydra-db-utils" "^3.0.0-beta.6"
+    "@dzlzv/hydra-common" "^3.1.0-alpha.0"
+    "@dzlzv/hydra-db-utils" "^3.1.0-alpha.0"
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1"
     "@oclif/errors" "^1.3.3"
@@ -7568,9 +7548,9 @@ aws-credstash@^3.0.0:
     debug "^4.3.1"
 
 aws-sdk@^2.567.0:
-  version "2.923.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.923.0.tgz#97a95686e9dba10f628092bfd90f84397c8ad55f"
-  integrity sha512-93YK9Mx32qvH5eLrDRVkvwpEc7GJ6mces1qQugmNZCuQT68baILyDs0IMRtHS6NYxxiM6XNRFc7ubgMlnafYjg==
+  version "2.925.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.925.0.tgz#a352f3adc8274120fb31fa4fc04527d44b6107cf"
+  integrity sha512-dHXngzuSTZvIFWizWbU+ceZTAKmgodzEIi/AWbB+z0THKfxD3Iz/CJ7kZ7a9QyZv7X082L68vv3siMhXBMoTLA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
After the update to Hydra `3.1.0-alpha.0` we can now query the latest events through `Event` interface, for example:
```graphql
{
  events(
    where:{ type_in: [MemberInvitedEvent, MemberProfileUpdatedEvent] },
    orderBy: [inBlock_DESC, indexInBlock_DESC],
    limit: 5
  ) {
    __typename
    inBlock
    indexInBlock
    ... on MemberProfileUpdatedEvent {
      member {
        id
      }
      newHandle
      newMetadata {
        name
      }
    }
    ... on MemberInvitedEvent {
      invitingMember {
        id
        handle
      }
      newMember {
        id
        handle
      }
    }
  }
}
```