### PR TITLE
Fix operations lead group earning value

### DIFF
--- a/pioneer/packages/joy-tokenomics/src/Overview/SpendingAndStakeDistributionTable.tsx
+++ b/pioneer/packages/joy-tokenomics/src/Overview/SpendingAndStakeDistributionTable.tsx
@@ -121,21 +121,21 @@ const SpendingAndStakeTableRow: React.FC<{
   );
 };
 
+const WORKING_GROUPS = ['storageProviders', 'contentCurators', 'operations'] as const;
+
 type TokenomicsGroup =
   'validators' |
   'council' |
-  'storageProviders' |
-  'contentCurators' |
-  'operations'
+  typeof WORKING_GROUPS[number]
 
 const SpendingAndStakeDistributionTable: React.FC<{data?: TokenomicsData; statusData?: StatusServerData | null}> = ({ data, statusData }) => {
   const { width } = useWindowDimensions();
 
   const displayStatusData = (group: TokenomicsGroup, dataType: 'rewardsPerWeek' | 'totalStake', lead = false): string | undefined => {
-    if ((group === 'storageProviders' || group === 'contentCurators') && lead) {
+    if ((WORKING_GROUPS.includes(group as any)) && lead) {
       return statusData === null
         ? 'Data currently unavailable...'
-        : (data && statusData) && `${(data[group].lead[dataType] * Number(statusData.price)).toFixed(2)}`;
+        : (data && statusData) && `${(data[group as typeof WORKING_GROUPS[number]].lead[dataType] * Number(statusData.price)).toFixed(2)}`;
     } else {
       return statusData === null
         ? 'Data currently unavailable...'


### PR DESCRIPTION
This PR aims to fix the problem from this issue: https://github.com/Joystream/joystream/issues/2463

The problem was that the value being shown was the same value as the one from the operations group as opposed to the lead. The solution was to add operations in the (lead) check for the function that displays this data.

The simplest solution was to add `'operations'` to the if case but could lead to a similar problem in the future. I went with creating an array for working groups so we only have one place to add the value. Typescript doesn't like the includes function so I had to add some type assertions to get around it. Am open to changing this if there's a better way to do it!