### PR TITLE
DevOps - Run setup in non interactive mode

### DIFF
--- a/devops/infrastructure/roles/common/tasks/run-setup-build.yml
+++ b/devops/infrastructure/roles/common/tasks/run-setup-build.yml
@@ -8,6 +8,8 @@
   command: ./setup.sh
   args:
     chdir: '{{ remote_code_path }}'
+  environment:
+    DEBIAN_FRONTEND: noninteractive
 
 - name: Build joystream node
   shell: . ~/.bash_profile && yarn cargo-build


### PR DESCRIPTION
This will prevent the system to prompt for anything