### PR TITLE
Giza fix working group enum

### DIFF
--- a/runtime-modules/common/src/working_group.rs
+++ b/runtime-modules/common/src/working_group.rs
@@ -11,28 +11,24 @@ use strum_macros::EnumIter;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, EnumIter))]
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Copy, Debug, PartialOrd, Ord)]
 pub enum WorkingGroup {
-    /* Reserved
-        /// Forum working group: working_group::Instance1.
-        Forum,
-    */
     /// Storage working group: working_group::Instance2.
-    Storage = 2isize,
+    Storage,
 
     /// Storage working group: working_group::Instance3.
-    Content = 3isize,
+    Content,
 
     /// Operations working group: working_group::Instance4.
-    OperationsAlpha = 4isize,
+    OperationsAlpha,
 
     /// Gateway working group: working_group::Instance5.
-    Gateway = 5isize,
+    Gateway,
 
     /// Distribution working group: working_group::Instance6.
-    Distribution = 6isize,
+    Distributione,
 
     /// Operations working group: working_group::Instance7.
-    OperationsBeta = 7isize,
+    OperationsBeta,
 
     /// Operations working group: working_group::Instance8.
-    OperationsGamma = 8isize,
+    OperationsGamma,
 }

--- a/types/augment/all/defs.json
+++ b/types/augment/all/defs.json
@@ -82,8 +82,6 @@
     },
     "WorkingGroup": {
         "_enum": [
-            "_Reserved0",
-            "_Reserved1",
             "Storage",
             "Content",
             "OperationsAlpha",

--- a/types/augment/all/types.ts
+++ b/types/augment/all/types.ts
@@ -1400,8 +1400,6 @@ export interface WorkerOf extends Struct {
 
 /** @name WorkingGroup */
 export interface WorkingGroup extends Enum {
-  readonly isReserved0: boolean;
-  readonly isReserved1: boolean;
   readonly isStorage: boolean;
   readonly isContent: boolean;
   readonly isOperationsAlpha: boolean;

--- a/types/src/common.ts
+++ b/types/src/common.ts
@@ -72,8 +72,6 @@ export class InputValidationLengthConstraint
 
 // Reserved keys are not part of the exported definition const, since they are not intented to be used
 export const WorkingGroupDef = {
-  // _Reserved0
-  // _Reserved1
   Storage: Null,
   Content: Null,
   OperationsAlpha: Null,
@@ -84,8 +82,6 @@ export const WorkingGroupDef = {
 } as const
 export type WorkingGroupKey = keyof typeof WorkingGroupDef
 export class WorkingGroup extends JoyEnum({
-  _Reserved0: Null,
-  _Reserved1: Null,
   ...WorkingGroupDef,
 }) {}
 


### PR DESCRIPTION
Fix joystream types definition for runtime `enum common::WorkingGroup` type.

Parity scale-coded encoding of `enum`s is simply the [index of the variant](https://docs.substrate.io/v3/advanced/scale-codec/#enumerations-tagged-unions).

Technically only the changes in `@joystream/types` package is needed, but I removed the redundant rust code to avoid any confusion.

