### PR TITLE
Colossus: More enhancements and improved helios

### DIFF
--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -143,15 +143,9 @@ function getStorage(runtimeApi, { ipfsHost }) {
     resolve_content_id: async (contentId) => {
       // Resolve accepted content from cache
       const hash = runtimeApi.assets.resolveContentIdToIpfsHash(contentId)
-      if (hash) return hash
-
-      // Resolve via API
-      const obj = await runtimeApi.assets.getDataObject(contentId)
-      if (!obj) {
-        return
+      if (hash) {
+        return hash
       }
-      // if obj.liaison_judgement !== Accepted .. throw ?
-      return obj.ipfs_content_id.toString()
     },
     ipfsHost,
   }
@@ -275,6 +269,10 @@ const commands = {
       port = cli.flags.port
     }
 
+    const store = getStorage(api, cli.flags)
+
+    await store.scanRepo()
+
     // Get initlal data objects into cache
     while (true) {
       try {
@@ -296,9 +294,6 @@ const commands = {
         debug('Failed updating data objects from chain', err)
       }
     }, 120000)
-
-    // TODO: check valid url, and valid port number
-    const store = getStorage(api, cli.flags)
 
     const ipfsHost = cli.flags.ipfsHost
     const ipfsHttpGatewayUrl = `http://${ipfsHost}:8080/`

--- a/storage-node/packages/colossus/bin/cli.js
+++ b/storage-node/packages/colossus/bin/cli.js
@@ -74,7 +74,7 @@ const FLAG_DEFINITIONS = {
   },
   maxSync: {
     type: 'number',
-    default: 200,
+    default: 100,
   },
 }
 
@@ -99,7 +99,7 @@ const cli = meow(
     --ipfs-host   hostname  ipfs host to use, default to 'localhost'. Default port 5001 is always used
     --anonymous             Runs server in anonymous mode. Replicates content without need to register
                             on-chain, and can serve content. Cannot be used to upload content.
-    --maxSync               The max number of items to sync concurrently. Defaults to 30.
+    --max-sync              The max number of items to sync concurrently. Defaults to 100.
   `,
   { flags: FLAG_DEFINITIONS }
 )
@@ -295,7 +295,7 @@ const commands = {
       } catch (err) {
         debug('Failed updating data objects from chain', err)
       }
-    }, 60000)
+    }, 120000)
 
     // TODO: check valid url, and valid port number
     const store = getStorage(api, cli.flags)

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -45,7 +45,16 @@ async function syncRun({ api, storage, flags }) {
     try {
       storage.pin(id, (err) => {
         if (!err) {
-          debug('synced:', id, '| total synced:', contentCompletedSync.size, '| remaining:', idsToSync.length)
+          debug(
+            'synced:',
+            id,
+            '| synced:',
+            contentCompletedSync.size,
+            '| syncing:',
+            contentBeingSynced.size,
+            '| queued:',
+            idsToSync.length
+          )
         }
       })
     } catch (err) {

--- a/storage-node/packages/colossus/lib/sync.js
+++ b/storage-node/packages/colossus/lib/sync.js
@@ -25,7 +25,7 @@ const { nextTick } = require('@joystream/storage-utils/sleep')
 
 // Time to wait between sync runs. The lower the better chance to consume all
 // available sync sessions allowed.
-const INTERVAL_BETWEEN_SYNC_RUNS_MS = 3000
+const INTERVAL_BETWEEN_SYNC_RUNS_MS = 500
 
 async function syncRun({ api, storage, contentBeingSynced, contentCompletedSync, flags }) {
   // The number of concurrent items to attemp to fetch.

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -75,7 +75,7 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
 
     // Not yet processed by sync run, check if we have it locally
     try {
-      const stat = await storage.ipfsStat(ipfs_content_id, 4000)
+      const stat = await storage.ipfsStat(ipfs_content_id, 1000)
 
       if (stat.local) {
         ipfsContentIdMap.set(content_id, {

--- a/storage-node/packages/colossus/paths/asset/v0/{id}.js
+++ b/storage-node/packages/colossus/paths/asset/v0/{id}.js
@@ -55,7 +55,7 @@ module.exports = function (storage, runtime, ipfsHttpGatewayUrl, anonymous) {
 
     if (!storage.syncStatus(hash).synced) {
       // We a void serving content we do not have locally to prevent poor performance
-      res.status(404).send({ message: 'Asset Not Available Locally' })
+      return res.status(404).send({ message: 'Asset Not Available Locally' })
     }
 
     // Pass on the ipfs hash to the ipfs proxy middleware

--- a/storage-node/packages/helios/bin/cli.js
+++ b/storage-node/packages/helios/bin/cli.js
@@ -230,7 +230,7 @@ async function main() {
   // limit number of assets to test ?
   const limit = cli.flags.limitAssets
   let contentToTest
-  if (limit && contentToTest.length) {
+  if (limit) {
     contentToTest = contentIds.slice(0, limit)
   } else {
     contentToTest = contentIds

--- a/storage-node/packages/helios/package.json
+++ b/storage-node/packages/helios/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/helios",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "bin": {
     "helios": "bin/cli.js"
   },
@@ -13,7 +13,9 @@
     "@joystream/storage-runtime-api": "^0.1.0",
     "@types/bn.js": "^4.11.5",
     "axios": "^0.19.0",
-    "bn.js": "^4.11.8"
+    "bn.js": "^4.11.8",
+    "cli-progress": "^3.9.0",
+    "lodash": "^4.17.11"
   },
   "volta": {
     "extends": "../../package.json"

--- a/storage-node/packages/runtime-api/assets.js
+++ b/storage-node/packages/runtime-api/assets.js
@@ -151,8 +151,19 @@ class AssetsApi {
    * Returns array of all the content ids in storage
    */
   async getKnownContentIds() {
-    const keys = await this.base.api.query.dataDirectory.dataByContentId.keys()
-    return keys.map(({ args: [contentId] }) => contentId)
+    if (!this._cachedEntries) {
+      return []
+    }
+
+    // const keys = await this.base.api.query.dataDirectory.dataByContentId.keys()
+    // return keys.map(({ args: [contentId] }) => contentId)
+    return this._cachedEntries.map(
+      ([
+        {
+          args: [contentId],
+        },
+      ]) => contentId
+    )
   }
 
   /*

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -435,17 +435,26 @@ class Storage {
    * Scan storage repo and determine sync state of all pins
    */
   async scanRepo() {
+    debug('scanning repo')
     let syncedPins = 0
-    for await (const { cid } of this.ipfs.pin.ls({ type: 'recursive' })) {
+    const pinset = await this.ipfs.pin.ls({ type: 'recursive' })
+
+    while (pinset.length) {
+      const { hash } = pinset.pop()
       try {
-        const hash = `${cid}`
-        await this.ipfsStat(hash, 200)
-        this.pinned[hash] = true
-        syncedPins++
+        // debug(hash)
+        const stat = await this.ipfsStat(hash, 200)
+        console.log(stat)
+        if (stat.local) {
+          this.pinned[hash] = true
+          syncedPins++
+        }
       } catch (_err) {
         // timeout
+        // debug(err)
       }
     }
+
     debug('repo scan found', syncedPins, 'fully synced pinned objects')
   }
 }

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -441,7 +441,7 @@ class Storage {
     let checks = 0
     while (pinset.length) {
       if (checks % 50 === 0) {
-        debug('scanned', checks, 'items')
+        debug('scanned', checks, 'objects')
         await sleep(50)
       }
       checks++

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -451,7 +451,6 @@ class Storage {
       } catch (err) {
         debug(err)
       }
-      // await nextTick()
     }
     await sleep(2000)
     debug('scanned', checks, 'objects')

--- a/storage-node/packages/storage/storage.js
+++ b/storage-node/packages/storage/storage.js
@@ -444,7 +444,6 @@ class Storage {
       try {
         // debug(hash)
         const stat = await this.ipfsStat(hash, 200)
-        console.log(stat)
         if (stat.local) {
           this.pinned[hash] = true
           syncedPins++


### PR DESCRIPTION
Series of optimizations for storage node syncing and assert serving of content

- Scan repo on startup, so we avoid doing file stat (slow and risks opening too many connections to ipfs rpc node on asset requests
- Speedup sync run, shorter intervals
- refresh objects every two minutes instead of every one minute
- improved caching of computed mapping and ipfs hash set
- pop instead of shift .. reducing computation per sync run

Improved Helios:

```
  yarn helios --help
```

```
  Helios - Storage Node diagnostics

  Usage:
    $ helios [arguments]

  Arguments (optional)
    --endpoint URL            Test only one specific colossus API endpoint (does not have to be 
                              an active worker).
                              When not specified all online storage providers will be tested.
    --limit-assets  N         Limit tests to N assets.
    --detailed                Includes list of failed assets in output report.
    --assets                  Path to a JSON file containing array of ContentIds to test.
                              When not specified all 'Accepted' content will be tested.
    --dump-assets             Dumps list of assets (content ids) which will be tested.
```

