### PR TITLE
Giza fix working group enum

### DIFF
--- a/runtime-modules/common/src/working_group.rs
+++ b/runtime-modules/common/src/working_group.rs
@@ -11,28 +11,24 @@ use strum_macros::EnumIter;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize, EnumIter))]
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Copy, Debug, PartialOrd, Ord)]
 pub enum WorkingGroup {
-    /* Reserved
-        /// Forum working group: working_group::Instance1.
-        Forum,
-    */
     /// Storage working group: working_group::Instance2.
-    Storage = 2isize,
+    Storage,
 
     /// Storage working group: working_group::Instance3.
-    Content = 3isize,
+    Content,
 
     /// Operations working group: working_group::Instance4.
-    OperationsAlpha = 4isize,
+    OperationsAlpha,
 
     /// Gateway working group: working_group::Instance5.
-    Gateway = 5isize,
+    Gateway,
 
     /// Distribution working group: working_group::Instance6.
-    Distribution = 6isize,
+    Distributione,
 
     /// Operations working group: working_group::Instance7.
-    OperationsBeta = 7isize,
+    OperationsBeta,
 
     /// Operations working group: working_group::Instance8.
-    OperationsGamma = 8isize,
+    OperationsGamma,
 }

--- a/runtime-modules/common/src/working_group.rs
+++ b/runtime-modules/common/src/working_group.rs
@@ -24,7 +24,7 @@ pub enum WorkingGroup {
     Gateway,
 
     /// Distribution working group: working_group::Instance6.
-    Distributione,
+    Distribution,
 
     /// Operations working group: working_group::Instance7.
     OperationsBeta,

--- a/types/augment/all/defs.json
+++ b/types/augment/all/defs.json
@@ -82,8 +82,6 @@
     },
     "WorkingGroup": {
         "_enum": [
-            "_Reserved0",
-            "_Reserved1",
             "Storage",
             "Content",
             "OperationsAlpha",

--- a/types/augment/all/types.ts
+++ b/types/augment/all/types.ts
@@ -1400,8 +1400,6 @@ export interface WorkerOf extends Struct {
 
 /** @name WorkingGroup */
 export interface WorkingGroup extends Enum {
-  readonly isReserved0: boolean;
-  readonly isReserved1: boolean;
   readonly isStorage: boolean;
   readonly isContent: boolean;
   readonly isOperationsAlpha: boolean;

--- a/types/src/common.ts
+++ b/types/src/common.ts
@@ -72,8 +72,6 @@ export class InputValidationLengthConstraint
 
 // Reserved keys are not part of the exported definition const, since they are not intented to be used
 export const WorkingGroupDef = {
-  // _Reserved0
-  // _Reserved1
   Storage: Null,
   Content: Null,
   OperationsAlpha: Null,
@@ -84,8 +82,6 @@ export const WorkingGroupDef = {
 } as const
 export type WorkingGroupKey = keyof typeof WorkingGroupDef
 export class WorkingGroup extends JoyEnum({
-  _Reserved0: Null,
-  _Reserved1: Null,
   ...WorkingGroupDef,
 }) {}
 

--- a/types/src/common.ts
+++ b/types/src/common.ts
@@ -70,7 +70,6 @@ export class InputValidationLengthConstraint
   }
 }
 
-// Reserved keys are not part of the exported definition const, since they are not intented to be used
 export const WorkingGroupDef = {
   Storage: Null,
   Content: Null,
@@ -81,9 +80,7 @@ export const WorkingGroupDef = {
   OperationsGamma: Null,
 } as const
 export type WorkingGroupKey = keyof typeof WorkingGroupDef
-export class WorkingGroup extends JoyEnum({
-  ...WorkingGroupDef,
-}) {}
+export class WorkingGroup extends JoyEnum(WorkingGroupDef) {}
 
 // Temporarly in "common", because used both by /working-group and /content-working-group:
 export type ISlashableTerms = {


### PR DESCRIPTION
We concluded that chancing the enum variant ordering for WorkingGroup type in a runtime upgrade while existing state (proposals) references the WorkingGroup vlaue should be avoided.