### PR TITLE
Query node: Fix for "table name x specified more than once"

### DIFF
--- a/query-node/codegen/package.json
+++ b/query-node/codegen/package.json
@@ -4,6 +4,9 @@
   "description": "Hydra codegen tools for Joystream Query Node",
   "author": "",
   "license": "ISC",
+  "scripts": {
+    "postinstall": "cd .. && yarn workspace query-node-mappings postHydraCLIInstall"
+  },
   "dependencies": {
     "@joystream/hydra-cli": "3.1.0-alpha.13",
     "@joystream/hydra-typegen": "3.1.0-alpha.13"

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -12,6 +12,7 @@
     "checks": "prettier ./ --check && yarn lint",
     "format": "prettier ./ --write ",
     "postinstall": "yarn ts-node ./scripts/postInstall.ts",
+    "postHydraCLIInstall": "yarn ts-node ./scripts/postHydraCLIInstall.ts",
     "bootstrap-data:fetch:members": "yarn ts-node ./bootstrap-data/scripts/fetchMembersData.ts",
     "bootstrap-data:fetch:categories": "yarn ts-node ./bootstrap-data/scripts/fetchCategories.ts",
     "bootstrap-data:fetch:workingGroups": "yarn ts-node ./bootstrap-data/scripts/fetchWorkingGroupsData.ts",

--- a/query-node/mappings/scripts/postHydraCLIInstall.ts
+++ b/query-node/mappings/scripts/postHydraCLIInstall.ts
@@ -1,0 +1,23 @@
+// A script to be executed post hydra-cli install, that may include patches for Hydra CLI
+import fs from 'fs'
+import path from 'path'
+
+// FIXME: Temporary fix for missing JOIN and HAVING conditions in search queries (Hydra)
+const searchServiceTemplatePath = path.resolve(
+  __dirname,
+  '../../codegen/node_modules/@joystream/hydra-cli/lib/src/templates/textsearch/service.ts.mst'
+)
+const searchServiceTemplateContent = fs.readFileSync(searchServiceTemplatePath).toString()
+const searchServiceTemplateContentLines = searchServiceTemplateContent.split('\n')
+searchServiceTemplateContentLines.splice(
+  searchServiceTemplateContentLines.findIndex((l) => l.match(/Add new query to queryString/)) + 1,
+  1, // remove 1 line
+  `queries = queries.concat(generateSqlQuery(repositories[index].metadata.tableName, qb.createJoinExpression(), WHERE, qb.createHavingExpression()));`
+)
+searchServiceTemplateContentLines.splice(
+  searchServiceTemplateContentLines.findIndex((l) => l.match(/const generateSqlQuery = /)),
+  3, // remove 3 lines
+  `const generateSqlQuery = (table: string, joins: string, where: string, having: string) =>
+    \`SELECT '\${table}_' || "\${table}"."id" AS unique_id FROM "\${table}" \` + joins + ' ' + where + ' ' + having;`
+)
+fs.writeFileSync(searchServiceTemplatePath, searchServiceTemplateContentLines.join('\n'))

--- a/query-node/mappings/scripts/postInstall.ts
+++ b/query-node/mappings/scripts/postInstall.ts
@@ -33,3 +33,18 @@ dataLoaderJsContentLines.splice(
   `
 )
 fs.writeFileSync(dataLoaderJsPath, dataLoaderJsContentLines.join('\n'))
+
+// FIXME: Temporary fix for "table name x specified more than once"
+const baseServiceJsPath = path.resolve(__dirname, '../../../node_modules/@joystream/warthog/dist/core/BaseService.js')
+const baseServiceJsContent = fs.readFileSync(baseServiceJsPath).toString()
+const baseServiceJsContentLines = baseServiceJsContent.split('\n')
+baseServiceJsContentLines.splice(
+  baseServiceJsContentLines.findIndex((l) => l.match(/function common/)) + 1,
+  4, // remove 4 lines (function body)
+  `const uuid = require('uuid/v4')
+  const foreignTableAlias = uuid().replace('-', '')
+  var foreingIdColumn = "\\"" + foreignTableAlias + "\\".\\"" + foreignColumnMap[foreignColumnName] + "\\"";
+  parameters.topLevelQb.leftJoin(foreignTableName, foreignTableAlias, localIdColumn + " = " + foreingIdColumn);
+  addWhereCondition(parameters, foreignTableAlias, foreignColumnMap);`
+)
+fs.writeFileSync(baseServiceJsPath, baseServiceJsContentLines.join('\n'))


### PR DESCRIPTION
Fixes `table name x specified more than once` issue spotted by @kdembler while executing a query:
```graphql
{
  videos(
    limit: 10
    where: {
      media: { isAccepted_eq: true }
      thumbnailPhoto: { isAccepted_eq: true }
    }
  ) {
    id
    title
    media {
      id
      isAccepted
    }
    thumbnailPhoto {
      id
      isAccepted
    }
  }
}
```
Previously this resulted in:
```
# ...
"message": "table name \"storage_data_object\" specified more than once"
# ...
```

**Reason:**
No aliasing was used when joining related tables. When the same table was joined twice (`storage_data_object` in this case), the query was failing due to name clash.

**Fix:**
I implemented a patch for `@joystream/warthog` to use `uuid/v4` as table alias when joining `OneToOne`, `ManyToOne` and `OneToMany` relationships. The logic for `ManyToMany` relationships is a bit different, but since we currently have no case of joining two separate `ManyToMany` relationships in the same query with the same table names, I decided to skip patching this part.

**Testing:**
The query mentioned above appears to work as expected now.
I also tested all [Colossus](https://github.com/Joystream/joystream/blob/giza_staging/storage-node-v2/src/services/queryNode/queries/queries.graphql) and [Argus](https://github.com/Joystream/joystream/blob/giza_staging/distributor-node/src/services/networking/query-node/queries/queries.graphql) - all of them also worked as expected.