### PR TITLE
DevOps - Automated deployment of node-network (Giza)

### DIFF
--- a/.github/workflows/create-node-network-pulumi.yml
+++ b/.github/workflows/create-node-network-pulumi.yml
@@ -1,0 +1,119 @@
+name: Create node-network using Pulumi
+
+on:
+  workflow_dispatch:
+    inputs:
+      pulumiToken:
+        description: 'Pulumi Access Token'
+        required: false
+      encryptionKey:
+        description: 'Encryption Key (will be used to password protect secrets 7z file)'
+        required: true
+        default: 'password'
+      stackName:
+        description: 'Pulumi Stack Name'
+        required: false
+        default: 'dev'
+      numberOfValidators:
+        description: 'Number of Validator nodes'
+        required: false
+        default: 2
+      networkSuffix:
+        description: 'Network Suffix'
+        required: false
+        default: 8122
+      nodeImage:
+        description: 'Joystream Docker image to be deployed (joystream/node:latest)'
+        required: false
+        default: 'joystream/node:latest'
+
+defaults:
+  run:
+    working-directory: devops/infrastructure/node-network
+
+jobs:
+  up:
+    name: Create Pulumi stack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Mask input key
+        id: add_mask
+        run: |
+          ENCRYPTION_KEY=$(jq -r '.inputs.encryptionKey' $GITHUB_EVENT_PATH)
+          ACCESS_TOKEN=$(jq -r '.inputs.pulumiToken' $GITHUB_EVENT_PATH)
+          echo "::add-mask::$ENCRYPTION_KEY"
+          echo "ENCRYPTION_KEY=$ENCRYPTION_KEY" >> $GITHUB_ENV
+          if [[ -z "${ACCESS_TOKEN}" ]] || [[ "$ACCESS_TOKEN" == "null" ]]
+          then
+            echo "No access token provided"
+            echo "PULUMI_ACCESS_TOKEN=${{ secrets.PULUMI_ACCESS_TOKEN }}" >> $GITHUB_ENV
+          else
+            echo "Found token"
+            echo "::add-mask::$ACCESS_TOKEN"
+            echo "PULUMI_ACCESS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
+          fi
+
+      - name: Create local stack
+        run: |
+          npm install
+          pulumi login
+          pulumi stack select ${{ github.event.inputs.stackName }} --non-interactive --create
+          pulumi config set-all --plaintext numberOfValidators=${{ github.event.inputs.numberOfValidators }} --plaintext isMinikube=false \
+            --plaintext networkSuffix=${{ github.event.inputs.networkSuffix }} \
+            --plaintext nodeImage=${{ github.event.inputs.nodeImage }} --plaintext encryptionKey=$ENCRYPTION_KEY
+
+      - uses: pulumi/actions@v3
+        name: Run pulumi up without load balancer
+        with:
+          work-dir: devops/infrastructure/node-network
+          command: up
+          refresh: true
+          stack-name: ${{ github.event.inputs.stackName }}
+
+      - name: Mark load balancer as active
+        run: |
+          sleep 30
+          pulumi config set isLoadBalancerReady true
+
+      - uses: pulumi/actions@v3
+        id: pulumi
+        name: Run pulumi up with load balancer
+        with:
+          work-dir: devops/infrastructure/node-network
+          command: up
+          stack-name: ${{ github.event.inputs.stackName }}
+
+      - name: Set KUBECONFIG
+        run: |
+          pulumi stack output kubeconfig > kubeconfig.yml
+          echo "KUBECONFIG=$PWD/kubeconfig.yml" >> $GITHUB_ENV
+
+      - name: Get chain-data from the pod
+        run: |
+          kubectl config set-context --current --namespace=${{ steps.pulumi.outputs.namespaceName }}
+          kubectl cp $(kubectl get pods | grep rpc-node | awk '{print $1}'):/chain-data/chain-data.7z ./chain-data.7z
+
+      - name: Get kubectl events for debugging
+        if: always()
+        run: |
+          kubectl get events
+
+      - name: Upload chain-spec files and other secrets as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: chain-data.7z
+          path: devops/infrastructure/node-network/chain-data.7z
+          retention-days: 1

--- a/.github/workflows/delete-node-network-pulumi.yml
+++ b/.github/workflows/delete-node-network-pulumi.yml
@@ -1,0 +1,61 @@
+name: Delete Pulumi stack
+
+on:
+  workflow_dispatch:
+    inputs:
+      pulumiToken:
+        description: 'Pulumi Access Token'
+        required: false
+      stackName:
+        description: 'Pulumi Stack Name'
+        required: false
+        default: 'dev'
+
+defaults:
+  run:
+    working-directory: devops/infrastructure/node-network
+
+jobs:
+  destroy:
+    name: Delete Pulumi stack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Mask input key
+        id: add_mask
+        run: |
+          if [[ -z "${ACCESS_TOKEN}" ]] || [[ "$ACCESS_TOKEN" == "null" ]]
+          then
+            echo "No access token provided"
+            echo "PULUMI_ACCESS_TOKEN=${{ secrets.PULUMI_ACCESS_TOKEN }}" >> $GITHUB_ENV
+          else
+            echo "Found token"
+            echo "::add-mask::$ACCESS_TOKEN"
+            echo "PULUMI_ACCESS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
+          fi
+
+      - name: Login and select stack
+        run: |
+          npm install
+          pulumi login
+          pulumi stack select ${{ github.event.inputs.stackName }} --non-interactive
+
+      - uses: pulumi/actions@v3
+        name: Run pulumi destory
+        with:
+          work-dir: devops/infrastructure/node-network
+          command: destroy
+          refresh: true
+          stack-name: ${{ github.event.inputs.stackName }}

--- a/.github/workflows/delete-pulumi-stack.yml
+++ b/.github/workflows/delete-pulumi-stack.yml
@@ -10,10 +10,10 @@ on:
         description: 'Pulumi Stack Name'
         required: false
         default: 'dev'
-
-defaults:
-  run:
-    working-directory: devops/infrastructure/node-network
+      componentName:
+        description: 'Joystream component that you deployed (node-network, query-node)'
+        required: true
+        default: 'node-network'
 
 jobs:
   destroy:
@@ -46,16 +46,29 @@ jobs:
             echo "PULUMI_ACCESS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
           fi
 
+      - id: compute_work_dir
+        name: Get working directory based on component deployed
+        run: |
+          if [[ "${{ github.event.inputs.componentName }}" = "query-node" ]]
+          then
+            echo "Component is Query Node"
+            echo "::set-output name=work_dir::devops/infrastructure/query-node"
+          else
+            echo "Component is Node Network"
+            echo "::set-output name=work_dir::devops/infrastructure/node-network"
+          fi
+
       - name: Login and select stack
         run: |
           npm install
           pulumi login
           pulumi stack select ${{ github.event.inputs.stackName }} --non-interactive
+        working-directory: ${{ steps.compute_work_dir.outputs.work_dir }}
 
       - uses: pulumi/actions@v3
         name: Run pulumi destory
         with:
-          work-dir: devops/infrastructure/node-network
+          work-dir: ${{ steps.compute_work_dir.outputs.work_dir }}
           command: destroy
           refresh: true
           stack-name: ${{ github.event.inputs.stackName }}


### PR DESCRIPTION
Adds a Github Action workflow dispatch to deploy the Pulumi stack for node-network

To test this Github Action

* Merge it to the default branch of the repository
* Set `PULUMI_ACCESS_TOKEN` in Repository Secrets
* To generate access token go to [https://app.pulumi.com/<USER>/settings/tokens](https://app.pulumi.com/<USER>/settings/tokens)
![Screenshot 2021-08-26 at 6 22 46 PM](https://user-images.githubusercontent.com/7795956/130966370-858084af-49b9-46a4-afa1-e4ea67066173.png)

* Go to Actions > `Create node-network using Pulumi` workflow > Run workflow

![Screenshot 2021-10-12 at 4 45 06 PM](https://user-images.githubusercontent.com/7795956/136945906-71e74661-c8e0-40ca-917c-edaeb97f5475.png)


* Enter your encryption key, this will be used to extract the contents of `chain-data.7z` file

### How to access the stack on your local

* Make sure you have Pulumi installed
* Set `PULUMI_ACCESS_TOKEN` environment variable in your terminal (`export PULUMI_ACCESS_TOKEN="pul..."`)
* Run `pulumi stack select <STACK_NAME>`
* To get output, run `pulumi stack output`
* To delete all the resources, run `pulumi destroy -s <STACK_NAME>`

### You can also delete the stack using Delete Pulumi stack GitHub action
![Screenshot 2021-10-12 at 5 32 44 PM](https://user-images.githubusercontent.com/7795956/136952510-a8ee6b78-17e5-4729-9ad2-750c7f421402.png)
