### PR TITLE
query node - mapping of language iso to id

### DIFF
--- a/query-node/mappings/src/content/utils.ts
+++ b/query-node/mappings/src/content/utils.ts
@@ -620,7 +620,9 @@ async function prepareLanguage(
 
   // create new language
   const newLanguage = new Language({
-    id: await getNextId(db),
+    // set id as iso to overcome current graphql filtering limitations (so we can use query `videos(where: {languageId_eq: 'en'})`)
+    // id: await getNextId(db),
+    id: languageIso,
     iso: languageIso,
     createdInBlock: event.blockNumber,
 


### PR DESCRIPTION
A little improvement in the video's language representation. Enables filtering by language in queries like `videos(where: {languageId_eq: 'en'})` before more sophisticated solution for `where` filtering of foreign fields.