### PR TITLE
Fix update_families_in_dynamic_bag_creation_policy extrinsic.

### DIFF
--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -2264,9 +2264,11 @@ decl_module! {
             // == MUTATION SAFE ==
             //
 
-            DynamicBagCreationPolicies::<T>::mutate(dynamic_bag_type, |creation_policy| {
-                creation_policy.families = families.clone();
-            });
+            // We initialize the default storage bucket number here if no policy exists.
+            let mut new_policy = Self::get_dynamic_bag_creation_policy(dynamic_bag_type);
+            new_policy.families = families.clone();
+
+            DynamicBagCreationPolicies::<T>::insert(dynamic_bag_type, new_policy);
 
             Self::deposit_event(
                 RawEvent::FamiliesInDynamicBagCreationPolicyUpdated(

--- a/runtime-modules/storage/src/tests/fixtures.rs
+++ b/runtime-modules/storage/src/tests/fixtures.rs
@@ -1624,6 +1624,11 @@ impl UpdateFamiliesInDynamicBagCreationPolicyFixture {
         assert_eq!(actual_result, expected_result);
 
         let new_policy = Storage::get_dynamic_bag_creation_policy(self.dynamic_bag_type);
+        assert_eq!(
+            old_policy.number_of_storage_buckets,
+            new_policy.number_of_storage_buckets
+        );
+
         if actual_result.is_ok() {
             assert_eq!(new_policy.families, self.families);
         } else {


### PR DESCRIPTION
Add default storage bucket number for the new policy.