### PR TITLE
runtime: do not init persisted working group modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "5.8.0"
+version = "5.9.0"
 dependencies = [
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node-runtime"
-version = "9.10.0"
+version = "9.11.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '5.8.0'
+version = '5.9.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 name = 'joystream-node-runtime'
 # Follow convention: https://github.com/Joystream/substrate-runtime-joystream/issues/1
 # {Authoring}.{Spec}.{Impl} of the RuntimeVersion
-version = '9.10.0'
+version = '9.11.0'
 
 [dependencies]
 # Third-party dependencies

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("joystream-node"),
     impl_name: create_runtime_str!("joystream-node"),
     authoring_version: 9,
-    spec_version: 10,
+    spec_version: 11,
     impl_version: 0,
     apis: crate::runtime_api::EXPORTED_RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/runtime_api.rs
+++ b/runtime/src/runtime_api.rs
@@ -92,13 +92,9 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
 
         let default_content_working_group_mint_capacity = 0;
 
-        OperationsWorkingGroupAlpha::<Runtime>::initialize_working_group(
-            default_text_constraint,
-            default_text_constraint,
-            default_text_constraint,
-            default_storage_size_constraint,
-            default_content_working_group_mint_capacity,
-        );
+        // Do not init persisted working group module instances
+        // OperationsWorkingGroupAlpha (previously OperationsWorkingGroup)
+        // ContentWorkingGroup (previously ContentDirectoryWorkingGroup)
 
         OperationsWorkingGroupBeta::<Runtime>::initialize_working_group(
             default_text_constraint,
@@ -109,14 +105,6 @@ impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
         );
 
         OperationsWorkingGroupGamma::<Runtime>::initialize_working_group(
-            default_text_constraint,
-            default_text_constraint,
-            default_text_constraint,
-            default_storage_size_constraint,
-            default_content_working_group_mint_capacity,
-        );
-
-        ContentWorkingGroup::<Runtime>::initialize_working_group(
             default_text_constraint,
             default_text_constraint,
             default_text_constraint,


### PR DESCRIPTION
We discovered that runtime modules instances of type WorkingGroup even if renamed persist their state presumably because the key (in key value store) is derived based on the module type name and instance number and not the unique name in decl_runtime construction macro.