### PR TITLE
Refactor distribution buckets.

### DIFF
--- a/runtime-modules/storage/src/distribution_bucket_picker.rs
+++ b/runtime-modules/storage/src/distribution_bucket_picker.rs
@@ -38,13 +38,18 @@ impl<T: Trait> DistributionBucketPicker<T> {
             .filter_map(|(family_id, bucket_num)| {
                 Module::<T>::ensure_distribution_bucket_family_exists(family_id)
                     .ok()
-                    .map(|fam| (fam, bucket_num))
+                    .map(|fam| (family_id, fam, bucket_num))
             })
-            .map(|(family, bucket_num)| {
+            .map(|(family_id, family, bucket_num)| {
                 let filtered_ids = family
                     .distribution_buckets
                     .iter()
-                    .filter_map(|(id, bucket)| bucket.accepting_new_bags.then(|| *id))
+                    .filter_map(|id| {
+                        Module::<T>::ensure_distribution_bucket_exists(family_id, id)
+                            .ok()
+                            .map(|bucket| bucket.accepting_new_bags.then(|| *id))
+                            .flatten()
+                    })
                     .collect::<Vec<_>>();
 
                 (filtered_ids, bucket_num)

--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -587,6 +587,8 @@ pub enum DynamicBagType {
 
     /// Channel dynamic bag type.
     Channel,
+
+    // Modify 'delete_distribution_bucket_family' on adding the new type!
 }
 
 impl Default for DynamicBagType {

--- a/runtime-modules/storage/src/tests/fixtures.rs
+++ b/runtime-modules/storage/src/tests/fixtures.rs
@@ -14,7 +14,7 @@ use crate::tests::mocks::{
     DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID, DISTRIBUTION_WG_LEADER_ACCOUNT_ID,
 };
 use crate::{
-    BagId, Cid, DataObjectCreationParameters, DataObjectStorage, DistributionBucketFamily,
+    BagId, Cid, DataObjectCreationParameters, DataObjectStorage, DistributionBucket,
     DynamicBagDeletionPrize, DynamicBagId, DynamicBagType, RawEvent, StaticBagId,
     StorageBucketOperatorStatus, UploadParameters,
 };
@@ -1307,18 +1307,10 @@ impl CreateDistributionBucketFixture {
         if actual_result.is_ok() {
             assert_eq!(next_bucket_id + 1, Storage::next_distribution_bucket_id());
 
-            let family: DistributionBucketFamily<Test> =
-                Storage::distribution_bucket_family_by_id(self.family_id);
+            let bucket: DistributionBucket<Test> =
+                Storage::distribution_bucket_by_family_id_by_id(self.family_id, next_bucket_id);
 
-            assert!(family.distribution_buckets.contains_key(&next_bucket_id));
-            assert_eq!(
-                family
-                    .distribution_buckets
-                    .get(&next_bucket_id)
-                    .unwrap()
-                    .accepting_new_bags,
-                self.accept_new_bags
-            );
+            assert_eq!(bucket.accepting_new_bags, self.accept_new_bags);
 
             Some(next_bucket_id)
         } else {
@@ -1664,11 +1656,8 @@ impl InviteDistributionBucketOperatorFixture {
         assert_eq!(actual_result, expected_result);
 
         if actual_result.is_ok() {
-            let new_family = Storage::distribution_bucket_family_by_id(self.family_id);
-            let new_bucket = new_family
-                .distribution_buckets
-                .get(&self.bucket_id)
-                .unwrap();
+            let new_bucket: DistributionBucket<Test> =
+                Storage::distribution_bucket_by_family_id_by_id(self.family_id, self.bucket_id);
 
             assert!(new_bucket
                 .pending_invitations
@@ -1724,11 +1713,8 @@ impl CancelDistributionBucketInvitationFixture {
         assert_eq!(actual_result, expected_result);
 
         if actual_result.is_ok() {
-            let new_family = Storage::distribution_bucket_family_by_id(self.family_id);
-            let new_bucket = new_family
-                .distribution_buckets
-                .get(&self.bucket_id)
-                .unwrap();
+            let new_bucket: DistributionBucket<Test> =
+                Storage::distribution_bucket_by_family_id_by_id(self.family_id, self.bucket_id);
 
             assert!(!new_bucket
                 .pending_invitations
@@ -1781,11 +1767,8 @@ impl AcceptDistributionBucketInvitationFixture {
         assert_eq!(actual_result, expected_result);
 
         if actual_result.is_ok() {
-            let new_family = Storage::distribution_bucket_family_by_id(self.family_id);
-            let new_bucket = new_family
-                .distribution_buckets
-                .get(&self.bucket_id)
-                .unwrap();
+            let new_bucket: DistributionBucket<Test> =
+                Storage::distribution_bucket_by_family_id_by_id(self.family_id, self.bucket_id);
 
             assert!(!new_bucket.pending_invitations.contains(&self.worker_id));
 
@@ -1892,11 +1875,8 @@ impl RemoveDistributionBucketOperatorFixture {
 
         assert_eq!(actual_result, expected_result);
         if actual_result.is_ok() {
-            let new_family = Storage::distribution_bucket_family_by_id(self.family_id);
-            let new_bucket = new_family
-                .distribution_buckets
-                .get(&self.bucket_id)
-                .unwrap();
+            let new_bucket: DistributionBucket<Test> =
+                Storage::distribution_bucket_by_family_id_by_id(self.family_id, self.bucket_id);
 
             assert!(!new_bucket.operators.contains(&self.operator_worker_id));
         }

--- a/types/augment/all/defs.json
+++ b/types/augment/all/defs.json
@@ -601,7 +601,7 @@
         "assigned_bags": "u64"
     },
     "DistributionBucketFamily": {
-        "distribution_buckets": "BTreeMap<DistributionBucketId,DistributionBucket>"
+        "distribution_buckets": "BTreeSet<DistributionBucketId>"
     },
     "DataObjectIdMap": "BTreeMap<DataObjectId,DataObject>",
     "DistributionBucketIdSet": "BTreeSet<DistributionBucketId>",

--- a/types/augment/all/types.ts
+++ b/types/augment/all/types.ts
@@ -416,7 +416,7 @@ export interface DistributionBucket extends Struct {
 
 /** @name DistributionBucketFamily */
 export interface DistributionBucketFamily extends Struct {
-  readonly distribution_buckets: BTreeMap<DistributionBucketId, DistributionBucket>;
+  readonly distribution_buckets: BTreeSet<DistributionBucketId>;
 }
 
 /** @name DistributionBucketFamilyId */

--- a/types/src/storage.ts
+++ b/types/src/storage.ts
@@ -221,12 +221,12 @@ export class DistributionBucket
   implements IDistributionBucket {}
 
 export type IDistributionBucketFamily = {
-  distribution_buckets: BTreeMap<DistributionBucketId, DistributionBucket>
+  distribution_buckets: BTreeSet<DistributionBucketId>
 }
 
 export class DistributionBucketFamily
   extends JoyStructDecorated({
-    distribution_buckets: BTreeMap.with(DistributionBucketId, DistributionBucket),
+    distribution_buckets: BTreeSet.with(DistributionBucketId),
   })
   implements IDistributionBucketFamily {}
 


### PR DESCRIPTION
#### Changes
- updated distribution bucket storage (from distribution type family container to a double map)
- types

#### Review comments
- Please, pay attention to the newly introduced iterations for the double map prefix (by family id). The most dangerous code change is in the `DistributionBucketPicker` struct implementation - it introduces the NxM iterations over the distribution bucket families and distribution buckets. It looks bad. The mitigation would be introducing and supporting a cache (denormalization) in the distribution bucket family to save `accepting new bags` status for buckets. Should we just roll back the changes from this PR?