### PR TITLE
metadata-protobuf: do not run build script on package install

### DIFF
--- a/metadata-protobuf/package.json
+++ b/metadata-protobuf/package.json
@@ -27,8 +27,7 @@
     "lint": "eslint ./src --ext .ts",
     "checks": "tsc --noEmit --pretty && prettier ./ --check && yarn lint",
     "format": "prettier ./ --write",
-    "prepublishOnly": "npm run prepack",
-    "prepack": "npm run checks && npm run build"
+    "prepack": "npm run build && npm run checks"
   },
   "files": [
     "lib/**/*",

--- a/metadata-protobuf/package.json
+++ b/metadata-protobuf/package.json
@@ -27,7 +27,8 @@
     "lint": "eslint ./src --ext .ts",
     "checks": "tsc --noEmit --pretty && prettier ./ --check && yarn lint",
     "format": "prettier ./ --write",
-    "prepublish": "yarn build"
+    "prepublishOnly": "npm run prepack",
+    "prepack": "npm run checks && npm run build"
   },
   "files": [
     "lib/**/*",

--- a/metadata-protobuf/package.json
+++ b/metadata-protobuf/package.json
@@ -19,6 +19,10 @@
   "author": "Joystream Contributors",
   "license": "MIT",
   "private": false,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "scripts": {
     "build": "yarn compile && rm -rf lib && tsc",
     "compile": "yarn ts-node ./scripts/compile.ts",


### PR DESCRIPTION
While preparing to publish the package I tried to installed locally `npm pack`ed package and got:

```
npm i

> protobufjs@6.11.2 postinstall /Users/mokhtar/tmp/package/node_modules/protobufjs
> node scripts/postinstall

npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```

The `prepublish` script was running on package install.

This PR fixes it as recommended in the warning message. (The same way we do for our @joystream/types package)