### PR TITLE
Giza staging: query-node/kill.sh script fix

### DIFF
--- a/query-node/kill.sh
+++ b/query-node/kill.sh
@@ -11,3 +11,4 @@ docker-compose -f ../docker-compose.yml rm -vsf indexer
 docker-compose -f ../docker-compose.yml rm -vsf hydra-indexer-gateway
 docker-compose -f ../docker-compose.yml rm -vsf redis
 docker-compose -f ../docker-compose.yml rm -vsf db
+docker volume rm joystream_query-node-data


### PR DESCRIPTION
Remove `query-node-data` volume during `query-node/kill.sh` to allow restarting the query node via `./query-node/kill.sh && ./query-node/start.sh`