### PR TITLE
Giza relationships querying workaround

### DIFF
--- a/metadata-protobuf/src/utils.ts
+++ b/metadata-protobuf/src/utils.ts
@@ -5,7 +5,7 @@ export function isSet<T>(v: T | null | undefined): v is T {
   return v !== null && v !== undefined
 }
 
-export function isEmptyObject(object: Record<string, unknown>): boolean {
+export function isEmptyObject<T>(object: T): boolean {
   return Object.keys(object).length === 0
 }
 

--- a/query-node/schemas/storage.graphql
+++ b/query-node/schemas/storage.graphql
@@ -161,8 +161,8 @@ type StorageBagDistributionAssignment @entity {
   distributionBucket: DistributionBucket!
 
   # Relationship filtering workaround
-  storageBagId: Int
-  distributionBucketId: Int
+  storageBagId: ID
+  distributionBucketId: ID
 }
 
 type StorageDataObject @entity {

--- a/query-node/schemas/storage.graphql
+++ b/query-node/schemas/storage.graphql
@@ -144,6 +144,10 @@ type StorageBagStorageAssignment @entity {
 
   "Storage bucket that should store the bag"
   storageBucket: StorageBucket!
+
+  # Relationship filtering workaround
+  storageBagId: ID
+  storageBucketId: ID
 }
 
 type StorageBagDistributionAssignment @entity {
@@ -155,6 +159,10 @@ type StorageBagDistributionAssignment @entity {
 
   "Distribution bucket that should distribute the bag"
   distributionBucket: DistributionBucket!
+
+  # Relationship filtering workaround
+  storageBagId: Int
+  distributionBucketId: Int
 }
 
 type StorageDataObject @entity {


### PR DESCRIPTION
1. Input schema workaround for allowing the use of queries like:
```
  storageBags(
    where: {
      storageAssignments_some: {
        storageBucketId_in: ["1", "2"]
      }
    }
  ) {
    id
  }
```

Since relations like `storageBucket` and `storageBag` already create `storage_bucket_id` and `storage_bag_id` fields in the database that are populated when the relationship is saved, no changes in the mappings are required.

2. Fix for `@joystream/metadata-protobuf` typings which caused query node build to fail