### PR TITLE
Content migration script: Wait for finalization, improve error handling and logging

### DIFF
--- a/utils/migration-scripts/.prettierignore
+++ b/utils/migration-scripts/.prettierignore
@@ -1,2 +1,3 @@
+lib
 results
 src/sumer-giza/sumer-query-node/generated

--- a/utils/migration-scripts/package.json
+++ b/utils/migration-scripts/package.json
@@ -31,7 +31,9 @@
     "@types/sharp": "^0.29.2",
     "form-data": "^4.0.0",
     "node-cleanup": "^2.1.2",
-    "@types/node-cleanup": "^2.1.2"
+    "@types/node-cleanup": "^2.1.2",
+    "winston": "^3.3.3",
+    "fast-safe-stringify": "^2.1.1"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.21.4",

--- a/utils/migration-scripts/src/commands/sumer-giza/retryFailedUploads.ts
+++ b/utils/migration-scripts/src/commands/sumer-giza/retryFailedUploads.ts
@@ -38,7 +38,10 @@ export class RetryFailedUploadsCommand extends Command {
       await api.isReadyOrError
       const assetsManager = await AssetsManager.create({
         api,
-        config: opts,
+        config: {
+          ...opts,
+          migrationStatePath: path.dirname(opts.failedUploadsPath),
+        },
       })
       assetsManager.loadQueue(opts.failedUploadsPath)
       await assetsManager.processQueuedUploads()

--- a/utils/migration-scripts/src/logging.ts
+++ b/utils/migration-scripts/src/logging.ts
@@ -10,6 +10,7 @@ winston.addColors(colors)
 
 export function createLogger(label: string): Logger {
   return winston.createLogger({
+    level: 'debug',
     transports: [new winston.transports.Console()],
     defaultMeta: { label },
     format: winston.format.combine(

--- a/utils/migration-scripts/src/logging.ts
+++ b/utils/migration-scripts/src/logging.ts
@@ -1,0 +1,26 @@
+import winston, { Logger } from 'winston'
+import stringify from 'fast-safe-stringify'
+
+const colors = {
+  error: 'red',
+  warn: 'yellow',
+  info: 'green',
+}
+winston.addColors(colors)
+
+export function createLogger(label: string): Logger {
+  return winston.createLogger({
+    transports: [new winston.transports.Console()],
+    defaultMeta: { label },
+    format: winston.format.combine(
+      winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss:ms' }),
+      winston.format.metadata({ fillExcept: ['label', 'level', 'timestamp', 'message'] }),
+      winston.format.colorize(),
+      winston.format.printf(
+        (info) =>
+          `${info.timestamp} ${info.label} [${info.level}]: ${info.message}` +
+          (Object.keys(info.metadata).length ? `\n${stringify(info.metadata, undefined, 4)}` : '')
+      )
+    ),
+  })
+}

--- a/utils/migration-scripts/src/sumer-giza/AssetsMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/AssetsMigration.ts
@@ -27,9 +27,9 @@ export abstract class AssetsMigration extends BaseMigration {
 
   public abstract run(): Promise<MigrationResult>
 
-  protected saveMigrationState(): void {
-    super.saveMigrationState()
-    if (this.assetsManager.queueSize) {
+  protected saveMigrationState(isExitting: boolean): void {
+    super.saveMigrationState(isExitting)
+    if (isExitting && this.assetsManager.queueSize) {
       const failedUploadsFilePath = this.getMigrationStateFilePath().replace(
         '.json',
         `FailedUploads_${Date.now()}.json`

--- a/utils/migration-scripts/src/sumer-giza/AssetsMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/AssetsMigration.ts
@@ -1,40 +1,20 @@
-import { BaseMigration, BaseMigrationConfig, BaseMigrationParams, MigrationResult } from './BaseMigration'
+import { BaseMigration, BaseMigrationConfig, BaseMigrationParams } from './BaseMigration'
 import { AssetsManager, AssetsManagerConfig } from './AssetsManager'
 
 export type AssetsMigrationConfig = BaseMigrationConfig & AssetsManagerConfig
 
 export type AssetsMigrationParams = BaseMigrationParams & {
+  assetsManager: AssetsManager
   config: AssetsMigrationConfig
 }
 
 export abstract class AssetsMigration extends BaseMigration {
   protected config: AssetsMigrationConfig
-  protected assetsManager!: AssetsManager
+  protected assetsManager: AssetsManager
 
-  public constructor({ api, queryNodeApi, config }: AssetsMigrationParams) {
+  public constructor({ api, queryNodeApi, config, assetsManager }: AssetsMigrationParams) {
     super({ api, queryNodeApi, config })
     this.config = config
-  }
-
-  public async init(): Promise<void> {
-    await super.init()
-    this.assetsManager = await AssetsManager.create({
-      api: this.api,
-      queryNodeApi: this.queryNodeApi,
-      config: this.config,
-    })
-  }
-
-  public abstract run(): Promise<MigrationResult>
-
-  protected saveMigrationState(isExitting: boolean): void {
-    super.saveMigrationState(isExitting)
-    if (isExitting && this.assetsManager.queueSize) {
-      const failedUploadsFilePath = this.getMigrationStateFilePath().replace(
-        '.json',
-        `FailedUploads_${Date.now()}.json`
-      )
-      this.assetsManager.saveQueue(failedUploadsFilePath)
-    }
+    this.assetsManager = assetsManager
   }
 }

--- a/utils/migration-scripts/src/sumer-giza/ChannelsMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/ChannelsMigration.ts
@@ -8,6 +8,8 @@ import { CHANNEL_AVATAR_TARGET_SIZE, CHANNEL_COVER_TARGET_SIZE } from './ImageRe
 import { ChannelId } from '@joystream/types/common'
 import _ from 'lodash'
 import { MigrationResult } from './BaseMigration'
+import { Logger } from 'winston'
+import { createLogger } from '../logging'
 
 export type ChannelsMigrationConfig = AssetsMigrationConfig & {
   channelIds: number[]
@@ -29,11 +31,13 @@ export class ChannelMigration extends AssetsMigration {
   protected config: ChannelsMigrationConfig
   protected videoIds: number[] = []
   protected forcedChannelOwner: { id: string; controllerAccount: string } | undefined
+  protected logger: Logger
 
   public constructor(params: ChannelsMigrationParams) {
     super(params)
     this.config = params.config
     this.forcedChannelOwner = params.forcedChannelOwner
+    this.logger = createLogger(this.name)
   }
 
   private getChannelOwnerMember({ id, ownerMember }: ChannelFieldsFragment) {
@@ -48,21 +52,46 @@ export class ChannelMigration extends AssetsMigration {
     return ownerMember
   }
 
+  protected async migrateBatch(channels: ChannelFieldsFragment[]): Promise<void> {
+    const { api } = this
+    const txs = _.flatten(await Promise.all(channels.map((c) => this.prepareChannel(c))))
+    const result = await api.sendExtrinsic(this.sudo, api.tx.utility.batch(txs))
+    const channelCreatedEvents = api.findEvents(result, 'content', 'ChannelCreated')
+    const newChannelIds: ChannelId[] = channelCreatedEvents.map((e) => e.data[1])
+    if (channelCreatedEvents.length !== channels.length) {
+      this.extractFailedMigrations(result, channels)
+    }
+    const newChannelMapEntries: [number, number][] = []
+    let newChannelIdIndex = 0
+    channels.forEach(({ id }) => {
+      if (this.failedMigrations.has(parseInt(id))) {
+        return
+      }
+      const newChannelId = newChannelIds[newChannelIdIndex++].toNumber()
+      this.idsMap.set(parseInt(id), newChannelId)
+      newChannelMapEntries.push([parseInt(id), newChannelId])
+    })
+    if (newChannelMapEntries.length) {
+      this.logger.info('Channel map entries added!', { newChannelMapEntries })
+      const dataObjectsUploadedEvents = this.api.findEvents(result, 'storage', 'DataObjectsUploaded')
+      this.assetsManager.queueUploadsFromEvents(dataObjectsUploadedEvents)
+    }
+  }
+
   public async run(): Promise<ChannelsMigrationResult> {
     await this.init()
     const {
-      api,
       config: { channelIds, channelBatchSize },
     } = this
     const ids = channelIds.sort((a, b) => a - b)
     while (ids.length) {
       const idsBatch = ids.splice(0, channelBatchSize)
-      console.log(`Fetching a batch of ${idsBatch.length} channels...`)
+      this.logger.info(`Fetching a batch of ${idsBatch.length} channels...`)
       const channelsBatch = (await this.queryNodeApi.getChannelsByIds(idsBatch)).sort(
         (a, b) => parseInt(a.id) - parseInt(b.id)
       )
       if (channelsBatch.length < idsBatch.length) {
-        console.error(
+        this.logger.warn(
           `Some channels were not be found: ${_.difference(
             idsBatch,
             channelsBatch.map((c) => parseInt(c.id))
@@ -71,34 +100,14 @@ export class ChannelMigration extends AssetsMigration {
       }
       const channelsToMigrate = channelsBatch.filter((c) => !this.idsMap.has(parseInt(c.id)))
       if (channelsToMigrate.length < channelsBatch.length) {
-        console.log(
+        this.logger.info(
           `${channelsToMigrate.length ? 'Some' : 'All'} channels in this batch were already migrated ` +
             `(${channelsBatch.length - channelsToMigrate.length}/${channelsBatch.length})`
         )
       }
       if (channelsToMigrate.length) {
-        const txs = _.flatten(await Promise.all(channelsToMigrate.map((c) => this.prepareChannel(c))))
-        const result = await api.sendExtrinsic(this.sudo, api.tx.utility.batch(txs))
-        const channelCreatedEvents = api.findEvents(result, 'content', 'ChannelCreated')
-        const newChannelIds: ChannelId[] = channelCreatedEvents.map((e) => e.data[1])
-        if (channelCreatedEvents.length !== channelsToMigrate.length) {
-          this.extractFailedSudoAsMigrations(result, channelsToMigrate)
-        }
-        const dataObjectsUploadedEvents = api.findEvents(result, 'storage', 'DataObjectsUploaded')
-        const newChannelMapEntries: [number, number][] = []
-        let newChannelIdIndex = 0
-        channelsToMigrate.forEach(({ id }) => {
-          if (this.failedMigrations.has(parseInt(id))) {
-            return
-          }
-          const newChannelId = newChannelIds[newChannelIdIndex++].toNumber()
-          this.idsMap.set(parseInt(id), newChannelId)
-          newChannelMapEntries.push([parseInt(id), newChannelId])
-        })
-        if (newChannelMapEntries.length) {
-          console.log('Channel map entries added!', newChannelMapEntries)
-          await this.assetsManager.uploadFromEvents(dataObjectsUploadedEvents)
-        }
+        await this.executeBatchMigration(channelsToMigrate)
+        await this.assetsManager.processQueuedUploads()
       }
       const videoIdsToMigrate: number[] = channelsBatch.reduce<number[]>(
         (res, { id, videos }) => (this.idsMap.has(parseInt(id)) ? res.concat(videos.map((v) => parseInt(v.id))) : res),
@@ -106,7 +115,7 @@ export class ChannelMigration extends AssetsMigration {
       )
       this.videoIds = this.videoIds.concat(videoIdsToMigrate)
       if (videoIdsToMigrate.length) {
-        console.log(`Added ${videoIdsToMigrate.length} video ids to the list of videos to migrate`)
+        this.logger.info(`Added ${videoIdsToMigrate.length} video ids to the list of videos to migrate`)
       }
     }
     return {

--- a/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
@@ -3,6 +3,7 @@ import { QueryNodeApi } from './sumer-query-node/api'
 import { RuntimeApi } from '../RuntimeApi'
 import { VideosMigration } from './VideosMigration'
 import { ChannelMigration } from './ChannelsMigration'
+import { AssetsManager } from './AssetsManager'
 
 export type ContentMigrationConfig = {
   queryNodeUri: string
@@ -51,11 +52,16 @@ export class ContentMigration {
     const { api, queryNodeApi, config } = this
     await this.api.isReadyOrError
     const forcedChannelOwner = await this.getForcedChannelOwner()
+    const assetsManager = await AssetsManager.create({
+      api,
+      config,
+    })
     const { idsMap: channelsMap, videoIds } = await new ChannelMigration({
       api,
       queryNodeApi,
       config,
       forcedChannelOwner,
+      assetsManager,
     }).run()
     await new VideosMigration({
       api,
@@ -64,6 +70,7 @@ export class ContentMigration {
       channelsMap,
       videoIds,
       forcedChannelOwner,
+      assetsManager,
     }).run()
   }
 }

--- a/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
@@ -34,7 +34,7 @@ export class ContentMigration {
 
   private async getForcedChannelOwner(): Promise<{ id: string; controllerAccount: string } | undefined> {
     const { forceChannelOwnerMemberId } = this.config
-    if (forceChannelOwnerMemberId) {
+    if (forceChannelOwnerMemberId !== undefined) {
       const ownerMember = await this.api.query.members.membershipById(forceChannelOwnerMemberId)
       if (ownerMember.isEmpty) {
         throw new Error(`Membership by id ${forceChannelOwnerMemberId} not found!`)

--- a/utils/migration-scripts/src/sumer-giza/VideosMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/VideosMigration.ts
@@ -31,12 +31,12 @@ export class VideosMigration extends AssetsMigration {
   protected forcedChannelOwner: { id: string; controllerAccount: string } | undefined
   protected logger: Logger
 
-  public constructor({ api, queryNodeApi, config, videoIds, channelsMap, forcedChannelOwner }: VideosMigrationParams) {
-    super({ api, queryNodeApi, config })
-    this.config = config
-    this.channelsMap = channelsMap
-    this.videoIds = videoIds
-    this.forcedChannelOwner = forcedChannelOwner
+  public constructor(params: VideosMigrationParams) {
+    super(params)
+    this.config = params.config
+    this.channelsMap = params.channelsMap
+    this.videoIds = params.videoIds
+    this.forcedChannelOwner = params.forcedChannelOwner
     this.logger = createLogger(this.name)
   }
 


### PR DESCRIPTION
- Wait until `utility.batch` tx is finalized before processing the result and uploading the objects
- Graceful exit: Make sure pending transactions are finalized and processed by the script before saving the state and exiting (after recieving an exit signal like `CTRL + C`)
- Add handling for `BatchInterrupted` case (for example: insufficient balance on sudo account)
- Improve logging: use `winson` for logging, add more messages