### PR TITLE
Pioneer: Show active proposals per default

### DIFF
--- a/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
+++ b/pioneer/packages/joy-proposals/src/Proposal/ProposalPreviewList.tsx
@@ -35,7 +35,7 @@ const PaginationBox = styled.div`
 function ProposalPreviewList ({ bestNumber, historical }: ProposalPreviewListProps) {
   const { pathname } = useLocation();
   const transport = useTransport();
-  const [activeFilter, setActiveFilter] = useState<ProposalStatusFilter>('All');
+  const [activeFilter, setActiveFilter] = useState<ProposalStatusFilter>('Active');
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [proposalsBatch, error, loading] = usePromise<ProposalsBatch | undefined>(
     () => historical


### PR DESCRIPTION
Small change to save load time for often used route:
https://pioneer.joystreamstats.live/#/proposals