### PR TITLE
Storage v2 auth schema fixes.

### DIFF
--- a/runtime-modules/storage/src/tests/mocks.rs
+++ b/runtime-modules/storage/src/tests/mocks.rs
@@ -65,6 +65,7 @@ parameter_types! {
     pub const DefaultChannelDynamicBagNumberOfStorageBuckets: u64 = 4;
     pub const DistributionBucketsPerBagValueConstraint: crate::DistributionBucketsPerBagValueConstraint =
         crate::StorageBucketsPerBagValueConstraint {min: 3, max_min_diff: 7};
+    pub const MaxDataObjectSize: u64 = 400;
 }
 
 pub const STORAGE_WG_LEADER_ACCOUNT_ID: u64 = 100001;
@@ -101,6 +102,7 @@ impl crate::Trait for Test {
     type DistributionBucketsPerBagValueConstraint = DistributionBucketsPerBagValueConstraint;
     type MaxNumberOfPendingInvitationsPerDistributionBucket =
         MaxNumberOfPendingInvitationsPerDistributionBucket;
+    type MaxDataObjectSize = MaxDataObjectSize;
 
     fn ensure_storage_working_group_leader_origin(origin: Self::Origin) -> DispatchResult {
         let account_id = ensure_signed(origin)?;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -694,6 +694,7 @@ parameter_types! {
     pub const DefaultChannelDynamicBagNumberOfStorageBuckets: u64 = 4; //TODO: adjust value
     pub const DistributionBucketsPerBagValueConstraint: storage::DistributionBucketsPerBagValueConstraint =
         storage::DistributionBucketsPerBagValueConstraint {min: 3, max_min_diff: 7}; //TODO: adjust value
+    pub const MaxDataObjectSize: u64 = 10 * 1024 * 1024 * 1024; // 10 GB
 }
 
 impl storage::Trait for Runtime {
@@ -721,6 +722,7 @@ impl storage::Trait for Runtime {
     type DistributionBucketOperatorId = DistributionBucketOperatorId;
     type MaxNumberOfPendingInvitationsPerDistributionBucket =
         MaxNumberOfPendingInvitationsPerDistributionBucket;
+    type MaxDataObjectSize = MaxDataObjectSize;
 
     fn ensure_storage_working_group_leader_origin(origin: Self::Origin) -> DispatchResult {
         StorageWorkingGroup::ensure_origin_is_active_leader(origin)

--- a/storage-node-v2/package.json
+++ b/storage-node-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storage-node-v2",
-  "description": "Jostream storage subsystem.",
+  "description": "Joystream storage subsystem.",
   "version": "0.1.0",
   "author": "Joystream contributors",
   "bin": {

--- a/storage-node-v2/src/api-spec/openapi.yaml
+++ b/storage-node-v2/src/api-spec/openapi.yaml
@@ -174,6 +174,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        401:
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
 components:
   securitySchemes:

--- a/storage-node-v2/src/commands/server.ts
+++ b/storage-node-v2/src/commands/server.ts
@@ -45,7 +45,10 @@ export default class Server extends ApiCommandBase {
     try {
       const port = flags.port
       const workerId = flags.worker ?? 0
-      const app = await createApp(api, account, workerId, flags.uploads)
+      const maxFileSize = await api.consts.storage.maxDataObjectSize.toNumber()
+      logger.debug(`Max file size runtime parameter: ${maxFileSize}`)
+
+      const app = await createApp(api, account, workerId, flags.uploads, maxFileSize)
       logger.info(`Listening on http://localhost:${port}`)
       app.listen(port)
     } catch (err) {

--- a/storage-node-v2/src/services/webApi/app.ts
+++ b/storage-node-v2/src/services/webApi/app.ts
@@ -114,8 +114,6 @@ function validateUpload(api: ApiPromise, account: KeyringPair): ValidateUploadFu
   // We don't use these variables yet.
   /* eslint-disable @typescript-eslint/no-unused-vars */
   return (req: express.Request, scopes: string[], schema: OpenAPIV3.SecuritySchemeObject) => {
-    return true
-
     const tokenString = req.headers['x-api-key'] as string
     const token = parseUploadToken(tokenString)
 

--- a/storage-node-v2/src/services/webApi/app.ts
+++ b/storage-node-v2/src/services/webApi/app.ts
@@ -76,12 +76,17 @@ export async function createApp(
 
   /* eslint-disable @typescript-eslint/no-unused-vars */
   app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
-    // Request validation error handler.
+    // Express error handling recommendation:
+    // https://expressjs.com/en/guide/error-handling.html
+    if (res.headersSent) {
+      return next(err)
+    }
+
+    // Request error handler.
     if (err instanceof HttpError) {
-      res.status(err.status).json({
-        type: 'request_validation',
+      res.status(err.status || 500).json({
+        type: 'request_exception',
         message: err.message,
-        errors: err.errors,
       })
     } else {
       res.status(500).json({

--- a/storage-node-v2/src/services/webApi/controllers/publicApi.ts
+++ b/storage-node-v2/src/services/webApi/controllers/publicApi.ts
@@ -19,6 +19,7 @@ import * as express from 'express'
 import fs from 'fs'
 import path from 'path'
 import send from 'send'
+import BN from 'bn.js'
 import { CLIError } from '@oclif/errors'
 import { hexToString } from '@polkadot/util'
 const fsPromises = fs.promises
@@ -336,7 +337,11 @@ async function verifyDataObjectInfo(
     throw new WebApiError(`Data object had been already accepted ID = ${dataObjectId}`, 400)
   }
 
-  if (dataObject.get('size').toNumber() !== fileSize) {
+  // Cannot get 'size' as a regular property.
+  const probablyDataObjectSize = dataObject.get('size') as unknown
+  const dataObjectSize = probablyDataObjectSize as BN
+
+  if (dataObjectSize?.toNumber() !== fileSize) {
     throw new WebApiError(`File size doesn't match the data object's size for data object ID = ${dataObjectId}`, 400)
   }
 

--- a/storage-node-v2/src/services/webApi/controllers/publicApi.ts
+++ b/storage-node-v2/src/services/webApi/controllers/publicApi.ts
@@ -11,6 +11,7 @@ import { hashFile } from '../../../services/helpers/hashing'
 import { createNonce, getTokenExpirationTime } from '../../../services/helpers/tokenNonceKeeper'
 import { getFileInfo } from '../../../services/helpers/fileInfo'
 import { parseBagId } from '../../helpers/bagTypes'
+import { BagId } from '@joystream/types/storage'
 import logger from '../../../services/logger'
 import { KeyringPair } from '@polkadot/keyring/types'
 import { ApiPromise } from '@polkadot/api'
@@ -19,6 +20,7 @@ import fs from 'fs'
 import path from 'path'
 import send from 'send'
 import { CLIError } from '@oclif/errors'
+import { hexToString } from '@polkadot/util'
 const fsPromises = fs.promises
 
 /**
@@ -107,10 +109,14 @@ export async function uploadFile(req: express.Request, res: express.Response): P
     const fileObj = getFileObject(req)
     cleanupFileName = fileObj.path
 
-    verifyFileSize(fileObj.size)
+    const api = getApi(res)
+    await verifyFileSize(api, fileObj.size)
     await verifyFileMimeType(fileObj.path)
 
     const hash = await hashFile(fileObj.path)
+    const bagId = parseBagId(api, uploadRequest.bagId)
+
+    await verifyDataObjectInfo(api, bagId, uploadRequest.dataObjectId, fileObj.size, hash)
 
     // Prepare new file name
     const newPath = fileObj.path.replace(fileObj.filename, hash)
@@ -119,8 +125,6 @@ export async function uploadFile(req: express.Request, res: express.Response): P
     await fsPromises.rename(fileObj.path, newPath)
     cleanupFileName = newPath
 
-    const api = getApi(res)
-    const bagId = parseBagId(api, uploadRequest.bagId)
     await acceptPendingDataObjects(api, bagId, getAccount(res), getWorkerId(res), uploadRequest.storageBucketId, [
       uploadRequest.dataObjectId,
     ])
@@ -296,14 +300,52 @@ async function validateTokenRequest(api: ApiPromise, tokenRequest: UploadTokenRe
 /**
  * Validates file size. It throws an error when file size exceeds the limit
  *
- * @param fileSize - runtime API promise
+ * @param api - runtime API promise
+ * @param fileSize - file size to validate
  * @returns void promise.
  */
-function verifyFileSize(fileSize: number) {
-  const MAX_FILE_SIZE = 1000000 // TODO: Get this const from the runtime
+async function verifyFileSize(api: ApiPromise, fileSize: number) {
+  const maxRuntimeFileSize = await api.consts.storage.maxDataObjectSize.toNumber()
 
-  if (fileSize > MAX_FILE_SIZE) {
+  if (fileSize > maxRuntimeFileSize) {
     throw new WebApiError('Max file size exceeded.', 400)
+  }
+}
+
+/**
+ * Validates the runtime info for the data object. It verifies contentID,
+ * file size, and 'accepted' status.
+ *
+ * @param api - runtime API promise
+ * @param bagId - bag ID
+ * @param dataObjectId - data object ID to validate in runtime
+ * @param fileSize - file size to validate
+ * @param hash - file multihash
+ * @returns void promise.
+ */
+async function verifyDataObjectInfo(
+  api: ApiPromise,
+  bagId: BagId,
+  dataObjectId: number,
+  fileSize: number,
+  hash: string
+) {
+  const dataObject = await api.query.storage.dataObjectsById(bagId, dataObjectId)
+
+  if (dataObject.accepted.valueOf()) {
+    throw new WebApiError(`Data object had been already accepted ID = ${dataObjectId}`, 400)
+  }
+
+  if (dataObject.get('size').toNumber() !== fileSize) {
+    throw new WebApiError(`File size doesn't match the data object's size for data object ID = ${dataObjectId}`, 400)
+  }
+
+  const runtimeHash = hexToString(dataObject.ipfsContentId.toString())
+  if (runtimeHash !== hash) {
+    throw new WebApiError(
+      `File multihash doesn't match the data object's ipfsContentId for data object ID = ${dataObjectId}`,
+      400
+    )
   }
 }
 

--- a/types/augment-codec/augment-api-consts.ts
+++ b/types/augment-codec/augment-api-consts.ts
@@ -194,6 +194,10 @@ declare module '@polkadot/api/types/consts' {
        **/
       distributionBucketsPerBagValueConstraint: StorageBucketsPerBagValueConstraint & AugmentedConst<ApiType>;
       /**
+       * Exports const - max data object size in bytes.
+       **/
+      maxDataObjectSize: u64 & AugmentedConst<ApiType>;
+      /**
        * Exports const - max allowed distribution bucket family number.
        **/
       maxDistributionBucketFamilyNumber: u64 & AugmentedConst<ApiType>;

--- a/types/augment-codec/augment-api-errors.ts
+++ b/types/augment-codec/augment-api-errors.ts
@@ -2316,6 +2316,10 @@ declare module '@polkadot/api/types/errors' {
        **/
       InvitedStorageProvider: AugmentedError<ApiType>;
       /**
+       * Max data object size exceeded.
+       **/
+      MaxDataObjectSizeExceeded: AugmentedError<ApiType>;
+      /**
        * Max distribution bucket family number limit exceeded.
        **/
       MaxDistributionBucketFamilyNumberLimitExceeded: AugmentedError<ApiType>;

--- a/types/augment-codec/augment-api-tx.ts
+++ b/types/augment-codec/augment-api-tx.ts
@@ -1365,7 +1365,7 @@ declare module '@polkadot/api/types/submittable' {
       /**
        * Upload new data objects. Development mode.
        **/
-      sudoUploadDataObjects: AugmentedSubmittable<(params: UploadParameters | { authenticationKey?: any; bagId?: any; objectCreationList?: any; deletionPrizeSourceAccountId?: any; expectedDataSizeFee?: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [UploadParameters]>;
+      sudoUploadDataObjects: AugmentedSubmittable<(params: UploadParameters | { bagId?: any; objectCreationList?: any; deletionPrizeSourceAccountId?: any; expectedDataSizeFee?: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [UploadParameters]>;
       /**
        * Add and remove hashes to the current blacklist.
        **/

--- a/types/augment/all/defs.json
+++ b/types/augment/all/defs.json
@@ -563,7 +563,6 @@
         }
     },
     "UploadParameters": {
-        "authenticationKey": "Bytes",
         "bagId": "BagId",
         "objectCreationList": "Vec<DataObjectCreationParameters>",
         "deletionPrizeSourceAccountId": "GenericAccountId",
@@ -583,7 +582,8 @@
     "DataObject": {
         "accepted": "bool",
         "deletion_prize": "u128",
-        "size": "u64"
+        "size": "u64",
+        "ipfsContentId": "Bytes"
     },
     "DistributionBucketId": "u64",
     "DistributionBucketFamilyId": "u64",

--- a/types/augment/all/types.ts
+++ b/types/augment/all/types.ts
@@ -366,6 +366,7 @@ export interface DAOId extends u64 {}
 export interface DataObject extends Struct {
   readonly accepted: bool;
   readonly deletion_prize: u128;
+  readonly ipfsContentId: Bytes;
 }
 
 /** @name DataObjectCreationParameters */
@@ -1292,7 +1293,6 @@ export interface UpdatePropertyValuesOperation extends Null {}
 
 /** @name UploadParameters */
 export interface UploadParameters extends Struct {
-  readonly authenticationKey: Bytes;
   readonly bagId: BagId;
   readonly objectCreationList: Vec<DataObjectCreationParameters>;
   readonly deletionPrizeSourceAccountId: GenericAccountId;

--- a/types/augment/augment-api-consts.ts
+++ b/types/augment/augment-api-consts.ts
@@ -194,6 +194,10 @@ declare module '@polkadot/api/types/consts' {
        **/
       distributionBucketsPerBagValueConstraint: StorageBucketsPerBagValueConstraint & AugmentedConst<ApiType>;
       /**
+       * Exports const - max data object size in bytes.
+       **/
+      maxDataObjectSize: u64 & AugmentedConst<ApiType>;
+      /**
        * Exports const - max allowed distribution bucket family number.
        **/
       maxDistributionBucketFamilyNumber: u64 & AugmentedConst<ApiType>;

--- a/types/augment/augment-api-errors.ts
+++ b/types/augment/augment-api-errors.ts
@@ -2316,6 +2316,10 @@ declare module '@polkadot/api/types/errors' {
        **/
       InvitedStorageProvider: AugmentedError<ApiType>;
       /**
+       * Max data object size exceeded.
+       **/
+      MaxDataObjectSizeExceeded: AugmentedError<ApiType>;
+      /**
        * Max distribution bucket family number limit exceeded.
        **/
       MaxDistributionBucketFamilyNumberLimitExceeded: AugmentedError<ApiType>;

--- a/types/augment/augment-api-tx.ts
+++ b/types/augment/augment-api-tx.ts
@@ -1365,7 +1365,7 @@ declare module '@polkadot/api/types/submittable' {
       /**
        * Upload new data objects. Development mode.
        **/
-      sudoUploadDataObjects: AugmentedSubmittable<(params: UploadParameters | { authenticationKey?: any; bagId?: any; objectCreationList?: any; deletionPrizeSourceAccountId?: any; expectedDataSizeFee?: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [UploadParameters]>;
+      sudoUploadDataObjects: AugmentedSubmittable<(params: UploadParameters | { bagId?: any; objectCreationList?: any; deletionPrizeSourceAccountId?: any; expectedDataSizeFee?: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [UploadParameters]>;
       /**
        * Add and remove hashes to the current blacklist.
        **/

--- a/types/src/storage.ts
+++ b/types/src/storage.ts
@@ -23,6 +23,7 @@ export type IDataObject = {
   accepted: bool
   deletion_prize: BalanceOf
   size: u64
+  ipfsContentId: Bytes
 }
 
 export class DataObject
@@ -30,6 +31,7 @@ export class DataObject
     accepted: bool,
     deletion_prize: BalanceOf,
     size: u64,
+    ipfsContentId: Bytes,
   })
   implements IDataObject {}
 
@@ -164,7 +166,6 @@ export class DataObjectCreationParameters
   implements IDataObjectCreationParameters {}
 
 export type IUploadParameters = {
-  authenticationKey: Bytes
   bagId: BagId
   objectCreationList: Vec<DataObjectCreationParameters>
   deletionPrizeSourceAccountId: AccountId
@@ -173,7 +174,6 @@ export type IUploadParameters = {
 
 export class UploadParameters
   extends JoyStructDecorated({
-    authenticationKey: Bytes,
     bagId: BagId,
     objectCreationList: Vec.with(DataObjectCreationParameters),
     deletionPrizeSourceAccountId: AccountId,


### PR DESCRIPTION
This PR intends to update the authentication schema for the uploading. It changes the runtime, type, and storage-node projects.

#### Changes
- remove obsolete `authentication_key` from uploading parameters
- add `MaxDataObjectSize` runtime constant (defaulted to 10 GB)
- add `ipfs_content_id` to the `DataObject` runtime state
- add CID and size verification on the data uploading