### PR TITLE
Devops: create-ami: manually instead of on push

### DIFF
--- a/.github/workflows/create-ami.yml
+++ b/.github/workflows/create-ami.yml
@@ -1,11 +1,7 @@
-name: Build code and create AMI
+name: Create AWS AMI
 
 on:
-  push:
-    branches:
-      - master
-      - olympia
-      - create-joystream-node-ami
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
To have better control on when we create new AMI images turn the workflow to be dispatched manually.