### PR TITLE
Fix: Add repository to image name for latest tag

### DIFF
--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -178,8 +178,9 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
           IMAGE=${{ env.REPOSITORY }}:${{ env.TAG_SHASUM }}
-          docker manifest create latest $IMAGE-amd64 $IMAGE-arm64 $IMAGE-arm
-          docker manifest annotate latest $IMAGE-amd64 --arch amd64
-          docker manifest annotate latest $IMAGE-arm64 --arch arm64
-          docker manifest annotate latest $IMAGE-arm --arch arm
-          docker manifest push latest
+          LATEST_TAG=${{ env.REPOSITORY }}:latest
+          docker manifest create $LATEST_TAG $IMAGE-amd64 $IMAGE-arm64 $IMAGE-arm
+          docker manifest annotate $LATEST_TAG $IMAGE-amd64 --arch amd64
+          docker manifest annotate $LATEST_TAG $IMAGE-arm64 --arch arm64
+          docker manifest annotate $LATEST_TAG $IMAGE-arm --arch arm
+          docker manifest push $LATEST_TAG


### PR DESCRIPTION
The latest manifest does not have the repository name in the Github Action workflow.
This PR fixes that issue.

![image](https://user-images.githubusercontent.com/7795956/129062460-b47e3ab2-2cae-4f30-8f75-55cef8372d5d.png)
