### PR TITLE
Update election salt function to use proven crypto implementation

### DIFF
--- a/pioneer/packages/joy-election/src/VoteForm.tsx
+++ b/pioneer/packages/joy-election/src/VoteForm.tsx
@@ -1,5 +1,5 @@
 import BN from 'bn.js';
-import uuid from 'uuid/v4';
+import { randomAsHex } from '@polkadot/util-crypto';
 
 import React from 'react';
 import { Message, Table } from 'semantic-ui-react';
@@ -25,9 +25,8 @@ import { saveVote, NewVote } from './myVotesStore';
 import { TxFailedCallback } from '@polkadot/react-components/Status/types';
 import { RouteProps } from 'react-router-dom';
 
-// TODO use a crypto-prooven generator instead of UUID 4.
 function randomSalt () {
-  return uuid().replace(/-/g, '');
+  return randomAsHex();
 }
 
 // AppsProps is needed to get a location from the route.


### PR DESCRIPTION
This PR aims to change the current uuid implementation for the salt used in voting and revealing votes into a cryptographically secure random number generator. Issue further explained here: https://github.com/Joystream/audits/issues/4

After doing some research, I found the best/easiest option would be to use the browsers crypto api for this but upon further research I've found that polkadot in their own `util-crypto` random functions uses this same api. 

Due to this I've decided to go with `randomAsHex()`. Without any parameters, the size of the sequence will be 32 bytes which is coincidentally exactly the limit the current olympia runtime currently has for it. I've tested it with [this code](https://github.com/Lezek123/substrate-runtime-joystream/blob/olympia-proposals-mappings/tests/integration-tests/src/fixtures/council/ElectCouncilFixture.tshttps://github.com/Lezek123/substrate-runtime-joystream/blob/olympia-proposals-mappings/tests/integration-tests/src/fixtures/council/ElectCouncilFixture.ts) to make sure that it indeed works!