### PR TITLE
Query node - error prevention for data object deletion

### DIFF
--- a/query-node/mappings/src/content/channel.ts
+++ b/query-node/mappings/src/content/channel.ts
@@ -13,6 +13,7 @@ import {
   convertContentActorToChannelOwner,
   convertContentActorToDataObjectOwner,
 } from './utils'
+import { disconnectDataObjectRelations } from '../storage'
 
 import { Channel, ChannelCategory, DataObject, AssetAvailability } from 'query-node'
 import { inconsistentState, logger } from '../common'
@@ -127,6 +128,10 @@ export async function content_ChannelAssetsRemoved(db: DatabaseManager, event: S
 
   // delete assets
   for (const asset of assets) {
+    // ensure dataObject is nowhere used to prevent db constraint error
+    await disconnectDataObjectRelations(db, asset)
+
+    // remove data object
     await db.remove<DataObject>(asset)
   }
 

--- a/query-node/mappings/src/storage.ts
+++ b/query-node/mappings/src/storage.ts
@@ -179,7 +179,7 @@ async function updateSingleConnectedAsset<T extends Channel | Video>(
 }
 
 // removes connection between dataObject and other entities
-async function disconnectDataObjectRelations(db: DatabaseManager, dataObject: DataObject) {
+export async function disconnectDataObjectRelations(db: DatabaseManager, dataObject: DataObject) {
   await disconnectSingleDataObjectRelation(db, new Channel(), 'avatarPhoto', dataObject)
   await disconnectSingleDataObjectRelation(db, new Channel(), 'coverPhoto', dataObject)
 


### PR DESCRIPTION
Fixes #2575.

There was only one place that needed the safeguard. I was wondering if we should also delete assets when channel/video is deleted, but it seems that runtime does no such thing. Is that correct?