### PR TITLE
closes #2821 Built-in reward for bounty oracles

### DIFF
--- a/runtime-modules/bounty/src/actors.rs
+++ b/runtime-modules/bounty/src/actors.rs
@@ -58,7 +58,7 @@ impl<T: Trait> BountyActorManager<T> {
         }
     }
 
-    // Validate balance is sufficient for the bounty
+    /// Validate balance is sufficient for the bounty
     pub(crate) fn validate_balance_sufficiency(
         &self,
         required_balance: BalanceOf<T>,
@@ -85,7 +85,7 @@ impl<T: Trait> BountyActorManager<T> {
         T::CouncilBudgetManager::get_budget() >= amount
     }
 
-    // Validate that provided actor relates to the initial BountyActor.
+    /// Validate that provided actor relates to the initial BountyActor.
     pub(crate) fn validate_actor(&self, actor: &BountyActor<MemberId<T>>) -> DispatchResult {
         let initial_actor = match self {
             BountyActorManager::Council => BountyActor::Council,
@@ -97,7 +97,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    // Transfer funds for the bounty creation.
+    /// Transfer funds for the bounty creation.
     pub(crate) fn transfer_funds_to_bounty_account(
         &self,
         bounty_id: T::BountyId,
@@ -122,7 +122,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    // Restore a balance for the bounty creator.
+    /// Restore a balance for the bounty creator.
     pub(crate) fn transfer_funds_from_bounty_account(
         &self,
         bounty_id: T::BountyId,

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -137,6 +137,9 @@ pub trait Trait: frame_system::Trait + balances::Trait + common::membership::Tra
     /// Defines min cherry for a bounty.
     type MinCherryLimit: Get<BalanceOf<Self>>;
 
+    /// Defines min oracle cherry for a bounty.
+    type MinOracleCherryLimit: Get<BalanceOf<Self>>;
+
     /// Defines min funding amount for a bounty.
     type MinFundingLimit: Get<BalanceOf<Self>>;
 
@@ -213,10 +216,16 @@ pub struct BountyParameters<Balance, BlockNumber, MemberId: Ord> {
     pub creator: BountyActor<MemberId>,
 
     /// An amount of funding provided by the creator which will be split among all other
-    /// contributors should the bounty not be successful. If successful, cherry is returned to
+    /// contributors should the bounty be successful. If not successful, cherry is returned to
     /// the creator. When council is creating bounty, this comes out of their budget, when a member
     /// does it, it comes from an account.
     pub cherry: Balance,
+
+    /// An amount of funding provided by the creator which will be attributed to the
+    /// oracle should the oracle submit a judgement. even if this judgement is negative, this cherry should be attributed to
+    /// the oracle. When council is creating bounty, this comes out of their budget, when a member
+    /// does it, it comes from an account.
+    pub oracle_cherry: Balance,
 
     /// Amount of stake required to enter bounty as entrant.
     pub entrant_stake: Balance,
@@ -525,6 +534,17 @@ decl_event! {
         /// - bounty creator
         BountyCreatorCherryWithdrawal(BountyId, BountyActor<MemberId>),
 
+        /// A bounty creator has withdrawn the oracle cherry (member or council).
+        /// Params:
+        /// - bounty ID
+        /// - bounty creator
+        BountyCreatorOracleCherryWithdrawal(BountyId, BountyActor<MemberId>),
+
+        /// A Oracle has withdrawn the oracle cherry (member or council).
+        /// Params:
+        /// - bounty ID
+        /// - bounty creator
+        BountyOracleCherryWithdrawal(BountyId, BountyActor<MemberId>),
         /// A bounty was removed.
         /// Params:
         /// - bounty ID
@@ -641,6 +661,9 @@ decl_error! {
         /// Cherry less then minimum allowed.
         CherryLessThenMinimumAllowed,
 
+        /// Oracle Cherry less then minimum allowed.
+        OracleCherryLessThenMinimumAllowed,
+
         /// Funding amount less then minimum allowed.
         FundingLessThenMinimumAllowed,
 
@@ -697,6 +720,9 @@ decl_module! {
         /// Exports const - min cherry value limit for a bounty.
         const MinCherryLimit: BalanceOf<T> = T::MinCherryLimit::get();
 
+        /// Exports const - min oracle cherry value limit for a bounty.
+        const MinOracleCherryLimit: BalanceOf<T> = T::MinOracleCherryLimit::get();
+
         /// Exports const - min funding amount limit for a bounty.
         const MinFundingLimit: BalanceOf<T> = T::MinFundingLimit::get();
 
@@ -722,7 +748,7 @@ decl_module! {
 
             Self::ensure_create_bounty_parameters_valid(&params)?;
 
-            bounty_creator_manager.validate_balance_sufficiency(params.cherry)?;
+            bounty_creator_manager.validate_balance_sufficiency(params.cherry + params.oracle_cherry)?;
 
             //
             // == MUTATION SAFE ==
@@ -731,7 +757,7 @@ decl_module! {
             let next_bounty_count_value = Self::bounty_count() + 1;
             let bounty_id = T::BountyId::from(next_bounty_count_value);
 
-            bounty_creator_manager.transfer_funds_to_bounty_account(bounty_id, params.cherry)?;
+            bounty_creator_manager.transfer_funds_to_bounty_account(bounty_id, params.cherry + params.oracle_cherry)?;
 
             let created_bounty_milestone = BountyMilestone::Created {
                 created_at: Self::current_block(),
@@ -782,6 +808,7 @@ decl_module! {
             //
 
             Self::return_bounty_cherry_to_creator(bounty_id, &bounty)?;
+            Self::return_bounty_oracle_cherry_to_creator(bounty_id, &bounty)?;
 
             Self::remove_bounty(&bounty_id);
 
@@ -815,7 +842,7 @@ decl_module! {
             //
 
             Self::return_bounty_cherry_to_creator(bounty_id, &bounty)?;
-
+            Self::return_bounty_oracle_cherry_to_creator(bounty_id, &bounty)?;
             Self::remove_bounty(&bounty_id);
 
             Self::deposit_event(RawEvent::BountyVetoed(bounty_id));
@@ -941,7 +968,10 @@ decl_module! {
 
             Self::deposit_event(RawEvent::BountyFundingWithdrawal(bounty_id, funder));
 
+
             if Self::withdrawal_completed(&current_bounty_stage, &bounty_id) {
+                //Only when all funds are withdrawn, should the oracle cherry reeturn to the creator.
+                Self::return_bounty_oracle_cherry_to_creator(bounty_id, &bounty)?;
                 Self::remove_bounty(&bounty_id);
             }
         }
@@ -1169,6 +1199,17 @@ decl_module! {
                 }
             }
 
+
+            //Transferers oracle cherry to the oracle
+            bounty_oracle_manager
+                .transfer_funds_from_bounty_account(bounty_id, bounty.creation_params.oracle_cherry)?;
+
+            Self::deposit_event(RawEvent::BountyOracleCherryWithdrawal(
+                bounty_id,
+                bounty.creation_params.oracle,
+            ));
+
+
             // Fire a judgment event.
             Self::deposit_event(RawEvent::OracleJudgmentSubmitted(bounty_id, oracle, judgment));
         }
@@ -1291,6 +1332,11 @@ impl<T: Trait> Module<T> {
         }
 
         ensure!(
+            params.oracle_cherry >= T::MinOracleCherryLimit::get(),
+            Error::<T>::OracleCherryLessThenMinimumAllowed
+        );
+
+        ensure!(
             params.cherry >= T::MinCherryLimit::get(),
             Error::<T>::CherryLessThenMinimumAllowed
         );
@@ -1377,7 +1423,7 @@ impl<T: Trait> Module<T> {
         funding_share * bounty.creation_params.cherry
     }
 
-    // Remove bounty and all related info from the storage.
+    /// Remove bounty and all related info from the storage.
     fn remove_bounty(bounty_id: &T::BountyId) {
         <Bounties<T>>::remove(bounty_id);
         <BountyContributions<T>>::remove_prefix(bounty_id);
@@ -1707,6 +1753,26 @@ impl<T: Trait> Module<T> {
             .transfer_funds_from_bounty_account(bounty_id, bounty.creation_params.cherry)?;
 
         Self::deposit_event(RawEvent::BountyCreatorCherryWithdrawal(
+            bounty_id,
+            bounty.creation_params.creator.clone(),
+        ));
+
+        Ok(())
+    }
+
+    /// Transfers oracle cherry back to the bounty creator and fires an event.
+    fn return_bounty_oracle_cherry_to_creator(
+        bounty_id: T::BountyId,
+        bounty: &Bounty<T>,
+    ) -> DispatchResult {
+        let bounty_creator_manager = BountyActorManager::<T>::get_bounty_actor_manager(
+            bounty.creation_params.creator.clone(),
+        )?;
+
+        bounty_creator_manager
+            .transfer_funds_from_bounty_account(bounty_id, bounty.creation_params.oracle_cherry)?;
+
+        Self::deposit_event(RawEvent::BountyCreatorOracleCherryWithdrawal(
             bounty_id,
             bounty.creation_params.creator.clone(),
         ));

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -101,6 +101,7 @@ impl EventFixture {
 }
 
 pub const DEFAULT_BOUNTY_CHERRY: u64 = 10;
+pub const DEFAULT_BOUNTY_ORACLE_CHERRY: u64 = 10;
 pub const DEFAULT_BOUNTY_ENTRANT_STAKE: u64 = 10;
 pub const DEFAULT_BOUNTY_MAX_AMOUNT: u64 = 1000;
 pub const DEFAULT_BOUNTY_MIN_AMOUNT: u64 = 1;
@@ -114,6 +115,7 @@ pub struct CreateBountyFixture {
     work_period: u64,
     judging_period: u64,
     cherry: u64,
+    oracle_cherry: u64,
     expected_milestone: Option<BountyMilestone<u64>>,
     entrant_stake: u64,
     contract_type: AssuranceContractType<u64>,
@@ -132,6 +134,7 @@ impl CreateBountyFixture {
             work_period: 1,
             judging_period: 1,
             cherry: DEFAULT_BOUNTY_CHERRY,
+            oracle_cherry: DEFAULT_BOUNTY_ORACLE_CHERRY,
             expected_milestone: None,
             entrant_stake: DEFAULT_BOUNTY_ENTRANT_STAKE,
             contract_type: AssuranceContractType::Open,
@@ -224,6 +227,13 @@ impl CreateBountyFixture {
         Self { cherry, ..self }
     }
 
+    pub fn with_oracle_cherry(self, oracle_cherry: u64) -> Self {
+        Self {
+            oracle_cherry,
+            ..self
+        }
+    }
+
     pub fn with_entrant_stake(self, entrant_stake: u64) -> Self {
         Self {
             entrant_stake,
@@ -247,6 +257,7 @@ impl CreateBountyFixture {
             work_period: self.work_period.clone(),
             judging_period: self.judging_period.clone(),
             cherry: self.cherry,
+            oracle_cherry: self.oracle_cherry,
             entrant_stake: self.entrant_stake,
             contract_type: self.contract_type.clone(),
             oracle: self.oracle.clone(),

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -59,6 +59,7 @@ parameter_types! {
     pub const BountyLockId: [u8; 8] = [12; 8];
     pub const ClosedContractSizeLimit: u32 = 3;
     pub const MinCherryLimit: u64 = 10;
+    pub const MinOracleCherryLimit: u64 = 10;
     pub const MinFundingLimit: u64 = 50;
     pub const MinWorkEntrantStake: u64 = 10;
 }
@@ -102,6 +103,7 @@ impl Trait for Test {
     type EntryId = u64;
     type ClosedContractSizeLimit = ClosedContractSizeLimit;
     type MinCherryLimit = MinCherryLimit;
+    type MinOracleCherryLimit = MinOracleCherryLimit;
     type MinFundingLimit = MinFundingLimit;
     type MinWorkEntrantStake = MinWorkEntrantStake;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -923,6 +923,7 @@ parameter_types! {
     pub const BountyModuleId: ModuleId = ModuleId(*b"m:bounty"); // module : bounty
     pub const ClosedContractSizeLimit: u32 = 50;
     pub const MinCherryLimit: Balance = 10;
+    pub const MinOracleCherryLimit: Balance = 10;
     pub const MinFundingLimit: Balance = 10;
     pub const MinWorkEntrantStake: Balance = 100;
 }
@@ -938,6 +939,7 @@ impl bounty::Trait for Runtime {
     type EntryId = u64;
     type ClosedContractSizeLimit = ClosedContractSizeLimit;
     type MinCherryLimit = MinCherryLimit;
+    type MinOracleCherryLimit = MinOracleCherryLimit;
     type MinFundingLimit = MinFundingLimit;
     type MinWorkEntrantStake = MinWorkEntrantStake;
 }


### PR DESCRIPTION
A new field was added to the bounty pallet "MinOracleCherryLimit" 
When a creator creates a bounty he has to set a specific cherry and oracle cherry,

If the bounty is in the "Founding Period", has no contributions and is cancelled,
the cherry and oracle cherry must return to the bounty creator.

If the bounty is in the "Founding Period", has no contributions and is vetoed,
the cherry and oracle cherry must return to the bounty creator.

If the bounty the "Working Period" expires and there are no active entries, 
the cherry is divided between the workers, and the oracle cherry goes to the creator. 

if an oracle submits a judgement, he gets the oracle cherry, even if It's a negative judgement. 