### PR TITLE
Improve proposal page performance when council key is used

### DIFF
--- a/pioneer/packages/joy-utils/src/transport/proposals.ts
+++ b/pioneer/packages/joy-utils/src/transport/proposals.ts
@@ -185,12 +185,16 @@ export default class ProposalsTransport extends BaseTransport {
       proposals
     };
   }
+  
+  async voteByProposalAndMember(proposalId: ProposalId, voterId: MemberId): Promise<VoteKind | null> {
+    const votesEntries = await this.api.query.proposalsEngine.voteExistsByProposalByVoter.entries(proposalId);
+    const voteEntry = votesEntries.find((voteEntry) => {
+      const memberId = voteEntry[0].args[1] as MemberId;
 
-  async voteByProposalAndMember (proposalId: ProposalId, voterId: MemberId): Promise<VoteKind | null> {
-    const vote = (await this.proposalsEngine.voteExistsByProposalByVoter(proposalId, voterId)) as VoteKind;
-    const hasVoted = (await this.api.query.proposalsEngine.voteExistsByProposalByVoter.size(proposalId, voterId)).toNumber();
+      return memberId.eq(voterId);
+    });
 
-    return hasVoted ? vote : null;
+    return voteEntry ? voteEntry[1] as VoteKind : null;
   }
 
   async votes (proposalId: ProposalId): Promise<ProposalVotes> {

--- a/pioneer/packages/joy-utils/src/transport/proposals.ts
+++ b/pioneer/packages/joy-utils/src/transport/proposals.ts
@@ -185,8 +185,8 @@ export default class ProposalsTransport extends BaseTransport {
       proposals
     };
   }
-  
-  async voteByProposalAndMember(proposalId: ProposalId, voterId: MemberId): Promise<VoteKind | null> {
+
+  async voteByProposalAndMember (proposalId: ProposalId, voterId: MemberId): Promise<VoteKind | null> {
     const votesEntries = await this.api.query.proposalsEngine.voteExistsByProposalByVoter.entries(proposalId);
     const voteEntry = votesEntries.find((voteEntry) => {
       const memberId = voteEntry[0].args[1] as MemberId;


### PR DESCRIPTION
As described in [here](https://github.com/Joystream/joystream/issues/2556) votes in proposals were taking too long to load  
it seems to be related with `api.query.proposalsEngine.voteExistsByProposalByVoter.size`. 
Replacing it with `api.query.proposalsEngine.voteExistsByProposalByVoter.entries` and filtering the votes locally seems to be a lot faster :rocket: .