### PR TITLE
Fix cross-platform issue with tests

### DIFF
--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -108,7 +108,7 @@ jobs:
         run: npm -g install @joystream/cli
       - name: Execute network tests
         run: |
-          export HOME=$(pwd)
+          export HOME=${PWD}
           mkdir -p ${HOME}/.local/share/joystream-cli
           joystream-cli api:setUri ws://localhost:9944
           export RUNTIME=sumer

--- a/tests/network-tests/run-migration-tests.sh
+++ b/tests/network-tests/run-migration-tests.sh
@@ -5,7 +5,7 @@ SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
 cd $SCRIPT_PATH
 
 # Location to store runtime WASM for runtime upgrade
-DATA_PATH=${DATA_PATH:=$(pwd)/data}
+DATA_PATH=${DATA_PATH:=$PWD/data}
 
 # The joystream/node docker image tag to start chain
 export RUNTIME=${RUNTIME:=latest}
@@ -17,7 +17,7 @@ TARGET_RUNTIME=${TARGET_RUNTIME:=latest}
 export AUTO_CONFIRM=true
 
 # Create chainspec with Alice (sudo) as member so we can use her in joystream-cli
-CONTAINER_ID=`MAKE_SUDO_MEMBER=true ./run-test-node-docker.sh`
+CONTAINER_ID=$(MAKE_SUDO_MEMBER=true ./run-test-node-docker.sh)
 
 function cleanup() {
     docker logs ${CONTAINER_ID} --tail 15

--- a/tests/network-tests/run-test-node-docker.sh
+++ b/tests/network-tests/run-test-node-docker.sh
@@ -9,7 +9,7 @@ cd $SCRIPT_PATH
 
 # Location that will be mounted as the /data volume in containers
 # This is where the initial members and balances files and generated chainspec files will be located.
-DATA_PATH=${DATA_PATH:=$(pwd)/data}
+DATA_PATH=${DATA_PATH:=$PWD/data}
 mkdir -p ${DATA_PATH}
 
 # Initial account balance for sudo account

--- a/tests/network-tests/run-tests.sh
+++ b/tests/network-tests/run-tests.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
 cd $SCRIPT_PATH
 
-CONTAINER_ID=`./run-test-node-docker.sh`
+CONTAINER_ID=$(./run-test-node-docker.sh)
 
 function cleanup() {
     docker logs ${CONTAINER_ID} --tail 15


### PR DESCRIPTION
Fixes getting different behaviors on linux vs mac in some bash scripts.

use `$PWD`  not $(pwd)
and `$(command)` not \`command\`

ref: 
https://stackoverflow.com/questions/10795014/pwd-vs-pwd-regarding-portability
https://stackoverflow.com/questions/22709371/backticks-vs-braces-in-bash