### PR TITLE
DevOps - Create AMI - ansible-base to ansible-core

### DIFF
--- a/.github/workflows/create-ami.yml
+++ b/.github/workflows/create-ami.yml
@@ -45,7 +45,7 @@ jobs:
         parameter-overrides: "KeyName=${{ env.KEY_NAME }}"
 
     - name: Install Ansible dependencies
-      run: pipx inject ansible-base boto3 botocore
+      run: pipx inject ansible-core boto3 botocore
 
     - name: Run playbook
       uses: dawidd6/action-ansible-playbook@v2


### PR DESCRIPTION
Github actions virtual environment for Ubuntu has been updated to use Ansible 4. This is breaking change which needs modification of our github action. References to `ansible-base` needs to be changed to `ansible-core`.

https://github.com/actions/virtual-environments/issues/3714

Some of our previous runs for the action have failed because of this change:
https://github.com/Joystream/joystream/actions/runs/1052365818
https://github.com/Joystream/joystream/actions/runs/1066304340

Tested and working on:
https://github.com/ahhda/joystream/actions/runs/1073701818