### PR TITLE
query-node: fix date types (exported as string by fetch scripts)

### DIFF
--- a/query-node/mappings/bootstrap-data/types.ts
+++ b/query-node/mappings/bootstrap-data/types.ts
@@ -38,14 +38,14 @@ export type VideoCategoryJson = {
   id: string
   name: string
   createdInBlock: number
-  createdAt: Date
-  updatedAt: Date
+  createdAt: string
+  updatedAt: string
 }
 
 export type ChannelCategoryJson = {
   id: string
   name: string
   createdInBlock: number
-  createdAt: Date
-  updatedAt: Date
+  createdAt: string
+  updatedAt: string
 }


### PR DESCRIPTION
exported dates from graphql query are in string format.