### PR TITLE
Modify DataObjectsUploaded event for the storage runtime pallet.

### DIFF
--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -1012,7 +1012,8 @@ decl_event! {
         /// Params
         /// - data objects IDs
         /// - initial uploading parameters
-        DataObjectsUploaded(Vec<DataObjectId>, UploadParameters),
+        /// - deletion prize for objects
+        DataObjectsUploaded(Vec<DataObjectId>, UploadParameters, Balance),
 
         /// Emits on setting the storage operator metadata.
         /// Params
@@ -2581,6 +2582,7 @@ impl<T: Trait> DataObjectStorage<T> for Module<T> {
         Self::deposit_event(RawEvent::DataObjectsUploaded(
             data.data_objects_map.keys().cloned().collect(),
             params,
+            T::DataObjectDeletionPrize::get(),
         ));
 
         Ok(())

--- a/runtime-modules/storage/src/tests/mod.rs
+++ b/runtime-modules/storage/src/tests/mod.rs
@@ -712,6 +712,7 @@ fn upload_succeeded() {
         EventFixture::assert_last_crate_event(RawEvent::DataObjectsUploaded(
             vec![data_object_id],
             upload_params,
+            DataObjectDeletionPrize::get(),
         ));
     });
 }


### PR DESCRIPTION
We need to  add `deletion_prize` to `DataObjectsUploaded` event to enable query-node mappings.