### PR TITLE
Giza: Fix StorageBucket type mismatch

### DIFF
--- a/types/augment/all/defs.json
+++ b/types/augment/all/defs.json
@@ -529,8 +529,7 @@
     "StorageBucket": {
         "operator_status": "StorageBucketOperatorStatus",
         "accepting_new_bags": "bool",
-        "voucher": "Voucher",
-        "metadata": "Bytes"
+        "voucher": "Voucher"
     },
     "StaticBagId": {
         "_enum": {

--- a/types/augment/all/types.ts
+++ b/types/augment/all/types.ts
@@ -1205,7 +1205,6 @@ export interface StorageBucket extends Struct {
   readonly operator_status: StorageBucketOperatorStatus;
   readonly accepting_new_bags: bool;
   readonly voucher: Voucher;
-  readonly metadata: Bytes;
 }
 
 /** @name StorageBucketId */

--- a/types/src/storage.ts
+++ b/types/src/storage.ts
@@ -159,7 +159,6 @@ export type IStorageBucket = {
   operator_status: StorageBucketOperatorStatus
   accepting_new_bags: bool
   voucher: Voucher
-  metadata: Bytes
 }
 
 export class StorageBucket
@@ -167,7 +166,6 @@ export class StorageBucket
     operator_status: StorageBucketOperatorStatus,
     accepting_new_bags: bool,
     voucher: Voucher,
-    metadata: Bytes,
   })
   implements IStorageBucket {}
 


### PR DESCRIPTION
Fix `StorageBucket` type mismatch between the runtime and `@joystream/types` (ref: https://github.com/Joystream/joystream/blob/giza/runtime-modules/storage/src/lib.rs#L785)