### PR TITLE
query node - active video counters

### DIFF
--- a/cli/src/base/StateAwareCommandBase.ts
+++ b/cli/src/base/StateAwareCommandBase.ts
@@ -88,7 +88,7 @@ export default abstract class StateAwareCommandBase extends DefaultCommandBase {
 
   private initStateFs(): void {
     if (!fs.existsSync(this.getAppDataPath())) {
-      fs.mkdirSync(this.getAppDataPath())
+      fs.mkdirSync(this.getAppDataPath(), {recursive: true})
     }
     if (!fs.existsSync(this.getStateFilePath())) {
       fs.writeFileSync(this.getStateFilePath(), JSON.stringify(DEFAULT_STATE))

--- a/cli/src/base/StateAwareCommandBase.ts
+++ b/cli/src/base/StateAwareCommandBase.ts
@@ -88,7 +88,7 @@ export default abstract class StateAwareCommandBase extends DefaultCommandBase {
 
   private initStateFs(): void {
     if (!fs.existsSync(this.getAppDataPath())) {
-      fs.mkdirSync(this.getAppDataPath(), {recursive: true})
+      fs.mkdirSync(this.getAppDataPath(), { recursive: true })
     }
     if (!fs.existsSync(this.getStateFilePath())) {
       fs.writeFileSync(this.getStateFilePath(), JSON.stringify(DEFAULT_STATE))

--- a/query-node/generated/graphql-server/generated/binding.ts
+++ b/query-node/generated/graphql-server/generated/binding.ts
@@ -125,6 +125,8 @@ export type ChannelCategoryOrderByInput =   'createdAt_ASC' |
   'deletedAt_DESC' |
   'name_ASC' |
   'name_DESC' |
+  'activeVideosCounter_ASC' |
+  'activeVideosCounter_DESC' |
   'createdInBlock_ASC' |
   'createdInBlock_DESC'
 
@@ -152,6 +154,8 @@ export type ChannelOrderByInput =   'createdAt_ASC' |
   'title_DESC' |
   'description_ASC' |
   'description_DESC' |
+  'activeVideosCounter_ASC' |
+  'activeVideosCounter_DESC' |
   'coverPhotoDataObject_ASC' |
   'coverPhotoDataObject_DESC' |
   'coverPhotoDataObjectId_ASC' |
@@ -246,6 +250,8 @@ export type VideoCategoryOrderByInput =   'createdAt_ASC' |
   'deletedAt_DESC' |
   'name_ASC' |
   'name_DESC' |
+  'activeVideosCounter_ASC' |
+  'activeVideosCounter_DESC' |
   'createdInBlock_ASC' |
   'createdInBlock_DESC'
 
@@ -789,11 +795,13 @@ export interface DataObjectWhereUniqueInput {
 
 export interface ChannelCategoryCreateInput {
   name?: String | null
+  activeVideosCounter: Float
   createdInBlock: Float
 }
 
 export interface ChannelCategoryUpdateInput {
   name?: String | null
+  activeVideosCounter?: Float | null
   createdInBlock?: Float | null
 }
 
@@ -827,6 +835,12 @@ export interface ChannelCategoryWhereInput {
   name_startsWith?: String | null
   name_endsWith?: String | null
   name_in?: String[] | String | null
+  activeVideosCounter_eq?: Int | null
+  activeVideosCounter_gt?: Int | null
+  activeVideosCounter_gte?: Int | null
+  activeVideosCounter_lt?: Int | null
+  activeVideosCounter_lte?: Int | null
+  activeVideosCounter_in?: Int[] | Int | null
   createdInBlock_eq?: Int | null
   createdInBlock_gt?: Int | null
   createdInBlock_gte?: Int | null
@@ -854,6 +868,7 @@ export interface ChannelCreateInput {
   rewardAccount?: String | null
   title?: String | null
   description?: String | null
+  activeVideosCounter: Float
   coverPhotoDataObject?: ID_Input | null
   coverPhotoDataObjectId?: ID_Input | null
   coverPhotoUrls: Array<String>
@@ -879,6 +894,7 @@ export interface ChannelUpdateInput {
   rewardAccount?: String | null
   title?: String | null
   description?: String | null
+  activeVideosCounter?: Float | null
   coverPhotoDataObject?: ID_Input | null
   coverPhotoDataObjectId?: ID_Input | null
   coverPhotoUrls?: String[] | String | null
@@ -940,6 +956,12 @@ export interface ChannelWhereInput {
   description_startsWith?: String | null
   description_endsWith?: String | null
   description_in?: String[] | String | null
+  activeVideosCounter_eq?: Int | null
+  activeVideosCounter_gt?: Int | null
+  activeVideosCounter_gte?: Int | null
+  activeVideosCounter_lt?: Int | null
+  activeVideosCounter_lte?: Int | null
+  activeVideosCounter_in?: Int[] | Int | null
   coverPhotoDataObjectId_eq?: ID_Input | null
   coverPhotoDataObjectId_in?: ID_Output[] | ID_Output | null
   coverPhotoUrls_containsAll?: String[] | String | null
@@ -1254,11 +1276,13 @@ export interface NextEntityIdWhereUniqueInput {
 
 export interface VideoCategoryCreateInput {
   name?: String | null
+  activeVideosCounter: Float
   createdInBlock: Float
 }
 
 export interface VideoCategoryUpdateInput {
   name?: String | null
+  activeVideosCounter?: Float | null
   createdInBlock?: Float | null
 }
 
@@ -1292,6 +1316,12 @@ export interface VideoCategoryWhereInput {
   name_startsWith?: String | null
   name_endsWith?: String | null
   name_in?: String[] | String | null
+  activeVideosCounter_eq?: Int | null
+  activeVideosCounter_gt?: Int | null
+  activeVideosCounter_gte?: Int | null
+  activeVideosCounter_lt?: Int | null
+  activeVideosCounter_lte?: Int | null
+  activeVideosCounter_in?: Int[] | Int | null
   createdInBlock_eq?: Int | null
   createdInBlock_gt?: Int | null
   createdInBlock_gte?: Int | null

--- a/query-node/generated/graphql-server/generated/binding.ts
+++ b/query-node/generated/graphql-server/generated/binding.ts
@@ -1819,6 +1819,7 @@ export interface Channel extends BaseGraphQLObject {
   rewardAccount?: String | null
   title?: String | null
   description?: String | null
+  activeVideosCounter: Int
   coverPhotoDataObject?: DataObject | null
   coverPhotoDataObjectId?: String | null
   coverPhotoUrls: Array<String>
@@ -1856,6 +1857,7 @@ export interface ChannelCategory extends BaseGraphQLObject {
   deletedById?: String | null
   version: Int
   name?: String | null
+  activeVideosCounter: Int
   channels: Array<Channel>
   createdInBlock: Int
 }
@@ -2080,6 +2082,7 @@ export interface VideoCategory extends BaseGraphQLObject {
   deletedById?: String | null
   version: Int
   name?: String | null
+  activeVideosCounter: Int
   videos: Array<Video>
   createdInBlock: Int
 }

--- a/query-node/generated/graphql-server/generated/classes.ts
+++ b/query-node/generated/graphql-server/generated/classes.ts
@@ -23,21 +23,19 @@ const { GraphQLJSONObject } = require('graphql-type-json');
 // @ts-ignore
 import { BaseWhereInput, JsonObject, PaginationArgs, DateOnlyString, DateTimeString, BigInt, Bytes } from 'warthog';
 
-import { WorkerType } from "../src/modules/worker/worker.model";
+import { MembershipEntryMethod } from "../src/modules/membership/membership.model";
 import { AssetAvailability } from "../src/modules/video/video.model";
 import { LiaisonJudgement } from "../src/modules/data-object/data-object.model";
-import { MembershipEntryMethod } from "../src/modules/membership/membership.model";
+import { WorkerType } from "../src/modules/worker/worker.model";
 
+// @ts-ignore
+import { Membership } from "../src/modules/membership/membership.model";
 // @ts-ignore
 import { CuratorGroup } from "../src/modules/curator-group/curator-group.model";
 // @ts-ignore
 import { ChannelCategory } from "../src/modules/channel-category/channel-category.model";
 // @ts-ignore
-import { Worker } from "../src/modules/worker/worker.model";
-// @ts-ignore
 import { VideoCategory } from "../src/modules/video-category/video-category.model";
-// @ts-ignore
-import { Language } from "../src/modules/language/language.model";
 // @ts-ignore
 import { License } from "../src/modules/license/license.model";
 // @ts-ignore
@@ -47,370 +45,15 @@ import { VideoMediaMetadata } from "../src/modules/video-media-metadata/video-me
 // @ts-ignore
 import { Video } from "../src/modules/video/video.model";
 // @ts-ignore
-import { DataObject } from "../src/modules/data-object/data-object.model";
+import { Language } from "../src/modules/language/language.model";
 // @ts-ignore
 import { Channel } from "../src/modules/channel/channel.model";
 // @ts-ignore
-import { Membership } from "../src/modules/membership/membership.model";
+import { DataObject } from "../src/modules/data-object/data-object.model";
+// @ts-ignore
+import { Worker } from "../src/modules/worker/worker.model";
 // @ts-ignore
 import { NextEntityId } from "../src/modules/next-entity-id/next-entity-id.model";
-
-export enum CuratorGroupOrderByEnum {
-  createdAt_ASC = "createdAt_ASC",
-  createdAt_DESC = "createdAt_DESC",
-
-  updatedAt_ASC = "updatedAt_ASC",
-  updatedAt_DESC = "updatedAt_DESC",
-
-  deletedAt_ASC = "deletedAt_ASC",
-  deletedAt_DESC = "deletedAt_DESC",
-
-  isActive_ASC = "isActive_ASC",
-  isActive_DESC = "isActive_DESC"
-}
-
-registerEnumType(CuratorGroupOrderByEnum, {
-  name: "CuratorGroupOrderByInput"
-});
-
-@TypeGraphQLInputType()
-export class CuratorGroupWhereInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  id_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  id_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  createdById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  createdById_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  updatedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  updatedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  deletedAt_all?: Boolean;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  deletedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  deletedById_in?: string[];
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  curatorIds_containsAll?: [number];
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  curatorIds_containsNone?: [number];
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  curatorIds_containsAny?: [number];
-
-  @TypeGraphQLField(() => Boolean, { nullable: true })
-  isActive_eq?: Boolean;
-
-  @TypeGraphQLField(() => [Boolean], { nullable: true })
-  isActive_in?: Boolean[];
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_none?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_some?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_every?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
-  AND?: [CuratorGroupWhereInput];
-
-  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
-  OR?: [CuratorGroupWhereInput];
-}
-
-@TypeGraphQLInputType()
-export class CuratorGroupWhereUniqueInput {
-  @TypeGraphQLField(() => ID)
-  id?: string;
-}
-
-@TypeGraphQLInputType()
-export class CuratorGroupCreateInput {
-  @TypeGraphQLField(() => [Int])
-  curatorIds!: number[];
-
-  @TypeGraphQLField()
-  isActive!: boolean;
-}
-
-@TypeGraphQLInputType()
-export class CuratorGroupUpdateInput {
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  curatorIds?: number[];
-
-  @TypeGraphQLField({ nullable: true })
-  isActive?: boolean;
-}
-
-@ArgsType()
-export class CuratorGroupWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
-  where?: CuratorGroupWhereInput;
-
-  @TypeGraphQLField(() => CuratorGroupOrderByEnum, { nullable: true })
-  orderBy?: CuratorGroupOrderByEnum[];
-}
-
-@ArgsType()
-export class CuratorGroupCreateManyArgs {
-  @TypeGraphQLField(() => [CuratorGroupCreateInput])
-  data!: CuratorGroupCreateInput[];
-}
-
-@ArgsType()
-export class CuratorGroupUpdateArgs {
-  @TypeGraphQLField() data!: CuratorGroupUpdateInput;
-  @TypeGraphQLField() where!: CuratorGroupWhereUniqueInput;
-}
-
-export enum ChannelCategoryOrderByEnum {
-  createdAt_ASC = "createdAt_ASC",
-  createdAt_DESC = "createdAt_DESC",
-
-  updatedAt_ASC = "updatedAt_ASC",
-  updatedAt_DESC = "updatedAt_DESC",
-
-  deletedAt_ASC = "deletedAt_ASC",
-  deletedAt_DESC = "deletedAt_DESC",
-
-  name_ASC = "name_ASC",
-  name_DESC = "name_DESC",
-
-  createdInBlock_ASC = "createdInBlock_ASC",
-  createdInBlock_DESC = "createdInBlock_DESC"
-}
-
-registerEnumType(ChannelCategoryOrderByEnum, {
-  name: "ChannelCategoryOrderByInput"
-});
-
-@TypeGraphQLInputType()
-export class ChannelCategoryWhereInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  id_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  id_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  createdById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  createdById_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  updatedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  updatedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  deletedAt_all?: Boolean;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  deletedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  deletedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  name_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  name_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  name_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  name_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  name_in?: string[];
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_eq?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gte?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lte?: number;
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  createdInBlock_in?: number[];
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_none?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_some?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_every?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
-  AND?: [ChannelCategoryWhereInput];
-
-  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
-  OR?: [ChannelCategoryWhereInput];
-}
-
-@TypeGraphQLInputType()
-export class ChannelCategoryWhereUniqueInput {
-  @TypeGraphQLField(() => ID)
-  id?: string;
-}
-
-@TypeGraphQLInputType()
-export class ChannelCategoryCreateInput {
-  @TypeGraphQLField({ nullable: true })
-  name?: string;
-
-  @TypeGraphQLField()
-  createdInBlock!: number;
-}
-
-@TypeGraphQLInputType()
-export class ChannelCategoryUpdateInput {
-  @TypeGraphQLField({ nullable: true })
-  name?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  createdInBlock?: number;
-}
-
-@ArgsType()
-export class ChannelCategoryWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
-  where?: ChannelCategoryWhereInput;
-
-  @TypeGraphQLField(() => ChannelCategoryOrderByEnum, { nullable: true })
-  orderBy?: ChannelCategoryOrderByEnum[];
-}
-
-@ArgsType()
-export class ChannelCategoryCreateManyArgs {
-  @TypeGraphQLField(() => [ChannelCategoryCreateInput])
-  data!: ChannelCategoryCreateInput[];
-}
-
-@ArgsType()
-export class ChannelCategoryUpdateArgs {
-  @TypeGraphQLField() data!: ChannelCategoryUpdateInput;
-  @TypeGraphQLField() where!: ChannelCategoryWhereUniqueInput;
-}
 
 export enum DataObjectOwnerChannelOrderByEnum {
   createdAt_ASC = "createdAt_ASC",
@@ -1254,7 +897,7 @@ export class DataObjectOwnerWorkingGroupUpdateArgs {
   @TypeGraphQLField() where!: DataObjectOwnerWorkingGroupWhereUniqueInput;
 }
 
-export enum WorkerOrderByEnum {
+export enum MembershipOrderByEnum {
   createdAt_ASC = "createdAt_ASC",
   createdAt_DESC = "createdAt_DESC",
 
@@ -1264,25 +907,37 @@ export enum WorkerOrderByEnum {
   deletedAt_ASC = "deletedAt_ASC",
   deletedAt_DESC = "deletedAt_DESC",
 
-  isActive_ASC = "isActive_ASC",
-  isActive_DESC = "isActive_DESC",
+  handle_ASC = "handle_ASC",
+  handle_DESC = "handle_DESC",
 
-  workerId_ASC = "workerId_ASC",
-  workerId_DESC = "workerId_DESC",
+  avatarUri_ASC = "avatarUri_ASC",
+  avatarUri_DESC = "avatarUri_DESC",
 
-  type_ASC = "type_ASC",
-  type_DESC = "type_DESC",
+  about_ASC = "about_ASC",
+  about_DESC = "about_DESC",
 
-  metadata_ASC = "metadata_ASC",
-  metadata_DESC = "metadata_DESC"
+  controllerAccount_ASC = "controllerAccount_ASC",
+  controllerAccount_DESC = "controllerAccount_DESC",
+
+  rootAccount_ASC = "rootAccount_ASC",
+  rootAccount_DESC = "rootAccount_DESC",
+
+  createdInBlock_ASC = "createdInBlock_ASC",
+  createdInBlock_DESC = "createdInBlock_DESC",
+
+  entry_ASC = "entry_ASC",
+  entry_DESC = "entry_DESC",
+
+  subscription_ASC = "subscription_ASC",
+  subscription_DESC = "subscription_DESC"
 }
 
-registerEnumType(WorkerOrderByEnum, {
-  name: "WorkerOrderByInput"
+registerEnumType(MembershipOrderByEnum, {
+  name: "MembershipOrderByInput"
 });
 
 @TypeGraphQLInputType()
-export class WorkerWhereInput {
+export class MembershipWhereInput {
   @TypeGraphQLField(() => ID, { nullable: true })
   id_eq?: string;
 
@@ -1355,119 +1010,605 @@ export class WorkerWhereInput {
   @TypeGraphQLField(() => [ID], { nullable: true })
   deletedById_in?: string[];
 
+  @TypeGraphQLField({ nullable: true })
+  handle_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  handle_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  handle_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  handle_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  handle_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  avatarUri_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  about_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  about_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  controllerAccount_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  rootAccount_in?: string[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  createdInBlock_in?: number[];
+
+  @TypeGraphQLField(() => MembershipEntryMethod, { nullable: true })
+  entry_eq?: MembershipEntryMethod;
+
+  @TypeGraphQLField(() => [MembershipEntryMethod], { nullable: true })
+  entry_in?: MembershipEntryMethod[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  subscription_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  subscription_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  subscription_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  subscription_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  subscription_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  subscription_in?: number[];
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_none?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_some?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_every?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
+  AND?: [MembershipWhereInput];
+
+  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
+  OR?: [MembershipWhereInput];
+}
+
+@TypeGraphQLInputType()
+export class MembershipWhereUniqueInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  id?: string;
+
+  @TypeGraphQLField(() => String, { nullable: true })
+  handle?: string;
+}
+
+@TypeGraphQLInputType()
+export class MembershipCreateInput {
+  @TypeGraphQLField()
+  handle!: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about?: string;
+
+  @TypeGraphQLField()
+  controllerAccount!: string;
+
+  @TypeGraphQLField()
+  rootAccount!: string;
+
+  @TypeGraphQLField()
+  createdInBlock!: number;
+
+  @TypeGraphQLField(() => MembershipEntryMethod)
+  entry!: MembershipEntryMethod;
+
+  @TypeGraphQLField({ nullable: true })
+  subscription?: number;
+}
+
+@TypeGraphQLInputType()
+export class MembershipUpdateInput {
+  @TypeGraphQLField({ nullable: true })
+  handle?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  createdInBlock?: number;
+
+  @TypeGraphQLField(() => MembershipEntryMethod, { nullable: true })
+  entry?: MembershipEntryMethod;
+
+  @TypeGraphQLField({ nullable: true })
+  subscription?: number;
+}
+
+@ArgsType()
+export class MembershipWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
+  where?: MembershipWhereInput;
+
+  @TypeGraphQLField(() => MembershipOrderByEnum, { nullable: true })
+  orderBy?: MembershipOrderByEnum[];
+}
+
+@ArgsType()
+export class MembershipCreateManyArgs {
+  @TypeGraphQLField(() => [MembershipCreateInput])
+  data!: MembershipCreateInput[];
+}
+
+@ArgsType()
+export class MembershipUpdateArgs {
+  @TypeGraphQLField() data!: MembershipUpdateInput;
+  @TypeGraphQLField() where!: MembershipWhereUniqueInput;
+}
+
+export enum CuratorGroupOrderByEnum {
+  createdAt_ASC = "createdAt_ASC",
+  createdAt_DESC = "createdAt_DESC",
+
+  updatedAt_ASC = "updatedAt_ASC",
+  updatedAt_DESC = "updatedAt_DESC",
+
+  deletedAt_ASC = "deletedAt_ASC",
+  deletedAt_DESC = "deletedAt_DESC",
+
+  isActive_ASC = "isActive_ASC",
+  isActive_DESC = "isActive_DESC"
+}
+
+registerEnumType(CuratorGroupOrderByEnum, {
+  name: "CuratorGroupOrderByInput"
+});
+
+@TypeGraphQLInputType()
+export class CuratorGroupWhereInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  id_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  id_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  createdById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  createdById_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  updatedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  updatedById_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  deletedAt_all?: Boolean;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  deletedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  deletedById_in?: string[];
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  curatorIds_containsAll?: [number];
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  curatorIds_containsNone?: [number];
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  curatorIds_containsAny?: [number];
+
   @TypeGraphQLField(() => Boolean, { nullable: true })
   isActive_eq?: Boolean;
 
   @TypeGraphQLField(() => [Boolean], { nullable: true })
   isActive_in?: Boolean[];
 
-  @TypeGraphQLField({ nullable: true })
-  workerId_eq?: string;
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_none?: ChannelWhereInput;
 
-  @TypeGraphQLField({ nullable: true })
-  workerId_contains?: string;
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_some?: ChannelWhereInput;
 
-  @TypeGraphQLField({ nullable: true })
-  workerId_startsWith?: string;
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_every?: ChannelWhereInput;
 
-  @TypeGraphQLField({ nullable: true })
-  workerId_endsWith?: string;
+  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
+  AND?: [CuratorGroupWhereInput];
 
-  @TypeGraphQLField(() => [String], { nullable: true })
-  workerId_in?: string[];
-
-  @TypeGraphQLField(() => WorkerType, { nullable: true })
-  type_eq?: WorkerType;
-
-  @TypeGraphQLField(() => [WorkerType], { nullable: true })
-  type_in?: WorkerType[];
-
-  @TypeGraphQLField({ nullable: true })
-  metadata_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  metadata_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  metadata_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  metadata_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  metadata_in?: string[];
-
-  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  dataObjects_none?: DataObjectWhereInput;
-
-  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  dataObjects_some?: DataObjectWhereInput;
-
-  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  dataObjects_every?: DataObjectWhereInput;
-
-  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
-  AND?: [WorkerWhereInput];
-
-  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
-  OR?: [WorkerWhereInput];
+  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
+  OR?: [CuratorGroupWhereInput];
 }
 
 @TypeGraphQLInputType()
-export class WorkerWhereUniqueInput {
+export class CuratorGroupWhereUniqueInput {
   @TypeGraphQLField(() => ID)
   id?: string;
 }
 
 @TypeGraphQLInputType()
-export class WorkerCreateInput {
+export class CuratorGroupCreateInput {
+  @TypeGraphQLField(() => [Int])
+  curatorIds!: number[];
+
   @TypeGraphQLField()
   isActive!: boolean;
-
-  @TypeGraphQLField()
-  workerId!: string;
-
-  @TypeGraphQLField(() => WorkerType)
-  type!: WorkerType;
-
-  @TypeGraphQLField({ nullable: true })
-  metadata?: string;
 }
 
 @TypeGraphQLInputType()
-export class WorkerUpdateInput {
+export class CuratorGroupUpdateInput {
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  curatorIds?: number[];
+
   @TypeGraphQLField({ nullable: true })
   isActive?: boolean;
+}
+
+@ArgsType()
+export class CuratorGroupWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
+  where?: CuratorGroupWhereInput;
+
+  @TypeGraphQLField(() => CuratorGroupOrderByEnum, { nullable: true })
+  orderBy?: CuratorGroupOrderByEnum[];
+}
+
+@ArgsType()
+export class CuratorGroupCreateManyArgs {
+  @TypeGraphQLField(() => [CuratorGroupCreateInput])
+  data!: CuratorGroupCreateInput[];
+}
+
+@ArgsType()
+export class CuratorGroupUpdateArgs {
+  @TypeGraphQLField() data!: CuratorGroupUpdateInput;
+  @TypeGraphQLField() where!: CuratorGroupWhereUniqueInput;
+}
+
+export enum ChannelCategoryOrderByEnum {
+  createdAt_ASC = "createdAt_ASC",
+  createdAt_DESC = "createdAt_DESC",
+
+  updatedAt_ASC = "updatedAt_ASC",
+  updatedAt_DESC = "updatedAt_DESC",
+
+  deletedAt_ASC = "deletedAt_ASC",
+  deletedAt_DESC = "deletedAt_DESC",
+
+  name_ASC = "name_ASC",
+  name_DESC = "name_DESC",
+
+  activeVideosCounter_ASC = "activeVideosCounter_ASC",
+  activeVideosCounter_DESC = "activeVideosCounter_DESC",
+
+  createdInBlock_ASC = "createdInBlock_ASC",
+  createdInBlock_DESC = "createdInBlock_DESC"
+}
+
+registerEnumType(ChannelCategoryOrderByEnum, {
+  name: "ChannelCategoryOrderByInput"
+});
+
+@TypeGraphQLInputType()
+export class ChannelCategoryWhereInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  id_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  id_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  createdById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  createdById_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  updatedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  updatedById_in?: string[];
 
   @TypeGraphQLField({ nullable: true })
-  workerId?: string;
+  deletedAt_all?: Boolean;
 
-  @TypeGraphQLField(() => WorkerType, { nullable: true })
-  type?: WorkerType;
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  deletedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  deletedById_in?: string[];
 
   @TypeGraphQLField({ nullable: true })
-  metadata?: string;
+  name_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  name_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  name_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  name_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  name_in?: string[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  activeVideosCounter_in?: number[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  createdInBlock_in?: number[];
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_none?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_some?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_every?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
+  AND?: [ChannelCategoryWhereInput];
+
+  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
+  OR?: [ChannelCategoryWhereInput];
+}
+
+@TypeGraphQLInputType()
+export class ChannelCategoryWhereUniqueInput {
+  @TypeGraphQLField(() => ID)
+  id?: string;
+}
+
+@TypeGraphQLInputType()
+export class ChannelCategoryCreateInput {
+  @TypeGraphQLField({ nullable: true })
+  name?: string;
+
+  @TypeGraphQLField()
+  activeVideosCounter!: number;
+
+  @TypeGraphQLField()
+  createdInBlock!: number;
+}
+
+@TypeGraphQLInputType()
+export class ChannelCategoryUpdateInput {
+  @TypeGraphQLField({ nullable: true })
+  name?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  activeVideosCounter?: number;
+
+  @TypeGraphQLField({ nullable: true })
+  createdInBlock?: number;
 }
 
 @ArgsType()
-export class WorkerWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
-  where?: WorkerWhereInput;
+export class ChannelCategoryWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
+  where?: ChannelCategoryWhereInput;
 
-  @TypeGraphQLField(() => WorkerOrderByEnum, { nullable: true })
-  orderBy?: WorkerOrderByEnum[];
+  @TypeGraphQLField(() => ChannelCategoryOrderByEnum, { nullable: true })
+  orderBy?: ChannelCategoryOrderByEnum[];
 }
 
 @ArgsType()
-export class WorkerCreateManyArgs {
-  @TypeGraphQLField(() => [WorkerCreateInput])
-  data!: WorkerCreateInput[];
+export class ChannelCategoryCreateManyArgs {
+  @TypeGraphQLField(() => [ChannelCategoryCreateInput])
+  data!: ChannelCategoryCreateInput[];
 }
 
 @ArgsType()
-export class WorkerUpdateArgs {
-  @TypeGraphQLField() data!: WorkerUpdateInput;
-  @TypeGraphQLField() where!: WorkerWhereUniqueInput;
+export class ChannelCategoryUpdateArgs {
+  @TypeGraphQLField() data!: ChannelCategoryUpdateInput;
+  @TypeGraphQLField() where!: ChannelCategoryWhereUniqueInput;
 }
 
 export enum VideoCategoryOrderByEnum {
@@ -1482,6 +1623,9 @@ export enum VideoCategoryOrderByEnum {
 
   name_ASC = "name_ASC",
   name_DESC = "name_DESC",
+
+  activeVideosCounter_ASC = "activeVideosCounter_ASC",
+  activeVideosCounter_DESC = "activeVideosCounter_DESC",
 
   createdInBlock_ASC = "createdInBlock_ASC",
   createdInBlock_DESC = "createdInBlock_DESC"
@@ -1581,6 +1725,24 @@ export class VideoCategoryWhereInput {
   name_in?: string[];
 
   @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  activeVideosCounter_in?: number[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
   createdInBlock_eq?: number;
 
   @TypeGraphQLField(() => Int, { nullable: true })
@@ -1626,6 +1788,9 @@ export class VideoCategoryCreateInput {
   name?: string;
 
   @TypeGraphQLField()
+  activeVideosCounter!: number;
+
+  @TypeGraphQLField()
   createdInBlock!: number;
 }
 
@@ -1633,6 +1798,9 @@ export class VideoCategoryCreateInput {
 export class VideoCategoryUpdateInput {
   @TypeGraphQLField({ nullable: true })
   name?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  activeVideosCounter?: number;
 
   @TypeGraphQLField({ nullable: true })
   createdInBlock?: number;
@@ -1657,204 +1825,6 @@ export class VideoCategoryCreateManyArgs {
 export class VideoCategoryUpdateArgs {
   @TypeGraphQLField() data!: VideoCategoryUpdateInput;
   @TypeGraphQLField() where!: VideoCategoryWhereUniqueInput;
-}
-
-export enum LanguageOrderByEnum {
-  createdAt_ASC = "createdAt_ASC",
-  createdAt_DESC = "createdAt_DESC",
-
-  updatedAt_ASC = "updatedAt_ASC",
-  updatedAt_DESC = "updatedAt_DESC",
-
-  deletedAt_ASC = "deletedAt_ASC",
-  deletedAt_DESC = "deletedAt_DESC",
-
-  iso_ASC = "iso_ASC",
-  iso_DESC = "iso_DESC",
-
-  createdInBlock_ASC = "createdInBlock_ASC",
-  createdInBlock_DESC = "createdInBlock_DESC"
-}
-
-registerEnumType(LanguageOrderByEnum, {
-  name: "LanguageOrderByInput"
-});
-
-@TypeGraphQLInputType()
-export class LanguageWhereInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  id_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  id_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  createdById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  createdById_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  updatedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  updatedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  deletedAt_all?: Boolean;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  deletedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  deletedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  iso_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  iso_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  iso_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  iso_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  iso_in?: string[];
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_eq?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gte?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lte?: number;
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  createdInBlock_in?: number[];
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channellanguage_none?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channellanguage_some?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channellanguage_every?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
-  videolanguage_none?: VideoWhereInput;
-
-  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
-  videolanguage_some?: VideoWhereInput;
-
-  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
-  videolanguage_every?: VideoWhereInput;
-
-  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
-  AND?: [LanguageWhereInput];
-
-  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
-  OR?: [LanguageWhereInput];
-}
-
-@TypeGraphQLInputType()
-export class LanguageWhereUniqueInput {
-  @TypeGraphQLField(() => ID)
-  id?: string;
-}
-
-@TypeGraphQLInputType()
-export class LanguageCreateInput {
-  @TypeGraphQLField()
-  iso!: string;
-
-  @TypeGraphQLField()
-  createdInBlock!: number;
-}
-
-@TypeGraphQLInputType()
-export class LanguageUpdateInput {
-  @TypeGraphQLField({ nullable: true })
-  iso?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  createdInBlock?: number;
-}
-
-@ArgsType()
-export class LanguageWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
-  where?: LanguageWhereInput;
-
-  @TypeGraphQLField(() => LanguageOrderByEnum, { nullable: true })
-  orderBy?: LanguageOrderByEnum[];
-}
-
-@ArgsType()
-export class LanguageCreateManyArgs {
-  @TypeGraphQLField(() => [LanguageCreateInput])
-  data!: LanguageCreateInput[];
-}
-
-@ArgsType()
-export class LanguageUpdateArgs {
-  @TypeGraphQLField() data!: LanguageUpdateInput;
-  @TypeGraphQLField() where!: LanguageWhereUniqueInput;
 }
 
 export enum LicenseOrderByEnum {
@@ -3126,6 +3096,720 @@ export class VideoUpdateArgs {
   @TypeGraphQLField() where!: VideoWhereUniqueInput;
 }
 
+export enum LanguageOrderByEnum {
+  createdAt_ASC = "createdAt_ASC",
+  createdAt_DESC = "createdAt_DESC",
+
+  updatedAt_ASC = "updatedAt_ASC",
+  updatedAt_DESC = "updatedAt_DESC",
+
+  deletedAt_ASC = "deletedAt_ASC",
+  deletedAt_DESC = "deletedAt_DESC",
+
+  iso_ASC = "iso_ASC",
+  iso_DESC = "iso_DESC",
+
+  createdInBlock_ASC = "createdInBlock_ASC",
+  createdInBlock_DESC = "createdInBlock_DESC"
+}
+
+registerEnumType(LanguageOrderByEnum, {
+  name: "LanguageOrderByInput"
+});
+
+@TypeGraphQLInputType()
+export class LanguageWhereInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  id_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  id_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  createdById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  createdById_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  updatedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  updatedById_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  deletedAt_all?: Boolean;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  deletedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  deletedById_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  iso_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  iso_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  iso_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  iso_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  iso_in?: string[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  createdInBlock_in?: number[];
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channellanguage_none?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channellanguage_some?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channellanguage_every?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
+  videolanguage_none?: VideoWhereInput;
+
+  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
+  videolanguage_some?: VideoWhereInput;
+
+  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
+  videolanguage_every?: VideoWhereInput;
+
+  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
+  AND?: [LanguageWhereInput];
+
+  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
+  OR?: [LanguageWhereInput];
+}
+
+@TypeGraphQLInputType()
+export class LanguageWhereUniqueInput {
+  @TypeGraphQLField(() => ID)
+  id?: string;
+}
+
+@TypeGraphQLInputType()
+export class LanguageCreateInput {
+  @TypeGraphQLField()
+  iso!: string;
+
+  @TypeGraphQLField()
+  createdInBlock!: number;
+}
+
+@TypeGraphQLInputType()
+export class LanguageUpdateInput {
+  @TypeGraphQLField({ nullable: true })
+  iso?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  createdInBlock?: number;
+}
+
+@ArgsType()
+export class LanguageWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
+  where?: LanguageWhereInput;
+
+  @TypeGraphQLField(() => LanguageOrderByEnum, { nullable: true })
+  orderBy?: LanguageOrderByEnum[];
+}
+
+@ArgsType()
+export class LanguageCreateManyArgs {
+  @TypeGraphQLField(() => [LanguageCreateInput])
+  data!: LanguageCreateInput[];
+}
+
+@ArgsType()
+export class LanguageUpdateArgs {
+  @TypeGraphQLField() data!: LanguageUpdateInput;
+  @TypeGraphQLField() where!: LanguageWhereUniqueInput;
+}
+
+export enum ChannelOrderByEnum {
+  createdAt_ASC = "createdAt_ASC",
+  createdAt_DESC = "createdAt_DESC",
+
+  updatedAt_ASC = "updatedAt_ASC",
+  updatedAt_DESC = "updatedAt_DESC",
+
+  deletedAt_ASC = "deletedAt_ASC",
+  deletedAt_DESC = "deletedAt_DESC",
+
+  ownerMember_ASC = "ownerMember_ASC",
+  ownerMember_DESC = "ownerMember_DESC",
+
+  ownerMemberId_ASC = "ownerMemberId_ASC",
+  ownerMemberId_DESC = "ownerMemberId_DESC",
+
+  ownerCuratorGroup_ASC = "ownerCuratorGroup_ASC",
+  ownerCuratorGroup_DESC = "ownerCuratorGroup_DESC",
+
+  ownerCuratorGroupId_ASC = "ownerCuratorGroupId_ASC",
+  ownerCuratorGroupId_DESC = "ownerCuratorGroupId_DESC",
+
+  category_ASC = "category_ASC",
+  category_DESC = "category_DESC",
+
+  categoryId_ASC = "categoryId_ASC",
+  categoryId_DESC = "categoryId_DESC",
+
+  rewardAccount_ASC = "rewardAccount_ASC",
+  rewardAccount_DESC = "rewardAccount_DESC",
+
+  title_ASC = "title_ASC",
+  title_DESC = "title_DESC",
+
+  description_ASC = "description_ASC",
+  description_DESC = "description_DESC",
+
+  activeVideosCounter_ASC = "activeVideosCounter_ASC",
+  activeVideosCounter_DESC = "activeVideosCounter_DESC",
+
+  coverPhotoDataObject_ASC = "coverPhotoDataObject_ASC",
+  coverPhotoDataObject_DESC = "coverPhotoDataObject_DESC",
+
+  coverPhotoDataObjectId_ASC = "coverPhotoDataObjectId_ASC",
+  coverPhotoDataObjectId_DESC = "coverPhotoDataObjectId_DESC",
+
+  coverPhotoAvailability_ASC = "coverPhotoAvailability_ASC",
+  coverPhotoAvailability_DESC = "coverPhotoAvailability_DESC",
+
+  avatarPhotoDataObject_ASC = "avatarPhotoDataObject_ASC",
+  avatarPhotoDataObject_DESC = "avatarPhotoDataObject_DESC",
+
+  avatarPhotoDataObjectId_ASC = "avatarPhotoDataObjectId_ASC",
+  avatarPhotoDataObjectId_DESC = "avatarPhotoDataObjectId_DESC",
+
+  avatarPhotoAvailability_ASC = "avatarPhotoAvailability_ASC",
+  avatarPhotoAvailability_DESC = "avatarPhotoAvailability_DESC",
+
+  isPublic_ASC = "isPublic_ASC",
+  isPublic_DESC = "isPublic_DESC",
+
+  isCensored_ASC = "isCensored_ASC",
+  isCensored_DESC = "isCensored_DESC",
+
+  language_ASC = "language_ASC",
+  language_DESC = "language_DESC",
+
+  languageId_ASC = "languageId_ASC",
+  languageId_DESC = "languageId_DESC",
+
+  createdInBlock_ASC = "createdInBlock_ASC",
+  createdInBlock_DESC = "createdInBlock_DESC"
+}
+
+registerEnumType(ChannelOrderByEnum, {
+  name: "ChannelOrderByInput"
+});
+
+@TypeGraphQLInputType()
+export class ChannelWhereInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  id_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  id_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  createdById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  createdById_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  updatedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  updatedById_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  deletedAt_all?: Boolean;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  deletedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  deletedById_in?: string[];
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerMemberId_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  ownerMemberId_in?: string[];
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerCuratorGroupId_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  ownerCuratorGroupId_in?: string[];
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  categoryId_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  categoryId_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  rewardAccount_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rewardAccount_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rewardAccount_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rewardAccount_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  rewardAccount_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  title_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  title_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  title_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  title_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  title_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  description_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  description_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  description_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  description_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  description_in?: string[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  activeVideosCounter_in?: number[];
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  coverPhotoDataObjectId_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  coverPhotoDataObjectId_in?: string[];
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  coverPhotoUrls_containsAll?: [string];
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  coverPhotoUrls_containsNone?: [string];
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  coverPhotoUrls_containsAny?: [string];
+
+  @TypeGraphQLField(() => AssetAvailability, { nullable: true })
+  coverPhotoAvailability_eq?: AssetAvailability;
+
+  @TypeGraphQLField(() => [AssetAvailability], { nullable: true })
+  coverPhotoAvailability_in?: AssetAvailability[];
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  avatarPhotoDataObjectId_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  avatarPhotoDataObjectId_in?: string[];
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  avatarPhotoUrls_containsAll?: [string];
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  avatarPhotoUrls_containsNone?: [string];
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  avatarPhotoUrls_containsAny?: [string];
+
+  @TypeGraphQLField(() => AssetAvailability, { nullable: true })
+  avatarPhotoAvailability_eq?: AssetAvailability;
+
+  @TypeGraphQLField(() => [AssetAvailability], { nullable: true })
+  avatarPhotoAvailability_in?: AssetAvailability[];
+
+  @TypeGraphQLField(() => Boolean, { nullable: true })
+  isPublic_eq?: Boolean;
+
+  @TypeGraphQLField(() => [Boolean], { nullable: true })
+  isPublic_in?: Boolean[];
+
+  @TypeGraphQLField(() => Boolean, { nullable: true })
+  isCensored_eq?: Boolean;
+
+  @TypeGraphQLField(() => [Boolean], { nullable: true })
+  isCensored_in?: Boolean[];
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  languageId_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  languageId_in?: string[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  createdInBlock_in?: number[];
+
+  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
+  ownerMember?: MembershipWhereInput;
+
+  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
+  ownerCuratorGroup?: CuratorGroupWhereInput;
+
+  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
+  category?: ChannelCategoryWhereInput;
+
+  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
+  coverPhotoDataObject?: DataObjectWhereInput;
+
+  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
+  avatarPhotoDataObject?: DataObjectWhereInput;
+
+  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
+  language?: LanguageWhereInput;
+
+  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
+  videos_none?: VideoWhereInput;
+
+  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
+  videos_some?: VideoWhereInput;
+
+  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
+  videos_every?: VideoWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  AND?: [ChannelWhereInput];
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  OR?: [ChannelWhereInput];
+}
+
+@TypeGraphQLInputType()
+export class ChannelWhereUniqueInput {
+  @TypeGraphQLField(() => ID)
+  id?: string;
+}
+
+@TypeGraphQLInputType()
+export class ChannelCreateInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerMember?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerMemberId?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerCuratorGroup?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerCuratorGroupId?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  category?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  categoryId?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rewardAccount?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  title?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  description?: string;
+
+  @TypeGraphQLField()
+  activeVideosCounter!: number;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  coverPhotoDataObject?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  coverPhotoDataObjectId?: string;
+
+  @TypeGraphQLField(() => [String])
+  coverPhotoUrls!: string[];
+
+  @TypeGraphQLField(() => AssetAvailability)
+  coverPhotoAvailability!: AssetAvailability;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  avatarPhotoDataObject?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  avatarPhotoDataObjectId?: string;
+
+  @TypeGraphQLField(() => [String])
+  avatarPhotoUrls!: string[];
+
+  @TypeGraphQLField(() => AssetAvailability)
+  avatarPhotoAvailability!: AssetAvailability;
+
+  @TypeGraphQLField({ nullable: true })
+  isPublic?: boolean;
+
+  @TypeGraphQLField()
+  isCensored!: boolean;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  language?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  languageId?: string;
+
+  @TypeGraphQLField()
+  createdInBlock!: number;
+}
+
+@TypeGraphQLInputType()
+export class ChannelUpdateInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerMember?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerMemberId?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerCuratorGroup?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  ownerCuratorGroupId?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  category?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  categoryId?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rewardAccount?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  title?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  description?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  activeVideosCounter?: number;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  coverPhotoDataObject?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  coverPhotoDataObjectId?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  coverPhotoUrls?: string[];
+
+  @TypeGraphQLField(() => AssetAvailability, { nullable: true })
+  coverPhotoAvailability?: AssetAvailability;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  avatarPhotoDataObject?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  avatarPhotoDataObjectId?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  avatarPhotoUrls?: string[];
+
+  @TypeGraphQLField(() => AssetAvailability, { nullable: true })
+  avatarPhotoAvailability?: AssetAvailability;
+
+  @TypeGraphQLField({ nullable: true })
+  isPublic?: boolean;
+
+  @TypeGraphQLField({ nullable: true })
+  isCensored?: boolean;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  language?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  languageId?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  createdInBlock?: number;
+}
+
+@ArgsType()
+export class ChannelWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  where?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelOrderByEnum, { nullable: true })
+  orderBy?: ChannelOrderByEnum[];
+}
+
+@ArgsType()
+export class ChannelCreateManyArgs {
+  @TypeGraphQLField(() => [ChannelCreateInput])
+  data!: ChannelCreateInput[];
+}
+
+@ArgsType()
+export class ChannelUpdateArgs {
+  @TypeGraphQLField() data!: ChannelUpdateInput;
+  @TypeGraphQLField() where!: ChannelWhereUniqueInput;
+}
+
 export enum DataObjectOrderByEnum {
   createdAt_ASC = "createdAt_ASC",
   createdAt_DESC = "createdAt_DESC",
@@ -3471,7 +4155,7 @@ export class DataObjectUpdateArgs {
   @TypeGraphQLField() where!: DataObjectWhereUniqueInput;
 }
 
-export enum ChannelOrderByEnum {
+export enum WorkerOrderByEnum {
   createdAt_ASC = "createdAt_ASC",
   createdAt_DESC = "createdAt_DESC",
 
@@ -3481,73 +4165,25 @@ export enum ChannelOrderByEnum {
   deletedAt_ASC = "deletedAt_ASC",
   deletedAt_DESC = "deletedAt_DESC",
 
-  ownerMember_ASC = "ownerMember_ASC",
-  ownerMember_DESC = "ownerMember_DESC",
+  isActive_ASC = "isActive_ASC",
+  isActive_DESC = "isActive_DESC",
 
-  ownerMemberId_ASC = "ownerMemberId_ASC",
-  ownerMemberId_DESC = "ownerMemberId_DESC",
+  workerId_ASC = "workerId_ASC",
+  workerId_DESC = "workerId_DESC",
 
-  ownerCuratorGroup_ASC = "ownerCuratorGroup_ASC",
-  ownerCuratorGroup_DESC = "ownerCuratorGroup_DESC",
+  type_ASC = "type_ASC",
+  type_DESC = "type_DESC",
 
-  ownerCuratorGroupId_ASC = "ownerCuratorGroupId_ASC",
-  ownerCuratorGroupId_DESC = "ownerCuratorGroupId_DESC",
-
-  category_ASC = "category_ASC",
-  category_DESC = "category_DESC",
-
-  categoryId_ASC = "categoryId_ASC",
-  categoryId_DESC = "categoryId_DESC",
-
-  rewardAccount_ASC = "rewardAccount_ASC",
-  rewardAccount_DESC = "rewardAccount_DESC",
-
-  title_ASC = "title_ASC",
-  title_DESC = "title_DESC",
-
-  description_ASC = "description_ASC",
-  description_DESC = "description_DESC",
-
-  coverPhotoDataObject_ASC = "coverPhotoDataObject_ASC",
-  coverPhotoDataObject_DESC = "coverPhotoDataObject_DESC",
-
-  coverPhotoDataObjectId_ASC = "coverPhotoDataObjectId_ASC",
-  coverPhotoDataObjectId_DESC = "coverPhotoDataObjectId_DESC",
-
-  coverPhotoAvailability_ASC = "coverPhotoAvailability_ASC",
-  coverPhotoAvailability_DESC = "coverPhotoAvailability_DESC",
-
-  avatarPhotoDataObject_ASC = "avatarPhotoDataObject_ASC",
-  avatarPhotoDataObject_DESC = "avatarPhotoDataObject_DESC",
-
-  avatarPhotoDataObjectId_ASC = "avatarPhotoDataObjectId_ASC",
-  avatarPhotoDataObjectId_DESC = "avatarPhotoDataObjectId_DESC",
-
-  avatarPhotoAvailability_ASC = "avatarPhotoAvailability_ASC",
-  avatarPhotoAvailability_DESC = "avatarPhotoAvailability_DESC",
-
-  isPublic_ASC = "isPublic_ASC",
-  isPublic_DESC = "isPublic_DESC",
-
-  isCensored_ASC = "isCensored_ASC",
-  isCensored_DESC = "isCensored_DESC",
-
-  language_ASC = "language_ASC",
-  language_DESC = "language_DESC",
-
-  languageId_ASC = "languageId_ASC",
-  languageId_DESC = "languageId_DESC",
-
-  createdInBlock_ASC = "createdInBlock_ASC",
-  createdInBlock_DESC = "createdInBlock_DESC"
+  metadata_ASC = "metadata_ASC",
+  metadata_DESC = "metadata_DESC"
 }
 
-registerEnumType(ChannelOrderByEnum, {
-  name: "ChannelOrderByInput"
+registerEnumType(WorkerOrderByEnum, {
+  name: "WorkerOrderByInput"
 });
 
 @TypeGraphQLInputType()
-export class ChannelWhereInput {
+export class WorkerWhereInput {
   @TypeGraphQLField(() => ID, { nullable: true })
   id_eq?: string;
 
@@ -3620,674 +4256,119 @@ export class ChannelWhereInput {
   @TypeGraphQLField(() => [ID], { nullable: true })
   deletedById_in?: string[];
 
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerMemberId_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  ownerMemberId_in?: string[];
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerCuratorGroupId_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  ownerCuratorGroupId_in?: string[];
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  categoryId_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  categoryId_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  rewardAccount_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rewardAccount_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rewardAccount_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rewardAccount_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  rewardAccount_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  title_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  title_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  title_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  title_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  title_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  description_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  description_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  description_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  description_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  description_in?: string[];
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  coverPhotoDataObjectId_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  coverPhotoDataObjectId_in?: string[];
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  coverPhotoUrls_containsAll?: [string];
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  coverPhotoUrls_containsNone?: [string];
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  coverPhotoUrls_containsAny?: [string];
-
-  @TypeGraphQLField(() => AssetAvailability, { nullable: true })
-  coverPhotoAvailability_eq?: AssetAvailability;
-
-  @TypeGraphQLField(() => [AssetAvailability], { nullable: true })
-  coverPhotoAvailability_in?: AssetAvailability[];
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  avatarPhotoDataObjectId_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  avatarPhotoDataObjectId_in?: string[];
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  avatarPhotoUrls_containsAll?: [string];
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  avatarPhotoUrls_containsNone?: [string];
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  avatarPhotoUrls_containsAny?: [string];
-
-  @TypeGraphQLField(() => AssetAvailability, { nullable: true })
-  avatarPhotoAvailability_eq?: AssetAvailability;
-
-  @TypeGraphQLField(() => [AssetAvailability], { nullable: true })
-  avatarPhotoAvailability_in?: AssetAvailability[];
-
   @TypeGraphQLField(() => Boolean, { nullable: true })
-  isPublic_eq?: Boolean;
+  isActive_eq?: Boolean;
 
   @TypeGraphQLField(() => [Boolean], { nullable: true })
-  isPublic_in?: Boolean[];
+  isActive_in?: Boolean[];
 
-  @TypeGraphQLField(() => Boolean, { nullable: true })
-  isCensored_eq?: Boolean;
+  @TypeGraphQLField({ nullable: true })
+  workerId_eq?: string;
 
-  @TypeGraphQLField(() => [Boolean], { nullable: true })
-  isCensored_in?: Boolean[];
+  @TypeGraphQLField({ nullable: true })
+  workerId_contains?: string;
 
-  @TypeGraphQLField(() => ID, { nullable: true })
-  languageId_eq?: string;
+  @TypeGraphQLField({ nullable: true })
+  workerId_startsWith?: string;
 
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  languageId_in?: string[];
+  @TypeGraphQLField({ nullable: true })
+  workerId_endsWith?: string;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_eq?: number;
+  @TypeGraphQLField(() => [String], { nullable: true })
+  workerId_in?: string[];
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gt?: number;
+  @TypeGraphQLField(() => WorkerType, { nullable: true })
+  type_eq?: WorkerType;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gte?: number;
+  @TypeGraphQLField(() => [WorkerType], { nullable: true })
+  type_in?: WorkerType[];
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lt?: number;
+  @TypeGraphQLField({ nullable: true })
+  metadata_eq?: string;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lte?: number;
+  @TypeGraphQLField({ nullable: true })
+  metadata_contains?: string;
 
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  createdInBlock_in?: number[];
+  @TypeGraphQLField({ nullable: true })
+  metadata_startsWith?: string;
 
-  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
-  ownerMember?: MembershipWhereInput;
+  @TypeGraphQLField({ nullable: true })
+  metadata_endsWith?: string;
 
-  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
-  ownerCuratorGroup?: CuratorGroupWhereInput;
-
-  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
-  category?: ChannelCategoryWhereInput;
+  @TypeGraphQLField(() => [String], { nullable: true })
+  metadata_in?: string[];
 
   @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  coverPhotoDataObject?: DataObjectWhereInput;
+  dataObjects_none?: DataObjectWhereInput;
 
   @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  avatarPhotoDataObject?: DataObjectWhereInput;
+  dataObjects_some?: DataObjectWhereInput;
 
-  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
-  language?: LanguageWhereInput;
+  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
+  dataObjects_every?: DataObjectWhereInput;
 
-  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
-  videos_none?: VideoWhereInput;
+  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
+  AND?: [WorkerWhereInput];
 
-  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
-  videos_some?: VideoWhereInput;
-
-  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
-  videos_every?: VideoWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  AND?: [ChannelWhereInput];
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  OR?: [ChannelWhereInput];
+  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
+  OR?: [WorkerWhereInput];
 }
 
 @TypeGraphQLInputType()
-export class ChannelWhereUniqueInput {
+export class WorkerWhereUniqueInput {
   @TypeGraphQLField(() => ID)
   id?: string;
 }
 
 @TypeGraphQLInputType()
-export class ChannelCreateInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerMember?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerMemberId?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerCuratorGroup?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerCuratorGroupId?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  category?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  categoryId?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rewardAccount?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  title?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  description?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  coverPhotoDataObject?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  coverPhotoDataObjectId?: string;
-
-  @TypeGraphQLField(() => [String])
-  coverPhotoUrls!: string[];
-
-  @TypeGraphQLField(() => AssetAvailability)
-  coverPhotoAvailability!: AssetAvailability;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  avatarPhotoDataObject?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  avatarPhotoDataObjectId?: string;
-
-  @TypeGraphQLField(() => [String])
-  avatarPhotoUrls!: string[];
-
-  @TypeGraphQLField(() => AssetAvailability)
-  avatarPhotoAvailability!: AssetAvailability;
-
-  @TypeGraphQLField({ nullable: true })
-  isPublic?: boolean;
+export class WorkerCreateInput {
+  @TypeGraphQLField()
+  isActive!: boolean;
 
   @TypeGraphQLField()
-  isCensored!: boolean;
+  workerId!: string;
 
-  @TypeGraphQLField(() => ID, { nullable: true })
-  language?: string;
+  @TypeGraphQLField(() => WorkerType)
+  type!: WorkerType;
 
-  @TypeGraphQLField(() => ID, { nullable: true })
-  languageId?: string;
-
-  @TypeGraphQLField()
-  createdInBlock!: number;
+  @TypeGraphQLField({ nullable: true })
+  metadata?: string;
 }
 
 @TypeGraphQLInputType()
-export class ChannelUpdateInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerMember?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerMemberId?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerCuratorGroup?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  ownerCuratorGroupId?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  category?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  categoryId?: string;
+export class WorkerUpdateInput {
+  @TypeGraphQLField({ nullable: true })
+  isActive?: boolean;
 
   @TypeGraphQLField({ nullable: true })
-  rewardAccount?: string;
+  workerId?: string;
+
+  @TypeGraphQLField(() => WorkerType, { nullable: true })
+  type?: WorkerType;
 
   @TypeGraphQLField({ nullable: true })
-  title?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  description?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  coverPhotoDataObject?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  coverPhotoDataObjectId?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  coverPhotoUrls?: string[];
-
-  @TypeGraphQLField(() => AssetAvailability, { nullable: true })
-  coverPhotoAvailability?: AssetAvailability;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  avatarPhotoDataObject?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  avatarPhotoDataObjectId?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  avatarPhotoUrls?: string[];
-
-  @TypeGraphQLField(() => AssetAvailability, { nullable: true })
-  avatarPhotoAvailability?: AssetAvailability;
-
-  @TypeGraphQLField({ nullable: true })
-  isPublic?: boolean;
-
-  @TypeGraphQLField({ nullable: true })
-  isCensored?: boolean;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  language?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  languageId?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  createdInBlock?: number;
+  metadata?: string;
 }
 
 @ArgsType()
-export class ChannelWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  where?: ChannelWhereInput;
+export class WorkerWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
+  where?: WorkerWhereInput;
 
-  @TypeGraphQLField(() => ChannelOrderByEnum, { nullable: true })
-  orderBy?: ChannelOrderByEnum[];
+  @TypeGraphQLField(() => WorkerOrderByEnum, { nullable: true })
+  orderBy?: WorkerOrderByEnum[];
 }
 
 @ArgsType()
-export class ChannelCreateManyArgs {
-  @TypeGraphQLField(() => [ChannelCreateInput])
-  data!: ChannelCreateInput[];
+export class WorkerCreateManyArgs {
+  @TypeGraphQLField(() => [WorkerCreateInput])
+  data!: WorkerCreateInput[];
 }
 
 @ArgsType()
-export class ChannelUpdateArgs {
-  @TypeGraphQLField() data!: ChannelUpdateInput;
-  @TypeGraphQLField() where!: ChannelWhereUniqueInput;
-}
-
-export enum MembershipOrderByEnum {
-  createdAt_ASC = "createdAt_ASC",
-  createdAt_DESC = "createdAt_DESC",
-
-  updatedAt_ASC = "updatedAt_ASC",
-  updatedAt_DESC = "updatedAt_DESC",
-
-  deletedAt_ASC = "deletedAt_ASC",
-  deletedAt_DESC = "deletedAt_DESC",
-
-  handle_ASC = "handle_ASC",
-  handle_DESC = "handle_DESC",
-
-  avatarUri_ASC = "avatarUri_ASC",
-  avatarUri_DESC = "avatarUri_DESC",
-
-  about_ASC = "about_ASC",
-  about_DESC = "about_DESC",
-
-  controllerAccount_ASC = "controllerAccount_ASC",
-  controllerAccount_DESC = "controllerAccount_DESC",
-
-  rootAccount_ASC = "rootAccount_ASC",
-  rootAccount_DESC = "rootAccount_DESC",
-
-  createdInBlock_ASC = "createdInBlock_ASC",
-  createdInBlock_DESC = "createdInBlock_DESC",
-
-  entry_ASC = "entry_ASC",
-  entry_DESC = "entry_DESC",
-
-  subscription_ASC = "subscription_ASC",
-  subscription_DESC = "subscription_DESC"
-}
-
-registerEnumType(MembershipOrderByEnum, {
-  name: "MembershipOrderByInput"
-});
-
-@TypeGraphQLInputType()
-export class MembershipWhereInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  id_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  id_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  createdById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  createdById_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  updatedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  updatedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  deletedAt_all?: Boolean;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  deletedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  deletedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  handle_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  handle_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  handle_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  handle_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  handle_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  avatarUri_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  about_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  about_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  controllerAccount_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  rootAccount_in?: string[];
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_eq?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gte?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lte?: number;
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  createdInBlock_in?: number[];
-
-  @TypeGraphQLField(() => MembershipEntryMethod, { nullable: true })
-  entry_eq?: MembershipEntryMethod;
-
-  @TypeGraphQLField(() => [MembershipEntryMethod], { nullable: true })
-  entry_in?: MembershipEntryMethod[];
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_eq?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_gt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_gte?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_lt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_lte?: number;
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  subscription_in?: number[];
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_none?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_some?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_every?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
-  AND?: [MembershipWhereInput];
-
-  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
-  OR?: [MembershipWhereInput];
-}
-
-@TypeGraphQLInputType()
-export class MembershipWhereUniqueInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  id?: string;
-
-  @TypeGraphQLField(() => String, { nullable: true })
-  handle?: string;
-}
-
-@TypeGraphQLInputType()
-export class MembershipCreateInput {
-  @TypeGraphQLField()
-  handle!: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about?: string;
-
-  @TypeGraphQLField()
-  controllerAccount!: string;
-
-  @TypeGraphQLField()
-  rootAccount!: string;
-
-  @TypeGraphQLField()
-  createdInBlock!: number;
-
-  @TypeGraphQLField(() => MembershipEntryMethod)
-  entry!: MembershipEntryMethod;
-
-  @TypeGraphQLField({ nullable: true })
-  subscription?: number;
-}
-
-@TypeGraphQLInputType()
-export class MembershipUpdateInput {
-  @TypeGraphQLField({ nullable: true })
-  handle?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  createdInBlock?: number;
-
-  @TypeGraphQLField(() => MembershipEntryMethod, { nullable: true })
-  entry?: MembershipEntryMethod;
-
-  @TypeGraphQLField({ nullable: true })
-  subscription?: number;
-}
-
-@ArgsType()
-export class MembershipWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
-  where?: MembershipWhereInput;
-
-  @TypeGraphQLField(() => MembershipOrderByEnum, { nullable: true })
-  orderBy?: MembershipOrderByEnum[];
-}
-
-@ArgsType()
-export class MembershipCreateManyArgs {
-  @TypeGraphQLField(() => [MembershipCreateInput])
-  data!: MembershipCreateInput[];
-}
-
-@ArgsType()
-export class MembershipUpdateArgs {
-  @TypeGraphQLField() data!: MembershipUpdateInput;
-  @TypeGraphQLField() where!: MembershipWhereUniqueInput;
+export class WorkerUpdateArgs {
+  @TypeGraphQLField() data!: WorkerUpdateInput;
+  @TypeGraphQLField() where!: WorkerWhereUniqueInput;
 }
 
 export enum NextEntityIdOrderByEnum {

--- a/query-node/generated/graphql-server/generated/classes.ts
+++ b/query-node/generated/graphql-server/generated/classes.ts
@@ -23,19 +23,21 @@ const { GraphQLJSONObject } = require('graphql-type-json');
 // @ts-ignore
 import { BaseWhereInput, JsonObject, PaginationArgs, DateOnlyString, DateTimeString, BigInt, Bytes } from 'warthog';
 
-import { MembershipEntryMethod } from "../src/modules/membership/membership.model";
+import { WorkerType } from "../src/modules/worker/worker.model";
 import { AssetAvailability } from "../src/modules/video/video.model";
 import { LiaisonJudgement } from "../src/modules/data-object/data-object.model";
-import { WorkerType } from "../src/modules/worker/worker.model";
+import { MembershipEntryMethod } from "../src/modules/membership/membership.model";
 
-// @ts-ignore
-import { Membership } from "../src/modules/membership/membership.model";
 // @ts-ignore
 import { CuratorGroup } from "../src/modules/curator-group/curator-group.model";
 // @ts-ignore
 import { ChannelCategory } from "../src/modules/channel-category/channel-category.model";
 // @ts-ignore
+import { Worker } from "../src/modules/worker/worker.model";
+// @ts-ignore
 import { VideoCategory } from "../src/modules/video-category/video-category.model";
+// @ts-ignore
+import { Language } from "../src/modules/language/language.model";
 // @ts-ignore
 import { License } from "../src/modules/license/license.model";
 // @ts-ignore
@@ -45,15 +47,397 @@ import { VideoMediaMetadata } from "../src/modules/video-media-metadata/video-me
 // @ts-ignore
 import { Video } from "../src/modules/video/video.model";
 // @ts-ignore
-import { Language } from "../src/modules/language/language.model";
+import { DataObject } from "../src/modules/data-object/data-object.model";
 // @ts-ignore
 import { Channel } from "../src/modules/channel/channel.model";
 // @ts-ignore
-import { DataObject } from "../src/modules/data-object/data-object.model";
-// @ts-ignore
-import { Worker } from "../src/modules/worker/worker.model";
+import { Membership } from "../src/modules/membership/membership.model";
 // @ts-ignore
 import { NextEntityId } from "../src/modules/next-entity-id/next-entity-id.model";
+
+export enum CuratorGroupOrderByEnum {
+  createdAt_ASC = "createdAt_ASC",
+  createdAt_DESC = "createdAt_DESC",
+
+  updatedAt_ASC = "updatedAt_ASC",
+  updatedAt_DESC = "updatedAt_DESC",
+
+  deletedAt_ASC = "deletedAt_ASC",
+  deletedAt_DESC = "deletedAt_DESC",
+
+  isActive_ASC = "isActive_ASC",
+  isActive_DESC = "isActive_DESC"
+}
+
+registerEnumType(CuratorGroupOrderByEnum, {
+  name: "CuratorGroupOrderByInput"
+});
+
+@TypeGraphQLInputType()
+export class CuratorGroupWhereInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  id_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  id_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  createdById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  createdById_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  updatedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  updatedById_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  deletedAt_all?: Boolean;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  deletedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  deletedById_in?: string[];
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  curatorIds_containsAll?: [number];
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  curatorIds_containsNone?: [number];
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  curatorIds_containsAny?: [number];
+
+  @TypeGraphQLField(() => Boolean, { nullable: true })
+  isActive_eq?: Boolean;
+
+  @TypeGraphQLField(() => [Boolean], { nullable: true })
+  isActive_in?: Boolean[];
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_none?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_some?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_every?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
+  AND?: [CuratorGroupWhereInput];
+
+  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
+  OR?: [CuratorGroupWhereInput];
+}
+
+@TypeGraphQLInputType()
+export class CuratorGroupWhereUniqueInput {
+  @TypeGraphQLField(() => ID)
+  id?: string;
+}
+
+@TypeGraphQLInputType()
+export class CuratorGroupCreateInput {
+  @TypeGraphQLField(() => [Int])
+  curatorIds!: number[];
+
+  @TypeGraphQLField()
+  isActive!: boolean;
+}
+
+@TypeGraphQLInputType()
+export class CuratorGroupUpdateInput {
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  curatorIds?: number[];
+
+  @TypeGraphQLField({ nullable: true })
+  isActive?: boolean;
+}
+
+@ArgsType()
+export class CuratorGroupWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
+  where?: CuratorGroupWhereInput;
+
+  @TypeGraphQLField(() => CuratorGroupOrderByEnum, { nullable: true })
+  orderBy?: CuratorGroupOrderByEnum[];
+}
+
+@ArgsType()
+export class CuratorGroupCreateManyArgs {
+  @TypeGraphQLField(() => [CuratorGroupCreateInput])
+  data!: CuratorGroupCreateInput[];
+}
+
+@ArgsType()
+export class CuratorGroupUpdateArgs {
+  @TypeGraphQLField() data!: CuratorGroupUpdateInput;
+  @TypeGraphQLField() where!: CuratorGroupWhereUniqueInput;
+}
+
+export enum ChannelCategoryOrderByEnum {
+  createdAt_ASC = "createdAt_ASC",
+  createdAt_DESC = "createdAt_DESC",
+
+  updatedAt_ASC = "updatedAt_ASC",
+  updatedAt_DESC = "updatedAt_DESC",
+
+  deletedAt_ASC = "deletedAt_ASC",
+  deletedAt_DESC = "deletedAt_DESC",
+
+  name_ASC = "name_ASC",
+  name_DESC = "name_DESC",
+
+  activeVideosCounter_ASC = "activeVideosCounter_ASC",
+  activeVideosCounter_DESC = "activeVideosCounter_DESC",
+
+  createdInBlock_ASC = "createdInBlock_ASC",
+  createdInBlock_DESC = "createdInBlock_DESC"
+}
+
+registerEnumType(ChannelCategoryOrderByEnum, {
+  name: "ChannelCategoryOrderByInput"
+});
+
+@TypeGraphQLInputType()
+export class ChannelCategoryWhereInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  id_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  id_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  createdById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  createdById_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  updatedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  updatedById_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  deletedAt_all?: Boolean;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  deletedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  deletedById_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  name_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  name_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  name_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  name_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  name_in?: string[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  activeVideosCounter_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  activeVideosCounter_in?: number[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  createdInBlock_in?: number[];
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_none?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_some?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_every?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
+  AND?: [ChannelCategoryWhereInput];
+
+  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
+  OR?: [ChannelCategoryWhereInput];
+}
+
+@TypeGraphQLInputType()
+export class ChannelCategoryWhereUniqueInput {
+  @TypeGraphQLField(() => ID)
+  id?: string;
+}
+
+@TypeGraphQLInputType()
+export class ChannelCategoryCreateInput {
+  @TypeGraphQLField({ nullable: true })
+  name?: string;
+
+  @TypeGraphQLField()
+  activeVideosCounter!: number;
+
+  @TypeGraphQLField()
+  createdInBlock!: number;
+}
+
+@TypeGraphQLInputType()
+export class ChannelCategoryUpdateInput {
+  @TypeGraphQLField({ nullable: true })
+  name?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  activeVideosCounter?: number;
+
+  @TypeGraphQLField({ nullable: true })
+  createdInBlock?: number;
+}
+
+@ArgsType()
+export class ChannelCategoryWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
+  where?: ChannelCategoryWhereInput;
+
+  @TypeGraphQLField(() => ChannelCategoryOrderByEnum, { nullable: true })
+  orderBy?: ChannelCategoryOrderByEnum[];
+}
+
+@ArgsType()
+export class ChannelCategoryCreateManyArgs {
+  @TypeGraphQLField(() => [ChannelCategoryCreateInput])
+  data!: ChannelCategoryCreateInput[];
+}
+
+@ArgsType()
+export class ChannelCategoryUpdateArgs {
+  @TypeGraphQLField() data!: ChannelCategoryUpdateInput;
+  @TypeGraphQLField() where!: ChannelCategoryWhereUniqueInput;
+}
 
 export enum DataObjectOwnerChannelOrderByEnum {
   createdAt_ASC = "createdAt_ASC",
@@ -897,337 +1281,7 @@ export class DataObjectOwnerWorkingGroupUpdateArgs {
   @TypeGraphQLField() where!: DataObjectOwnerWorkingGroupWhereUniqueInput;
 }
 
-export enum MembershipOrderByEnum {
-  createdAt_ASC = "createdAt_ASC",
-  createdAt_DESC = "createdAt_DESC",
-
-  updatedAt_ASC = "updatedAt_ASC",
-  updatedAt_DESC = "updatedAt_DESC",
-
-  deletedAt_ASC = "deletedAt_ASC",
-  deletedAt_DESC = "deletedAt_DESC",
-
-  handle_ASC = "handle_ASC",
-  handle_DESC = "handle_DESC",
-
-  avatarUri_ASC = "avatarUri_ASC",
-  avatarUri_DESC = "avatarUri_DESC",
-
-  about_ASC = "about_ASC",
-  about_DESC = "about_DESC",
-
-  controllerAccount_ASC = "controllerAccount_ASC",
-  controllerAccount_DESC = "controllerAccount_DESC",
-
-  rootAccount_ASC = "rootAccount_ASC",
-  rootAccount_DESC = "rootAccount_DESC",
-
-  createdInBlock_ASC = "createdInBlock_ASC",
-  createdInBlock_DESC = "createdInBlock_DESC",
-
-  entry_ASC = "entry_ASC",
-  entry_DESC = "entry_DESC",
-
-  subscription_ASC = "subscription_ASC",
-  subscription_DESC = "subscription_DESC"
-}
-
-registerEnumType(MembershipOrderByEnum, {
-  name: "MembershipOrderByInput"
-});
-
-@TypeGraphQLInputType()
-export class MembershipWhereInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  id_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  id_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  createdById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  createdById_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  updatedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  updatedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  deletedAt_all?: Boolean;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  deletedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  deletedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  handle_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  handle_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  handle_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  handle_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  handle_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  avatarUri_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  about_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  about_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  controllerAccount_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  rootAccount_in?: string[];
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_eq?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gte?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lte?: number;
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  createdInBlock_in?: number[];
-
-  @TypeGraphQLField(() => MembershipEntryMethod, { nullable: true })
-  entry_eq?: MembershipEntryMethod;
-
-  @TypeGraphQLField(() => [MembershipEntryMethod], { nullable: true })
-  entry_in?: MembershipEntryMethod[];
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_eq?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_gt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_gte?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_lt?: number;
-
-  @TypeGraphQLField(() => Int, { nullable: true })
-  subscription_lte?: number;
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  subscription_in?: number[];
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_none?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_some?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_every?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
-  AND?: [MembershipWhereInput];
-
-  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
-  OR?: [MembershipWhereInput];
-}
-
-@TypeGraphQLInputType()
-export class MembershipWhereUniqueInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  id?: string;
-
-  @TypeGraphQLField(() => String, { nullable: true })
-  handle?: string;
-}
-
-@TypeGraphQLInputType()
-export class MembershipCreateInput {
-  @TypeGraphQLField()
-  handle!: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about?: string;
-
-  @TypeGraphQLField()
-  controllerAccount!: string;
-
-  @TypeGraphQLField()
-  rootAccount!: string;
-
-  @TypeGraphQLField()
-  createdInBlock!: number;
-
-  @TypeGraphQLField(() => MembershipEntryMethod)
-  entry!: MembershipEntryMethod;
-
-  @TypeGraphQLField({ nullable: true })
-  subscription?: number;
-}
-
-@TypeGraphQLInputType()
-export class MembershipUpdateInput {
-  @TypeGraphQLField({ nullable: true })
-  handle?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  avatarUri?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  about?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  controllerAccount?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  rootAccount?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  createdInBlock?: number;
-
-  @TypeGraphQLField(() => MembershipEntryMethod, { nullable: true })
-  entry?: MembershipEntryMethod;
-
-  @TypeGraphQLField({ nullable: true })
-  subscription?: number;
-}
-
-@ArgsType()
-export class MembershipWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
-  where?: MembershipWhereInput;
-
-  @TypeGraphQLField(() => MembershipOrderByEnum, { nullable: true })
-  orderBy?: MembershipOrderByEnum[];
-}
-
-@ArgsType()
-export class MembershipCreateManyArgs {
-  @TypeGraphQLField(() => [MembershipCreateInput])
-  data!: MembershipCreateInput[];
-}
-
-@ArgsType()
-export class MembershipUpdateArgs {
-  @TypeGraphQLField() data!: MembershipUpdateInput;
-  @TypeGraphQLField() where!: MembershipWhereUniqueInput;
-}
-
-export enum CuratorGroupOrderByEnum {
+export enum WorkerOrderByEnum {
   createdAt_ASC = "createdAt_ASC",
   createdAt_DESC = "createdAt_DESC",
 
@@ -1238,15 +1292,24 @@ export enum CuratorGroupOrderByEnum {
   deletedAt_DESC = "deletedAt_DESC",
 
   isActive_ASC = "isActive_ASC",
-  isActive_DESC = "isActive_DESC"
+  isActive_DESC = "isActive_DESC",
+
+  workerId_ASC = "workerId_ASC",
+  workerId_DESC = "workerId_DESC",
+
+  type_ASC = "type_ASC",
+  type_DESC = "type_DESC",
+
+  metadata_ASC = "metadata_ASC",
+  metadata_DESC = "metadata_DESC"
 }
 
-registerEnumType(CuratorGroupOrderByEnum, {
-  name: "CuratorGroupOrderByInput"
+registerEnumType(WorkerOrderByEnum, {
+  name: "WorkerOrderByInput"
 });
 
 @TypeGraphQLInputType()
-export class CuratorGroupWhereInput {
+export class WorkerWhereInput {
   @TypeGraphQLField(() => ID, { nullable: true })
   id_eq?: string;
 
@@ -1318,15 +1381,6 @@ export class CuratorGroupWhereInput {
 
   @TypeGraphQLField(() => [ID], { nullable: true })
   deletedById_in?: string[];
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  curatorIds_containsAll?: [number];
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  curatorIds_containsNone?: [number];
-
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  curatorIds_containsAny?: [number];
 
   @TypeGraphQLField(() => Boolean, { nullable: true })
   isActive_eq?: Boolean;
@@ -1334,281 +1388,113 @@ export class CuratorGroupWhereInput {
   @TypeGraphQLField(() => [Boolean], { nullable: true })
   isActive_in?: Boolean[];
 
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_none?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_some?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_every?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
-  AND?: [CuratorGroupWhereInput];
-
-  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
-  OR?: [CuratorGroupWhereInput];
-}
-
-@TypeGraphQLInputType()
-export class CuratorGroupWhereUniqueInput {
-  @TypeGraphQLField(() => ID)
-  id?: string;
-}
-
-@TypeGraphQLInputType()
-export class CuratorGroupCreateInput {
-  @TypeGraphQLField(() => [Int])
-  curatorIds!: number[];
-
-  @TypeGraphQLField()
-  isActive!: boolean;
-}
-
-@TypeGraphQLInputType()
-export class CuratorGroupUpdateInput {
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  curatorIds?: number[];
+  @TypeGraphQLField({ nullable: true })
+  workerId_eq?: string;
 
   @TypeGraphQLField({ nullable: true })
-  isActive?: boolean;
-}
-
-@ArgsType()
-export class CuratorGroupWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => CuratorGroupWhereInput, { nullable: true })
-  where?: CuratorGroupWhereInput;
-
-  @TypeGraphQLField(() => CuratorGroupOrderByEnum, { nullable: true })
-  orderBy?: CuratorGroupOrderByEnum[];
-}
-
-@ArgsType()
-export class CuratorGroupCreateManyArgs {
-  @TypeGraphQLField(() => [CuratorGroupCreateInput])
-  data!: CuratorGroupCreateInput[];
-}
-
-@ArgsType()
-export class CuratorGroupUpdateArgs {
-  @TypeGraphQLField() data!: CuratorGroupUpdateInput;
-  @TypeGraphQLField() where!: CuratorGroupWhereUniqueInput;
-}
-
-export enum ChannelCategoryOrderByEnum {
-  createdAt_ASC = "createdAt_ASC",
-  createdAt_DESC = "createdAt_DESC",
-
-  updatedAt_ASC = "updatedAt_ASC",
-  updatedAt_DESC = "updatedAt_DESC",
-
-  deletedAt_ASC = "deletedAt_ASC",
-  deletedAt_DESC = "deletedAt_DESC",
-
-  name_ASC = "name_ASC",
-  name_DESC = "name_DESC",
-
-  activeVideosCounter_ASC = "activeVideosCounter_ASC",
-  activeVideosCounter_DESC = "activeVideosCounter_DESC",
-
-  createdInBlock_ASC = "createdInBlock_ASC",
-  createdInBlock_DESC = "createdInBlock_DESC"
-}
-
-registerEnumType(ChannelCategoryOrderByEnum, {
-  name: "ChannelCategoryOrderByInput"
-});
-
-@TypeGraphQLInputType()
-export class ChannelCategoryWhereInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  id_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  id_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  createdById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  createdById_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  updatedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  updatedById_in?: string[];
+  workerId_contains?: string;
 
   @TypeGraphQLField({ nullable: true })
-  deletedAt_all?: Boolean;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  deletedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  deletedById_in?: string[];
+  workerId_startsWith?: string;
 
   @TypeGraphQLField({ nullable: true })
-  name_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  name_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  name_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  name_endsWith?: string;
+  workerId_endsWith?: string;
 
   @TypeGraphQLField(() => [String], { nullable: true })
-  name_in?: string[];
+  workerId_in?: string[];
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  activeVideosCounter_eq?: number;
+  @TypeGraphQLField(() => WorkerType, { nullable: true })
+  type_eq?: WorkerType;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  activeVideosCounter_gt?: number;
+  @TypeGraphQLField(() => [WorkerType], { nullable: true })
+  type_in?: WorkerType[];
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  activeVideosCounter_gte?: number;
+  @TypeGraphQLField({ nullable: true })
+  metadata_eq?: string;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  activeVideosCounter_lt?: number;
+  @TypeGraphQLField({ nullable: true })
+  metadata_contains?: string;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  activeVideosCounter_lte?: number;
+  @TypeGraphQLField({ nullable: true })
+  metadata_startsWith?: string;
 
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  activeVideosCounter_in?: number[];
+  @TypeGraphQLField({ nullable: true })
+  metadata_endsWith?: string;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_eq?: number;
+  @TypeGraphQLField(() => [String], { nullable: true })
+  metadata_in?: string[];
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gt?: number;
+  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
+  dataObjects_none?: DataObjectWhereInput;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_gte?: number;
+  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
+  dataObjects_some?: DataObjectWhereInput;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lt?: number;
+  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
+  dataObjects_every?: DataObjectWhereInput;
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  createdInBlock_lte?: number;
+  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
+  AND?: [WorkerWhereInput];
 
-  @TypeGraphQLField(() => [Int], { nullable: true })
-  createdInBlock_in?: number[];
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_none?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_some?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channels_every?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
-  AND?: [ChannelCategoryWhereInput];
-
-  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
-  OR?: [ChannelCategoryWhereInput];
+  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
+  OR?: [WorkerWhereInput];
 }
 
 @TypeGraphQLInputType()
-export class ChannelCategoryWhereUniqueInput {
+export class WorkerWhereUniqueInput {
   @TypeGraphQLField(() => ID)
   id?: string;
 }
 
 @TypeGraphQLInputType()
-export class ChannelCategoryCreateInput {
+export class WorkerCreateInput {
+  @TypeGraphQLField()
+  isActive!: boolean;
+
+  @TypeGraphQLField()
+  workerId!: string;
+
+  @TypeGraphQLField(() => WorkerType)
+  type!: WorkerType;
+
   @TypeGraphQLField({ nullable: true })
-  name?: string;
-
-  @TypeGraphQLField()
-  activeVideosCounter!: number;
-
-  @TypeGraphQLField()
-  createdInBlock!: number;
+  metadata?: string;
 }
 
 @TypeGraphQLInputType()
-export class ChannelCategoryUpdateInput {
+export class WorkerUpdateInput {
   @TypeGraphQLField({ nullable: true })
-  name?: string;
+  isActive?: boolean;
 
   @TypeGraphQLField({ nullable: true })
-  activeVideosCounter?: number;
+  workerId?: string;
+
+  @TypeGraphQLField(() => WorkerType, { nullable: true })
+  type?: WorkerType;
 
   @TypeGraphQLField({ nullable: true })
-  createdInBlock?: number;
+  metadata?: string;
 }
 
 @ArgsType()
-export class ChannelCategoryWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => ChannelCategoryWhereInput, { nullable: true })
-  where?: ChannelCategoryWhereInput;
+export class WorkerWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
+  where?: WorkerWhereInput;
 
-  @TypeGraphQLField(() => ChannelCategoryOrderByEnum, { nullable: true })
-  orderBy?: ChannelCategoryOrderByEnum[];
+  @TypeGraphQLField(() => WorkerOrderByEnum, { nullable: true })
+  orderBy?: WorkerOrderByEnum[];
 }
 
 @ArgsType()
-export class ChannelCategoryCreateManyArgs {
-  @TypeGraphQLField(() => [ChannelCategoryCreateInput])
-  data!: ChannelCategoryCreateInput[];
+export class WorkerCreateManyArgs {
+  @TypeGraphQLField(() => [WorkerCreateInput])
+  data!: WorkerCreateInput[];
 }
 
 @ArgsType()
-export class ChannelCategoryUpdateArgs {
-  @TypeGraphQLField() data!: ChannelCategoryUpdateInput;
-  @TypeGraphQLField() where!: ChannelCategoryWhereUniqueInput;
+export class WorkerUpdateArgs {
+  @TypeGraphQLField() data!: WorkerUpdateInput;
+  @TypeGraphQLField() where!: WorkerWhereUniqueInput;
 }
 
 export enum VideoCategoryOrderByEnum {
@@ -1825,6 +1711,204 @@ export class VideoCategoryCreateManyArgs {
 export class VideoCategoryUpdateArgs {
   @TypeGraphQLField() data!: VideoCategoryUpdateInput;
   @TypeGraphQLField() where!: VideoCategoryWhereUniqueInput;
+}
+
+export enum LanguageOrderByEnum {
+  createdAt_ASC = "createdAt_ASC",
+  createdAt_DESC = "createdAt_DESC",
+
+  updatedAt_ASC = "updatedAt_ASC",
+  updatedAt_DESC = "updatedAt_DESC",
+
+  deletedAt_ASC = "deletedAt_ASC",
+  deletedAt_DESC = "deletedAt_DESC",
+
+  iso_ASC = "iso_ASC",
+  iso_DESC = "iso_DESC",
+
+  createdInBlock_ASC = "createdInBlock_ASC",
+  createdInBlock_DESC = "createdInBlock_DESC"
+}
+
+registerEnumType(LanguageOrderByEnum, {
+  name: "LanguageOrderByInput"
+});
+
+@TypeGraphQLInputType()
+export class LanguageWhereInput {
+  @TypeGraphQLField(() => ID, { nullable: true })
+  id_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  id_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  createdAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  createdById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  createdById_in?: string[];
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  updatedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  updatedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  updatedById_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  deletedAt_all?: Boolean;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_eq?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_lte?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gt?: Date;
+
+  @TypeGraphQLField(() => DateTime, { nullable: true })
+  deletedAt_gte?: Date;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  deletedById_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  deletedById_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  iso_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  iso_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  iso_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  iso_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  iso_in?: string[];
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  createdInBlock_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  createdInBlock_in?: number[];
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channellanguage_none?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channellanguage_some?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channellanguage_every?: ChannelWhereInput;
+
+  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
+  videolanguage_none?: VideoWhereInput;
+
+  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
+  videolanguage_some?: VideoWhereInput;
+
+  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
+  videolanguage_every?: VideoWhereInput;
+
+  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
+  AND?: [LanguageWhereInput];
+
+  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
+  OR?: [LanguageWhereInput];
+}
+
+@TypeGraphQLInputType()
+export class LanguageWhereUniqueInput {
+  @TypeGraphQLField(() => ID)
+  id?: string;
+}
+
+@TypeGraphQLInputType()
+export class LanguageCreateInput {
+  @TypeGraphQLField()
+  iso!: string;
+
+  @TypeGraphQLField()
+  createdInBlock!: number;
+}
+
+@TypeGraphQLInputType()
+export class LanguageUpdateInput {
+  @TypeGraphQLField({ nullable: true })
+  iso?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  createdInBlock?: number;
+}
+
+@ArgsType()
+export class LanguageWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
+  where?: LanguageWhereInput;
+
+  @TypeGraphQLField(() => LanguageOrderByEnum, { nullable: true })
+  orderBy?: LanguageOrderByEnum[];
+}
+
+@ArgsType()
+export class LanguageCreateManyArgs {
+  @TypeGraphQLField(() => [LanguageCreateInput])
+  data!: LanguageCreateInput[];
+}
+
+@ArgsType()
+export class LanguageUpdateArgs {
+  @TypeGraphQLField() data!: LanguageUpdateInput;
+  @TypeGraphQLField() where!: LanguageWhereUniqueInput;
 }
 
 export enum LicenseOrderByEnum {
@@ -3096,7 +3180,7 @@ export class VideoUpdateArgs {
   @TypeGraphQLField() where!: VideoWhereUniqueInput;
 }
 
-export enum LanguageOrderByEnum {
+export enum DataObjectOrderByEnum {
   createdAt_ASC = "createdAt_ASC",
   createdAt_DESC = "createdAt_DESC",
 
@@ -3106,19 +3190,37 @@ export enum LanguageOrderByEnum {
   deletedAt_ASC = "deletedAt_ASC",
   deletedAt_DESC = "deletedAt_DESC",
 
-  iso_ASC = "iso_ASC",
-  iso_DESC = "iso_DESC",
-
   createdInBlock_ASC = "createdInBlock_ASC",
-  createdInBlock_DESC = "createdInBlock_DESC"
+  createdInBlock_DESC = "createdInBlock_DESC",
+
+  typeId_ASC = "typeId_ASC",
+  typeId_DESC = "typeId_DESC",
+
+  size_ASC = "size_ASC",
+  size_DESC = "size_DESC",
+
+  liaison_ASC = "liaison_ASC",
+  liaison_DESC = "liaison_DESC",
+
+  liaisonId_ASC = "liaisonId_ASC",
+  liaisonId_DESC = "liaisonId_DESC",
+
+  liaisonJudgement_ASC = "liaisonJudgement_ASC",
+  liaisonJudgement_DESC = "liaisonJudgement_DESC",
+
+  ipfsContentId_ASC = "ipfsContentId_ASC",
+  ipfsContentId_DESC = "ipfsContentId_DESC",
+
+  joystreamContentId_ASC = "joystreamContentId_ASC",
+  joystreamContentId_DESC = "joystreamContentId_DESC"
 }
 
-registerEnumType(LanguageOrderByEnum, {
-  name: "LanguageOrderByInput"
+registerEnumType(DataObjectOrderByEnum, {
+  name: "DataObjectOrderByInput"
 });
 
 @TypeGraphQLInputType()
-export class LanguageWhereInput {
+export class DataObjectWhereInput {
   @TypeGraphQLField(() => ID, { nullable: true })
   id_eq?: string;
 
@@ -3191,20 +3293,8 @@ export class LanguageWhereInput {
   @TypeGraphQLField(() => [ID], { nullable: true })
   deletedById_in?: string[];
 
-  @TypeGraphQLField({ nullable: true })
-  iso_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  iso_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  iso_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  iso_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  iso_in?: string[];
+  @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
+  owner_json?: JsonObject;
 
   @TypeGraphQLField(() => Int, { nullable: true })
   createdInBlock_eq?: number;
@@ -3224,74 +3314,215 @@ export class LanguageWhereInput {
   @TypeGraphQLField(() => [Int], { nullable: true })
   createdInBlock_in?: number[];
 
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channellanguage_none?: ChannelWhereInput;
+  @TypeGraphQLField(() => Int, { nullable: true })
+  typeId_eq?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  typeId_gt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  typeId_gte?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  typeId_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  typeId_lte?: number;
+
+  @TypeGraphQLField(() => [Int], { nullable: true })
+  typeId_in?: number[];
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  size_eq?: number;
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  size_gt?: number;
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  size_gte?: number;
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  size_lt?: number;
+
+  @TypeGraphQLField(() => Float, { nullable: true })
+  size_lte?: number;
+
+  @TypeGraphQLField(() => [Float], { nullable: true })
+  size_in?: number[];
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  liaisonId_eq?: string;
+
+  @TypeGraphQLField(() => [ID], { nullable: true })
+  liaisonId_in?: string[];
+
+  @TypeGraphQLField(() => LiaisonJudgement, { nullable: true })
+  liaisonJudgement_eq?: LiaisonJudgement;
+
+  @TypeGraphQLField(() => [LiaisonJudgement], { nullable: true })
+  liaisonJudgement_in?: LiaisonJudgement[];
+
+  @TypeGraphQLField({ nullable: true })
+  ipfsContentId_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  ipfsContentId_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  ipfsContentId_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  ipfsContentId_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  ipfsContentId_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  joystreamContentId_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  joystreamContentId_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  joystreamContentId_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  joystreamContentId_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  joystreamContentId_in?: string[];
+
+  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
+  liaison?: WorkerWhereInput;
 
   @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channellanguage_some?: ChannelWhereInput;
+  channelcoverPhotoDataObject_none?: ChannelWhereInput;
 
   @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channellanguage_every?: ChannelWhereInput;
+  channelcoverPhotoDataObject_some?: ChannelWhereInput;
 
-  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
-  videolanguage_none?: VideoWhereInput;
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channelcoverPhotoDataObject_every?: ChannelWhereInput;
 
-  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
-  videolanguage_some?: VideoWhereInput;
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channelavatarPhotoDataObject_none?: ChannelWhereInput;
 
-  @TypeGraphQLField(() => VideoWhereInput, { nullable: true })
-  videolanguage_every?: VideoWhereInput;
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channelavatarPhotoDataObject_some?: ChannelWhereInput;
 
-  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
-  AND?: [LanguageWhereInput];
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channelavatarPhotoDataObject_every?: ChannelWhereInput;
 
-  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
-  OR?: [LanguageWhereInput];
+  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
+  videothumbnailPhotoDataObject_none?: VideoMediaMetadataWhereInput;
+
+  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
+  videothumbnailPhotoDataObject_some?: VideoMediaMetadataWhereInput;
+
+  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
+  videothumbnailPhotoDataObject_every?: VideoMediaMetadataWhereInput;
+
+  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
+  videomediaDataObject_none?: VideoMediaMetadataWhereInput;
+
+  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
+  videomediaDataObject_some?: VideoMediaMetadataWhereInput;
+
+  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
+  videomediaDataObject_every?: VideoMediaMetadataWhereInput;
+
+  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
+  AND?: [DataObjectWhereInput];
+
+  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
+  OR?: [DataObjectWhereInput];
 }
 
 @TypeGraphQLInputType()
-export class LanguageWhereUniqueInput {
+export class DataObjectWhereUniqueInput {
   @TypeGraphQLField(() => ID)
   id?: string;
 }
 
 @TypeGraphQLInputType()
-export class LanguageCreateInput {
-  @TypeGraphQLField()
-  iso!: string;
+export class DataObjectCreateInput {
+  @TypeGraphQLField(() => GraphQLJSONObject)
+  owner!: JsonObject;
 
   @TypeGraphQLField()
   createdInBlock!: number;
+
+  @TypeGraphQLField()
+  typeId!: number;
+
+  @TypeGraphQLField()
+  size!: number;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  liaison?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  liaisonId?: string;
+
+  @TypeGraphQLField(() => LiaisonJudgement)
+  liaisonJudgement!: LiaisonJudgement;
+
+  @TypeGraphQLField()
+  ipfsContentId!: string;
+
+  @TypeGraphQLField()
+  joystreamContentId!: string;
 }
 
 @TypeGraphQLInputType()
-export class LanguageUpdateInput {
-  @TypeGraphQLField({ nullable: true })
-  iso?: string;
+export class DataObjectUpdateInput {
+  @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
+  owner?: JsonObject;
 
   @TypeGraphQLField({ nullable: true })
   createdInBlock?: number;
+
+  @TypeGraphQLField({ nullable: true })
+  typeId?: number;
+
+  @TypeGraphQLField({ nullable: true })
+  size?: number;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  liaison?: string;
+
+  @TypeGraphQLField(() => ID, { nullable: true })
+  liaisonId?: string;
+
+  @TypeGraphQLField(() => LiaisonJudgement, { nullable: true })
+  liaisonJudgement?: LiaisonJudgement;
+
+  @TypeGraphQLField({ nullable: true })
+  ipfsContentId?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  joystreamContentId?: string;
 }
 
 @ArgsType()
-export class LanguageWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => LanguageWhereInput, { nullable: true })
-  where?: LanguageWhereInput;
+export class DataObjectWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
+  where?: DataObjectWhereInput;
 
-  @TypeGraphQLField(() => LanguageOrderByEnum, { nullable: true })
-  orderBy?: LanguageOrderByEnum[];
+  @TypeGraphQLField(() => DataObjectOrderByEnum, { nullable: true })
+  orderBy?: DataObjectOrderByEnum[];
 }
 
 @ArgsType()
-export class LanguageCreateManyArgs {
-  @TypeGraphQLField(() => [LanguageCreateInput])
-  data!: LanguageCreateInput[];
+export class DataObjectCreateManyArgs {
+  @TypeGraphQLField(() => [DataObjectCreateInput])
+  data!: DataObjectCreateInput[];
 }
 
 @ArgsType()
-export class LanguageUpdateArgs {
-  @TypeGraphQLField() data!: LanguageUpdateInput;
-  @TypeGraphQLField() where!: LanguageWhereUniqueInput;
+export class DataObjectUpdateArgs {
+  @TypeGraphQLField() data!: DataObjectUpdateInput;
+  @TypeGraphQLField() where!: DataObjectWhereUniqueInput;
 }
 
 export enum ChannelOrderByEnum {
@@ -3810,7 +4041,7 @@ export class ChannelUpdateArgs {
   @TypeGraphQLField() where!: ChannelWhereUniqueInput;
 }
 
-export enum DataObjectOrderByEnum {
+export enum MembershipOrderByEnum {
   createdAt_ASC = "createdAt_ASC",
   createdAt_DESC = "createdAt_DESC",
 
@@ -3820,37 +4051,37 @@ export enum DataObjectOrderByEnum {
   deletedAt_ASC = "deletedAt_ASC",
   deletedAt_DESC = "deletedAt_DESC",
 
+  handle_ASC = "handle_ASC",
+  handle_DESC = "handle_DESC",
+
+  avatarUri_ASC = "avatarUri_ASC",
+  avatarUri_DESC = "avatarUri_DESC",
+
+  about_ASC = "about_ASC",
+  about_DESC = "about_DESC",
+
+  controllerAccount_ASC = "controllerAccount_ASC",
+  controllerAccount_DESC = "controllerAccount_DESC",
+
+  rootAccount_ASC = "rootAccount_ASC",
+  rootAccount_DESC = "rootAccount_DESC",
+
   createdInBlock_ASC = "createdInBlock_ASC",
   createdInBlock_DESC = "createdInBlock_DESC",
 
-  typeId_ASC = "typeId_ASC",
-  typeId_DESC = "typeId_DESC",
+  entry_ASC = "entry_ASC",
+  entry_DESC = "entry_DESC",
 
-  size_ASC = "size_ASC",
-  size_DESC = "size_DESC",
-
-  liaison_ASC = "liaison_ASC",
-  liaison_DESC = "liaison_DESC",
-
-  liaisonId_ASC = "liaisonId_ASC",
-  liaisonId_DESC = "liaisonId_DESC",
-
-  liaisonJudgement_ASC = "liaisonJudgement_ASC",
-  liaisonJudgement_DESC = "liaisonJudgement_DESC",
-
-  ipfsContentId_ASC = "ipfsContentId_ASC",
-  ipfsContentId_DESC = "ipfsContentId_DESC",
-
-  joystreamContentId_ASC = "joystreamContentId_ASC",
-  joystreamContentId_DESC = "joystreamContentId_DESC"
+  subscription_ASC = "subscription_ASC",
+  subscription_DESC = "subscription_DESC"
 }
 
-registerEnumType(DataObjectOrderByEnum, {
-  name: "DataObjectOrderByInput"
+registerEnumType(MembershipOrderByEnum, {
+  name: "MembershipOrderByInput"
 });
 
 @TypeGraphQLInputType()
-export class DataObjectWhereInput {
+export class MembershipWhereInput {
   @TypeGraphQLField(() => ID, { nullable: true })
   id_eq?: string;
 
@@ -3923,8 +4154,80 @@ export class DataObjectWhereInput {
   @TypeGraphQLField(() => [ID], { nullable: true })
   deletedById_in?: string[];
 
-  @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
-  owner_json?: JsonObject;
+  @TypeGraphQLField({ nullable: true })
+  handle_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  handle_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  handle_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  handle_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  handle_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  avatarUri_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  about_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  about_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  controllerAccount_in?: string[];
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount_eq?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount_contains?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount_startsWith?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount_endsWith?: string;
+
+  @TypeGraphQLField(() => [String], { nullable: true })
+  rootAccount_in?: string[];
 
   @TypeGraphQLField(() => Int, { nullable: true })
   createdInBlock_eq?: number;
@@ -3944,431 +4247,128 @@ export class DataObjectWhereInput {
   @TypeGraphQLField(() => [Int], { nullable: true })
   createdInBlock_in?: number[];
 
-  @TypeGraphQLField(() => Int, { nullable: true })
-  typeId_eq?: number;
+  @TypeGraphQLField(() => MembershipEntryMethod, { nullable: true })
+  entry_eq?: MembershipEntryMethod;
+
+  @TypeGraphQLField(() => [MembershipEntryMethod], { nullable: true })
+  entry_in?: MembershipEntryMethod[];
 
   @TypeGraphQLField(() => Int, { nullable: true })
-  typeId_gt?: number;
+  subscription_eq?: number;
 
   @TypeGraphQLField(() => Int, { nullable: true })
-  typeId_gte?: number;
+  subscription_gt?: number;
 
   @TypeGraphQLField(() => Int, { nullable: true })
-  typeId_lt?: number;
+  subscription_gte?: number;
 
   @TypeGraphQLField(() => Int, { nullable: true })
-  typeId_lte?: number;
+  subscription_lt?: number;
+
+  @TypeGraphQLField(() => Int, { nullable: true })
+  subscription_lte?: number;
 
   @TypeGraphQLField(() => [Int], { nullable: true })
-  typeId_in?: number[];
+  subscription_in?: number[];
 
-  @TypeGraphQLField(() => Float, { nullable: true })
-  size_eq?: number;
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_none?: ChannelWhereInput;
 
-  @TypeGraphQLField(() => Float, { nullable: true })
-  size_gt?: number;
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_some?: ChannelWhereInput;
 
-  @TypeGraphQLField(() => Float, { nullable: true })
-  size_gte?: number;
+  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
+  channels_every?: ChannelWhereInput;
 
-  @TypeGraphQLField(() => Float, { nullable: true })
-  size_lt?: number;
+  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
+  AND?: [MembershipWhereInput];
 
-  @TypeGraphQLField(() => Float, { nullable: true })
-  size_lte?: number;
+  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
+  OR?: [MembershipWhereInput];
+}
 
-  @TypeGraphQLField(() => [Float], { nullable: true })
-  size_in?: number[];
-
+@TypeGraphQLInputType()
+export class MembershipWhereUniqueInput {
   @TypeGraphQLField(() => ID, { nullable: true })
-  liaisonId_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  liaisonId_in?: string[];
-
-  @TypeGraphQLField(() => LiaisonJudgement, { nullable: true })
-  liaisonJudgement_eq?: LiaisonJudgement;
-
-  @TypeGraphQLField(() => [LiaisonJudgement], { nullable: true })
-  liaisonJudgement_in?: LiaisonJudgement[];
-
-  @TypeGraphQLField({ nullable: true })
-  ipfsContentId_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  ipfsContentId_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  ipfsContentId_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  ipfsContentId_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  ipfsContentId_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  joystreamContentId_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  joystreamContentId_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  joystreamContentId_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  joystreamContentId_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  joystreamContentId_in?: string[];
-
-  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
-  liaison?: WorkerWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channelcoverPhotoDataObject_none?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channelcoverPhotoDataObject_some?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channelcoverPhotoDataObject_every?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channelavatarPhotoDataObject_none?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channelavatarPhotoDataObject_some?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => ChannelWhereInput, { nullable: true })
-  channelavatarPhotoDataObject_every?: ChannelWhereInput;
-
-  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
-  videothumbnailPhotoDataObject_none?: VideoMediaMetadataWhereInput;
-
-  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
-  videothumbnailPhotoDataObject_some?: VideoMediaMetadataWhereInput;
-
-  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
-  videothumbnailPhotoDataObject_every?: VideoMediaMetadataWhereInput;
-
-  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
-  videomediaDataObject_none?: VideoMediaMetadataWhereInput;
-
-  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
-  videomediaDataObject_some?: VideoMediaMetadataWhereInput;
-
-  @TypeGraphQLField(() => VideoMediaMetadataWhereInput, { nullable: true })
-  videomediaDataObject_every?: VideoMediaMetadataWhereInput;
-
-  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  AND?: [DataObjectWhereInput];
-
-  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  OR?: [DataObjectWhereInput];
-}
-
-@TypeGraphQLInputType()
-export class DataObjectWhereUniqueInput {
-  @TypeGraphQLField(() => ID)
   id?: string;
+
+  @TypeGraphQLField(() => String, { nullable: true })
+  handle?: string;
 }
 
 @TypeGraphQLInputType()
-export class DataObjectCreateInput {
-  @TypeGraphQLField(() => GraphQLJSONObject)
-  owner!: JsonObject;
+export class MembershipCreateInput {
+  @TypeGraphQLField()
+  handle!: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about?: string;
+
+  @TypeGraphQLField()
+  controllerAccount!: string;
+
+  @TypeGraphQLField()
+  rootAccount!: string;
 
   @TypeGraphQLField()
   createdInBlock!: number;
 
-  @TypeGraphQLField()
-  typeId!: number;
+  @TypeGraphQLField(() => MembershipEntryMethod)
+  entry!: MembershipEntryMethod;
 
-  @TypeGraphQLField()
-  size!: number;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  liaison?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  liaisonId?: string;
-
-  @TypeGraphQLField(() => LiaisonJudgement)
-  liaisonJudgement!: LiaisonJudgement;
-
-  @TypeGraphQLField()
-  ipfsContentId!: string;
-
-  @TypeGraphQLField()
-  joystreamContentId!: string;
+  @TypeGraphQLField({ nullable: true })
+  subscription?: number;
 }
 
 @TypeGraphQLInputType()
-export class DataObjectUpdateInput {
-  @TypeGraphQLField(() => GraphQLJSONObject, { nullable: true })
-  owner?: JsonObject;
+export class MembershipUpdateInput {
+  @TypeGraphQLField({ nullable: true })
+  handle?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  avatarUri?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  about?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  controllerAccount?: string;
+
+  @TypeGraphQLField({ nullable: true })
+  rootAccount?: string;
 
   @TypeGraphQLField({ nullable: true })
   createdInBlock?: number;
 
-  @TypeGraphQLField({ nullable: true })
-  typeId?: number;
+  @TypeGraphQLField(() => MembershipEntryMethod, { nullable: true })
+  entry?: MembershipEntryMethod;
 
   @TypeGraphQLField({ nullable: true })
-  size?: number;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  liaison?: string;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  liaisonId?: string;
-
-  @TypeGraphQLField(() => LiaisonJudgement, { nullable: true })
-  liaisonJudgement?: LiaisonJudgement;
-
-  @TypeGraphQLField({ nullable: true })
-  ipfsContentId?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  joystreamContentId?: string;
+  subscription?: number;
 }
 
 @ArgsType()
-export class DataObjectWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  where?: DataObjectWhereInput;
+export class MembershipWhereArgs extends PaginationArgs {
+  @TypeGraphQLField(() => MembershipWhereInput, { nullable: true })
+  where?: MembershipWhereInput;
 
-  @TypeGraphQLField(() => DataObjectOrderByEnum, { nullable: true })
-  orderBy?: DataObjectOrderByEnum[];
+  @TypeGraphQLField(() => MembershipOrderByEnum, { nullable: true })
+  orderBy?: MembershipOrderByEnum[];
 }
 
 @ArgsType()
-export class DataObjectCreateManyArgs {
-  @TypeGraphQLField(() => [DataObjectCreateInput])
-  data!: DataObjectCreateInput[];
+export class MembershipCreateManyArgs {
+  @TypeGraphQLField(() => [MembershipCreateInput])
+  data!: MembershipCreateInput[];
 }
 
 @ArgsType()
-export class DataObjectUpdateArgs {
-  @TypeGraphQLField() data!: DataObjectUpdateInput;
-  @TypeGraphQLField() where!: DataObjectWhereUniqueInput;
-}
-
-export enum WorkerOrderByEnum {
-  createdAt_ASC = "createdAt_ASC",
-  createdAt_DESC = "createdAt_DESC",
-
-  updatedAt_ASC = "updatedAt_ASC",
-  updatedAt_DESC = "updatedAt_DESC",
-
-  deletedAt_ASC = "deletedAt_ASC",
-  deletedAt_DESC = "deletedAt_DESC",
-
-  isActive_ASC = "isActive_ASC",
-  isActive_DESC = "isActive_DESC",
-
-  workerId_ASC = "workerId_ASC",
-  workerId_DESC = "workerId_DESC",
-
-  type_ASC = "type_ASC",
-  type_DESC = "type_DESC",
-
-  metadata_ASC = "metadata_ASC",
-  metadata_DESC = "metadata_DESC"
-}
-
-registerEnumType(WorkerOrderByEnum, {
-  name: "WorkerOrderByInput"
-});
-
-@TypeGraphQLInputType()
-export class WorkerWhereInput {
-  @TypeGraphQLField(() => ID, { nullable: true })
-  id_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  id_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  createdAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  createdById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  createdById_in?: string[];
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  updatedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  updatedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  updatedById_in?: string[];
-
-  @TypeGraphQLField({ nullable: true })
-  deletedAt_all?: Boolean;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_eq?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_lte?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gt?: Date;
-
-  @TypeGraphQLField(() => DateTime, { nullable: true })
-  deletedAt_gte?: Date;
-
-  @TypeGraphQLField(() => ID, { nullable: true })
-  deletedById_eq?: string;
-
-  @TypeGraphQLField(() => [ID], { nullable: true })
-  deletedById_in?: string[];
-
-  @TypeGraphQLField(() => Boolean, { nullable: true })
-  isActive_eq?: Boolean;
-
-  @TypeGraphQLField(() => [Boolean], { nullable: true })
-  isActive_in?: Boolean[];
-
-  @TypeGraphQLField({ nullable: true })
-  workerId_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  workerId_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  workerId_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  workerId_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  workerId_in?: string[];
-
-  @TypeGraphQLField(() => WorkerType, { nullable: true })
-  type_eq?: WorkerType;
-
-  @TypeGraphQLField(() => [WorkerType], { nullable: true })
-  type_in?: WorkerType[];
-
-  @TypeGraphQLField({ nullable: true })
-  metadata_eq?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  metadata_contains?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  metadata_startsWith?: string;
-
-  @TypeGraphQLField({ nullable: true })
-  metadata_endsWith?: string;
-
-  @TypeGraphQLField(() => [String], { nullable: true })
-  metadata_in?: string[];
-
-  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  dataObjects_none?: DataObjectWhereInput;
-
-  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  dataObjects_some?: DataObjectWhereInput;
-
-  @TypeGraphQLField(() => DataObjectWhereInput, { nullable: true })
-  dataObjects_every?: DataObjectWhereInput;
-
-  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
-  AND?: [WorkerWhereInput];
-
-  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
-  OR?: [WorkerWhereInput];
-}
-
-@TypeGraphQLInputType()
-export class WorkerWhereUniqueInput {
-  @TypeGraphQLField(() => ID)
-  id?: string;
-}
-
-@TypeGraphQLInputType()
-export class WorkerCreateInput {
-  @TypeGraphQLField()
-  isActive!: boolean;
-
-  @TypeGraphQLField()
-  workerId!: string;
-
-  @TypeGraphQLField(() => WorkerType)
-  type!: WorkerType;
-
-  @TypeGraphQLField({ nullable: true })
-  metadata?: string;
-}
-
-@TypeGraphQLInputType()
-export class WorkerUpdateInput {
-  @TypeGraphQLField({ nullable: true })
-  isActive?: boolean;
-
-  @TypeGraphQLField({ nullable: true })
-  workerId?: string;
-
-  @TypeGraphQLField(() => WorkerType, { nullable: true })
-  type?: WorkerType;
-
-  @TypeGraphQLField({ nullable: true })
-  metadata?: string;
-}
-
-@ArgsType()
-export class WorkerWhereArgs extends PaginationArgs {
-  @TypeGraphQLField(() => WorkerWhereInput, { nullable: true })
-  where?: WorkerWhereInput;
-
-  @TypeGraphQLField(() => WorkerOrderByEnum, { nullable: true })
-  orderBy?: WorkerOrderByEnum[];
-}
-
-@ArgsType()
-export class WorkerCreateManyArgs {
-  @TypeGraphQLField(() => [WorkerCreateInput])
-  data!: WorkerCreateInput[];
-}
-
-@ArgsType()
-export class WorkerUpdateArgs {
-  @TypeGraphQLField() data!: WorkerUpdateInput;
-  @TypeGraphQLField() where!: WorkerWhereUniqueInput;
+export class MembershipUpdateArgs {
+  @TypeGraphQLField() data!: MembershipUpdateInput;
+  @TypeGraphQLField() where!: MembershipWhereUniqueInput;
 }
 
 export enum NextEntityIdOrderByEnum {

--- a/query-node/generated/graphql-server/generated/schema.graphql
+++ b/query-node/generated/graphql-server/generated/schema.graphql
@@ -647,6 +647,11 @@ type Channel implements BaseGraphQLObject {
 
   """The description of a Channel"""
   description: String
+
+  """
+  Count of channel's videos with an uploaded asset that are public and not censored.
+  """
+  activeVideosCounter: Int!
   coverPhotoDataObject: DataObject
   coverPhotoDataObjectId: String
 
@@ -697,6 +702,11 @@ type ChannelCategory implements BaseGraphQLObject {
 
   """The name of the category"""
   name: String
+
+  """
+  Count of channel's videos with an uploaded asset that are public and not censored.
+  """
+  activeVideosCounter: Int!
   channels: [Channel!]!
   createdInBlock: Int!
 }
@@ -1637,6 +1647,11 @@ type VideoCategory implements BaseGraphQLObject {
 
   """The name of the category"""
   name: String
+
+  """
+  Count of channel's videos with an uploaded asset that are public and not censored.
+  """
+  activeVideosCounter: Int!
   videos: [Video!]!
   createdInBlock: Int!
 }

--- a/query-node/generated/graphql-server/generated/schema.graphql
+++ b/query-node/generated/graphql-server/generated/schema.graphql
@@ -719,6 +719,7 @@ type ChannelCategoryConnection {
 
 input ChannelCategoryCreateInput {
   name: String
+  activeVideosCounter: Float!
   createdInBlock: Float!
 }
 
@@ -736,12 +737,15 @@ enum ChannelCategoryOrderByInput {
   deletedAt_DESC
   name_ASC
   name_DESC
+  activeVideosCounter_ASC
+  activeVideosCounter_DESC
   createdInBlock_ASC
   createdInBlock_DESC
 }
 
 input ChannelCategoryUpdateInput {
   name: String
+  activeVideosCounter: Float
   createdInBlock: Float
 }
 
@@ -775,6 +779,12 @@ input ChannelCategoryWhereInput {
   name_startsWith: String
   name_endsWith: String
   name_in: [String!]
+  activeVideosCounter_eq: Int
+  activeVideosCounter_gt: Int
+  activeVideosCounter_gte: Int
+  activeVideosCounter_lt: Int
+  activeVideosCounter_lte: Int
+  activeVideosCounter_in: [Int!]
   createdInBlock_eq: Int
   createdInBlock_gt: Int
   createdInBlock_gte: Int
@@ -808,6 +818,7 @@ input ChannelCreateInput {
   rewardAccount: String
   title: String
   description: String
+  activeVideosCounter: Float!
   coverPhotoDataObject: ID
   coverPhotoDataObjectId: ID
   coverPhotoUrls: [String!]!
@@ -853,6 +864,8 @@ enum ChannelOrderByInput {
   title_DESC
   description_ASC
   description_DESC
+  activeVideosCounter_ASC
+  activeVideosCounter_DESC
   coverPhotoDataObject_ASC
   coverPhotoDataObject_DESC
   coverPhotoDataObjectId_ASC
@@ -887,6 +900,7 @@ input ChannelUpdateInput {
   rewardAccount: String
   title: String
   description: String
+  activeVideosCounter: Float
   coverPhotoDataObject: ID
   coverPhotoDataObjectId: ID
   coverPhotoUrls: [String!]
@@ -948,6 +962,12 @@ input ChannelWhereInput {
   description_startsWith: String
   description_endsWith: String
   description_in: [String!]
+  activeVideosCounter_eq: Int
+  activeVideosCounter_gt: Int
+  activeVideosCounter_gte: Int
+  activeVideosCounter_lt: Int
+  activeVideosCounter_lte: Int
+  activeVideosCounter_in: [Int!]
   coverPhotoDataObjectId_eq: ID
   coverPhotoDataObjectId_in: [ID!]
   coverPhotoUrls_containsAll: [String!]
@@ -1664,6 +1684,7 @@ type VideoCategoryConnection {
 
 input VideoCategoryCreateInput {
   name: String
+  activeVideosCounter: Float!
   createdInBlock: Float!
 }
 
@@ -1681,12 +1702,15 @@ enum VideoCategoryOrderByInput {
   deletedAt_DESC
   name_ASC
   name_DESC
+  activeVideosCounter_ASC
+  activeVideosCounter_DESC
   createdInBlock_ASC
   createdInBlock_DESC
 }
 
 input VideoCategoryUpdateInput {
   name: String
+  activeVideosCounter: Float
   createdInBlock: Float
 }
 
@@ -1720,6 +1744,12 @@ input VideoCategoryWhereInput {
   name_startsWith: String
   name_endsWith: String
   name_in: [String!]
+  activeVideosCounter_eq: Int
+  activeVideosCounter_gt: Int
+  activeVideosCounter_gte: Int
+  activeVideosCounter_lt: Int
+  activeVideosCounter_lte: Int
+  activeVideosCounter_in: [Int!]
   createdInBlock_eq: Int
   createdInBlock_gt: Int
   createdInBlock_gte: Int

--- a/query-node/generated/graphql-server/src/modules/channel-category/channel-category.model.ts
+++ b/query-node/generated/graphql-server/src/modules/channel-category/channel-category.model.ts
@@ -10,6 +10,11 @@ export class ChannelCategory extends BaseModel {
   })
   name?: string;
 
+  @IntField({
+    description: `Count of channel's videos with an uploaded asset that are public and not censored.`,
+  })
+  activeVideosCounter!: number;
+
   @OneToMany(() => Channel, (param: Channel) => param.category, {
     modelName: 'ChannelCategory',
     relModelName: 'Channel',

--- a/query-node/generated/graphql-server/src/modules/channel/channel.model.ts
+++ b/query-node/generated/graphql-server/src/modules/channel/channel.model.ts
@@ -70,6 +70,11 @@ export class Channel extends BaseModel {
   })
   description?: string;
 
+  @IntField({
+    description: `Count of channel's videos with an uploaded asset that are public and not censored.`,
+  })
+  activeVideosCounter!: number;
+
   @ManyToOne(() => DataObject, (param: DataObject) => param.channelcoverPhotoDataObject, {
     skipGraphQLField: true,
     nullable: true,

--- a/query-node/generated/graphql-server/src/modules/video-category/video-category.model.ts
+++ b/query-node/generated/graphql-server/src/modules/video-category/video-category.model.ts
@@ -10,6 +10,11 @@ export class VideoCategory extends BaseModel {
   })
   name?: string;
 
+  @IntField({
+    description: `Count of channel's videos with an uploaded asset that are public and not censored.`,
+  })
+  activeVideosCounter!: number;
+
   @OneToMany(() => Video, (param: Video) => param.category, {
     cascade: ["insert", "update"],
     modelName: 'VideoCategory',

--- a/query-node/mappings/src/common.ts
+++ b/query-node/mappings/src/common.ts
@@ -197,6 +197,28 @@ export async function updateVideoActiveCounters(
   await Promise.all(promises)
 }
 
+export async function updateChannelCategoryVideoActiveCounter(
+  store: DatabaseManager,
+  originalCategory: ChannelCategory | undefined,
+  newCategory: ChannelCategory | undefined,
+  videosCount: number
+) {
+  // escape if no counter change needed
+  if (!videosCount || originalCategory === newCategory) {
+    return
+  }
+
+  if (originalCategory) {
+    originalCategory.activeVideosCounter -= videosCount
+    await store.save<ChannelCategory>(originalCategory)
+  }
+
+  if (newCategory) {
+    newCategory.activeVideosCounter += videosCount
+    await store.save<ChannelCategory>(newCategory)
+  }
+}
+
 /// ///////////////// Sudo extrinsic calls ///////////////////////////////////////
 
 // soft-peg interface for typegen-generated `*Call` types

--- a/query-node/mappings/src/content/channel.ts
+++ b/query-node/mappings/src/content/channel.ts
@@ -39,6 +39,7 @@ export async function content_ChannelCreated(db: DatabaseManager, event: Substra
     isCensored: false,
     videos: [],
     createdInBlock: event.blockNumber,
+    activeVideosCounter: 0,
 
     // default values for properties that might or might not be filled by metadata
     coverPhotoUrls: [],
@@ -185,6 +186,7 @@ export async function content_ChannelCategoryCreated(db: DatabaseManager, event:
     id: channelCategoryId.toString(),
     channels: [],
     createdInBlock: event.blockNumber,
+    activeVideosCounter: 0,
 
     // fill in auto-generated fields
     createdAt: new Date(fixBlockTimestamp(event.blockTimestamp).toNumber()),

--- a/query-node/mappings/src/content/video.ts
+++ b/query-node/mappings/src/content/video.ts
@@ -139,7 +139,9 @@ export async function content_VideoCreated(db: DatabaseManager, event: Substrate
   })
 
   // load channel
-  const channel = await db.get(Channel, { where: { id: channelId.toString() } as FindConditions<Channel> })
+  const channel = await db.get(Channel, {
+    where: { id: channelId.toString(), relations: ['category'] } as FindConditions<Channel>,
+  })
 
   // ensure channel exists
   if (!channel) {

--- a/query-node/run-tests.sh
+++ b/query-node/run-tests.sh
@@ -18,7 +18,7 @@ function cleanup() {
     docker-compose down -v
 }
 
-#trap cleanup EXIT
+trap cleanup EXIT
 
 # Bring up db
 docker-compose up -d db

--- a/query-node/run-tests.sh
+++ b/query-node/run-tests.sh
@@ -18,7 +18,7 @@ function cleanup() {
     docker-compose down -v
 }
 
-trap cleanup EXIT
+#trap cleanup EXIT
 
 # Bring up db
 docker-compose up -d db

--- a/query-node/schema.graphql
+++ b/query-node/schema.graphql
@@ -49,6 +49,9 @@ type ChannelCategory @entity {
   "The name of the category"
   name: String @fulltext(query: "channelCategoriesByName")
 
+  "Count of channel's videos with an uploaded asset that are public and not censored."
+  activeVideosCounter: Int!
+
   channels: [Channel!]! @derivedFrom(field: "category")
 
   createdInBlock: Int!
@@ -185,6 +188,9 @@ type Channel @entity {
   "The description of a Channel"
   description: String
 
+  "Count of channel's videos with an uploaded asset that are public and not censored."
+  activeVideosCounter: Int!
+
   ### Cover photo asset ###
 
   # Channel's cover (background) photo. Recommended ratio: 16:9.
@@ -246,6 +252,9 @@ type VideoCategory @entity {
 
   "The name of the category"
   name: String @fulltext(query: "videoCategoriesByName")
+
+  "Count of channel's videos with an uploaded asset that are public and not censored."
+  activeVideosCounter: Int!
 
   videos: [Video!]! @derivedFrom(field: "category")
 

--- a/tests/network-tests/.gitignore
+++ b/tests/network-tests/.gitignore
@@ -1,3 +1,4 @@
 output.json
 src/__CliApi_tempfile.json
 src/__CliApi_tempfile__rejectedContent.json
+src/__CliApi_appdata

--- a/tests/network-tests/.gitignore
+++ b/tests/network-tests/.gitignore
@@ -1,2 +1,3 @@
 output.json
-
+src/__CliApi_tempfile.json
+src/__CliApi_tempfile__rejectedContent.json

--- a/tests/network-tests/src/CliApi.ts
+++ b/tests/network-tests/src/CliApi.ts
@@ -32,6 +32,7 @@ export class CliApi {
       env: {
         ...env,
         PATH: process.env.PATH,
+        APPDATA: path.join(__dirname, '/__CliApi_appdata/')
       },
     })
     console.log('cli - output:', output)
@@ -68,6 +69,14 @@ export class CliApi {
   */
   private containsNoStorageWarning(text: string): boolean {
     return !!text.match(/^\s*\S\s*Warning: No storage provider is currently available!/)
+  }
+
+  async setApiUri(uri = 'ws://localhost:9944') {
+    const { stderr } = this.runCommand(['api:setUri', uri])
+
+    if (stderr) {
+      throw new Error(`Unexpected CLI failure on setting API URI: "${stderr}"`)
+    }
   }
 
   /**

--- a/tests/network-tests/src/CliApi.ts
+++ b/tests/network-tests/src/CliApi.ts
@@ -1,0 +1,203 @@
+import * as path from 'path'
+import { spawnSync } from 'child_process'
+import * as fs from 'fs'
+import { KeyringPair } from '@polkadot/keyring/types'
+
+export interface ICreatedVideoData {
+  videoId: number
+  assetContentIds: string[]
+}
+
+/**
+  Adapter for calling CLI commands from integration tests.
+*/
+export class CliApi {
+  private tmpFilePath: string // filepath for temporary file needed to transfer data from and to cli
+  readonly cliExamplesFolderPath: string
+
+  public constructor() {
+    this.tmpFilePath = path.join(__dirname, '/__CliApi_tempfile.json')
+    this.cliExamplesFolderPath = path.dirname(require.resolve('@joystream/cli/package.json')) + '/examples/content'
+  }
+
+  /**
+    Runs CLI command with specified arguments.
+  */
+  private runCommand(
+    parameters: string[],
+    env: Record<string, string> = {}
+  ): { error: boolean; stdout: string; stderr: string } {
+    // use sync spawn if that works without issues
+    const output = spawnSync('yarn', ['joystream-cli', ...parameters], { env })
+
+    return {
+      error: !!output.error,
+      stdout: (output.stdout || '').toString(),
+      stderr: (output.stderr || '').toString(),
+    }
+  }
+
+  /**
+    Saves data to temporary file that can be passed to CLI as data input.
+  */
+  private saveToTempFile(content: string) {
+    try {
+      fs.writeFileSync(this.tmpFilePath, content + '\n')
+    } catch (e) {
+      throw new Error(`Can't write to temporary file "${this.tmpFilePath}"`)
+    }
+  }
+
+  /**
+    Parses `id` of newly created content entity from CLI's stdout.
+  */
+  private parseCreatedIdFromStdout(stdout: string): number {
+    return parseInt((stdout.match(/with id (\d+) successfully created/) as RegExpMatchArray)[1])
+  }
+
+  /**
+    Checks if CLI's stderr contains warning about no storage provider available.
+  */
+  private containsNoStorageWarning(text: string): boolean {
+    return !!text.match(/^\s*\S\s*Warning: No storage provider is currently available!/)
+  }
+
+  /**
+    Imports an account from Polkadot's keyring keypair to CLI.
+  */
+  async importAccount(keyringPair: KeyringPair, password = ''): Promise<void> {
+    const importableAccount = JSON.stringify(keyringPair.toJson(password))
+    this.saveToTempFile(importableAccount)
+
+    const { stderr } = this.runCommand(['account:import', this.tmpFilePath])
+
+    if (stderr) {
+      throw new Error(`Unexpected CLI failure on importing account: "${stderr}"`)
+    }
+  }
+
+  /**
+    Selects an account that will be used by CLI for further commands.
+  */
+  async chooseAccount(accountAddress: string) {
+    const { stderr } = this.runCommand(['account:choose', '--address', accountAddress])
+
+    if (stderr) {
+      throw new Error(`Unexpected CLI failure on choosing account: "${stderr}"`)
+    }
+  }
+
+  /**
+    Creates a new channel.
+  */
+  async createChannel(channel: unknown): Promise<number> {
+    this.saveToTempFile(JSON.stringify(channel))
+
+    const { stdout, stderr } = this.runCommand(
+      ['content:createChannel', '--input', this.tmpFilePath, '--context', 'Member'],
+      { AUTO_CONFIRM: 'true' }
+    )
+
+    if (stderr && !this.containsNoStorageWarning(stderr)) {
+      // ignore warnings
+      throw new Error(`Unexpected CLI failure on creating channel: "${stderr}"`)
+    }
+
+    return this.parseCreatedIdFromStdout(stdout)
+  }
+
+  /**
+    Creates a new channel category.
+  */
+  async createChannelCategory(channelCategory: unknown): Promise<number> {
+    this.saveToTempFile(JSON.stringify(channelCategory))
+
+    const { stdout, stderr } = this.runCommand(
+      ['content:createChannelCategory', '--input', this.tmpFilePath, '--context', 'Lead'],
+      { AUTO_CONFIRM: 'true' }
+    )
+
+    if (stderr) {
+      throw new Error(`Unexpected CLI failure on creating channel category: "${stderr}"`)
+    }
+
+    return this.parseCreatedIdFromStdout(stdout)
+  }
+
+  /**
+    Creates a new video.
+  */
+  async createVideo(channelId: number, video: unknown): Promise<ICreatedVideoData> {
+    this.saveToTempFile(JSON.stringify(video))
+
+    const { stdout, stderr } = this.runCommand(
+      ['content:createVideo', '--input', this.tmpFilePath, '--channelId', channelId.toString()],
+      { AUTO_CONFIRM: 'true' }
+    )
+
+    if (stderr && !this.containsNoStorageWarning(stderr)) {
+      // ignore warnings
+      throw new Error(`Unexpected CLI failure on creating channel category: "${stderr}"`)
+    }
+
+    const videoId = this.parseCreatedIdFromStdout(stdout)
+    const assetContentIds = Array.from(stdout.matchAll(/ content_id: "(0x[a-z0-9]+)"/g)).map((item) => item[1])
+
+    return {
+      videoId,
+      assetContentIds,
+    }
+  }
+
+  /**
+    Creates a new video category.
+  */
+  async createVideoCategory(videoCategory: unknown): Promise<number> {
+    this.saveToTempFile(JSON.stringify(videoCategory))
+
+    const { stdout, stderr } = this.runCommand(
+      ['content:createVideoCategory', '--input', this.tmpFilePath, '--context', 'Lead'],
+      { AUTO_CONFIRM: 'true' }
+    )
+
+    if (stderr) {
+      throw new Error(`Unexpected CLI failure on creating video category: "${stderr}"`)
+    }
+
+    return this.parseCreatedIdFromStdout(stdout)
+  }
+
+  /**
+    Updates an existing video.
+  */
+  async updateVideo(videoId: number, video: unknown): Promise<void> {
+    this.saveToTempFile(JSON.stringify(video))
+
+    const { stdout, stderr } = this.runCommand(
+      ['content:updateVideo', '--input', this.tmpFilePath, videoId.toString()],
+      { AUTO_CONFIRM: 'true' }
+    )
+
+    if (stderr && !this.containsNoStorageWarning(stderr)) {
+      // ignore warnings
+      throw new Error(`Unexpected CLI failure on creating video category: "${stderr}"`)
+    }
+  }
+
+  /**
+    Updates a channel.
+  */
+  async updateChannel(channelId: number, channel: unknown): Promise<void> {
+    this.saveToTempFile(JSON.stringify(channel))
+
+    const { stdout, stderr } = this.runCommand(
+      ['content:updateChannel', '--input', this.tmpFilePath, channelId.toString()],
+      { AUTO_CONFIRM: 'true' }
+    )
+
+    if (stderr && !this.containsNoStorageWarning(stderr)) {
+      // ignore warnings
+      throw new Error(`Unexpected CLI failure on creating video category: "${stderr}"`)
+    }
+  }
+}

--- a/tests/network-tests/src/CliApi.ts
+++ b/tests/network-tests/src/CliApi.ts
@@ -7,7 +7,7 @@ export interface ICreatedVideoData {
   videoId: number
   assetContentIds: string[]
 }
-
+Buffer
 /**
   Adapter for calling CLI commands from integration tests.
 */
@@ -29,6 +29,9 @@ export class CliApi {
   ): { error: boolean; stdout: string; stderr: string } {
     // use sync spawn if that works without issues
     const output = spawnSync('yarn', ['joystream-cli', ...parameters], { env })
+    console.log('cli - output:', output)
+    console.log('cli - stdout:', output.stdout.toString())
+    console.log('cli - stderr:', output.stderr.toString())
 
     return {
       error: !!output.error,

--- a/tests/network-tests/src/CliApi.ts
+++ b/tests/network-tests/src/CliApi.ts
@@ -28,7 +28,12 @@ export class CliApi {
     env: Record<string, string> = {}
   ): { error: boolean; stdout: string; stderr: string } {
     // use sync spawn if that works without issues
-    const output = spawnSync('yarn', ['joystream-cli', ...parameters], { env })
+    const output = spawnSync('yarn', ['joystream-cli', ...parameters], {
+      env: {
+        ...env,
+        PATH: process.env.PATH,
+      },
+    })
     console.log('cli - output:', output)
     console.log('cli - stdout:', output.stdout.toString())
     console.log('cli - stderr:', output.stderr.toString())

--- a/tests/network-tests/src/CliApi.ts
+++ b/tests/network-tests/src/CliApi.ts
@@ -32,7 +32,7 @@ export class CliApi {
       env: {
         ...env,
         PATH: process.env.PATH,
-        APPDATA: path.join(__dirname, '/__CliApi_appdata/')
+        APPDATA: path.join(__dirname, '/__CliApi_appdata/'),
       },
     })
     console.log('cli - output:', output)

--- a/tests/network-tests/src/CliApi.ts
+++ b/tests/network-tests/src/CliApi.ts
@@ -7,7 +7,7 @@ export interface ICreatedVideoData {
   videoId: number
   assetContentIds: string[]
 }
-Buffer
+
 /**
   Adapter for calling CLI commands from integration tests.
 */

--- a/tests/network-tests/src/Fixture.ts
+++ b/tests/network-tests/src/Fixture.ts
@@ -2,6 +2,8 @@ import { Api } from './Api'
 import { assert } from 'chai'
 import { ISubmittableResult } from '@polkadot/types/types/'
 import { DispatchResult } from '@polkadot/types/interfaces/system'
+import { QueryNodeApi } from './QueryNodeApi'
+import { CliApi } from './CliApi'
 
 export abstract class BaseFixture {
   protected readonly api: Api
@@ -80,6 +82,17 @@ export abstract class BaseFixture {
     }
 
     return result
+  }
+}
+
+export abstract class BaseQueryNodeFixture extends BaseFixture {
+  protected readonly query: QueryNodeApi
+  protected readonly cli: CliApi
+
+  constructor(api: Api, query: QueryNodeApi, cli: CliApi) {
+    super(api)
+    this.query = query
+    this.cli = cli
   }
 }
 

--- a/tests/network-tests/src/Flow.ts
+++ b/tests/network-tests/src/Flow.ts
@@ -1,6 +1,13 @@
 import { Api } from './Api'
 import { QueryNodeApi } from './QueryNodeApi'
 import { ResourceLocker } from './Resources'
+import { CliApi } from './CliApi'
 
-export type FlowProps = { api: Api; env: NodeJS.ProcessEnv; query: QueryNodeApi; lock: ResourceLocker }
+export type FlowProps = {
+  api: Api
+  env: NodeJS.ProcessEnv
+  query: QueryNodeApi
+  cli: CliApi
+  lock: ResourceLocker
+}
 export type Flow = (args: FlowProps) => Promise<void>

--- a/tests/network-tests/src/Job.ts
+++ b/tests/network-tests/src/Job.ts
@@ -5,8 +5,14 @@ import { QueryNodeApi } from './QueryNodeApi'
 import { Flow } from './Flow'
 import { InvertedPromise } from './InvertedPromise'
 import { ResourceManager } from './Resources'
+import { CliApi } from './CliApi'
 
-export type JobProps = { apiFactory: ApiFactory; env: NodeJS.ProcessEnv; query: QueryNodeApi }
+export type JobProps = {
+  apiFactory: ApiFactory
+  env: NodeJS.ProcessEnv
+  query: QueryNodeApi
+  cli: CliApi
+}
 
 export enum JobOutcome {
   Succeeded = 'Succeeded',
@@ -100,6 +106,7 @@ export class Job {
             api: jobProps.apiFactory.getApi(`${this.label}:${flow.name}-${index}`),
             env: jobProps.env,
             query: jobProps.query,
+            cli: jobProps.cli,
             lock: locker.lock,
           })
         } catch (err) {

--- a/tests/network-tests/src/JobManager.ts
+++ b/tests/network-tests/src/JobManager.ts
@@ -4,18 +4,31 @@ import { Job, JobOutcome, JobProps } from './Job'
 import { ApiFactory } from './Api'
 import { QueryNodeApi } from './QueryNodeApi'
 import { ResourceManager } from './Resources'
+import { CliApi } from './CliApi'
 
 export class JobManager extends EventEmitter {
   private _jobs: Job[] = []
   private readonly _apiFactory: ApiFactory
   private readonly _env: NodeJS.ProcessEnv
   private readonly _query: QueryNodeApi
+  private readonly _cli: CliApi
 
-  constructor({ apiFactory, env, query }: { apiFactory: ApiFactory; env: NodeJS.ProcessEnv; query: QueryNodeApi }) {
+  constructor({
+    apiFactory,
+    env,
+    query,
+    cli,
+  }: {
+    apiFactory: ApiFactory
+    env: NodeJS.ProcessEnv
+    query: QueryNodeApi
+    cli: CliApi
+  }) {
     super()
     this._apiFactory = apiFactory
     this._env = env
     this._query = query
+    this._cli = cli
   }
 
   public createJob(label: string, flows: Flow[] | Flow): Job {
@@ -32,6 +45,7 @@ export class JobManager extends EventEmitter {
       env: this._env,
       query: this._query,
       apiFactory: this._apiFactory,
+      cli: this._cli,
     }
   }
 

--- a/tests/network-tests/src/Scenario.ts
+++ b/tests/network-tests/src/Scenario.ts
@@ -10,6 +10,7 @@ import { JobManager } from './JobManager'
 import { ResourceManager } from './Resources'
 import fetch from 'cross-fetch'
 import fs from 'fs'
+import { CliApi } from './CliApi'
 
 export type ScenarioProps = {
   env: NodeJS.ProcessEnv
@@ -42,7 +43,6 @@ export async function scenario(scene: (props: ScenarioProps) => Promise<void>): 
   }
 
   const queryNodeUrl: string = env.QUERY_NODE_URL || 'http://127.0.0.1:8081/graphql'
-
   const queryNodeProvider = new ApolloClient({
     link: new HttpLink({ uri: queryNodeUrl, fetch }),
     cache: new InMemoryCache(),
@@ -51,9 +51,11 @@ export async function scenario(scene: (props: ScenarioProps) => Promise<void>): 
 
   const query = new QueryNodeApi(queryNodeProvider)
 
+  const cli = new CliApi()
+
   const debug = extendDebug('scenario')
 
-  const jobs = new JobManager({ apiFactory, query, env })
+  const jobs = new JobManager({ apiFactory, query, env, cli })
 
   await scene({ env, debug, job: jobs.createJob.bind(jobs) })
 

--- a/tests/network-tests/src/consts.ts
+++ b/tests/network-tests/src/consts.ts
@@ -1,0 +1,2 @@
+// Test chain blocktime
+export const BLOCKTIME = 1000

--- a/tests/network-tests/src/fixtures/content/activeVideoCounters.ts
+++ b/tests/network-tests/src/fixtures/content/activeVideoCounters.ts
@@ -1,0 +1,331 @@
+import { assert } from 'chai'
+import { ApolloQueryResult } from '@apollo/client'
+import { Api, WorkingGroups } from '../../Api'
+import { BaseQueryNodeFixture, FixtureRunner } from '../../Fixture'
+import { BuyMembershipHappyCaseFixture } from '../membershipModule'
+import { KeyringPair } from '@polkadot/keyring/types'
+import { Bytes } from '@polkadot/types'
+import { QueryNodeApi } from '../../QueryNodeApi'
+import { CliApi, ICreatedVideoData } from '../../CliApi'
+import { PaidTermId, MemberId } from '@joystream/types/members'
+import { Debugger, extendDebug } from '../../Debugger'
+import BN from 'bn.js'
+import { addWorkerToGroup } from './addWorkerToGroup'
+import { Worker, WorkerId } from '@joystream/types/working-group'
+import {
+  getMemberDefaults,
+  getChannelCategoryDefaults,
+  getChannelDefaults,
+  getVideoDefaults,
+  getVideoCategoryDefaults,
+} from './contentTemplates'
+
+interface IMember {
+  keyringPair: KeyringPair
+  account: string
+  memberId: MemberId
+}
+
+// QN connection paramaters
+const qnConnection = {
+  numberOfRepeats: 20, // QN can take some time to catch up with node - repeat until then
+  repeatDelay: 3000, // delay between failed QN requests
+}
+
+// settings
+const contentDirectoryWorkingGroupId = 1 // TODO: retrieve group id programmatically
+const sufficientTopupAmount = new BN(1000000) // some very big number to cover fees of all transactions
+
+/**
+  Fixture that test Joystream content can be created, is reflected in query node,
+  and channel and categories counts their active videos properly.
+*/
+export class ActiveVideoCountersFixture extends BaseQueryNodeFixture {
+  private paidTerms: PaidTermId
+  private debug: Debugger.Debugger
+  private env: NodeJS.ProcessEnv
+
+  constructor(api: Api, query: QueryNodeApi, cli: CliApi, env: NodeJS.ProcessEnv, paidTerms: PaidTermId) {
+    super(api, query, cli)
+    this.paidTerms = paidTerms
+    this.env = env
+    this.debug = extendDebug('fixture:ActiveVideoCountersFixture')
+  }
+
+  // this could be used by other modules in some shared fixture or whatnot; membership creation is common to many flows
+  private async createMembers(numberOfMembers: number): Promise<IMember[]> {
+    const keyringPairs = (await this.api.createKeyPairs(numberOfMembers)).map((kp) => kp.key)
+    const accounts = keyringPairs.map((item) => item.address)
+    const buyMembershipsFixture = new BuyMembershipHappyCaseFixture(this.api, accounts, this.paidTerms)
+
+    await new FixtureRunner(buyMembershipsFixture).run()
+
+    const memberIds = buyMembershipsFixture.getCreatedMembers()
+
+    return keyringPairs.map((item, index) => ({
+      keyringPair: item,
+      account: accounts[index],
+      memberId: memberIds[index],
+    }))
+  }
+
+  /*
+    Topup a bunch of accounts by specified amount.
+  */
+  private async topupAddresses(accounts: string[], amount: BN) {
+    await this.api.treasuryTransferBalanceToAccounts(accounts, amount)
+  }
+
+  /*
+    Execute this Fixture.
+  */
+  public async execute(): Promise<void> {
+    const videoCount = 2
+    const videoCategoryCount = 2
+    const channelCount = 2
+    const channelCategoryCount = 2
+
+    // prepare accounts for group leads, storage worker, and content author
+
+    this.debug('Loading working group leaders')
+    const { contentLeader, storageLeader } = await this.retrieveWorkingGroupLeaders()
+
+    // prepare memberships
+    this.debug('Creating members')
+    const members = await this.createMembers(1)
+
+    const authorMemberIndex = 0
+    const author = members[authorMemberIndex]
+    author.keyringPair.setMeta({
+      ...author.keyringPair.meta,
+      ...getMemberDefaults(authorMemberIndex),
+    })
+    const storageGroupWorker = author
+
+    this.debug('Top-uping accounts')
+    await this.topupAddresses(
+      [
+        ...members.map((item) => item.keyringPair.address),
+        contentLeader.role_account_id.toString(),
+        storageLeader.role_account_id.toString(),
+      ],
+      sufficientTopupAmount
+    )
+
+    // switch to lead and create category structure as lead
+
+    this.debug(`Choosing content working group lead's account`)
+    // this expects lead account to be already imported into CLI
+    await this.cli.chooseAccount(contentLeader.role_account_id.toString())
+
+    this.debug('Creating channel categories')
+    const channelCategoryIds = await this.createChannelCategories(channelCategoryCount)
+
+    this.debug('Creating video categories')
+    const videoCategoryIds = await this.createVideoCategories(videoCategoryCount)
+
+    // switch to authors account
+
+    this.debug(`Importing author's account`)
+    await this.cli.importAccount(author.keyringPair)
+    await this.cli.chooseAccount(author.keyringPair.address)
+
+    // create content entities
+
+    this.debug('Creating channels')
+    const channelIds = await this.createChannels(channelCount, channelCategoryIds[0], author.account)
+
+    this.debug('Creating videos')
+    const videosData = await this.createVideos(videoCount, channelIds[0], videoCategoryIds[0])
+
+    // add `storageGroupWorker` to storage group and accept all storage content
+
+    this.debug('Adding worker to content directory group')
+    const workerId = await addWorkerToGroup(
+      this.api,
+      this.env,
+      WorkingGroups.StorageWorkingGroup,
+      storageGroupWorker.keyringPair.address
+    )
+
+    this.debug('Accepting content')
+    const allAssetIds = videosData.map((item) => item.assetContentIds).flat()
+    await Promise.all(
+      allAssetIds.map(async (contentIdHex) => {
+        const contentId = this.api.unpackContentId(contentIdHex)
+        await this.api.acceptContent(storageGroupWorker.keyringPair.address, workerId.toNumber(), contentId)
+      })
+    )
+
+    // check channel and categories con are counted as active
+
+    this.debug('Checking channels active video counters')
+    await this.assertCounterMatch('channels', channelIds[0], videoCount)
+
+    this.debug('Checking channel categories active video counters')
+    await this.assertCounterMatch('channelCategories', channelCategoryIds[0], videoCount)
+
+    this.debug('Checking video categories active video counters')
+    await this.assertCounterMatch('videoCategories', videoCategoryIds[0], videoCount)
+
+    // move channel to different channel category and video to different videoCategory
+
+    const oneMovedVideoCount = 1
+    this.debug('Move channel to different channel category')
+    await this.cli.updateChannel(channelIds[0], {
+      category: channelCategoryIds[1], // move from category 1 to category 2
+    })
+
+    this.debug('Move video to different video category')
+    await this.cli.updateVideo(videosData[0].videoId, {
+      category: videoCategoryIds[1], // move from category 1 to category 2
+    })
+
+    // check counters of channel category and video category with newly moved in video/channel
+
+    this.debug('Checking channel categories active video counters (2)')
+    await this.assertCounterMatch('channelCategories', channelCategoryIds[1], videoCount)
+
+    this.debug('Checking video categories active video counters (2)')
+    await this.assertCounterMatch('videoCategories', videoCategoryIds[1], oneMovedVideoCount)
+
+    /** Sumer doesn't support changing channels - uncoment this on later releases where it's supported
+
+    // move one video to another channel
+
+    this.debug('Move video to different channel')
+    await this.cli.updateVideo(videosData[0].videoId, {
+      channel: channelIds[1], // move from channel 1 to channel 2
+    })
+
+    // check counter of channel with newly moved video
+
+    this.debug('Checking channels active video counters (2)')
+    await this.assertCounterMatch('channels', channelIds[0], videoCount - oneMovedVideoCount)
+    await this.assertCounterMatch('channels', channelIds[1], oneMovedVideoCount)
+
+    // end
+    */
+
+    this.debug('Done')
+  }
+
+  /**
+    Asserts a channel, or a video/channel categories have their active videos counter set properly
+    in Query node.
+  */
+  private async assertCounterMatch(
+    entityName: 'channels' | 'channelCategories' | 'videoCategories',
+    entityId: number,
+    expectedCount: number
+  ) {
+    const qnConnectionNumberOfRepeats = 10
+
+    const getterName = `get${entityName[0].toUpperCase()}${entityName.slice(1)}`
+    await this.query.tryQueryWithTimeout(
+      () => (this.query as any)[getterName](),
+      (tmpEntity) => {
+        const entities = (tmpEntity as any).data[entityName]
+        assert(entities.length > 0) // some entities were loaded
+
+        const entity = entities.find((item: any) => item.id === entityId.toString())
+
+        // all videos created in this fixture should be active and belong to first entity
+        assert(entity.activeVideosCounter === expectedCount)
+      },
+      qnConnection.repeatDelay,
+      qnConnection.numberOfRepeats
+    )
+  }
+
+  /**
+    Retrieves information about accounts of group leads for content and storage working groups.
+  */
+  private async retrieveWorkingGroupLeaders(): Promise<{ contentLeader: Worker; storageLeader: Worker }> {
+    const contentLeader = await this.api.getGroupLead(WorkingGroups.ContentDirectoryWorkingGroup)
+    if (!contentLeader) {
+      throw new Error('Working group leader is missing!')
+    }
+
+    const storageLeader = await this.api.getGroupLead(WorkingGroups.StorageWorkingGroup)
+    if (!storageLeader) {
+      throw new Error('Working group leader is missing!')
+    }
+
+    return {
+      contentLeader,
+      storageLeader,
+    }
+  }
+
+  /**
+    Creates a new video.
+
+    Note: Assets have to be accepted later on for videos to be counted as active.
+  */
+  private async createVideos(count: number, channelId: number, videoCategoryId: number): Promise<ICreatedVideoData[]> {
+    const createVideo = async (index: number) => {
+      return await this.cli.createVideo(channelId, {
+        ...getVideoDefaults(index, this.cli.cliExamplesFolderPath),
+        category: videoCategoryId,
+      })
+    }
+    const newVideosData = (await this.createCommonEntities(count, createVideo)) as ICreatedVideoData[]
+
+    return newVideosData
+  }
+
+  /**
+    Creates a new video category. Can only be executed as content group leader.
+  */
+  private async createVideoCategories(count: number): Promise<number[]> {
+    const createdIds = (await this.createCommonEntities(count, (index) =>
+      this.cli.createVideoCategory({
+        ...getVideoCategoryDefaults(index),
+      })
+    )) as number[]
+
+    return createdIds
+  }
+
+  /**
+    Creates a new channel.
+  */
+  private async createChannels(count: number, channelCategoryId: number, authorAddress: string): Promise<number[]> {
+    const createdIds = (await this.createCommonEntities(count, (index) =>
+      this.cli.createChannel({
+        ...getChannelDefaults(index, authorAddress),
+        category: channelCategoryId,
+      })
+    )) as number[]
+
+    return createdIds
+  }
+
+  /**
+    Creates a new channel category. Can only be executed as content group leader.
+  */
+  private async createChannelCategories(count: number): Promise<number[]> {
+    const createdIds = (await this.createCommonEntities(count, (index) =>
+      this.cli.createChannelCategory({
+        ...getChannelCategoryDefaults(index),
+      })
+    )) as number[]
+
+    return createdIds
+  }
+
+  /**
+    Creates a bunch of content entities.
+  */
+  private async createCommonEntities<T>(count: number, createPromise: (index: number) => Promise<T>): Promise<T[]> {
+    const createdIds = await Array.from(Array(count).keys()).reduce(async (accPromise, index: number) => {
+      const acc = await accPromise
+      const createdId = await createPromise(index)
+
+      return [...acc, createdId]
+    }, Promise.resolve([]) as Promise<T[]>)
+
+    return createdIds
+  }
+}

--- a/tests/network-tests/src/fixtures/content/addWorkerToGroup.ts
+++ b/tests/network-tests/src/fixtures/content/addWorkerToGroup.ts
@@ -11,6 +11,7 @@ import {
 import { FixtureRunner } from '../../Fixture'
 import { OpeningId } from '@joystream/types/hiring'
 import { Api, WorkingGroups } from '../../Api'
+
 import BN from 'bn.js'
 import { WorkerId } from '@joystream/types/working-group'
 

--- a/tests/network-tests/src/fixtures/content/addWorkerToGroup.ts
+++ b/tests/network-tests/src/fixtures/content/addWorkerToGroup.ts
@@ -1,0 +1,76 @@
+// this file could be used by more fixtures - adding worker to group is quite common
+
+import {
+  AddWorkerOpeningFixture,
+  ApplyForOpeningFixture,
+  BeginApplicationReviewFixture,
+  FillOpeningFixture,
+  IncreaseStakeFixture,
+  UpdateRewardAccountFixture,
+} from '../../fixtures/workingGroupModule'
+import { FixtureRunner } from '../../Fixture'
+import { OpeningId } from '@joystream/types/hiring'
+import { Api, WorkingGroups } from '../../Api'
+import BN from 'bn.js'
+import { WorkerId } from '@joystream/types/working-group'
+
+export async function addWorkerToGroup(
+  api: Api,
+  env: NodeJS.ProcessEnv,
+  group: WorkingGroups,
+  applicant: string
+): Promise<WorkerId> {
+  const applicationStake: BN = new BN(env.WORKING_GROUP_APPLICATION_STAKE!)
+  const roleStake: BN = new BN(env.WORKING_GROUP_ROLE_STAKE!)
+  const firstRewardInterval: BN = new BN(env.LONG_REWARD_INTERVAL!)
+  const rewardInterval: BN = new BN(env.LONG_REWARD_INTERVAL!)
+  const payoutAmount: BN = new BN(env.PAYOUT_AMOUNT!)
+  const unstakingPeriod: BN = new BN(env.STORAGE_WORKING_GROUP_UNSTAKING_PERIOD!)
+  const openingActivationDelay: BN = new BN(0)
+  const paidTerms = api.createPaidTermId(new BN(+env.MEMBERSHIP_PAID_TERMS!))
+
+  const addWorkerOpeningFixture = new AddWorkerOpeningFixture(
+    api,
+    applicationStake,
+    roleStake,
+    openingActivationDelay,
+    unstakingPeriod,
+    group
+  )
+  // Add worker opening
+  await new FixtureRunner(addWorkerOpeningFixture).run()
+
+  // First apply for worker opening
+  const applyForWorkerOpeningFixture = new ApplyForOpeningFixture(
+    api,
+    [applicant],
+    applicationStake,
+    roleStake,
+    addWorkerOpeningFixture.getCreatedOpeningId() as OpeningId,
+    group
+  )
+  await new FixtureRunner(applyForWorkerOpeningFixture).run()
+  const applicationIdToHire = applyForWorkerOpeningFixture.getApplicationIds()[0]
+
+  // Begin application review
+  const beginApplicationReviewFixture = new BeginApplicationReviewFixture(
+    api,
+    addWorkerOpeningFixture.getCreatedOpeningId() as OpeningId,
+    group
+  )
+  await new FixtureRunner(beginApplicationReviewFixture).run()
+
+  // Fill worker opening
+  const fillOpeningFixture = new FillOpeningFixture(
+    api,
+    [applicationIdToHire],
+    addWorkerOpeningFixture.getCreatedOpeningId() as OpeningId,
+    firstRewardInterval,
+    rewardInterval,
+    payoutAmount,
+    group
+  )
+  await new FixtureRunner(fillOpeningFixture).run()
+
+  return fillOpeningFixture.getWorkerIds()[0]
+}

--- a/tests/network-tests/src/fixtures/content/contentTemplates.ts
+++ b/tests/network-tests/src/fixtures/content/contentTemplates.ts
@@ -1,0 +1,48 @@
+// basic templates for content entities
+
+export function getMemberDefaults(index: number) {
+  return {
+    name: 'TestingActiveVideoCounters',
+  }
+}
+
+export function getVideoDefaults(index: number, cliExamplesFolderPath: string) {
+  return {
+    title: 'Active video counters Testing channel',
+    description: 'Video for testing active video counters.',
+    videoPath: cliExamplesFolderPath + '/video.mp4',
+    thumbnailPhotoPath: cliExamplesFolderPath + '/avatar-photo-1.png',
+    language: 'en',
+    hasMarketing: false,
+    isPublic: true,
+    isExplicit: false,
+    personsList: [],
+    // category: 1, - no category set by default
+    license: {
+      code: 1001,
+      attribution: 'by Joystream Contributors',
+    },
+  }
+}
+
+export function getVideoCategoryDefaults(index: number) {
+  return {
+    name: 'Active video counters Testing video category',
+  }
+}
+
+export function getChannelDefaults(index: number, rewardAccountAddress: string) {
+  return {
+    title: 'Active video counters Testing channel',
+    description: 'Channel for testing active video counters.',
+    isPublic: true,
+    language: 'en',
+    rewardAccount: rewardAccountAddress,
+  }
+}
+
+export function getChannelCategoryDefaults(index: number) {
+  return {
+    name: 'Active video counters Testing channel category',
+  }
+}

--- a/tests/network-tests/src/fixtures/content/index.ts
+++ b/tests/network-tests/src/fixtures/content/index.ts
@@ -1,0 +1,1 @@
+export * from './activeVideoCounters'

--- a/tests/network-tests/src/flows/content/activeVideoCounters.ts
+++ b/tests/network-tests/src/flows/content/activeVideoCounters.ts
@@ -1,0 +1,19 @@
+import { FlowProps } from '../../Flow'
+import { extendDebug } from '../../Debugger'
+import { FixtureRunner } from '../../Fixture'
+import { ActiveVideoCountersFixture } from '../../fixtures/content'
+import { PaidTermId } from '@joystream/types/members'
+import BN from 'bn.js'
+
+export default async function activeVideoCounters({ api, query, cli, env }: FlowProps): Promise<void> {
+  const debug = extendDebug('flow:active-video-counters')
+  debug('Started')
+  api.enableDebugTxLogs()
+
+  const paidTerms: PaidTermId = api.createPaidTermId(new BN(+env.MEMBERSHIP_PAID_TERMS!))
+
+  const electCouncilFixture = new ActiveVideoCountersFixture(api, query, cli, env, paidTerms)
+  await new FixtureRunner(electCouncilFixture).run()
+
+  debug('Done')
+}

--- a/tests/network-tests/src/flows/content/activeVideoCounters.ts
+++ b/tests/network-tests/src/flows/content/activeVideoCounters.ts
@@ -12,8 +12,8 @@ export default async function activeVideoCounters({ api, query, cli, env }: Flow
 
   const paidTerms: PaidTermId = api.createPaidTermId(new BN(+env.MEMBERSHIP_PAID_TERMS!))
 
-  const electCouncilFixture = new ActiveVideoCountersFixture(api, query, cli, env, paidTerms)
-  await new FixtureRunner(electCouncilFixture).run()
+  const activeVideoCountersFixture = new ActiveVideoCountersFixture(api, query, cli, env, paidTerms)
+  await new FixtureRunner(activeVideoCountersFixture).run()
 
   debug('Done')
 }

--- a/tests/network-tests/src/flows/workingGroup/leaderSetup.ts
+++ b/tests/network-tests/src/flows/workingGroup/leaderSetup.ts
@@ -4,21 +4,22 @@ import BN from 'bn.js'
 import { PaidTermId } from '@joystream/types/members'
 import { SudoHireLeadFixture } from '../../fixtures/sudoHireLead'
 import { assert } from 'chai'
-// import { KeyringPair } from '@polkadot/keyring/types'
+import { KeyringPair } from '@polkadot/keyring/types'
 import { FixtureRunner } from '../../Fixture'
 import { extendDebug } from '../../Debugger'
+import { CliApi } from '../../CliApi'
 
 export default {
-  storage: async function ({ api, env }: FlowProps): Promise<void> {
-    return leaderSetup(api, env, WorkingGroups.StorageWorkingGroup)
+  storage: async function ({ api, env, cli }: FlowProps): Promise<void> {
+    return leaderSetup(api, env, cli, WorkingGroups.StorageWorkingGroup)
   },
-  content: async function ({ api, env }: FlowProps): Promise<void> {
-    return leaderSetup(api, env, WorkingGroups.ContentDirectoryWorkingGroup)
+  content: async function ({ api, env, cli }: FlowProps): Promise<void> {
+    return leaderSetup(api, env, cli, WorkingGroups.ContentDirectoryWorkingGroup)
   },
 }
 
 // Worker application happy case scenario
-async function leaderSetup(api: Api, env: NodeJS.ProcessEnv, group: WorkingGroups): Promise<void> {
+async function leaderSetup(api: Api, env: NodeJS.ProcessEnv, cli: CliApi, group: WorkingGroups): Promise<void> {
   const debug = extendDebug(`flow:leaderSetup:${group}`)
   debug('Started')
 
@@ -51,6 +52,9 @@ async function leaderSetup(api: Api, env: NodeJS.ProcessEnv, group: WorkingGroup
   const hiredLead = await api.getGroupLead(group)
   assert.notEqual(hiredLead, undefined, `${group} group Lead was not hired!`)
   assert(hiredLead!.role_account_id.eq(leadKeyPair.address))
+
+  debug(`Importing leader's account to CLI`)
+  await cli.importAccount(leadKeyPair)
 
   debug('Done')
 

--- a/tests/network-tests/src/flows/workingGroup/leaderSetup.ts
+++ b/tests/network-tests/src/flows/workingGroup/leaderSetup.ts
@@ -53,6 +53,13 @@ async function leaderSetup(api: Api, env: NodeJS.ProcessEnv, cli: CliApi, group:
   assert.notEqual(hiredLead, undefined, `${group} group Lead was not hired!`)
   assert(hiredLead!.role_account_id.eq(leadKeyPair.address))
 
+
+  // setup (ensure) CLI connection to node
+
+  await cli.setApiUri()
+
+  // import leader to CLI
+
   debug(`Importing leader's account to CLI`)
   await cli.importAccount(leadKeyPair)
 

--- a/tests/network-tests/src/flows/workingGroup/leaderSetup.ts
+++ b/tests/network-tests/src/flows/workingGroup/leaderSetup.ts
@@ -53,7 +53,6 @@ async function leaderSetup(api: Api, env: NodeJS.ProcessEnv, cli: CliApi, group:
   assert.notEqual(hiredLead, undefined, `${group} group Lead was not hired!`)
   assert(hiredLead!.role_account_id.eq(leadKeyPair.address))
 
-
   // setup (ensure) CLI connection to node
 
   await cli.setApiUri()

--- a/tests/network-tests/src/scenarios/content-directory.ts
+++ b/tests/network-tests/src/scenarios/content-directory.ts
@@ -1,6 +1,12 @@
 import leaderSetup from '../flows/workingGroup/leaderSetup'
+import activeVideoCounters from '../flows/content/activeVideoCounters'
 import { scenario } from '../Scenario'
 
 scenario(async ({ job }) => {
-  job('setup content lead', leaderSetup.content)
+  const setupContentLeaderSetup = job('setup content lead', leaderSetup.content)
+  const setupStorageLeaderSetup = job('setup storage lead', leaderSetup.storage)
+
+  job('check active video counters', activeVideoCounters)
+    .requires(setupContentLeaderSetup)
+    .requires(setupStorageLeaderSetup)
 })


### PR DESCRIPTION
This PR adds counters to query node's channels, channel categories, and video categories.

Use it in a query like this:


```
channels {id, activeVideosCounter}
channelCategories {id, activeVideosCounter}
videoCategories {id, activeVideosCounter}
```

Videos are considered active if all the following conditions are true: `isPublic == true`, `isCensored == false`, `thumbnailPhotoAvailability == AssetAvailability.Accepted`, and `mediaAvailability == AssetAvailability.Accepted`.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201703380142370/1201703601809148) by [Unito](https://www.unito.io)
