### PR TITLE
DevOps - Create separate deployment for processor [WIP]

### DIFF
--- a/devops/infrastructure/query-node/Pulumi.yaml
+++ b/devops/infrastructure/query-node/Pulumi.yaml
@@ -17,3 +17,6 @@ template:
       description: Path to members.json file for processor initialization
     workersFilePath:
       description: Path to workers.json file for processor initialization
+    indexerURL:
+      description: URL for the indexer endpoint
+      default: 'http://query-node:4000/graphql'

--- a/devops/infrastructure/query-node/README.md
+++ b/devops/infrastructure/query-node/README.md
@@ -38,7 +38,8 @@ After cloning this repo, from this working directory, run these commands:
 
    ```bash
    $ pulumi config set-all --plaintext aws:region=us-east-1 --plaintext aws:profile=joystream-user \
-    --plaintext workersFilePath=<PATH> --plaintext membersFilePath=<PATH> --plaintext isMinikube=true
+    --plaintext workersFilePath=<PATH> --plaintext membersFilePath=<PATH> --plaintext isMinikube=true \
+    --plaintext indexerURL=<URL>
    ```
 
    If you want to build the stack on AWS set the `isMinikube` config to `false`


### PR DESCRIPTION
This PR enables users to submit an external Indexer URL to be used as the processor for the query node #2406 

### Steps to run
* Run `pulumi login --local` or `export PULUMI_ACCESS_TOKEN` and run `pulumi login`
* Set Pulumi config (refer to Readme)
* Run `pulumi up -y`