### PR TITLE
content migration script: add excludeVideoIds argument

### DIFF
--- a/utils/migration-scripts/src/commands/sumer-giza/migrateContent.ts
+++ b/utils/migration-scripts/src/commands/sumer-giza/migrateContent.ts
@@ -57,6 +57,11 @@ export class MigrateContentCommand extends Command {
       description: 'Path to migration results directory',
       default: path.join(__dirname, '../../../results/sumer-giza'),
     }),
+    excludeVideoIds: flags.integer({
+      multiple: true,
+      description: 'Video ids to exclude from migration',
+      required: false,
+    }),
   }
 
   async run(): Promise<void> {

--- a/utils/migration-scripts/src/commands/sumer-giza/migrateContent.ts
+++ b/utils/migration-scripts/src/commands/sumer-giza/migrateContent.ts
@@ -61,6 +61,7 @@ export class MigrateContentCommand extends Command {
       multiple: true,
       description: 'Video ids to exclude from migration',
       required: false,
+      default: [],
     }),
   }
 

--- a/utils/migration-scripts/src/sumer-giza/ChannelsMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/ChannelsMigration.ts
@@ -13,6 +13,7 @@ export type ChannelsMigrationConfig = AssetsMigrationConfig & {
   channelIds: number[]
   channelBatchSize: number
   forceChannelOwnerMemberId: number | undefined
+  excludeVideoIds: number[]
 }
 
 export type ChannelsMigrationParams = AssetsMigrationParams & {
@@ -101,7 +102,10 @@ export class ChannelMigration extends AssetsMigration {
         }
       }
       const videoIdsToMigrate: number[] = channelsBatch.reduce<number[]>(
-        (res, { id, videos }) => (this.idsMap.has(parseInt(id)) ? res.concat(videos.map((v) => parseInt(v.id))) : res),
+        (res, { id, videos }) =>
+          this.idsMap.has(parseInt(id))
+            ? res.concat(videos.map((v) => parseInt(v.id)).filter((id) => !this.config.excludeVideoIds.includes(id)))
+            : res,
         []
       )
       this.videoIds = this.videoIds.concat(videoIdsToMigrate)

--- a/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
@@ -17,6 +17,7 @@ export type ContentMigrationConfig = {
   uploadSpBucketId: number
   uploadSpEndpoint: string
   migrationStatePath: string
+  excludeVideoIds: number[]
 }
 
 export class ContentMigration {


### PR DESCRIPTION
Add optional argument `--excludeVideoIds` to filter videos which we want to exclude from migration.