### PR TITLE
DevOps - Delegate CloudFormation deletion task to Github Action

### DIFF
--- a/.github/workflows/create-ami.yml
+++ b/.github/workflows/create-ami.yml
@@ -56,10 +56,11 @@ jobs:
           options: |
             --extra-vars "git_repo=https://github.com/${{ github.repository }} \
                           branch_name=${{ steps.extract_branch.outputs.branch }} instance_id=${{ steps.deploy_stack.outputs.InstanceId }}
-                          stack_name=${{ env.STACK_NAME }} ami_name=${{ env.ami_name }}"
+                          ami_name=${{ env.ami_name }}"
 
       - name: Delete CloudFormation Stack
         if: always()
+        continue-on-error: true
         run: |
           echo "Deleting ${{ env.STACK_NAME }} stack"
           aws cloudformation delete-stack --stack-name ${{ env.STACK_NAME }}

--- a/.github/workflows/create-ami.yml
+++ b/.github/workflows/create-ami.yml
@@ -57,3 +57,11 @@ jobs:
             --extra-vars "git_repo=https://github.com/${{ github.repository }} \
                           branch_name=${{ steps.extract_branch.outputs.branch }} instance_id=${{ steps.deploy_stack.outputs.InstanceId }}
                           stack_name=${{ env.STACK_NAME }} ami_name=${{ env.ami_name }}"
+
+      - name: Delete CloudFormation Stack
+        if: always()
+        run: |
+          echo "Deleting ${{ env.STACK_NAME }} stack"
+          aws cloudformation delete-stack --stack-name ${{ env.STACK_NAME }}
+          echo "Waiting for ${{ env.STACK_NAME }} to be deleted..."
+          aws cloudformation wait stack-delete-complete --stack-name ${{ env.STACK_NAME }}

--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -142,11 +142,12 @@ jobs:
                           docker_password=${{ secrets.DOCKERHUB_PASSWORD }} \
                           tag_name=${{ steps.compute_shasum.outputs.shasum }}-${{ matrix.platform_tag }} \
                           repository=${{ env.REPOSITORY }} dockerfile=${{ matrix.file }} \
-                          stack_name=${{ env.STACK_NAME }} platform=${{ matrix.platform }}"
+                          platform=${{ matrix.platform }}"
         if: ${{ steps.compute_image_exists.outputs.image_exists == 1 }}
 
       - name: Delete CloudFormation Stack
         if: always()
+        continue-on-error: true
         run: |
           echo "Deleting ${{ env.STACK_NAME }} stack"
           aws cloudformation delete-stack --stack-name ${{ env.STACK_NAME }}

--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -145,6 +145,14 @@ jobs:
                           stack_name=${{ env.STACK_NAME }} platform=${{ matrix.platform }}"
         if: ${{ steps.compute_image_exists.outputs.image_exists == 1 }}
 
+      - name: Delete CloudFormation Stack
+        if: always()
+        run: |
+          echo "Deleting ${{ env.STACK_NAME }} stack"
+          aws cloudformation delete-stack --stack-name ${{ env.STACK_NAME }}
+          echo "Waiting for ${{ env.STACK_NAME }} to be deleted..."
+          aws cloudformation wait stack-delete-complete --stack-name ${{ env.STACK_NAME }}
+
   push-manifest:
     name: Create manifest using both the arch images
     needs: [push-amd64, push-arm]

--- a/devops/infrastructure/build-arm64-playbook.yml
+++ b/devops/infrastructure/build-arm64-playbook.yml
@@ -5,49 +5,41 @@
   hosts: all
 
   tasks:
-    - block:
-        - name: Get code from git repo
-          include_role:
-            name: common
-            tasks_from: get-code-git
+    - name: Get code from git repo
+      include_role:
+        name: common
+        tasks_from: get-code-git
 
-        - name: Install Docker Module for Python
-          pip:
-            name: docker
+    - name: Install Docker Module for Python
+      pip:
+        name: docker
 
-        - name: Log into DockerHub
-          community.docker.docker_login:
-            username: '{{ docker_username }}'
-            password: '{{ docker_password }}'
+    - name: Log into DockerHub
+      community.docker.docker_login:
+        username: '{{ docker_username }}'
+        password: '{{ docker_password }}'
 
-        - name: Build an image and push it to a private repo
-          community.docker.docker_image:
-            build:
-              path: ./joystream
-              dockerfile: '{{ dockerfile }}'
-              platform: '{{ platform }}'
-            name: '{{ repository }}'
-            tag: '{{ tag_name }}'
-            push: yes
-            source: build
-          # Run in async fashion for max duration of 2 hours
-          async: 7200
-          poll: 0
-          register: build_result
+    - name: Build an image and push it to a private repo
+      community.docker.docker_image:
+        build:
+          path: ./joystream
+          dockerfile: '{{ dockerfile }}'
+          platform: '{{ platform }}'
+        name: '{{ repository }}'
+        tag: '{{ tag_name }}'
+        push: yes
+        source: build
+      # Run in async fashion for max duration of 2 hours
+      async: 7200
+      poll: 0
+      register: build_result
 
-        - name: Check on build async task
-          async_status:
-            jid: '{{ build_result.ansible_job_id }}'
-          register: job_result
-          until: job_result.finished
-          # Max number of times to check for status
-          retries: 72
-          # Check for the status every 100s
-          delay: 100
-
-      always:
-        - name: Delete the stack
-          amazon.aws.cloudformation:
-            stack_name: '{{ stack_name }}'
-            state: 'absent'
-          delegate_to: localhost
+    - name: Check on build async task
+      async_status:
+        jid: '{{ build_result.ansible_job_id }}'
+      register: job_result
+      until: job_result.finished
+      # Max number of times to check for status
+      retries: 72
+      # Check for the status every 100s
+      delay: 100

--- a/devops/infrastructure/github-action-playbook.yml
+++ b/devops/infrastructure/github-action-playbook.yml
@@ -5,41 +5,33 @@
   hosts: all
 
   tasks:
-    - block:
-      - name: Get code from git repo
-        include_role:
-          name: common
-          tasks_from: get-code-git
+    - name: Get code from git repo
+      include_role:
+        name: common
+        tasks_from: get-code-git
 
-      - name: Run setup and build
-        include_role:
-          name: common
-          tasks_from: run-setup-build
+    - name: Run setup and build
+      include_role:
+        name: common
+        tasks_from: run-setup-build
 
-      - name: Install subkey
-        include_role:
-          name: admin
-          tasks_from: main
+    - name: Install subkey
+      include_role:
+        name: admin
+        tasks_from: main
 
-      - name: Basic AMI Creation
-        amazon.aws.ec2_ami:
-          instance_id: "{{ instance_id }}"
-          wait: yes
-          name: "{{ ami_name }}"
-          launch_permissions:
-            group_names: ['all']
-          tags:
-            Name: "{{ ami_name }}"
-        register: ami_data
-        delegate_to: localhost
+    - name: Basic AMI Creation
+      amazon.aws.ec2_ami:
+        instance_id: '{{ instance_id }}'
+        wait: yes
+        name: '{{ ami_name }}'
+        launch_permissions:
+          group_names: ['all']
+        tags:
+          Name: '{{ ami_name }}'
+      register: ami_data
+      delegate_to: localhost
 
-      - name: Print AMI ID
-        debug:
-          msg: "AMI ID is: {{ ami_data.image_id }}"
-
-      always:
-      - name: Delete the stack
-        amazon.aws.cloudformation:
-          stack_name: "{{ stack_name }}"
-          state: "absent"
-        delegate_to: localhost
+    - name: Print AMI ID
+      debug:
+        msg: 'AMI ID is: {{ ami_data.image_id }}'


### PR DESCRIPTION
CloudFormation stack fails to delete if there is any issue in any of the steps in Github Action before the Ansible playbook runs.
This is because in the current implementation the task of deleting the CloudFormation Stack has been delegated to the Ansible playbook. If any step before the Playbook fails, the Playbook run step is not started leading to a dangling AWS CF stack.

This PR resolves the issue by delegating the task to the Github Action itself. The delete stack task will always run even if any other step previously failed.

### Manual Testing
* If no stack was created, the script continues and does not throw any error
![Screenshot 2021-10-20 at 1 05 49 PM](https://user-images.githubusercontent.com/7795956/138048607-8de9c2b0-fc98-419c-9781-0bfbc67fee3b.png)

* The stack is deleted if everything runs smoothly
![Screenshot 2021-10-20 at 1 09 07 PM](https://user-images.githubusercontent.com/7795956/138049101-f71eabe4-cfa2-47c6-9a53-39c8f32dbed7.png)

* The stack is deleted even if any of the steps failed
![Screenshot 2021-10-20 at 1 20 48 PM](https://user-images.githubusercontent.com/7795956/138050952-fe662363-0eda-48c5-ba1b-53f85990de72.png)
