### PR TITLE
DevOps - Add initial members, balances support

### DIFF
--- a/devops/infrastructure/cloudformation/infrastructure.yml
+++ b/devops/infrastructure/cloudformation/infrastructure.yml
@@ -74,6 +74,10 @@ Resources:
           ToPort: 443
           CidrIp: 0.0.0.0/0
         - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
           CidrIp: 0.0.0.0/0
@@ -112,7 +116,8 @@ Resources:
             # Update all packages
             apt-get update -y
 
-            # Install the updates
+            # Install the updates except docker
+            apt-mark hold docker.io
             apt-get upgrade -y
 
             # Get latest cfn scripts and install them;

--- a/devops/infrastructure/cloudformation/infrastructure.yml
+++ b/devops/infrastructure/cloudformation/infrastructure.yml
@@ -116,7 +116,7 @@ Resources:
             # Update all packages
             apt-get update -y
 
-            # Install the updates except docker
+            # Install the updates except docker, to avoid interactive prompt which blocks the flow of the script
             apt-mark hold docker.io
             apt-get upgrade -y
 

--- a/devops/infrastructure/deploy-config.sample.cfg
+++ b/devops/infrastructure/deploy-config.sample.cfg
@@ -36,6 +36,10 @@ CHAIN_SPEC_FILE="https://github.com/Joystream/joystream/releases/download/v9.3.0
 LOCAL_CODE_PATH="~/Joystream/joystream"
 NETWORK_SUFFIX=7891
 
+DEPLOYMENT_TYPE=live
+INITIAL_MEMBERS_PATH=""
+INITIAL_BALANCES_PATH=""
+
 GIT_REPO="https://github.com/Joystream/joystream.git"
 BRANCH_NAME=sumer
 

--- a/devops/infrastructure/deploy-infra.sh
+++ b/devops/infrastructure/deploy-infra.sh
@@ -81,15 +81,11 @@ if [ $? -eq 0 ]; then
     ansible-playbook -i $INVENTORY_PATH --private-key $KEY_PATH setup-admin.yml
   fi
 
-  DEPLOYMENT_TYPE=${DEPLOYMENT_TYPE:=live}
-
   echo -e "\n\n=========== Configure and start new validators, rpc node and pioneer ==========="
   ansible-playbook -i $INVENTORY_PATH --private-key $KEY_PATH chain-spec-pioneer.yml \
     --extra-vars "local_dir=$LOCAL_CODE_PATH network_suffix=$NETWORK_SUFFIX
                   data_path=data-$NEW_STACK_NAME bucket_name=$BUCKET_NAME number_of_validators=$NUMBER_OF_VALIDATORS
-                  deployment_type=$DEPLOYMENT_TYPE
-                 "
-
+                  deployment_type=$DEPLOYMENT_TYPE initial_balances_file=$INITIAL_BALANCES_PATH initial_members_file=$INITIAL_MEMBERS_PATH"
 
   echo -e "\n\n Pioneer URL: https://$DOMAIN_NAME"
 fi

--- a/devops/infrastructure/roles/common/tasks/chain-spec-node-keys.yml
+++ b/devops/infrastructure/roles/common/tasks/chain-spec-node-keys.yml
@@ -10,21 +10,23 @@
   copy:
     src: '{{ initial_members_file }}'
     dest: '{{ admin_code_dir }}/initial-members.json'
-  when: initial_members_file is defined
+  when: initial_members_file is defined and initial_members_file|length > 0
+  run_once: true
 
 - name: Copying initial balances file to the server
   copy:
     src: '{{ initial_balances_file }}'
     dest: '{{ admin_code_dir }}/initial-balances.json'
-  when: initial_balances_file is defined
+  when: initial_balances_file is defined and initial_balances_file|length > 0
+  run_once: true
 
 - name: Run chain-spec-builder to generate chainspec.json file (with initial data)
   shell: >
     {{ admin_code_dir }}/target/release/chain-spec-builder generate -a {{ number_of_validators }}
     --chain-spec-path {{ chain_spec_path }} --deployment {{ deployment_type }}
     --endowed 1 --keystore-path {{ data_path }}
-    {% if initial_members_file is defined %}--initial-balances-path {{ admin_code_dir }}/initial-balances.json{% endif %}
-    {% if initial_balances_file is defined %}--initial-members-path {{ admin_code_dir }}/initial-members.json{% endif %}
+    {% if initial_members_file is defined and initial_members_file|length > 0 %}--initial-balances-path {{ admin_code_dir }}/initial-balances.json{% endif %}
+    {% if initial_balances_file is defined and initial_balances_file|length > 0 %}--initial-members-path {{ admin_code_dir }}/initial-members.json{% endif %}
   register: chain_spec_output
   delegate_to: '{{ local_or_admin }}'
   run_once: true

--- a/devops/infrastructure/roles/common/tasks/chain-spec-node-keys.yml
+++ b/devops/infrastructure/roles/common/tasks/chain-spec-node-keys.yml
@@ -23,8 +23,9 @@
 - name: Run chain-spec-builder to generate chainspec.json file (with initial data)
   shell: >
     {{ admin_code_dir }}/target/release/chain-spec-builder generate -a {{ number_of_validators }}
-    --chain-spec-path {{ chain_spec_path }} --deployment {{ deployment_type }}
+    --chain-spec-path {{ chain_spec_path }}
     --endowed 1 --keystore-path {{ data_path }}
+    {% if deployment_type is defined and deployment_type|length > 0 %}--deployment {{ deployment_type }}{% endif %}
     {% if initial_members_file is defined and initial_members_file|length > 0 %}--initial-balances-path {{ admin_code_dir }}/initial-balances.json{% endif %}
     {% if initial_balances_file is defined and initial_balances_file|length > 0 %}--initial-members-path {{ admin_code_dir }}/initial-members.json{% endif %}
   register: chain_spec_output

--- a/devops/infrastructure/roles/common/tasks/chain-spec-node-keys.yml
+++ b/devops/infrastructure/roles/common/tasks/chain-spec-node-keys.yml
@@ -3,25 +3,42 @@
 
 - name: Debug to test variable
   debug:
-    msg: "Data path: {{ data_path }}, Chain Spec path: {{ chain_spec_path }}"
+    msg: 'Data path: {{ data_path }}, Chain Spec path: {{ chain_spec_path }}'
   run_once: true
 
-- name: Run chain-spec-builder to generate chainspec.json file
-  command: "{{ admin_code_dir }}/target/release/chain-spec-builder generate -a {{ number_of_validators }} --chain-spec-path {{ chain_spec_path }} --deployment {{ deployment_type }} --endowed 1 --keystore-path {{ data_path }}"
+- name: Copying initial members file to the server
+  copy:
+    src: '{{ initial_members_file }}'
+    dest: '{{ admin_code_dir }}/initial-members.json'
+  when: initial_members_file is defined
+
+- name: Copying initial balances file to the server
+  copy:
+    src: '{{ initial_balances_file }}'
+    dest: '{{ admin_code_dir }}/initial-balances.json'
+  when: initial_balances_file is defined
+
+- name: Run chain-spec-builder to generate chainspec.json file (with initial data)
+  shell: >
+    {{ admin_code_dir }}/target/release/chain-spec-builder generate -a {{ number_of_validators }}
+    --chain-spec-path {{ chain_spec_path }} --deployment {{ deployment_type }}
+    --endowed 1 --keystore-path {{ data_path }}
+    {% if initial_members_file is defined %}--initial-balances-path {{ admin_code_dir }}/initial-balances.json{% endif %}
+    {% if initial_balances_file is defined %}--initial-members-path {{ admin_code_dir }}/initial-members.json{% endif %}
   register: chain_spec_output
-  delegate_to: "{{ local_or_admin }}"
+  delegate_to: '{{ local_or_admin }}'
   run_once: true
 
 - name: Run subkey to generate node keys
   shell: subkey generate-node-key
-  delegate_to: "{{ local_or_admin }}"
+  delegate_to: '{{ local_or_admin }}'
   register: subkey_output
 
 - name: Print to stdout
   debug:
     msg:
-    - "Public Key: {{ subkey_output.stderr }}"
-    - "Private Key: {{ subkey_output.stdout }}"
+      - 'Public Key: {{ subkey_output.stderr }}'
+      - 'Private Key: {{ subkey_output.stdout }}'
 
 - name: Print to stdout chain spec
   debug: var=chain_spec_output.stdout
@@ -30,16 +47,16 @@
 - name: Save output of chain spec to local file
   copy:
     content: '{{ chain_spec_output.stdout | regex_replace("\x1B\[([0-9]{1,3}(;[0-9]{1,2})?)?[mGK]", "") }}'
-    dest: "{{ data_path }}/chain_spec_output.txt"
-  delegate_to: "{{ local_or_admin }}"
+    dest: '{{ data_path }}/chain_spec_output.txt'
+  delegate_to: '{{ local_or_admin }}'
   run_once: true
 
 - name: Change chain spec name, id, protocolId
   json_modify:
-    chain_spec_path: "{{ chain_spec_path }}"
-    prefix: "{{ network_suffix }}"
-    all_nodes: "{{ hostvars }}"
-  delegate_to: "{{ local_or_admin }}"
+    chain_spec_path: '{{ chain_spec_path }}'
+    prefix: '{{ network_suffix }}'
+    all_nodes: '{{ hostvars }}'
+  delegate_to: '{{ local_or_admin }}'
   register: result
   run_once: true
 
@@ -49,28 +66,28 @@
   run_once: true
 
 - name: Run build-spec to generate raw chainspec file
-  shell: "{{ admin_code_dir }}/target/release/joystream-node build-spec --chain {{ chain_spec_path }} --raw > {{ raw_chain_spec_path }}"
-  delegate_to: "{{ local_or_admin }}"
+  shell: '{{ admin_code_dir }}/target/release/joystream-node build-spec --chain {{ chain_spec_path }} --raw > {{ raw_chain_spec_path }}'
+  delegate_to: '{{ local_or_admin }}'
   run_once: true
 
 - name: Copying chain spec files to localhost
   synchronize:
-    src: "/home/ubuntu/{{ data_path }}/"
-    dest: "{{ data_path }}"
+    src: '/home/ubuntu/{{ data_path }}/'
+    dest: '{{ data_path }}'
     mode: pull
   run_once: true
   when: run_on_admin_server|bool
 
 - name: Copy joystream-node binary to localhost
   fetch:
-    src: "{{ admin_code_dir }}/target/release/joystream-node"
-    dest: "{{ data_path }}/joystream-node"
+    src: '{{ admin_code_dir }}/target/release/joystream-node'
+    dest: '{{ data_path }}/joystream-node'
     flat: yes
-  delegate_to: "{{ local_or_admin }}"
+  delegate_to: '{{ local_or_admin }}'
   run_once: true
   when: run_on_admin_server|bool
 
 - name: Copying raw chain spec file to all servers
   copy:
-    src: "{{ raw_chain_spec_path }}"
-    dest: "{{ remote_chain_spec_path }}"
+    src: '{{ raw_chain_spec_path }}'
+    dest: '{{ remote_chain_spec_path }}'


### PR DESCRIPTION
This PR adds the ability to specify initial members and balances while creating the chain spec file

Also resolves the following bugs:
* Docker upgrades via (`apt-get upgrade -y`) shows a prompt that prevents the user data script from completing. It has been marked as on hold when upgrading.
* Caddy requires port 80 to be open for downloading the certificates. The security group has been updated.

### How to run
* Update the config file with members and balances
![Screenshot 2021-10-20 at 6 40 49 PM](https://user-images.githubusercontent.com/7795956/138099292-134d66ff-dbf4-4a5e-b566-b53c37f7dfaf.png)

* Run `./deploy-infra.sh ~/Joystream/bash-config.cfg`

