### PR TITLE
Giza: Make public services reachable on all interfaces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,7 @@ services:
       - DB_HOST=db
       - WARTHOG_APP_PORT=${GRAPHQL_SERVER_PORT}
     ports:
-      - '127.0.0.1:${GRAPHQL_SERVER_PORT}:${GRAPHQL_SERVER_PORT}'
+      - "${GRAPHQL_SERVER_PORT}:${GRAPHQL_SERVER_PORT}"
     depends_on:
       - db
     volumes:
@@ -247,7 +247,7 @@ services:
       - PORT=${HYDRA_INDEXER_GATEWAY_PORT}
       - DEBUG=*
     ports:
-      - '127.0.0.1:${HYDRA_INDEXER_GATEWAY_PORT}:${HYDRA_INDEXER_GATEWAY_PORT}'
+      - "${HYDRA_INDEXER_GATEWAY_PORT}:${HYDRA_INDEXER_GATEWAY_PORT}"
     depends_on:
       - db
       - redis
@@ -257,7 +257,7 @@ services:
     container_name: redis
     restart: unless-stopped
     ports:
-      - '127.0.0.1:6379:6379'
+      - "127.0.0.1:6379:6379"
 
   pioneer:
     image: nginx
@@ -266,7 +266,7 @@ services:
     volumes:
       - ./pioneer/packages/apps/build:/usr/share/nginx/html
     ports:
-      - "127.0.0.1:3000:80"
+      - "3000:80"
     environment:
       - NGINX_PORT=80
 
@@ -280,7 +280,7 @@ services:
       - PROVIDER=ws://joystream-node:9944
       - ENDOWMENT=0
     ports:
-      - "127.0.0.1:3002:3002"
+      - "3002:3002"
 
   orion:
     container_name: orion


### PR DESCRIPTION
Let public services listen on all interfaces to make them more easily accessible from other services running in containers from a different docker-compose network. (They will be reachable on their public interface address)