### PR TITLE
Giza staging query node fixes

### DIFF
--- a/query-node/mappings/bootstrap-data/scripts/api.ts
+++ b/query-node/mappings/bootstrap-data/scripts/api.ts
@@ -1,5 +1,5 @@
 import { ApiPromise, WsProvider } from '@polkadot/api'
-import types from '@joystream/sumer-types/augment/all/defs.json'
+import types from '@joystream/types/augment/all/defs.json'
 
 export default async function createApi(): Promise<ApiPromise> {
   // Get URL to websocket endpoint from environment or connect to local node by default

--- a/query-node/mappings/bootstrap-data/scripts/fetchMembersData.ts
+++ b/query-node/mappings/bootstrap-data/scripts/fetchMembersData.ts
@@ -1,6 +1,6 @@
 import createApi from './api'
 import { ApiPromise } from '@polkadot/api'
-import { MemberId, Membership } from '@joystream/sumer-types/augment/all'
+import { MemberId, Membership } from '@joystream/types/augment/all'
 import { BlockHash } from '@polkadot/types/interfaces'
 import { MemberJson } from '../types'
 import fs from 'fs'

--- a/query-node/mappings/bootstrap-data/types.ts
+++ b/query-node/mappings/bootstrap-data/types.ts
@@ -38,14 +38,14 @@ export type VideoCategoryJson = {
   id: string
   name: string
   createdInBlock: number
-  createdAt: Date
-  updatedAt: Date
+  createdAt: string
+  updatedAt: string
 }
 
 export type ChannelCategoryJson = {
   id: string
   name: string
   createdInBlock: number
-  createdAt: Date
-  updatedAt: Date
+  createdAt: string
+  updatedAt: string
 }

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -21,7 +21,6 @@
     "@joystream/hydra-common": "3.1.0-alpha.1",
     "@joystream/hydra-db-utils": "3.1.0-alpha.1",
     "@joystream/metadata-protobuf": "^1.0.0",
-    "@joystream/sumer-types": "npm:@joystream/types@^0.16.0",
     "@joystream/types": "^0.17.0",
     "@joystream/warthog": "2.35.0",
     "@apollo/client": "^3.2.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2932,20 +2932,6 @@
     yaml "^1.10.0"
     yaml-validator "^3.0.0"
 
-"@joystream/sumer-types@npm:@joystream/types@^0.16.0":
-  version "0.16.1"
-  resolved "https://registry.yarnpkg.com/@joystream/types/-/types-0.16.1.tgz#40f5014a9b64928ccea634a1f0f5d2b0392de293"
-  integrity sha512-Jz8M6F4oRKH4WtEn8kpZvSMi0mVbfGSmjt38CcEu2946TYmCwlC3Ad1RFH8Wlcylqz/fMLL+pe0z1Dvo6dfzJA==
-  dependencies:
-    "@polkadot/api" "4.2.1"
-    "@polkadot/keyring" "^6.0.5"
-    "@polkadot/types" "4.2.1"
-    "@types/lodash" "^4.14.157"
-    "@types/vfile" "^4.0.0"
-    ajv "^6.11.0"
-    lodash "^4.17.15"
-    moment "^2.24.0"
-
 "@joystream/types@link:types":
   version "0.17.0"
   dependencies:
@@ -4227,7 +4213,7 @@
     "@polkadot/util-crypto" "^7.3.1"
     rxjs "^7.3.0"
 
-"@polkadot/api@4.2.1", "@polkadot/api@5.9.1":
+"@polkadot/api@5.9.1":
   version "5.9.1"
   resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-5.9.1.tgz#ce314cc34f0a47098d039db7b9036bb491c2898c"
   integrity sha512-POpIXn/Ao+NLB0uMldXdXU44dVbRr6+6Ax77Z0R285M8Z2EiF5jl2K3SPvlowLo4SntxiCSaHQxCekYhUcJKlw==
@@ -4355,7 +4341,7 @@
     "@polkadot/util" "7.4.1"
     "@zondax/ledger-substrate" "^0.18.0"
 
-"@polkadot/keyring@7.3.1", "@polkadot/keyring@^6.0.5", "@polkadot/keyring@^7.3.1", "@polkadot/keyring@^7.4.1":
+"@polkadot/keyring@7.3.1", "@polkadot/keyring@^7.3.1", "@polkadot/keyring@^7.4.1":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-7.3.1.tgz#bf36115cfb395567bec9cf13c8e3fc0fb39c802a"
   integrity sha512-3lbwIjUql8yjs6AR2fMdCgmTc5D9ne7+y2jqHmGjyzVQFz1w1jiHb+N38L0pwl9/23UxmzC3aVvHLfl3gEGSIQ==
@@ -4459,7 +4445,7 @@
     "@babel/runtime" "^7.15.4"
     "@polkadot/util" "^7.3.1"
 
-"@polkadot/types@4.2.1", "@polkadot/types@5.9.1":
+"@polkadot/types@5.9.1":
   version "5.9.1"
   resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-5.9.1.tgz#74cf4695795f2aa365ff85d3873e22c430100bc9"
   integrity sha512-30vcSlNBxPyWYZaxKDr/BoMhfLCRKB265XxpnnNJmbdZZsL+N4Zp2mJR9/UbA6ypmJBkUjD7b1s9AYsLwUs+8w==


### PR DESCRIPTION
- date type fix from giza branch
- avoid using old types in bootstrap fetch scripts. Typically we are running the scripts after the upgrade and connecting to joystream-node with new runtime using old types is failing because new types are not defined. In this particular scenario for Giza, the types being exported are unchanged in Giza so we can use the new types version, and since we add "legacy" types the new version also works when connecting to old (sumer) runtime.