### PR TITLE
DevOps - Update wait time for AMI creation to 1 hour

### DIFF
--- a/devops/infrastructure/github-action-playbook.yml
+++ b/devops/infrastructure/github-action-playbook.yml
@@ -24,6 +24,8 @@
       amazon.aws.ec2_ami:
         instance_id: '{{ instance_id }}'
         wait: yes
+        # How long before wait gives up, in seconds
+        wait_timeout: 3600
         name: '{{ ami_name }}'
         launch_permissions:
           group_names: ['all']


### PR DESCRIPTION
Updates the wait timeout for creation of AWS AMI from 20 minutes (default) to 1 hour.