### PR TITLE
Working groups mappings - worker status and missingRewardAmount fix

### DIFF
--- a/query-node/mappings/workingGroups.ts
+++ b/query-node/mappings/workingGroups.ts
@@ -71,6 +71,7 @@ import {
   BudgetSetEvent,
   BudgetSpendingEvent,
   LeaderSetEvent,
+  WorkerStatusLeaving,
 } from 'query-node/dist/model'
 import { createType } from '@joystream/types'
 
@@ -800,9 +801,15 @@ export async function workingGroups_WorkerExited({ store, event }: EventContext 
   })
 
   await store.save<WorkerExitedEvent>(workerExitedEvent)
-  ;(worker.status as WorkerStatusLeft).workerExitedEventId = workerExitedEvent.id
+
+  const newStatus = new WorkerStatusLeft()
+  newStatus.workerStartedLeavingEventId = (worker.status as WorkerStatusLeaving).workerStartedLeavingEventId
+  newStatus.workerExitedEventId = workerExitedEvent.id
+
+  worker.status = newStatus
   worker.stake = new BN(0)
   worker.rewardPerBlock = new BN(0)
+  worker.missingRewardAmount = undefined
   worker.updatedAt = eventTime
 
   await store.save<Worker>(worker)
@@ -916,7 +923,7 @@ export async function workingGroups_WorkerStartedLeaving({ store, event }: Event
 
   await store.save<WorkerStartedLeavingEvent>(workerStartedLeavingEvent)
 
-  const status = new WorkerStatusLeft()
+  const status = new WorkerStatusLeaving()
   status.workerStartedLeavingEventId = workerStartedLeavingEvent.id
   worker.status = status
   worker.updatedAt = eventTime

--- a/query-node/schemas/workingGroups.graphql
+++ b/query-node/schemas/workingGroups.graphql
@@ -3,12 +3,17 @@ type WorkerStatusActive @variant {
   _phantom: Int
 }
 
+type WorkerStatusLeaving @variant {
+  "Related event emitted on leaving initialization"
+  workerStartedLeavingEvent: WorkerStartedLeavingEvent!
+}
+
 type WorkerStatusLeft @variant {
   "Related event emitted on leaving initialization"
   workerStartedLeavingEvent: WorkerStartedLeavingEvent!
 
-  "Related event emitted (and set) when the unstaking period is finished"
-  workerExitedEvent: WorkerExitedEvent
+  "Related event emitted once the worker has exited the role (after the unstaking period)"
+  workerExitedEvent: WorkerExitedEvent!
 }
 
 type WorkerStatusTerminated @variant {
@@ -16,7 +21,7 @@ type WorkerStatusTerminated @variant {
   terminatedWorkerEvent: TerminatedWorkerEvent!
 }
 
-union WorkerStatus = WorkerStatusActive | WorkerStatusLeft | WorkerStatusTerminated
+union WorkerStatus = WorkerStatusActive | WorkerStatusLeaving | WorkerStatusLeft | WorkerStatusTerminated
 
 # Working Groups
 type Worker @entity {

--- a/tests/integration-tests/src/fixtures/workingGroups/LeaveRoleFixture.ts
+++ b/tests/integration-tests/src/fixtures/workingGroups/LeaveRoleFixture.ts
@@ -56,7 +56,7 @@ export class LeaveRoleFixture extends BaseWorkingGroupFixture {
       const worker = qWorkers.find((w) => w.runtimeId === workerId.toNumber())
       Utils.assert(worker, 'Query node: Worker not found!')
       Utils.assert(
-        worker.status.__typename === 'WorkerStatusLeft',
+        worker.status.__typename === 'WorkerStatusLeaving',
         `Invalid worker status: ${worker.status.__typename}`
       )
       Utils.assert(worker.status.workerStartedLeavingEvent, 'Query node: Missing workerStartedLeavingEvent relation')

--- a/tests/integration-tests/src/graphql/generated/queries.ts
+++ b/tests/integration-tests/src/graphql/generated/queries.ts
@@ -348,6 +348,7 @@ export type WorkerFieldsFragment = {
   membership: { id: string }
   status:
     | { __typename: 'WorkerStatusActive' }
+    | { __typename: 'WorkerStatusLeaving'; workerStartedLeavingEvent?: Types.Maybe<{ id: string }> }
     | {
         __typename: 'WorkerStatusLeft'
         workerStartedLeavingEvent?: Types.Maybe<{ id: string }>
@@ -1308,6 +1309,11 @@ export const WorkerFields = gql`
     stakeAccount
     status {
       __typename
+      ... on WorkerStatusLeaving {
+        workerStartedLeavingEvent {
+          id
+        }
+      }
       ... on WorkerStatusLeft {
         workerStartedLeavingEvent {
           id

--- a/tests/integration-tests/src/graphql/generated/schema.ts
+++ b/tests/integration-tests/src/graphql/generated/schema.ts
@@ -8175,7 +8175,7 @@ export type WorkerStartedLeavingEventWhereUniqueInput = {
   id: Scalars['ID']
 }
 
-export type WorkerStatus = WorkerStatusActive | WorkerStatusLeft | WorkerStatusTerminated
+export type WorkerStatus = WorkerStatusActive | WorkerStatusLeaving | WorkerStatusLeft | WorkerStatusTerminated
 
 export type WorkerStatusActive = {
   phantom?: Maybe<Scalars['Int']>
@@ -8228,10 +8228,15 @@ export type WorkerStatusActiveWhereUniqueInput = {
   id: Scalars['ID']
 }
 
+export type WorkerStatusLeaving = {
+  /** Related event emitted on leaving initialization */
+  workerStartedLeavingEvent?: Maybe<WorkerStartedLeavingEvent>
+}
+
 export type WorkerStatusLeft = {
   /** Related event emitted on leaving initialization */
   workerStartedLeavingEvent?: Maybe<WorkerStartedLeavingEvent>
-  /** Related event emitted (and set) when the unstaking period is finished */
+  /** Related event emitted once the worker has exited the role (after the unstaking period) */
   workerExitedEvent?: Maybe<WorkerExitedEvent>
 }
 

--- a/tests/integration-tests/src/graphql/queries/workingGroups.graphql
+++ b/tests/integration-tests/src/graphql/queries/workingGroups.graphql
@@ -71,6 +71,11 @@ fragment WorkerFields on Worker {
   stakeAccount
   status {
     __typename
+    ... on WorkerStatusLeaving {
+      workerStartedLeavingEvent {
+        id
+      }
+    }
     ... on WorkerStatusLeft {
       workerStartedLeavingEvent {
         id

--- a/yarn.lock
+++ b/yarn.lock
@@ -7568,9 +7568,9 @@ aws-credstash@^3.0.0:
     debug "^4.3.1"
 
 aws-sdk@^2.567.0:
-  version "2.923.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.923.0.tgz#97a95686e9dba10f628092bfd90f84397c8ad55f"
-  integrity sha512-93YK9Mx32qvH5eLrDRVkvwpEc7GJ6mces1qQugmNZCuQT68baILyDs0IMRtHS6NYxxiM6XNRFc7ubgMlnafYjg==
+  version "2.926.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.926.0.tgz#96f40b3e8400957becc5b8446e2322c0ff0e8a85"
+  integrity sha512-GFdAznnwxBxRPUTLP8gyFG8GhbUQ0sWwNCocYHkS/FB18hr8gmB3xv2m7VVWA/YkPDXvviPnoB680Z47VSEkqA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
- Split `WorkerStatusLeft` into `WorkerStatusLeaving` and `WorkerStatusLeft` for easier parsing
- Clear `worker.missingRewardAmount` on `WorkerExited` event