### PR TITLE
storage-node: ensure write stream flushed correctly

### DIFF
--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -193,7 +193,7 @@ jobs:
           docker-compose up -d joystream-node
       - name: Configure and start development storage node
         run: |
-          DEBUG=* yarn storage-cli dev-init
+          DEBUG=joystream:* yarn storage-cli dev-init
           docker-compose up -d colossus
       - name: Test uploading
         run: |

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -25,7 +25,9 @@ const assert = require('assert')
 
 function errorHandler(response, err, code) {
   debug(err)
-  response.status(err.code || code || 500).send({ message: err.toString() })
+  // Some err types don't have a valid http status code such as one that come from ipfs node for example
+  const statusCode = typeof err.code === 'number' ? err.code : code
+  response.status(statusCode || 500).send({ message: err.toString() })
   response.end()
 }
 

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -206,7 +206,10 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
           }
         })
 
-        stream.on('error', (err) => errorHandler(res, err))
+        stream.on('error', (err) => {
+          stream.cleanup()
+          errorHandler(res, err)
+        })
         req.pipe(stream)
       } catch (err) {
         errorHandler(res, err)

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -146,7 +146,7 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
           }
         })
 
-        stream.on('finish', async () => {
+        stream.on('end', async () => {
           if (!aborted) {
             try {
               // try to get file info and compute ipfs hash before committing the stream to ifps node.

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -26,6 +26,7 @@ const assert = require('assert')
 function errorHandler(response, err, code) {
   debug(err)
   response.status(err.code || code || 500).send({ message: err.toString() })
+  response.end()
 }
 
 // The maximum total estimated balance that will be spent submitting transactions
@@ -207,6 +208,7 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
         })
 
         stream.on('error', (err) => {
+          stream.end()
           stream.cleanup()
           errorHandler(res, err)
         })

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -133,7 +133,9 @@ class StorageWriteStream extends Transform {
   _flush(callback) {
     debug('Flushing temporary stream:', this.temp.path)
     this.temp.end(() => {
+      debug('flushed!')
       callback(null)
+      this.emit('end')
     })
   }
 

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -103,7 +103,7 @@ class StorageWriteStream extends Transform {
     if (!this.fileInfo && this.buf.byteLength <= fileType.minimumBytes) {
       this.buf = Buffer.concat([this.buf, chunk])
 
-      if (this.buf >= fileType.minimumBytes) {
+      if (this.buf.byteLength >= fileType.minimumBytes) {
         const info = fileType(this.buf)
         // No info? We will try again at the end of the stream.
         if (info) {

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -99,20 +99,21 @@ class StorageWriteStream extends Transform {
       chunk = Buffer.from(chunk)
     }
 
-    this.temp.write(chunk, (err) => {
-      // Try to detect file type during streaming.
-      if (!this.fileInfo && this.buf.byteLength <= fileType.minimumBytes) {
-        this.buf = Buffer.concat([this.buf, chunk])
+    // Try to detect file type during streaming.
+    if (!this.fileInfo && this.buf.byteLength <= fileType.minimumBytes) {
+      this.buf = Buffer.concat([this.buf, chunk])
 
-        if (this.buf >= fileType.minimumBytes) {
-          const info = fileType(this.buf)
-          // No info? We will try again at the end of the stream.
-          if (info) {
-            this.fileInfo = fixFileInfo(info)
-            this.emit('fileInfo', this.fileInfo)
-          }
+      if (this.buf >= fileType.minimumBytes) {
+        const info = fileType(this.buf)
+        // No info? We will try again at the end of the stream.
+        if (info) {
+          this.fileInfo = fixFileInfo(info)
+          this.emit('fileInfo', this.fileInfo)
         }
       }
+    }
+
+    this.temp.write(chunk, (err) => {
       callback(err)
     })
   }

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -183,6 +183,8 @@ class StorageWriteStream extends Transform {
    * Clean up temporary data.
    */
   cleanup() {
+    // Make it safe to call cleanup more than once
+    if (!this.temp) return
     debug('Cleaning up temporary file: ', this.temp.path)
     fs.unlink(this.temp.path, () => {
       /* Ignore errors. */

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -90,6 +90,10 @@ class StorageWriteStream extends Transform {
 
     // Create temp target.
     this.temp = temp.createWriteStream()
+    this.temp.on('error', (err) => this.emit('error', err))
+
+    // Small temporary buffer storing first fileType.minimumBytes of stream
+    // used for early file type detection
     this.buf = Buffer.alloc(0)
   }
 
@@ -118,11 +122,11 @@ class StorageWriteStream extends Transform {
     //   callback(err)
     // })
 
-    // Respect backpressure
+    // Respect backpressure and handle write error
     if (!this.temp.write(chunk)) {
-      this.temp.once('drain', callback)
+      this.temp.once('drain', () => callback(null))
     } else {
-      process.nextTick(callback)
+      process.nextTick(() => callback(null))
     }
   }
 

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -99,29 +99,29 @@ class StorageWriteStream extends Transform {
       chunk = Buffer.from(chunk)
     }
 
-    this.temp.write(chunk)
+    this.temp.write(chunk, (err) => {
+      // Try to detect file type during streaming.
+      if (!this.fileInfo && this.buf.byteLength <= fileType.minimumBytes) {
+        this.buf = Buffer.concat([this.buf, chunk])
 
-    // Try to detect file type during streaming.
-    if (!this.fileInfo && this.buf.byteLength <= fileType.minimumBytes) {
-      this.buf = Buffer.concat([this.buf, chunk])
-
-      if (this.buf >= fileType.minimumBytes) {
-        const info = fileType(this.buf)
-        // No info? We will try again at the end of the stream.
-        if (info) {
-          this.fileInfo = fixFileInfo(info)
-          this.emit('fileInfo', this.fileInfo)
+        if (this.buf >= fileType.minimumBytes) {
+          const info = fileType(this.buf)
+          // No info? We will try again at the end of the stream.
+          if (info) {
+            this.fileInfo = fixFileInfo(info)
+            this.emit('fileInfo', this.fileInfo)
+          }
         }
       }
-    }
-
-    callback(null)
+      callback(err)
+    })
   }
 
   _flush(callback) {
     debug('Flushing temporary stream:', this.temp.path)
-    this.temp.end()
-    callback(null)
+    this.temp.end(() => {
+      callback(null)
+    })
   }
 
   /*

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -336,22 +336,15 @@ class Storage {
 
     // Write stream
     if (mode === 'w') {
-      return await this.createWriteStream(contentId, timeout)
+      return this.createWriteStream(contentId, timeout)
     }
 
     // Read stream - with file type detection
     return await this.createReadStream(contentId, timeout)
   }
 
-  async createWriteStream() {
-    // IPFS wants us to just dump a stream into its storage, then returns a
-    // content ID (of its own).
-    // We need to instead return a stream immediately, that we eventually
-    // decorate with the content ID when that's available.
-    return new Promise((resolve) => {
-      const stream = new StorageWriteStream(this)
-      resolve(stream)
-    })
+  createWriteStream() {
+    return new StorageWriteStream(this)
   }
 
   async createReadStream(contentId, timeout) {

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -113,9 +113,17 @@ class StorageWriteStream extends Transform {
       }
     }
 
-    this.temp.write(chunk, (err) => {
-      callback(err)
-    })
+    // Always waiting for write flush can be slow..
+    // this.temp.write(chunk, (err) => {
+    //   callback(err)
+    // })
+
+    // Respect backpressure
+    if (!this.temp.write(chunk)) {
+      this.temp.once('drain', callback)
+    } else {
+      process.nextTick(callback)
+    }
   }
 
   _flush(callback) {


### PR DESCRIPTION
Bug Fixes:
- On heavy load and large file uploads Colossus was sometimes not matching IPFS hash of file correctly. This was due to the hash being calculated early, before the entire temporary stream was flushed to disk. Fixed by calling callbacks after writes and flushes were complete.
- Added error handling for write errors to temporary stream, and proper handling of backpressure
- Fixed early file type detection check during upload - buffer length was not correctly checked to know if it was time to test
- Fix for  https://github.com/Joystream/joystream/issues/2306 - adjust errorHandler to deal with error objects that may not contain a proper http numeric status code