### PR TITLE
Content migration script: Fix alternativeEndpoints

### DIFF
--- a/utils/migration-scripts/src/logging.ts
+++ b/utils/migration-scripts/src/logging.ts
@@ -10,7 +10,7 @@ winston.addColors(colors)
 
 export function createLogger(label: string): Logger {
   return winston.createLogger({
-    level: 'debug',
+    level: process.env.DEBUG ? 'debug' : 'info',
     transports: [new winston.transports.Console()],
     defaultMeta: { label },
     format: winston.format.combine(

--- a/utils/migration-scripts/src/sumer-giza/AssetsManager.ts
+++ b/utils/migration-scripts/src/sumer-giza/AssetsManager.ts
@@ -202,9 +202,11 @@ export class AssetsManager {
     let lastError: Error | undefined
     for (const endpoint of endpoints) {
       try {
+        this.logger.debug(`Trying to fetch asset ${contentId} from ${endpoint}...`)
         const tmpAssetPath = await this.fetchAsset(endpoint, contentId, expectedSize)
         return tmpAssetPath
       } catch (e) {
+        this.logger.debug(`Fetching ${contentId} from ${endpoint} failed: ${(e as Error).message}`)
         lastError = e as Error
         continue
       }

--- a/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
@@ -54,6 +54,7 @@ export class ContentMigration {
     const forcedChannelOwner = await this.getForcedChannelOwner()
     const assetsManager = await AssetsManager.create({
       api,
+      queryNodeApi,
       config,
     })
     const { idsMap: channelsMap, videoIds } = await new ChannelMigration({


### PR DESCRIPTION
Adds missing `queryNodeApi` to `AssetsManager.create` call, allowing the `AssetsManager` to use alternative Sumer storage node endpoints when the default storage endpoint(s) fail(s).

Adds more `debug` logs and allows controlling the log level through `DEBUG` env, ie:
```
# Log level = debug:
DEBUG=true yarn migration-scripts ...

# Log level = info (default):
yarn migration-scripts ...
```