### PR TITLE
Olympia. Runtime. Bounty pallet: fix bounty and work entry association.

### DIFF
--- a/runtime-modules/bounty/src/benchmarking.rs
+++ b/runtime-modules/bounty/src/benchmarking.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "runtime-benchmarks")]
 
 use frame_benchmarking::{account, benchmarks};
-use frame_support::storage::StorageMap;
+use frame_support::storage::{StorageDoubleMap, StorageMap};
 use frame_support::traits::{Currency, Get, OnFinalize, OnInitialize};
 use frame_system::{EventRecord, RawOrigin};
 use sp_arithmetic::traits::{One, Zero};
@@ -566,7 +566,7 @@ benchmarks! {
     verify {
         let entry_id: T::EntryId = Bounty::<T>::entry_count().into();
 
-        assert!(Entries::<T>::contains_key(entry_id));
+        assert!(Entries::<T>::contains_key(bounty_id, entry_id));
         assert_last_event::<T>(
             Event::<T>::WorkEntryAnnounced(
                 bounty_id,
@@ -606,7 +606,7 @@ benchmarks! {
 
     }: _(RawOrigin::Signed(account_id.clone()), member_id, bounty_id, entry_id)
     verify {
-        assert!(!Entries::<T>::contains_key(entry_id));
+        assert!(!Entries::<T>::contains_key(bounty_id, entry_id));
         assert_last_event::<T>(
             Event::<T>::WorkEntryWithdrawn(bounty_id, entry_id, member_id).into()
         );
@@ -657,7 +657,7 @@ benchmarks! {
 
     }: _(RawOrigin::Signed(account_id.clone()), member_id, bounty_id, entry_id, work_data.clone())
     verify {
-        let entry = Bounty::<T>::entries(entry_id);
+        let entry = Bounty::<T>::entries(bounty_id, entry_id);
 
         assert!(entry.work_submitted);
         assert_last_event::<T>(
@@ -712,7 +712,7 @@ benchmarks! {
     }: submit_oracle_judgment(RawOrigin::Root, oracle.clone(), bounty_id, judgment.clone())
     verify {
         for entry_id in entry_ids {
-            let entry = Bounty::<T>::entries(entry_id);
+            let entry = Bounty::<T>::entries(bounty_id, entry_id);
             let corrected_winner_reward = if entry_id == One::one() {
                     winner_reward + correction
                 } else {
@@ -764,7 +764,7 @@ benchmarks! {
     }: submit_oracle_judgment(RawOrigin::Root, oracle.clone(), bounty_id, judgment.clone())
     verify {
         for entry_id in entry_ids {
-            assert!(!<Entries<T>>::contains_key(entry_id));
+            assert!(!<Entries<T>>::contains_key(bounty_id, entry_id));
         }
         assert_last_event::<T>(
             Event::<T>::OracleJudgmentSubmitted(bounty_id, oracle, judgment).into()
@@ -825,7 +825,7 @@ benchmarks! {
     )
     verify {
         for entry_id in entry_ids {
-            let entry = Bounty::<T>::entries(entry_id);
+            let entry = Bounty::<T>::entries(bounty_id, entry_id);
             let corrected_winner_reward = if entry_id == One::one() {
                     winner_reward + correction
                 } else {
@@ -884,7 +884,7 @@ benchmarks! {
     )
     verify {
         for entry_id in entry_ids {
-            assert!(!<Entries<T>>::contains_key(entry_id));
+            assert!(!<Entries<T>>::contains_key(bounty_id, entry_id));
         }
         assert_last_event::<T>(
             Event::<T>::OracleJudgmentSubmitted(bounty_id, oracle, judgment).into()
@@ -952,7 +952,7 @@ benchmarks! {
 
     }: _ (RawOrigin::Signed(work_account_id), work_member_id, bounty_id, entry_id)
     verify {
-        assert!(!<Entries<T>>::contains_key(entry_id));
+        assert!(!<Entries<T>>::contains_key(bounty_id, entry_id));
         assert_was_fired::<T>(
             Event::<T>::WorkEntrantFundsWithdrawn(bounty_id, entry_id, work_member_id).into()
         );

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -472,7 +472,9 @@ decl_storage! {
         pub BountyCount get(fn bounty_count): u32;
 
         /// Work entry storage map.
-        pub Entries get(fn entries): map hasher(blake2_128_concat) T::EntryId => Entry<T>;
+        pub Entries get(fn entries): double_map
+            hasher(blake2_128_concat) T::BountyId,
+            hasher(blake2_128_concat) T::EntryId => Entry<T>;
 
         /// Count of all work entries that have been created.
         pub EntryCount get(fn entry_count): u32;
@@ -1009,7 +1011,7 @@ decl_module! {
                 oracle_judgment_result: None,
             };
 
-            <Entries<T>>::insert(entry_id, entry);
+            <Entries<T>>::insert(bounty_id, entry_id, entry);
             EntryCount::mutate(|count| {
                 *count = next_entry_count_value
             });
@@ -1050,7 +1052,7 @@ decl_module! {
 
             Self::ensure_bounty_stage(current_bounty_stage, BountyStage::WorkSubmission)?;
 
-            let entry = Self::ensure_work_entry_exists(&entry_id)?;
+            let entry = Self::ensure_work_entry_exists(&bounty_id, &entry_id)?;
 
             //
             // == MUTATION SAFE ==
@@ -1088,14 +1090,14 @@ decl_module! {
 
             Self::ensure_bounty_stage(current_bounty_stage, BountyStage::WorkSubmission)?;
 
-            Self::ensure_work_entry_exists(&entry_id)?;
+            Self::ensure_work_entry_exists(&bounty_id, &entry_id)?;
 
             //
             // == MUTATION SAFE ==
             //
 
             // Update entry
-            <Entries<T>>::mutate(entry_id, |entry| {
+            <Entries<T>>::mutate(bounty_id, entry_id, |entry| {
                 entry.work_submitted = true;
             });
 
@@ -1140,7 +1142,7 @@ decl_module! {
 
             ensure!(bounty.active_work_entry_count != 0, Error::<T>::NoActiveWorkEntries);
 
-            Self::validate_judgment(&bounty, &judgment)?;
+            Self::validate_judgment(&bounty_id, &bounty, &judgment)?;
 
             // Lookup for any winners in the judgment.
             let successful_bounty = Self::judgment_has_winners(&judgment);
@@ -1165,11 +1167,11 @@ decl_module! {
             for (entry_id, work_entry_judgment) in judgment.iter() {
                 // Update work entries for winners.
                 if matches!(*work_entry_judgment, OracleWorkEntryJudgment::Winner{ .. }) {
-                    <Entries<T>>::mutate(entry_id, |entry| {
+                    <Entries<T>>::mutate(bounty_id, entry_id, |entry| {
                         entry.oracle_judgment_result = Some(*work_entry_judgment);
                     });
                 } else {
-                    let entry = Self::entries(entry_id);
+                    let entry = Self::entries(bounty_id, entry_id);
 
                     Self::slash_work_entry_stake(&entry);
 
@@ -1214,7 +1216,7 @@ decl_module! {
                 Self::unexpected_bounty_stage_error(current_bounty_stage)
             );
 
-            let entry = Self::ensure_work_entry_exists(&entry_id)?;
+            let entry = Self::ensure_work_entry_exists(&bounty_id, &entry_id)?;
 
             //
             // == MUTATION SAFE ==
@@ -1524,13 +1526,16 @@ impl<T: Trait> Module<T> {
     }
 
     // Verifies work entry existence and retrieves an entry from the storage.
-    fn ensure_work_entry_exists(entry_id: &T::EntryId) -> Result<Entry<T>, DispatchError> {
+    fn ensure_work_entry_exists(
+        bounty_id: &T::BountyId,
+        entry_id: &T::EntryId,
+    ) -> Result<Entry<T>, DispatchError> {
         ensure!(
-            <Entries<T>>::contains_key(entry_id),
+            <Entries<T>>::contains_key(bounty_id, entry_id),
             Error::<T>::WorkEntryDoesntExist
         );
 
-        let entry = Self::entries(entry_id);
+        let entry = Self::entries(bounty_id, entry_id);
 
         Ok(entry)
     }
@@ -1591,7 +1596,11 @@ impl<T: Trait> Module<T> {
     }
 
     // Validates oracle judgment.
-    fn validate_judgment(bounty: &Bounty<T>, judgment: &OracleJudgmentOf<T>) -> DispatchResult {
+    fn validate_judgment(
+        bounty_id: &T::BountyId,
+        bounty: &Bounty<T>,
+        judgment: &OracleJudgmentOf<T>,
+    ) -> DispatchResult {
         // Total judgment reward accumulator.
         let mut reward_sum_from_judgment: BalanceOf<T> = Zero::zero();
 
@@ -1605,7 +1614,7 @@ impl<T: Trait> Module<T> {
             }
 
             // Check winner work submission.
-            let entry = Self::ensure_work_entry_exists(entry_id)?;
+            let entry = Self::ensure_work_entry_exists(bounty_id, entry_id)?;
             ensure!(
                 entry.work_submitted,
                 Error::<T>::WinnerShouldHasWorkSubmission
@@ -1625,7 +1634,7 @@ impl<T: Trait> Module<T> {
 
     // Removes the work entry and decrements active entry count in a bounty.
     fn remove_work_entry(bounty_id: &T::BountyId, entry_id: &T::EntryId) {
-        <Entries<T>>::remove(entry_id);
+        <Entries<T>>::remove(bounty_id, entry_id);
 
         // Decrement work entry counter and update bounty record.
         <Bounties<T>>::mutate(bounty_id, |bounty| {

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -1,5 +1,5 @@
 use frame_support::dispatch::DispatchResult;
-use frame_support::storage::StorageMap;
+use frame_support::storage::{StorageDoubleMap, StorageMap};
 use frame_support::traits::{Currency, OnFinalize, OnInitialize};
 use frame_system::{EventRecord, Phase, RawOrigin};
 use sp_runtime::offchain::storage_lock::BlockNumberProvider;
@@ -550,7 +550,10 @@ impl AnnounceWorkEntryFixture {
         let new_bounty = Bounty::bounties(self.bounty_id);
         if actual_result.is_ok() {
             assert_eq!(next_entry_count_value, Bounty::entry_count());
-            assert!(<crate::Entries<Test>>::contains_key(&entry_id));
+            assert!(<crate::Entries<Test>>::contains_key(
+                self.bounty_id,
+                &entry_id
+            ));
 
             let expected_entry = Entry::<Test> {
                 member_id: self.member_id,
@@ -560,7 +563,7 @@ impl AnnounceWorkEntryFixture {
                 oracle_judgment_result: None,
             };
 
-            assert_eq!(expected_entry, Bounty::entries(entry_id));
+            assert_eq!(expected_entry, Bounty::entries(self.bounty_id, entry_id));
 
             assert_eq!(
                 new_bounty.active_work_entry_count,
@@ -568,7 +571,10 @@ impl AnnounceWorkEntryFixture {
             );
         } else {
             assert_eq!(next_entry_count_value - 1, Bounty::entry_count());
-            assert!(!<crate::Entries<Test>>::contains_key(&entry_id));
+            assert!(!<crate::Entries<Test>>::contains_key(
+                self.bounty_id,
+                &entry_id
+            ));
 
             assert_eq!(
                 new_bounty.active_work_entry_count,
@@ -623,7 +629,10 @@ impl WithdrawWorkEntryFixture {
         assert_eq!(actual_result, expected_result);
 
         if actual_result.is_ok() {
-            assert!(!<crate::Entries<Test>>::contains_key(&self.entry_id));
+            assert!(!<crate::Entries<Test>>::contains_key(
+                self.bounty_id,
+                &self.entry_id
+            ));
 
             let new_bounty = Bounty::bounties(self.bounty_id);
             assert_eq!(
@@ -674,7 +683,7 @@ impl SubmitWorkFixture {
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
-        let old_entry = Bounty::entries(self.entry_id);
+        let old_entry = Bounty::entries(self.bounty_id, self.entry_id);
         let actual_result = Bounty::submit_work(
             self.origin.clone().into(),
             self.member_id,
@@ -685,7 +694,7 @@ impl SubmitWorkFixture {
 
         assert_eq!(actual_result, expected_result);
 
-        let new_entry = Bounty::entries(self.entry_id);
+        let new_entry = Bounty::entries(self.bounty_id, self.entry_id);
 
         if actual_result.is_ok() {
             assert!(new_entry.work_submitted);
@@ -802,7 +811,10 @@ impl WithdrawWorkEntrantFundsFixture {
         assert_eq!(actual_result, expected_result);
 
         if actual_result.is_ok() {
-            assert!(!<crate::Entries<Test>>::contains_key(&self.entry_id));
+            assert!(!<crate::Entries<Test>>::contains_key(
+                self.bounty_id,
+                &self.entry_id
+            ));
 
             if <crate::Bounties<Test>>::contains_key(self.bounty_id) {
                 let new_bounty = Bounty::bounties(self.bounty_id);

--- a/runtime-modules/bounty/src/tests/mod.rs
+++ b/runtime-modules/bounty/src/tests/mod.rs
@@ -3,7 +3,7 @@
 pub(crate) mod fixtures;
 pub(crate) mod mocks;
 
-use frame_support::storage::StorageMap;
+use frame_support::storage::{StorageDoubleMap, StorageMap};
 use frame_support::traits::Currency;
 use frame_system::RawOrigin;
 use sp_runtime::DispatchError;
@@ -2554,7 +2554,7 @@ fn submit_judgment_by_council_succeeded_with_complex_judgment() {
         .cloned()
         .collect::<BTreeMap<_, _>>();
 
-        assert!(<Entries<Test>>::contains_key(entry_id3));
+        assert!(<Entries<Test>>::contains_key(bounty_id, entry_id3));
         assert_eq!(Balances::total_balance(&account_id), initial_balance);
 
         SubmitJudgmentFixture::default()
@@ -2563,11 +2563,14 @@ fn submit_judgment_by_council_succeeded_with_complex_judgment() {
             .call_and_assert(Ok(()));
 
         assert_eq!(
-            Bounty::entries(entry_id1).oracle_judgment_result,
+            Bounty::entries(bounty_id, entry_id1).oracle_judgment_result,
             Some(OracleWorkEntryJudgment::Winner { reward: max_amount })
         );
-        assert_eq!(Bounty::entries(entry_id2).oracle_judgment_result, None);
-        assert!(!<Entries<Test>>::contains_key(entry_id3));
+        assert_eq!(
+            Bounty::entries(bounty_id, entry_id2).oracle_judgment_result,
+            None
+        );
+        assert!(!<Entries<Test>>::contains_key(bounty_id, entry_id3));
         assert_eq!(
             Balances::total_balance(&account_id),
             initial_balance - entrant_stake
@@ -2652,7 +2655,7 @@ fn submit_judgment_returns_cherry_on_successful_bounty() {
             .call_and_assert(Ok(()));
 
         assert_eq!(
-            Bounty::entries(entry_id).oracle_judgment_result,
+            Bounty::entries(bounty_id, entry_id).oracle_judgment_result,
             Some(OracleWorkEntryJudgment::Winner { reward: max_amount })
         );
 
@@ -2730,14 +2733,14 @@ fn submit_judgment_dont_return_cherry_on_unsuccessful_bounty() {
             .cloned()
             .collect::<BTreeMap<_, _>>();
 
-        assert!(<Entries<Test>>::contains_key(entry_id));
+        assert!(<Entries<Test>>::contains_key(bounty_id, entry_id));
 
         SubmitJudgmentFixture::default()
             .with_bounty_id(bounty_id)
             .with_judgment(judgment.clone())
             .call_and_assert(Ok(()));
 
-        assert!(!<Entries<Test>>::contains_key(entry_id));
+        assert!(!<Entries<Test>>::contains_key(bounty_id, entry_id));
 
         // Cherry not returned.
         assert_eq!(


### PR DESCRIPTION
We need to change the work entry storage map to a double map to restore the bounty-to-work-entry association.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201709380879215/1201710195932150) by [Unito](https://www.unito.io)
