### PR TITLE
Storage-Node: Improve Sync Run

### DIFF
--- a/storage-node/packages/colossus/api-base.yml
+++ b/storage-node/packages/colossus/api-base.yml
@@ -1,7 +1,7 @@
 openapi: '3.0.0'
 info:
-  title: 'Joystream Storage Node API.'
-  version: '1.0.0'
+  title: 'Colossus - Joystream Storage Node'
+  version: '1.1.0'
 paths: {} # Will be populated by express-openapi
 
 components:

--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -99,7 +99,7 @@ const cli = meow(
     --ipfs-host   hostname  ipfs host to use, default to 'localhost'. Default port 5001 is always used
     --anonymous             Runs server in anonymous mode. Replicates content without need to register
                             on-chain, and can serve content. Cannot be used to upload content.
-    --maxSync               The max number of items to sync concurrently. Defaults to 30. Must be greater than 0.
+    --maxSync               The max number of items to sync concurrently. Defaults to 30.
   `,
   { flags: FLAG_DEFINITIONS }
 )

--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -19,7 +19,7 @@ const debug = require('debug')('joystream:colossus')
 const PROJECT_ROOT = path.resolve(__dirname, '..')
 
 // Number of milliseconds to wait between synchronization runs.
-const SYNC_PERIOD_MS = 120000 // 2min
+const SYNC_PERIOD_MS = 30000
 
 // Parse CLI
 const FLAG_DEFINITIONS = {

--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -74,7 +74,7 @@ const FLAG_DEFINITIONS = {
   },
   maxSync: {
     type: 'number',
-    default: 30,
+    default: 200,
   },
 }
 

--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -18,9 +18,6 @@ const debug = require('debug')('joystream:colossus')
 // Project root
 const PROJECT_ROOT = path.resolve(__dirname, '..')
 
-// Number of milliseconds to wait between synchronization runs.
-const SYNC_PERIOD_MS = 30000
-
 // Parse CLI
 const FLAG_DEFINITIONS = {
   port: {
@@ -75,6 +72,10 @@ const FLAG_DEFINITIONS = {
     type: 'boolean',
     default: false,
   },
+  maxSync: {
+    type: 'number',
+    default: 30,
+  },
 }
 
 const cli = meow(
@@ -98,6 +99,7 @@ const cli = meow(
     --ipfs-host   hostname  ipfs host to use, default to 'localhost'. Default port 5001 is always used
     --anonymous             Runs server in anonymous mode. Replicates content without need to register
                             on-chain, and can serve content. Cannot be used to upload content.
+    --maxSync               The max number of items to sync concurrently. Defaults to 30. Must be greater than 0.
   `,
   { flags: FLAG_DEFINITIONS }
 )
@@ -276,7 +278,7 @@ const commands = {
     const ipfsHttpGatewayUrl = `http://${ipfsHost}:8080/`
 
     const { startSyncing } = require('../lib/sync')
-    startSyncing(api, { syncPeriod: SYNC_PERIOD_MS, anonymous: cli.flags.anonymous }, store)
+    startSyncing(api, { anonymous: cli.flags.anonymous, maxSync: cli.flags.maxSync }, store)
 
     if (!cli.flags.anonymous) {
       announcePublicUrl(api, publicUrl)

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -28,12 +28,10 @@ const { nextTick } = require('@joystream/storage-utils/sleep')
 const INTERVAL_BETWEEN_SYNC_RUNS_MS = 3000
 // Time between refreshing content ids from chain
 const CONTENT_ID_REFRESH_INTERVAL_MS = 60000
-// Minimum concurrency. Must be greater than zero.
-const MIN_CONCURRENT_SYNC_ITEMS = 5
 
 async function syncRun({ api, storage, contentBeingSynced, contentCompletedSync, flags, contentIds }) {
   // The number of concurrent items to attemp to fetch.
-  const MAX_CONCURRENT_SYNC_ITEMS = Math.max(MIN_CONCURRENT_SYNC_ITEMS, flags.maxSync)
+  const MAX_CONCURRENT_SYNC_ITEMS = Math.max(1, flags.maxSync)
 
   // Select ids which may need to be synced
   const idsNotSynced = contentIds

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -48,9 +48,9 @@ async function syncContent({ api, storage, contentBeingSynced, contentCompleteSy
   while (contentBeingSynced.size < MAX_CONCURRENT_SYNC_ITEMS && candidatesForSync.length) {
     const id = candidatesForSync.shift()
 
-    // Log progress every 100 items
+    // Log progress
     if (syncedItemsCount % 100 === 0) {
-      debug(`${candidatesForSync.length} items remaining to sync.`)
+      debug(`${candidatesForSync.length} items remaining to process`)
     }
 
     try {

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -21,7 +21,7 @@
 const debug = require('debug')('joystream:sync')
 const _ = require('lodash')
 const { ContentId } = require('@joystream/types/storage')
-const { sleep } = require('@joystream/storage-utils/sleep')
+const { nextTick } = require('@joystream/storage-utils/sleep')
 
 // The number of concurrent items to attemp to fetch. Must be greater than zero.
 const MAX_CONCURRENT_SYNC_ITEMS = 30
@@ -69,7 +69,7 @@ async function syncContent({ api, storage, contentBeingSynced, contentCompleteSy
 
       // Allow short time for checking if content is already stored locally.
       // So we can handle more new items per run.
-      await sleep(50)
+      await nextTick()
     } catch (err) {
       // Most likely failed to resolve the content id
       debug(`Failed calling synchronize ${err}`)

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -42,6 +42,9 @@ async function syncContent({ api, storage, contentBeingSynced, contentCompleteSy
   // we simply shuffle.
   const candidatesForSync = _.shuffle(needsSync)
 
+  debug(`${candidatesForSync.length} items remaining to process`)
+  let syncedItemsCount = 0
+
   while (contentBeingSynced.size < MAX_CONCURRENT_SYNC_ITEMS && candidatesForSync.length) {
     const id = candidatesForSync.shift()
 
@@ -53,6 +56,7 @@ async function syncContent({ api, storage, contentBeingSynced, contentCompleteSy
           contentBeingSynced.delete(id)
           debug(`Error Syncing ${err}`)
         } else if (status.synced) {
+          syncedItemsCount++
           contentBeingSynced.delete(id)
           contentCompleteSynced.set(id)
         }
@@ -67,6 +71,8 @@ async function syncContent({ api, storage, contentBeingSynced, contentCompleteSy
       contentBeingSynced.delete(id)
     }
   }
+
+  debug(`Items processed in this sync run ${syncedItemsCount}`)
 }
 
 async function syncPeriodic({ api, flags, storage, contentBeingSynced, contentCompleteSynced }) {

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -40,9 +40,6 @@ async function syncContent({ api, storage, contentBeingSynced, contentCompleteSy
   // we simply shuffle.
   const candidatesForSync = _.shuffle(needsSync)
 
-  // TODO: get the data object
-  // make sure the data object was Accepted by the liaison,
-  // don't just blindly attempt to fetch them
   while (contentBeingSynced.size < MAX_CONCURRENT_SYNC_ITEMS && candidatesForSync.length) {
     const id = candidatesForSync.shift()
 
@@ -61,7 +58,7 @@ async function syncContent({ api, storage, contentBeingSynced, contentCompleteSy
 
       // Allow short time for checking if content is already stored locally.
       // So we can handle more new items per run.
-      await sleep(100)
+      await sleep(250)
     } catch (err) {
       // Most likely failed to resolve the content id
       debug(`Failed calling synchronize ${err}`)

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -49,8 +49,7 @@ async function syncRun({ api, storage, contentBeingSynced, contentCompletedSync,
 
     try {
       contentBeingSynced.set(id)
-      const contentId = ContentId.decode(api.api.registry, id)
-      await storage.pin(contentId, (err, status) => {
+      await storage.pin(id, (err, status) => {
         if (err) {
           contentBeingSynced.delete(id)
           debug(`Error Syncing ${err}`)

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -96,11 +96,7 @@ async function syncRunner({ api, flags, storage, contentBeingSynced, contentComp
         // re-fetch content ids
         contentIds = (await api.assets.getAcceptedContentIds()).map((id) => id.encode())
         contentIds.fetchedAt = Date.now()
-
-        debug(`======== sync status ==========`)
-        debug(`objects syncing : ${contentBeingSynced.size}`)
-        debug(`objects local   : ${contentCompletedSync.size}`)
-        debug(`objects known   : ${contentIds.length}`)
+        debug(`objects known: ${contentIds.length}`)
       }
 
       await syncRun({
@@ -127,6 +123,11 @@ function startSyncing(api, flags, storage) {
   const contentCompletedSync = new Map()
 
   syncRunner({ api, flags, storage, contentBeingSynced, contentCompletedSync })
+
+  setInterval(() => {
+    debug(`objects syncing: ${contentBeingSynced.size}`)
+    debug(`objects local: ${contentCompletedSync.size}`)
+  }, 60000)
 }
 
 module.exports = {

--- a/storage-node/packages/colossus/package.json
+++ b/storage-node/packages/colossus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/colossus",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Colossus - Joystream Storage Node",
   "author": "Joystream",
   "homepage": "https://github.com/Joystream/joystream",

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -227,6 +227,11 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
           // they cannot be different unless we did something stupid!
           assert(hash === dataObject.ipfs_content_id.toString())
 
+          ipfsContentIdMap.set(id, {
+            ipfs_content_id: hash,
+            local: true,
+          })
+
           // Send ok response early, no need for client to wait for relationships to be created.
           debug('Sending OK response.')
           res.status(200).send({ message: 'Asset uploaded.' })

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -242,17 +242,6 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
             if (dataObject.liaison_judgement.type === 'Pending') {
               await runtime.assets.acceptContent(roleAddress, providerId, id)
             }
-
-            // Is there any real value in updating this state? Nobody uses it!
-            const { relationshipId } = await runtime.assets.getStorageRelationshipAndId(providerId, id)
-            if (!relationshipId) {
-              debug('creating storage relationship for newly uploaded content')
-              // Create storage relationship and flip it to ready.
-              const dosrId = await runtime.assets.createStorageRelationship(roleAddress, providerId, id)
-
-              debug('toggling storage relationship for newly uploaded content')
-              await runtime.assets.toggleStorageRelationshipReady(roleAddress, providerId, dosrId, true)
-            }
           } catch (err) {
             debug(`${err.message}`)
           }

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -75,7 +75,7 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
 
     // Not yet processed by sync run, check if we have it locally
     try {
-      const stat = await storage.ipfsStat(ipfs_content_id, 250)
+      const stat = await storage.ipfsStat(ipfs_content_id, 4000)
 
       if (stat.local) {
         ipfsContentIdMap.set(content_id, {
@@ -87,8 +87,8 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
         return proxy(req, res, next)
       }
     } catch (_err) {
-      // timeout or some other error trying to stat
-      debug('Failed to stat', ipfs_content_id)
+      // timeout trying to stat which most likely means we do not have it
+      // debug('Failed to stat', ipfs_content_id)
     }
 
     // Valid content but no certainty that the node has it locally yet.

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -43,6 +43,8 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
 
   const proxyAcceptedContentToIpfsGateway = async (req, res, next) => {
     // make sure id exists and was Accepted only then proxy
+    // todo? stat file only server if local
+    // cache id -> ipfs hash mapping
     const dataObject = await runtime.assets.getDataObject(req.params.id)
 
     if (dataObject && dataObject.liaison_judgement.type === 'Accepted') {

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -51,20 +51,15 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
     const content_id = req.params.id
 
     if (!ipfsContentIdMap.has(content_id)) {
-      const dataObject = await runtime.assets.getDataObject(req.params.id)
+      const hash = runtime.assets.resolveContentIdToIpfsHash(req.params.id)
 
-      if (!dataObject) {
+      if (!hash) {
         return res.status(404).send({ message: 'Unknown content' })
-      }
-
-      // Has content ever been uploaded and accepted by a provider?
-      if (dataObject.liaison_judgement.type !== 'Accepted') {
-        return res.status(404).send({ message: 'Not processed yet' })
       }
 
       ipfsContentIdMap.set(content_id, {
         local: false,
-        ipfs_content_id: dataObject.ipfs_content_id.toString(),
+        ipfs_content_id: hash,
       })
     }
 
@@ -92,7 +87,7 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
         return proxy(req, res, next)
       }
     } catch (_err) {
-      // timeout of some other error trying to stat
+      // timeout or some other error trying to stat
       debug('Failed to stat', ipfs_content_id)
     }
 

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -75,7 +75,7 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
 
     // Not yet processed by sync run, check if we have it locally
     try {
-      const stat = await storage.statIpfs(ipfs_content_id, 250)
+      const stat = await storage.ipfsStat(ipfs_content_id, 250)
 
       if (stat.local) {
         ipfsContentIdMap.set(content_id, {

--- a/storage-node/packages/helios/bin/cli.js
+++ b/storage-node/packages/helios/bin/cli.js
@@ -18,7 +18,7 @@ async function countContentAvailability(providerId, endpoint, contentIds) {
   // Avoid opening too many connections, do it in chunks.. otherwise we get
   // "Client network socket disconnected before secure TLS connection was established" errors
   while (contentIds.length) {
-    const chunk = contentIds.splice(0, 500)
+    const chunk = contentIds.splice(0, 100)
     requestsSent += chunk.length
     const results = await Promise.allSettled(chunk.map((id) => axios.head(makeAssetUrl(id, endpoint))))
 

--- a/storage-node/packages/helios/bin/cli.js
+++ b/storage-node/packages/helios/bin/cli.js
@@ -97,10 +97,17 @@ async function main() {
     })
   )
 
-  const allContentIds = await runtime.assets.getKnownContentIds()
-  const acceptedContentIds = await runtime.assets.getAcceptedContentIds()
+  // Load data objects
+  await runtime.assets.fetchDataObjects()
 
-  console.log(`\nData Directory has ${acceptedContentIds.length} 'Accepted' objects out of ${allContentIds.length}`)
+  const allContentIds = await runtime.assets.getKnownContentIds()
+  const acceptedContentIds = runtime.assets.getAcceptedContentIds()
+  const ipfsHashes = runtime.assets.getAcceptedIpfsHashes()
+
+  console.log('\nData Directory objects:')
+  console.log(allContentIds.length, 'created')
+  console.log(acceptedContentIds.length, 'accepted')
+  console.log(ipfsHashes.length, 'unique accepted hashes')
 
   // We no longer need a connection to the chain
   api.disconnect()

--- a/storage-node/packages/helios/bin/cli.js
+++ b/storage-node/packages/helios/bin/cli.js
@@ -10,34 +10,44 @@ function makeAssetUrl(contentId, source) {
   return `${source}/asset/v0/${encodeAddress(contentId)}`
 }
 
-// HTTP HEAD with axios all known content ids on each provider
-async function countContentAvailability(contentIds, source) {
+// HTTP HEAD with axios all known content ids on given endpoint
+async function countContentAvailability(contentIds, endpoint) {
   let found = 0
   let errored = 0
+  let requestsSent = 0
+  // Avoid opening too many connections, do it in chunks.. otherwise we get
+  // "Client network socket disconnected before secure TLS connection was established" errors
+  while (contentIds.length) {
+    const chunk = contentIds.splice(0, 500)
+    requestsSent += chunk.length
+    const results = await Promise.allSettled(chunk.map((id) => axios.head(makeAssetUrl(id, endpoint))))
 
-  // TODO: To avoid opening too many connections do it in chunks.. otherwise were are getting
-  // Error: Client network socket disconnected before secure TLS connection was established
-  contentIds = contentIds.slice(0, 200)
+    results.forEach((result, _ix) => {
+      if (result.status === 'rejected') {
+        errored++
+      } else {
+        found++
+      }
+    })
 
-  // use axios.all() instead ?
-  const results = await Promise.allSettled(contentIds.map((id) => axios.head(makeAssetUrl(id, source))))
-
-  results.forEach((result, _ix) => {
-    if (result.status === 'rejected') {
-      errored++
-    } else {
-      found++
-    }
-  })
+    // show some progress
+    console.error(`${endpoint}:`, `total requests sent: ${requestsSent}`, `found: ${found}`, `failed: ${errored}`)
+  }
 
   return { found, errored }
 }
 
 async function testProviderHasAssets(providerId, endpoint, contentIds) {
   const total = contentIds.length
+  const startedAt = Date.now()
   const { found, errored } = await countContentAvailability(contentIds, endpoint)
-  console.log(`provider ${providerId}: has ${errored} errored assets`)
-  console.log(`provider ${providerId}: has ${found} out of ${total}`)
+  const completedAt = Date.now()
+  console.log(`
+    Final Result for provider ${providerId}
+    fetched: ${found}/${total}
+    failed: ${errored}
+    took: ${(completedAt - startedAt) / 1000}s
+  `)
 }
 
 async function main() {
@@ -70,15 +80,17 @@ async function main() {
         return
       }
       const swaggerUrl = `${stripEndingSlash(provider.endpoint)}/swagger.json`
-      let error
       try {
-        await axios.get(swaggerUrl)
-        // maybe print out api version information to detect which version of colossus is running?
-        // or add anothe api endpoint for diagnostics information
+        const { data } = await axios.get(swaggerUrl)
+        console.log(
+          `${provider.providerId}:`,
+          `${provider.endpoint}`,
+          '- OK -',
+          `storage node version ${data.info.version}`
+        )
       } catch (err) {
-        error = err
+        console.log(`${provider.providerId}`, `${provider.endpoint} - ${err.message}`)
       }
-      console.log(`${provider.providerId}`, `${provider.endpoint} - ${error ? error.message : 'OK'}`)
     })
   )
 
@@ -87,20 +99,19 @@ async function main() {
 
   console.log(`\nData Directory has ${acceptedContentIds.length} 'Accepted' objects out of ${allContentIds.length}`)
 
-  // interesting disconnect doesn't work unless an explicit provider was created
-  // for underlying api instance
   // We no longer need a connection to the chain
   api.disconnect()
 
-  console.log(`\nChecking available assets on providers (this can take some time)...`)
+  console.log(`
+    Checking available assets on providers (this can take some time)
+    This is done by sending HEAD requests for all 'Accepted' assets.
+  `)
 
-  // TODO: Do it sequentially one provider at a time.. to control connections/s to avoid
-  // connection resets?
   endpoints.forEach(async ({ providerId, endpoint }) => {
     if (!endpoint) {
       return
     }
-    return testProviderHasAssets(providerId, endpoint, acceptedContentIds)
+    return testProviderHasAssets(providerId, endpoint, acceptedContentIds.slice())
   })
 }
 

--- a/storage-node/packages/helios/bin/cli.js
+++ b/storage-node/packages/helios/bin/cli.js
@@ -11,7 +11,7 @@ function makeAssetUrl(contentId, source) {
 }
 
 // HTTP HEAD with axios all known content ids on given endpoint
-async function countContentAvailability(contentIds, endpoint) {
+async function countContentAvailability(providerId, endpoint, contentIds) {
   let found = 0
   let errored = 0
   let requestsSent = 0
@@ -31,7 +31,7 @@ async function countContentAvailability(contentIds, endpoint) {
     })
 
     // show some progress
-    console.error(`${endpoint}:`, `total requests sent: ${requestsSent}`, `found: ${found}`, `failed: ${errored}`)
+    console.error(`provider: ${providerId}:`, `total checks: ${requestsSent}`, `ok: ${found}`, `errors: ${errored}`)
   }
 
   return { found, errored }
@@ -40,13 +40,16 @@ async function countContentAvailability(contentIds, endpoint) {
 async function testProviderHasAssets(providerId, endpoint, contentIds) {
   const total = contentIds.length
   const startedAt = Date.now()
-  const { found, errored } = await countContentAvailability(contentIds, endpoint)
+  const { found, errored } = await countContentAvailability(providerId, endpoint, contentIds)
   const completedAt = Date.now()
   console.log(`
+    ---------------------------------------
     Final Result for provider ${providerId}
+    url: ${endpoint}
     fetched: ${found}/${total}
     failed: ${errored}
-    took: ${(completedAt - startedAt) / 1000}s
+    check took: ${(completedAt - startedAt) / 1000}s
+    ------------------------------------------
   `)
 }
 

--- a/storage-node/packages/runtime-api/assets.js
+++ b/storage-node/packages/runtime-api/assets.js
@@ -158,7 +158,7 @@ class AssetsApi {
   /*
    * Returns array of all content ids in storage where liaison judgement was Accepted
    */
-  async getAcceptedContentIds() {
+  getAcceptedContentIds() {
     if (!this._cachedEntries) {
       return []
     }
@@ -177,7 +177,7 @@ class AssetsApi {
   /*
    * Returns array of all ipfs hashes in storage where liaison judgement was Accepted
    */
-  async getAcceptedIpfsHashes() {
+  getAcceptedIpfsHashes() {
     if (!this._cachedEntries) {
       return []
     }

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -407,7 +407,7 @@ class Storage {
     // TODO: validate resolved id is proper ipfs_cid, not null or empty string
 
     if (!this.pinning[resolved] && !this.pinned[resolved]) {
-      debug(`Pinning hash: ${resolved} content-id: ${contentId}`)
+      // debug(`Pinning hash: ${resolved} content-id: ${contentId}`)
       this.pinning[resolved] = true
 
       // Callback passed to add() will be called on error or when the entire file
@@ -418,7 +418,7 @@ class Storage {
           debug(`Error Pinning: ${resolved}`)
           callback && callback(err)
         } else {
-          debug(`Pinned ${resolved}`)
+          // debug(`Pinned ${resolved}`)
           this.pinned[resolved] = true
           callback && callback(null, this.syncStatus(resolved))
         }

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -300,9 +300,9 @@ class Storage {
    * Stat a content ID.
    */
   async stat(contentId, timeout) {
-    const resolved = await this.resolveContentIdWithTimeout(timeout, contentId)
+    const ipfsHash = await this.resolveContentIdWithTimeout(timeout, contentId)
 
-    return this.ipfsStat(resolved, timeout)
+    return this.ipfsStat(ipfsHash, timeout)
   }
 
   /*
@@ -369,13 +369,13 @@ class Storage {
   }
 
   async createReadStream(contentId, timeout) {
-    const resolved = await this.resolveContentIdWithTimeout(timeout, contentId)
+    const ipfsHash = await this.resolveContentIdWithTimeout(timeout, contentId)
 
     let found = false
     return await this.withSpecifiedTimeout(timeout, (resolve, reject) => {
-      const ls = this.ipfs.getReadableStream(resolved)
+      const ls = this.ipfs.getReadableStream(ipfsHash)
       ls.on('data', async (result) => {
-        if (result.path === resolved) {
+        if (result.path === ipfsHash) {
           found = true
 
           const ftStream = await fileType.stream(result.content)
@@ -399,32 +399,28 @@ class Storage {
   }
 
   /*
-   * Synchronize the given content ID
+   * Pin the given IPFS CID
    */
-  async synchronize(contentId, callback) {
-    const resolved = await this.resolveContentIdWithTimeout(this._timeout, contentId)
-
-    // TODO: validate resolved id is proper ipfs_cid, not null or empty string
-
-    if (!this.pinning[resolved] && !this.pinned[resolved]) {
-      // debug(`Pinning hash: ${resolved} content-id: ${contentId}`)
-      this.pinning[resolved] = true
+  async pin(ipfsHash, callback) {
+    if (!this.pinning[ipfsHash] && !this.pinned[ipfsHash]) {
+      // debug(`Pinning hash: ${ipfsHash} content-id: ${contentId}`)
+      this.pinning[ipfsHash] = true
 
       // Callback passed to add() will be called on error or when the entire file
       // is retrieved. So on success we consider the content synced.
-      this.ipfs.pin.add(resolved, { quiet: true, pin: true }, (err) => {
-        delete this.pinning[resolved]
+      this.ipfs.pin.add(ipfsHash, { quiet: true, pin: true }, (err) => {
+        delete this.pinning[ipfsHash]
         if (err) {
-          debug(`Error Pinning: ${resolved}`)
+          debug(`Error Pinning: ${ipfsHash}`)
           callback && callback(err)
         } else {
-          // debug(`Pinned ${resolved}`)
-          this.pinned[resolved] = true
-          callback && callback(null, this.syncStatus(resolved))
+          // debug(`Pinned ${ipfsHash}`)
+          this.pinned[ipfsHash] = true
+          callback && callback(null, this.syncStatus(ipfsHash))
         }
       })
     } else {
-      callback && callback(null, this.syncStatus(resolved))
+      callback && callback(null, this.syncStatus(ipfsHash))
     }
   }
 

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -302,8 +302,15 @@ class Storage {
   async stat(contentId, timeout) {
     const resolved = await this.resolveContentIdWithTimeout(timeout, contentId)
 
-    return await this.withSpecifiedTimeout(timeout, (resolve, reject) => {
-      this.ipfs.files.stat(`/ipfs/${resolved}`, { withLocal: true }, (err, res) => {
+    return this.ipfsStat(resolved, timeout)
+  }
+
+  /*
+   * Stat IPFS hash
+   */
+  async ipfsStat(hash, timeout) {
+    return this.withSpecifiedTimeout(timeout, (resolve, reject) => {
+      this.ipfs.files.stat(`/ipfs/${hash}`, { withLocal: true }, (err, res) => {
         if (err) {
           reject(err)
           return

--- a/storage-node/packages/util/sleep.js
+++ b/storage-node/packages/util/sleep.js
@@ -4,6 +4,13 @@ function sleep(ms) {
   })
 }
 
+function nextTick() {
+  return new Promise((resolve) => {
+    process.nextTick(resolve)
+  })
+}
+
 module.exports = {
   sleep,
+  nextTick,
 }


### PR DESCRIPTION
Speedup the sync process, by simply allowing time for check for existence of content in IPFS we improve the number of new data objects that can be synced per "sync run". On startup expect high CPU as all objects will be effectively checked in a short time span.

Additionally dropping the need to create and update "storage-relationships" on chain also simplifies the sync process. We don't use that state in query-node/Atlas directly, or from helios. This also means the next sync run starts sooner and we can continue to process new set of content quicker.

Updating deployed storage nodes with this fix should significantly improve the UX from Atlas during playback and fetching assets as nodes will quickly sync up all the content.

Bumped version of colossus to v0.4.0 and the API version to 1.1.0 - the api version is now displayed when getting information from nodes with helios.

Improvements to helios tool to give better status of asset availability on nodes.
