### PR TITLE
github workflow: use correct script when running runtime upgrade tests

### DIFF
--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -100,10 +100,12 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           yarn workspace @joystream/types build
+          yarn workspace @joystream/metadata-protobuf build
+          yarn workspace @joystream/cli build
       - name: Ensure tests are runnable
         run: yarn workspace network-tests build
       - name: Execute network tests
-        run: RUNTIME=sumer tests/network-tests/run-tests.sh full
+        run: RUNTIME=sumer tests/network-tests/run-migration-tests.sh full
 
   basic_runtime:
     name: Integration Tests (New Chain)

--- a/tests/network-tests/run-migration-tests.sh
+++ b/tests/network-tests/run-migration-tests.sh
@@ -78,11 +78,11 @@ function cleanup() {
 
 function pre_migration_hook() {
 sleep 5 # needed otherwise docker image won't be ready yet
-joystream-cli account:choose --address 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
+yarn joystream-cli account:choose --address 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY # Alice
 echo "creating 1 channel"
-joystream-cli content:createChannel --input=./assets/TestChannel.json --context=Member || true
+yarn joystream-cli content:createChannel --input=./assets/TestChannel.json --context=Member || true
 echo "adding 1 video to the above channel"
-joystream-cli content:createVideo -c 1 --input=./assets/TestVideo.json || true
+yarn joystream-cli content:createVideo -c 1 --input=./assets/TestVideo.json || true
 }
 
 function post_migration_hook() {


### PR DESCRIPTION
Previously the wrong script was run from the github workflow for runtime upgrade test, which was resulting in giza tests running against sumer runtime. see: https://github.com/Joystream/joystream/runs/4155521389?check_suite_focus=true#step:8:84

This PR should fix it.

The `run-migrations-tests.sh` still needs some work @ignazio-bovo but at least the flow is setup correctly now.