### PR TITLE
Giza: Fix working groups events processing

### DIFF
--- a/query-node/mappings/workingGroup.ts
+++ b/query-node/mappings/workingGroup.ts
@@ -94,11 +94,13 @@ export async function workingGroup_TerminatedLeader({ event, store }: EventConte
 /// ///////////////// Helpers ////////////////////////////////////////////////////
 
 function getWorkerType(event: SubstrateEvent): WorkerType | null {
-  if (event.section === 'storageWorkingGroup') {
+  // Note: event.section is not available!
+  const [eventSection] = event.name.split('.')
+  if (eventSection === 'storageWorkingGroup') {
     return WorkerType.STORAGE
   }
 
-  if (event.section === 'gatewayWorkingGroup') {
+  if (eventSection === 'gatewayWorkingGroup') {
     return WorkerType.GATEWAY
   }
 


### PR DESCRIPTION
Small working groups events processing fix in query-node mappings due to `event.section` not beeing available.