### PR TITLE
Fix failing proposal tests for worker leads

### DIFF
--- a/tests/network-tests/src/fixtures/proposalsModule.ts
+++ b/tests/network-tests/src/fixtures/proposalsModule.ts
@@ -753,3 +753,12 @@ export class VoteForProposalFixture extends BaseFixture {
     this._events = proposalOutcome[1]
   }
 }
+
+export class VoteForProposalAndExpectExecutionFixture extends VoteForProposalFixture {
+  public async execute(): Promise<void> {
+    await super.execute()
+    if (!this.proposalExecuted) {
+      this.error(new Error('Proposal Expected to be executed'))
+    }
+  }
+}

--- a/tests/network-tests/src/fixtures/proposalsModule.ts
+++ b/tests/network-tests/src/fixtures/proposalsModule.ts
@@ -732,10 +732,22 @@ export class VoteForProposalFixture extends BaseFixture {
     const councilAccounts = await this.api.getCouncilAccounts()
     this.api.treasuryTransferBalanceToAccounts(councilAccounts, proposalVoteFee)
 
-    // Approving the proposal
+    // Catch the proposal execution result
     const proposalExecutionResult = await this.api.subscribeToProposalExecutionResult(this.proposalNumber)
-    const approvals = await this.api.batchApproveProposal(this.proposalNumber)
-    approvals.map((result) => this.expectDispatchSuccess(result, 'Proposal Approval Vote Expected To Be Successful'))
+
+    // Approve proposal
+    // const approvals =
+    await this.api.batchApproveProposal(this.proposalNumber)
+
+    // Depending on the "approval_threshold_percentage" paramater for the proposal type, it might happen
+    // that the proposal can pass before all votes are cast, and this can result in an approval vote
+    // failing with a 'ProposalFinalized' Dispatch error. Important to note that depending on how many
+    // votes make it into a block, it may not always manifest becasuse the check for proposal finalization
+    // happens in on_finalize. So we no longer assert that all vote dispatches are successful.
+    // "Not taking this into account has resulted in tests failing undeterminisctly in the past.."
+    // approvals.map((result) => this.expectDispatchSuccess(result, 'Proposal Approval Vote Expected To Be Successful'))
+
+    // Wait for the proposal to finalize
     const proposalOutcome = await proposalExecutionResult.promise
     this._proposalExecuted = proposalOutcome[0]
     this._events = proposalOutcome[1]

--- a/tests/network-tests/src/flows/membership/creatingMemberships.ts
+++ b/tests/network-tests/src/flows/membership/creatingMemberships.ts
@@ -12,7 +12,6 @@ import { assert } from 'chai'
 export default async function membershipCreation({ api, env }: FlowProps): Promise<void> {
   const debug = extendDebug('flow:memberships')
   debug('Started')
-  api.enableDebugTxLogs()
 
   const N: number = +env.MEMBERSHIP_CREATION_N!
   assert(N > 0)

--- a/tests/network-tests/src/flows/proposals/manageLeaderRole.ts
+++ b/tests/network-tests/src/flows/proposals/manageLeaderRole.ts
@@ -10,7 +10,7 @@ import {
   SetLeaderRewardProposalFixture,
   SlashLeaderProposalFixture,
   TerminateLeaderRoleProposalFixture,
-  VoteForProposalFixture,
+  VoteForProposalAndExpectExecutionFixture,
 } from '../../fixtures/proposalsModule'
 import { ApplyForOpeningFixture } from '../../fixtures/workingGroupModule'
 import { PaidTermId } from '@joystream/types/members'
@@ -76,13 +76,12 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
   await new FixtureRunner(createWorkingGroupLeaderOpeningFixture).run()
 
   // Approve add opening proposal
-  const voteForCreateOpeningProposalFixture = new VoteForProposalFixture(
+  const voteForCreateOpeningProposalFixture = new VoteForProposalAndExpectExecutionFixture(
     api,
     createWorkingGroupLeaderOpeningFixture.getCreatedProposalId() as ProposalId
   )
 
   await new FixtureRunner(voteForCreateOpeningProposalFixture).run()
-  assert(voteForCreateOpeningProposalFixture.proposalExecuted)
 
   const openingId = api.findOpeningAddedEvent(voteForCreateOpeningProposalFixture.events, group) as OpeningId
   assert(openingId)
@@ -107,13 +106,12 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
   // Propose begin leader application review
   await new FixtureRunner(beginWorkingGroupLeaderApplicationReviewFixture).run()
 
-  const voteForBeginReviewProposal = new VoteForProposalFixture(
+  const voteForBeginReviewProposal = new VoteForProposalAndExpectExecutionFixture(
     api,
     beginWorkingGroupLeaderApplicationReviewFixture.getCreatedProposalId() as ProposalId
   )
 
   await new FixtureRunner(voteForBeginReviewProposal).run()
-  assert(voteForBeginReviewProposal.proposalExecuted)
 
   const fillLeaderOpeningProposalFixture = new FillLeaderOpeningProposalFixture(
     api,
@@ -128,13 +126,12 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
   // Propose fill leader opening
   await new FixtureRunner(fillLeaderOpeningProposalFixture).run()
 
-  const voteForFillLeaderProposalFixture = new VoteForProposalFixture(
+  const voteForFillLeaderProposalFixture = new VoteForProposalAndExpectExecutionFixture(
     api,
     fillLeaderOpeningProposalFixture.getCreatedProposalId() as ProposalId
   )
   // Approve fill leader opening
   await new FixtureRunner(voteForFillLeaderProposalFixture).run()
-  assert(voteForFillLeaderProposalFixture.proposalExecuted)
 
   const hiredLead = await api.getGroupLead(group)
   assert(hiredLead)
@@ -143,14 +140,13 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
   // Propose leader reward
   await new FixtureRunner(setLeaderRewardProposalFixture).run()
 
-  const voteForeLeaderRewardFixture = new VoteForProposalFixture(
+  const voteForeLeaderRewardFixture = new VoteForProposalAndExpectExecutionFixture(
     api,
     setLeaderRewardProposalFixture.getCreatedProposalId() as ProposalId
   )
 
   // Approve new leader reward
   await new FixtureRunner(voteForeLeaderRewardFixture).run()
-  assert(voteForeLeaderRewardFixture.proposalExecuted)
 
   const leadId = (await api.getLeadWorkerId(group)) as WorkerId
   assert(leadId)
@@ -172,7 +168,7 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
 
   // let newStake: BN = applicationStake.sub(stakeDecrement)
   // Approve decreased leader stake
-  const voteForDecreaseStakeProposal = new VoteForProposalFixture(
+  const voteForDecreaseStakeProposal = new VoteForProposalAndExpectExecutionFixture(
     api,
     decreaseLeaderStakeProposalFixture.getCreatedProposalId() as ProposalId
   )
@@ -184,7 +180,7 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
 
   // Approve leader slash
   // newStake = newStake.sub(slashAmount)
-  const voteForSlashProposalFixture = new VoteForProposalFixture(
+  const voteForSlashProposalFixture = new VoteForProposalAndExpectExecutionFixture(
     api,
     slashLeaderProposalFixture.getCreatedProposalId() as ProposalId
   )
@@ -194,7 +190,7 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
   // Propose terminate leader role
   await new FixtureRunner(terminateLeaderRoleProposalFixture).run()
 
-  const voteForLeaderRoleTerminationFixture = new VoteForProposalFixture(
+  const voteForLeaderRoleTerminationFixture = new VoteForProposalAndExpectExecutionFixture(
     api,
     terminateLeaderRoleProposalFixture.getCreatedProposalId() as ProposalId
   )

--- a/tests/network-tests/src/flows/proposals/manageLeaderRole.ts
+++ b/tests/network-tests/src/flows/proposals/manageLeaderRole.ts
@@ -33,6 +33,7 @@ export default {
 
 async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: WorkingGroups, lock: ResourceLocker) {
   const debug = extendDebug(`flow:managerLeaderRole:${group}`)
+  api.enableDebugTxLogs()
   debug('Started')
   await lock(Resource.Proposals)
 

--- a/tests/network-tests/src/flows/proposals/manageLeaderRole.ts
+++ b/tests/network-tests/src/flows/proposals/manageLeaderRole.ts
@@ -33,7 +33,6 @@ export default {
 
 async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: WorkingGroups, lock: ResourceLocker) {
   const debug = extendDebug(`flow:managerLeaderRole:${group}`)
-  api.enableDebugTxLogs()
   debug('Started')
   await lock(Resource.Proposals)
 
@@ -83,6 +82,7 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
   )
 
   await new FixtureRunner(voteForCreateOpeningProposalFixture).run()
+  assert(voteForCreateOpeningProposalFixture.proposalExecuted)
 
   const openingId = api.findOpeningAddedEvent(voteForCreateOpeningProposalFixture.events, group) as OpeningId
   assert(openingId)
@@ -113,6 +113,7 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
   )
 
   await new FixtureRunner(voteForBeginReviewProposal).run()
+  assert(voteForBeginReviewProposal.proposalExecuted)
 
   const fillLeaderOpeningProposalFixture = new FillLeaderOpeningProposalFixture(
     api,
@@ -133,6 +134,7 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
   )
   // Approve fill leader opening
   await new FixtureRunner(voteForFillLeaderProposalFixture).run()
+  assert(voteForFillLeaderProposalFixture.proposalExecuted)
 
   const hiredLead = await api.getGroupLead(group)
   assert(hiredLead)
@@ -148,6 +150,7 @@ async function manageLeaderRole(api: Api, env: NodeJS.ProcessEnv, group: Working
 
   // Approve new leader reward
   await new FixtureRunner(voteForeLeaderRewardFixture).run()
+  assert(voteForeLeaderRewardFixture.proposalExecuted)
 
   const leadId = (await api.getLeadWorkerId(group)) as WorkerId
   assert(leadId)

--- a/tests/network-tests/src/flows/proposals/workingGroupMintCapacityProposal.ts
+++ b/tests/network-tests/src/flows/proposals/workingGroupMintCapacityProposal.ts
@@ -1,7 +1,10 @@
 import BN from 'bn.js'
 import { Api, WorkingGroups } from '../../Api'
 import { FlowProps } from '../../Flow'
-import { VoteForProposalFixture, WorkingGroupMintCapacityProposalFixture } from '../../fixtures/proposalsModule'
+import {
+  VoteForProposalAndExpectExecutionFixture,
+  WorkingGroupMintCapacityProposalFixture,
+} from '../../fixtures/proposalsModule'
 import { ProposalId } from '@joystream/types/proposals'
 import { assert } from 'chai'
 import { FixtureRunner } from '../../Fixture'
@@ -40,7 +43,7 @@ async function workingGroupMintCapactiy(api: Api, env: NodeJS.ProcessEnv, group:
   // Propose mint capacity
   await new FixtureRunner(workingGroupMintCapacityProposalFixture).run()
 
-  const voteForProposalFixture: VoteForProposalFixture = new VoteForProposalFixture(
+  const voteForProposalFixture = new VoteForProposalAndExpectExecutionFixture(
     api,
     workingGroupMintCapacityProposalFixture.getCreatedProposalId() as ProposalId
   )

--- a/tests/network-tests/src/flows/workingGroup/atLeastValueBug.ts
+++ b/tests/network-tests/src/flows/workingGroup/atLeastValueBug.ts
@@ -10,7 +10,6 @@ import { FixtureRunner } from '../../Fixture'
 export default async function zeroAtLeastValueBug({ api, env }: FlowProps): Promise<void> {
   const debug = extendDebug('flow:atLeastValueBug')
   debug('Started')
-  api.enableDebugTxLogs()
 
   const applicationStake: BN = new BN(env.WORKING_GROUP_APPLICATION_STAKE!)
   const roleStake: BN = new BN(env.WORKING_GROUP_ROLE_STAKE!)

--- a/tests/network-tests/src/flows/workingGroup/workerPayout.ts
+++ b/tests/network-tests/src/flows/workingGroup/workerPayout.ts
@@ -8,7 +8,10 @@ import {
   FillOpeningFixture,
 } from '../../fixtures/workingGroupModule'
 import BN from 'bn.js'
-import { VoteForProposalFixture, WorkingGroupMintCapacityProposalFixture } from '../../fixtures/proposalsModule'
+import {
+  VoteForProposalAndExpectExecutionFixture,
+  WorkingGroupMintCapacityProposalFixture,
+} from '../../fixtures/proposalsModule'
 import { PaidTermId } from '@joystream/types/members'
 import { OpeningId } from '@joystream/types/hiring'
 import { ProposalId } from '@joystream/types/proposals'
@@ -61,7 +64,7 @@ async function workerPayouts(api: Api, env: NodeJS.ProcessEnv, group: WorkingGro
   await new FixtureRunner(workingGroupMintCapacityProposalFixture).run()
 
   // Approve mint capacity
-  const voteForProposalFixture = new VoteForProposalFixture(
+  const voteForProposalFixture = new VoteForProposalAndExpectExecutionFixture(
     api,
     workingGroupMintCapacityProposalFixture.getCreatedProposalId() as ProposalId
   )

--- a/tests/network-tests/src/scenarios/full.ts
+++ b/tests/network-tests/src/scenarios/full.ts
@@ -18,18 +18,18 @@ scenario(async ({ job }) => {
 
   const councilJob = job('council setup', councilSetup)
 
-  job('proposals', [
+  const proposalsJob = job('proposals', [
     electionParametersProposal,
     spendingProposal,
     textProposal,
     validatorCountProposal,
     wgMintCapacityProposal.storage,
     wgMintCapacityProposal.content,
+    manageLeaderRole.storage,
+    manageLeaderRole.content,
   ]).requires(councilJob)
 
-  const manageLeadsJob = job('lead-roles', [manageLeaderRole.storage, manageLeaderRole.content]).requires(councilJob)
-
-  const leadSetupJob = job('setup leads', [leaderSetup.storage, leaderSetup.content]).after(manageLeadsJob)
+  const leadSetupJob = job('setup leads', [leaderSetup.storage, leaderSetup.content]).after(proposalsJob)
 
   // Test bug only on one instance of working group is sufficient
   job('at least value bug', atLeastValueBug).requires(leadSetupJob)

--- a/tests/network-tests/src/scenarios/full.ts
+++ b/tests/network-tests/src/scenarios/full.ts
@@ -25,8 +25,6 @@ scenario(async ({ job }) => {
     validatorCountProposal,
     wgMintCapacityProposal.storage,
     wgMintCapacityProposal.content,
-    manageLeaderRole.storage,
-    manageLeaderRole.content,
   ]).requires(councilJob)
 
   const manageLeadsJob = job('lead-roles', [manageLeaderRole.storage, manageLeaderRole.content]).requires(councilJob)


### PR DESCRIPTION
For a long time there has been observation that the tests specifically for hiring worker leads was failing occasionally. We would just re-run the tasks and they would pass. It was hard to re-produce so it was never properly fixed.

It turns out two jobs were trying to run the same flows and depending on the order in which they are executed was producing the failed outcome.

Example run when it fails:
https://github.com/Joystream/joystream/pull/2559/checks?check_run_id=3260753592#step:8:155

I think it would have been easier to diagnose the problem if the DispatchError was logged here: https://github.com/Joystream/joystream/blob/b43d9e1737c741ea9cb6ae8e14b85fdbe7c4b4d2/tests/network-tests/src/Fixture.ts#L79