### PR TITLE
Giza: docker-compose: add missing env var for latest version of orion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -289,6 +289,7 @@ services:
       - ORION_PORT=6116
       - ORION_MONGO_HOSTNAME=mongo
       - ORION_FEATURED_CONTENT_SECRET=password123
+      - ORION_QUERY_NODE_URL=http://graphql-server:${GRAPHQL_SERVER_PORT}/graphql
     ports:
       - "6116:6116"
     depends_on:


### PR DESCRIPTION
Latest version of orion which is published on docker hub `joystream/orion:latest` is now the main "backend" endpoint for Atlas, and needs to talk to a query-node.

Added configuration in docker-compose.