### PR TITLE
closes #2821 Built-in reward for bounty oracles

### DIFF
--- a/runtime-modules/bounty/src/actors.rs
+++ b/runtime-modules/bounty/src/actors.rs
@@ -58,7 +58,7 @@ impl<T: Trait> BountyActorManager<T> {
         }
     }
 
-    // Validate balance is sufficient for the bounty
+    /// Validate balance is sufficient for the bounty
     pub(crate) fn validate_balance_sufficiency(
         &self,
         required_balance: BalanceOf<T>,
@@ -85,7 +85,7 @@ impl<T: Trait> BountyActorManager<T> {
         T::CouncilBudgetManager::get_budget() >= amount
     }
 
-    // Validate that provided actor relates to the initial BountyActor.
+    /// Validate that provided actor relates to the initial BountyActor.
     pub(crate) fn validate_actor(&self, actor: &BountyActor<MemberId<T>>) -> DispatchResult {
         let initial_actor = match self {
             BountyActorManager::Council => BountyActor::Council,
@@ -97,7 +97,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    // Transfer funds for the bounty creation.
+    /// Transfer funds for the bounty creation.
     pub(crate) fn transfer_funds_to_bounty_account(
         &self,
         bounty_id: T::BountyId,
@@ -122,7 +122,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    // Restore a balance for the bounty creator.
+    /// Restore a balance for the bounty creator.
     pub(crate) fn transfer_funds_from_bounty_account(
         &self,
         bounty_id: T::BountyId,

--- a/runtime-modules/bounty/src/actors.rs
+++ b/runtime-modules/bounty/src/actors.rs
@@ -58,7 +58,7 @@ impl<T: Trait> BountyActorManager<T> {
         }
     }
 
-    /// Validate balance is sufficient for the bounty
+    // Validate balance is sufficient for the bounty
     pub(crate) fn validate_balance_sufficiency(
         &self,
         required_balance: BalanceOf<T>,
@@ -85,7 +85,7 @@ impl<T: Trait> BountyActorManager<T> {
         T::CouncilBudgetManager::get_budget() >= amount
     }
 
-    /// Validate that provided actor relates to the initial BountyActor.
+    // Validate that provided actor relates to the initial BountyActor.
     pub(crate) fn validate_actor(&self, actor: &BountyActor<MemberId<T>>) -> DispatchResult {
         let initial_actor = match self {
             BountyActorManager::Council => BountyActor::Council,
@@ -97,7 +97,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    /// Transfer funds for the bounty creation.
+    // Transfer funds for the bounty creation.
     pub(crate) fn transfer_funds_to_bounty_account(
         &self,
         bounty_id: T::BountyId,
@@ -122,7 +122,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    /// Restore a balance for the bounty creator.
+    // Restore a balance for the bounty creator.
     pub(crate) fn transfer_funds_from_bounty_account(
         &self,
         bounty_id: T::BountyId,

--- a/runtime-modules/bounty/src/benchmarking.rs
+++ b/runtime-modules/bounty/src/benchmarking.rs
@@ -992,6 +992,121 @@ benchmarks! {
         );
         assert_last_event::<T>(Event::<T>::BountyRemoved(bounty_id).into());
     }
+    oracle_council_switch_to_oracle_member {
+
+        let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
+
+        let oracle = BountyActor::Council;
+
+        let (new_oracle_account_id, new_oracle_member_id) = member_funded_account::<T>("new_oracle", 2);
+        let new_oracle = BountyActor::Member(new_oracle_member_id);
+
+        let creator = BountyActor::Council;
+
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
+
+        let params = BountyCreationParameters::<T>{
+            creator,
+            cherry,
+            oracle_cherry,
+            oracle: oracle.clone(),
+            work_period: One::one(),
+            judging_period: One::one(),
+            funding_type: FundingType::Perpetual{ target: 100u32.into() },
+            entrant_stake: 100u32.into(),
+            ..Default::default()
+        };
+
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params.clone(), Vec::new()).unwrap();
+
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
+
+    }: switch_oracle (RawOrigin::Root, new_oracle.clone(), bounty_id)
+    verify {
+        let bounty_id: T::BountyId = 1u32.into();
+
+        assert!(Bounties::<T>::contains_key(bounty_id));
+        assert_eq!(Bounty::<T>::bounty_count(), 1); // Bounty counter was updated.
+        assert_last_event::<T>(Event::<T>::BountyOracleSwitched(bounty_id, oracle, new_oracle).into());
+    }
+    oracle_member_switch_to_oracle_member{
+
+        let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
+
+        let (current_oracle_account_id, current_oracle_member_id) = member_funded_account::<T>("current_oracle", 1);
+        let oracle = BountyActor::Member(current_oracle_member_id);
+
+        let (new_oracle_account_id, new_oracle_member_id) = member_funded_account::<T>("new_oracle", 2);
+        let new_oracle = BountyActor::Member(new_oracle_member_id);
+
+        let creator = BountyActor::Council;
+
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
+
+        let params = BountyCreationParameters::<T>{
+            creator,
+            cherry,
+            oracle_cherry,
+            oracle: oracle.clone(),
+            work_period: One::one(),
+            judging_period: One::one(),
+            funding_type: FundingType::Perpetual{ target: 100u32.into() },
+            entrant_stake: 100u32.into(),
+            ..Default::default()
+        };
+
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params.clone(), Vec::new()).unwrap();
+
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
+
+    }: switch_oracle (RawOrigin::Signed(current_oracle_account_id), new_oracle.clone(), bounty_id)
+    verify {
+        let bounty_id: T::BountyId = 1u32.into();
+
+        assert!(Bounties::<T>::contains_key(bounty_id));
+        assert_eq!(Bounty::<T>::bounty_count(), 1); // Bounty counter was updated.
+        assert_last_event::<T>(Event::<T>::BountyOracleSwitched(bounty_id, oracle, new_oracle).into());
+    }
+    oracle_member_switch_to_oracle_council {
+
+        let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
+
+        let (current_oracle_account_id, current_oracle_member_id) = member_funded_account::<T>("current_oracle", 1);
+        let oracle = BountyActor::Member(current_oracle_member_id);
+
+        let new_oracle = BountyActor::Council;
+
+        let creator = BountyActor::Council;
+
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
+
+        let params = BountyCreationParameters::<T>{
+            creator,
+            cherry,
+            oracle_cherry,
+            oracle: oracle.clone(),
+            work_period: One::one(),
+            judging_period: One::one(),
+            funding_type: FundingType::Perpetual{ target: 100u32.into() },
+            entrant_stake: 100u32.into(),
+            ..Default::default()
+        };
+
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params.clone(), Vec::new()).unwrap();
+
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
+
+    }: switch_oracle (RawOrigin::Signed(current_oracle_account_id), new_oracle.clone(), bounty_id)
+    verify {
+        let bounty_id: T::BountyId = 1u32.into();
+
+        assert!(Bounties::<T>::contains_key(bounty_id));
+        assert_eq!(Bounty::<T>::bounty_count(), 1); // Bounty counter was updated.
+        assert_last_event::<T>(Event::<T>::BountyOracleSwitched(bounty_id, oracle, new_oracle).into());
+    }
 }
 
 #[cfg(test)]
@@ -1116,6 +1231,27 @@ mod tests {
     fn withdraw_work_entrant_funds() {
         build_test_externalities().execute_with(|| {
             assert_ok!(test_benchmark_withdraw_work_entrant_funds::<Test>());
+        });
+    }
+
+    #[test]
+    fn oracle_council_switch_to_oracle_member() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_oracle_council_switch_to_oracle_member::<Test>());
+        });
+    }
+
+    #[test]
+    fn oracle_member_switch_to_oracle_member() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_oracle_member_switch_to_oracle_member::<Test>());
+        });
+    }
+
+    #[test]
+    fn oracle_member_switch_to_oracle_council() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_oracle_member_switch_to_oracle_council::<Test>());
         });
     }
 }

--- a/runtime-modules/bounty/src/benchmarking.rs
+++ b/runtime-modules/bounty/src/benchmarking.rs
@@ -170,7 +170,7 @@ fn create_funded_bounty<T: Trait>(
     params: BountyCreationParameters<T>,
     funding_amount: BalanceOf<T>,
 ) -> T::BountyId {
-    T::CouncilBudgetManager::set_budget(params.cherry + funding_amount);
+    T::CouncilBudgetManager::set_budget(params.cherry + params.oracle_cherry + funding_amount);
 
     Bounty::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
 
@@ -208,10 +208,11 @@ benchmarks! {
 
         let metadata = vec![0u8].repeat(i as usize);
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
         let max_amount: BalanceOf<T> = 1000u32.into();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let members = (1..=j)
             .map(|id| id.saturated_into())
@@ -221,6 +222,7 @@ benchmarks! {
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: max_amount },
             contract_type: AssuranceContractType::Closed(members),
@@ -242,6 +244,7 @@ benchmarks! {
 
         let metadata = vec![0u8].repeat(i as usize);
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
         let max_amount: BalanceOf<T> = 1000u32.into();
 
@@ -257,6 +260,7 @@ benchmarks! {
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             entrant_stake,
             creator: BountyActor::Member(member_id),
             funding_type: FundingType::Perpetual{ target: max_amount },
@@ -275,16 +279,18 @@ benchmarks! {
 
     cancel_bounty_by_council {
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let max_amount: BalanceOf<T> = 1000u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let creator = BountyActor::Council;
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             creator: creator.clone(),
             // same complexity with limited funding and FundingExpired stage.
             funding_type: FundingType::Perpetual{ target: max_amount },
@@ -305,12 +311,13 @@ benchmarks! {
 
     cancel_bounty_by_member {
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let max_amount: BalanceOf<T> = 1000u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
         let (account_id, member_id) = member_funded_account::<T>("member1", 0);
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let creator = BountyActor::Member(member_id);
 
@@ -318,6 +325,7 @@ benchmarks! {
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             creator: creator.clone(),
             // same complexity with limited funding and FundingExpired stage.
             funding_type: FundingType::Perpetual{ target: max_amount },
@@ -343,15 +351,17 @@ benchmarks! {
     veto_bounty {
         let max_amount: BalanceOf<T> = 1000u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
             judging_period: One::one(),
             funding_type: FundingType::Perpetual{ target: max_amount },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -370,15 +380,17 @@ benchmarks! {
     fund_bounty_by_member {
         let max_amount: BalanceOf<T> = 100u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
             judging_period: One::one(),
             funding_type: FundingType::Perpetual{ target: max_amount },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -405,15 +417,17 @@ benchmarks! {
     fund_bounty_by_council {
         let max_amount: BalanceOf<T> = 100u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry + max_amount);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry + max_amount);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
             judging_period: One::one(),
             funding_type: FundingType::Perpetual{ target: max_amount },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -435,9 +449,10 @@ benchmarks! {
         let funding_period = 1u32;
         let bounty_amount: BalanceOf<T> = 200u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
@@ -448,6 +463,7 @@ benchmarks! {
                 funding_period: funding_period.into(),
             },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -488,10 +504,11 @@ benchmarks! {
         let funding_period = 1u32;
         let bounty_amount: BalanceOf<T> = 200u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry + funding_amount);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry + funding_amount);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
@@ -502,6 +519,7 @@ benchmarks! {
                 funding_period: funding_period.into(),
             },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -525,7 +543,7 @@ benchmarks! {
 
     }: withdraw_funding(RawOrigin::Root, funder, bounty_id)
     verify {
-        assert_eq!(T::CouncilBudgetManager::get_budget(), cherry + funding_amount);
+        assert_eq!(T::CouncilBudgetManager::get_budget(), cherry + oracle_cherry + funding_amount);
         assert_last_event::<T>(Event::<T>::BountyRemoved(bounty_id).into());
     }
 
@@ -533,6 +551,7 @@ benchmarks! {
         let i in 1 .. T::ClosedContractSizeLimit::get();
 
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let stake: BalanceOf<T> = 100u32.into();
 
@@ -548,6 +567,7 @@ benchmarks! {
             judging_period: One::one(),
             funding_type: FundingType::Perpetual{ target: funding_amount },
             cherry,
+            oracle_cherry,
             contract_type,
             entrant_stake: stake,
             ..Default::default()
@@ -579,6 +599,7 @@ benchmarks! {
 
     withdraw_work_entry {
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let stake: BalanceOf<T> = 100u32.into();
 
@@ -586,6 +607,7 @@ benchmarks! {
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             entrant_stake: stake,
             ..Default::default()
@@ -617,6 +639,7 @@ benchmarks! {
         let work_data = vec![0u8].repeat(i as usize);
 
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let max_amount: BalanceOf<T> = 10000u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
@@ -628,6 +651,7 @@ benchmarks! {
             work_period,
             judging_period,
             cherry,
+            oracle_cherry,
             funding_type: FundingType::Limited{
                 min_funding_amount: funding_amount,
                 max_funding_amount: max_amount,
@@ -670,6 +694,7 @@ benchmarks! {
 
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 10000000u32.into();
         let oracle = BountyActor::Council;
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
@@ -679,6 +704,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: BountyActor::Council,
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
@@ -733,6 +759,7 @@ benchmarks! {
 
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let oracle = BountyActor::Council;
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
@@ -742,6 +769,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: BountyActor::Council,
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
@@ -776,6 +804,7 @@ benchmarks! {
 
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 10000000u32.into();
         let work_period: T::BlockNumber = One::one();
         let (oracle_account_id, oracle_member_id) = member_funded_account::<T>("oracle", 1);
@@ -787,6 +816,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: BountyActor::Council,
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
@@ -846,6 +876,7 @@ benchmarks! {
 
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let work_period: T::BlockNumber = One::one();
         let (oracle_account_id, oracle_member_id) = member_funded_account::<T>("oracle", 1);
@@ -857,6 +888,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: BountyActor::Council,
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
@@ -894,6 +926,7 @@ benchmarks! {
     withdraw_work_entrant_funds {
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let work_period: T::BlockNumber = One::one();
         let (oracle_account_id, oracle_member_id) = member_funded_account::<T>("oracle", 1);
@@ -906,6 +939,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: creator.clone(),
             cherry,
+            oracle_cherry,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
             entrant_stake: stake,

--- a/runtime-modules/bounty/src/stages.rs
+++ b/runtime-modules/bounty/src/stages.rs
@@ -19,7 +19,9 @@ impl<'a, T: Trait> BountyStageCalculator<'a, T> {
             .or_else(|| self.is_work_submission_stage())
             .or_else(|| self.is_judgment_stage())
             .or_else(|| self.is_successful_bounty_withdrawal_stage())
-            .unwrap_or(BountyStage::FailedBountyWithdrawal)
+            .unwrap_or(BountyStage::FailedBountyWithdrawal {
+                judgment_submitted: false,
+            })
     }
 
     // Calculates funding stage of the bounty.
@@ -131,15 +133,20 @@ impl<'a, T: Trait> BountyStageCalculator<'a, T> {
         None
     }
 
-    // Calculates withdrawal stage for the successful bounty.
+    // Calculates withdrawal stage for the bounty.
     // Returns None if conditions are not met.
     fn is_successful_bounty_withdrawal_stage(&self) -> Option<BountyStage> {
-        // The bounty judgment was submitted and the bounty is successful (there are some winners).
+        //The bounty judgment was submitted and is successful (there are some winners)
+        //or unsuccessful (all entries rejected).
         if let BountyMilestone::JudgmentSubmitted { successful_bounty } =
             self.bounty.milestone.clone()
         {
             if successful_bounty {
                 return Some(BountyStage::SuccessfulBountyWithdrawal);
+            } else {
+                return Some(BountyStage::FailedBountyWithdrawal {
+                    judgment_submitted: true,
+                });
             }
         }
 

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -830,3 +830,39 @@ impl WithdrawWorkEntrantFundsFixture {
         }
     }
 }
+
+pub struct SwitchOracleFixture {
+    origin: RawOrigin<u128>,
+    new_oracle: BountyActor<u64>,
+    bounty_id: u64,
+}
+
+impl SwitchOracleFixture {
+    pub fn default() -> Self {
+        Self {
+            origin: RawOrigin::Root,
+            new_oracle: BountyActor::Member(2),
+            bounty_id: 1,
+        }
+    }
+    pub fn with_origin(self, origin: RawOrigin<u128>) -> Self {
+        Self { origin, ..self }
+    }
+
+    pub fn with_new_oracle_member_id(self, bounty_actor: BountyActor<u64>) -> Self {
+        Self {
+            new_oracle: bounty_actor,
+            ..self
+        }
+    }
+
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let actual_result = Bounty::switch_oracle(
+            self.origin.clone().into(),
+            self.new_oracle.clone(),
+            self.bounty_id,
+        );
+
+        assert_eq!(actual_result, expected_result);
+    }
+}

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -45,6 +45,11 @@ pub fn increase_account_balance(account_id: &u128, balance: u64) {
     let _ = Balances::deposit_creating(&account_id, balance);
 }
 
+pub fn decrease_bounty_account_balance(bounty_id: u64, amount: u64) {
+    let account_id = Bounty::bounty_account_id(bounty_id);
+    let _ = Balances::slash(&account_id, amount);
+}
+
 pub struct EventFixture;
 impl EventFixture {
     pub fn assert_last_crate_event(

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -101,6 +101,7 @@ impl EventFixture {
 }
 
 pub const DEFAULT_BOUNTY_CHERRY: u64 = 10;
+pub const DEFAULT_BOUNTY_ORACLE_CHERRY: u64 = 10;
 pub const DEFAULT_BOUNTY_ENTRANT_STAKE: u64 = 10;
 pub const DEFAULT_BOUNTY_MAX_AMOUNT: u64 = 1000;
 pub const DEFAULT_BOUNTY_MIN_AMOUNT: u64 = 1;
@@ -114,6 +115,7 @@ pub struct CreateBountyFixture {
     work_period: u64,
     judging_period: u64,
     cherry: u64,
+    oracle_cherry: u64,
     expected_milestone: Option<BountyMilestone<u64>>,
     entrant_stake: u64,
     contract_type: AssuranceContractType<u64>,
@@ -132,6 +134,7 @@ impl CreateBountyFixture {
             work_period: 1,
             judging_period: 1,
             cherry: DEFAULT_BOUNTY_CHERRY,
+            oracle_cherry: DEFAULT_BOUNTY_ORACLE_CHERRY,
             expected_milestone: None,
             entrant_stake: DEFAULT_BOUNTY_ENTRANT_STAKE,
             contract_type: AssuranceContractType::Open,
@@ -224,6 +227,13 @@ impl CreateBountyFixture {
         Self { cherry, ..self }
     }
 
+    pub fn with_oracle_cherry(self, oracle_cherry: u64) -> Self {
+        Self {
+            oracle_cherry,
+            ..self
+        }
+    }
+
     pub fn with_entrant_stake(self, entrant_stake: u64) -> Self {
         Self {
             entrant_stake,
@@ -247,6 +257,7 @@ impl CreateBountyFixture {
             work_period: self.work_period.clone(),
             judging_period: self.judging_period.clone(),
             cherry: self.cherry,
+            oracle_cherry: self.oracle_cherry,
             entrant_stake: self.entrant_stake,
             contract_type: self.contract_type.clone(),
             oracle: self.oracle.clone(),

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -59,6 +59,7 @@ parameter_types! {
     pub const BountyLockId: [u8; 8] = [12; 8];
     pub const ClosedContractSizeLimit: u32 = 3;
     pub const MinCherryLimit: u64 = 10;
+    pub const MinOracleCherryLimit: u64 = 10;
     pub const MinFundingLimit: u64 = 50;
     pub const MinWorkEntrantStake: u64 = 10;
 }
@@ -102,6 +103,7 @@ impl Trait for Test {
     type EntryId = u64;
     type ClosedContractSizeLimit = ClosedContractSizeLimit;
     type MinCherryLimit = MinCherryLimit;
+    type MinOracleCherryLimit = MinOracleCherryLimit;
     type MinFundingLimit = MinFundingLimit;
     type MinWorkEntrantStake = MinWorkEntrantStake;
 }

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -162,6 +162,15 @@ impl crate::WeightInfo for () {
     fn cancel_bounty_by_council() -> u64 {
         0
     }
+    fn oracle_council_switch_to_oracle_member() -> u64 {
+        0
+    }
+    fn oracle_member_switch_to_oracle_member() -> u64 {
+        0
+    }
+    fn oracle_member_switch_to_oracle_council() -> u64 {
+        0
+    }
     fn veto_bounty() -> u64 {
         0
     }

--- a/runtime-modules/membership/src/benchmarking.rs
+++ b/runtime-modules/membership/src/benchmarking.rs
@@ -16,7 +16,7 @@ use sp_arithmetic::traits::One;
 use sp_arithmetic::Perbill;
 use sp_runtime::traits::Bounded;
 use sp_std::prelude::*;
-
+use sp_std::vec;
 /// Balance alias for `balances` module.
 pub type BalanceOf<T> = <T as balances::Trait>::Balance;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -929,6 +929,7 @@ parameter_types! {
     pub const BountyModuleId: ModuleId = ModuleId(*b"m:bounty"); // module : bounty
     pub const ClosedContractSizeLimit: u32 = 50;
     pub const MinCherryLimit: Balance = 10;
+    pub const MinOracleCherryLimit: Balance = 10;
     pub const MinFundingLimit: Balance = 10;
     pub const MinWorkEntrantStake: Balance = 100;
 }
@@ -944,6 +945,7 @@ impl bounty::Trait for Runtime {
     type EntryId = u64;
     type ClosedContractSizeLimit = ClosedContractSizeLimit;
     type MinCherryLimit = MinCherryLimit;
+    type MinOracleCherryLimit = MinOracleCherryLimit;
     type MinFundingLimit = MinFundingLimit;
     type MinWorkEntrantStake = MinWorkEntrantStake;
 }

--- a/runtime/src/weights/bounty.rs
+++ b/runtime/src/weights/bounty.rs
@@ -1,4 +1,4 @@
-//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.1
 
 #![allow(unused_parens)]
 #![allow(unused_imports)]
@@ -8,106 +8,121 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl bounty::WeightInfo for WeightInfo {
     fn create_bounty_by_council(i: u32, j: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((194_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((28_742_000 as Weight).saturating_mul(j as Weight))
+        (642_459_000 as Weight)
+            .saturating_add((177_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((4_148_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn create_bounty_by_member(i: u32, j: u32) -> Weight {
-        (843_057_000 as Weight)
-            .saturating_add((174_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((6_931_000 as Weight).saturating_mul(j as Weight))
+        (753_803_000 as Weight)
+            .saturating_add((178_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((6_539_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn cancel_bounty_by_council() -> Weight {
-        (527_000_000 as Weight)
+        (763_334_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn cancel_bounty_by_member() -> Weight {
-        (872_000_000 as Weight)
+        (1_387_193_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn veto_bounty() -> Weight {
-        (576_000_000 as Weight)
+        (767_493_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn fund_bounty_by_member() -> Weight {
-        (866_000_000 as Weight)
+        (940_458_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn fund_bounty_by_council() -> Weight {
-        (559_000_000 as Weight)
+        (574_726_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn withdraw_funding_by_member() -> Weight {
-        (939_000_000 as Weight)
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
+        (1_236_102_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn withdraw_funding_by_council() -> Weight {
-        (688_000_000 as Weight)
+        (944_520_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn announce_work_entry(i: u32) -> Weight {
-        (774_826_000 as Weight)
-            .saturating_add((10_400_000 as Weight).saturating_mul(i as Weight))
+        (808_136_000 as Weight)
+            .saturating_add((9_176_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn withdraw_work_entry() -> Weight {
-        (911_000_000 as Weight)
+        (944_051_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn submit_work(i: u32) -> Weight {
-        (546_484_000 as Weight)
-            .saturating_add((171_000 as Weight).saturating_mul(i as Weight))
+        (589_391_000 as Weight)
+            .saturating_add((179_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn submit_oracle_judgment_by_council_all_winners(i: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((150_234_000 as Weight).saturating_mul(i as Weight))
+        (741_719_000 as Weight)
+            .saturating_add((125_997_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_council_all_rejected(i: u32) -> Weight {
-        (3_192_844_000 as Weight)
-            .saturating_add((552_887_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(1 as Weight))
+        (0 as Weight)
+            .saturating_add((647_153_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_member_all_winners(i: u32) -> Weight {
-        (317_671_000 as Weight)
-            .saturating_add((130_010_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
+        (1_129_839_000 as Weight)
+            .saturating_add((130_714_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_member_all_rejected(i: u32) -> Weight {
-        (261_974_000 as Weight)
-            .saturating_add((593_591_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(2 as Weight))
+        (1_282_401_000 as Weight)
+            .saturating_add((599_421_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn withdraw_work_entrant_funds() -> Weight {
-        (1_248_000_000 as Weight)
+        (1_388_099_000 as Weight)
             .saturating_add(DbWeight::get().reads(8 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
+    }
+    fn oracle_council_switch_to_oracle_member() -> Weight {
+        (430_417_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn oracle_member_switch_to_oracle_member() -> Weight {
+        (532_129_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn oracle_member_switch_to_oracle_council() -> Weight {
+        (417_054_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
     }
 }


### PR DESCRIPTION
A new field was added to the bounty pallet "MinOracleCherryLimit"
When a creator creates a bounty he has to set a specific cherry and oracle cherry,

If the bounty is in the "Founding Period", has no contributions and is cancelled,
the cherry and oracle cherry must return to the bounty creator.

If the bounty is in the "Founding Period", has no contributions and is vetoed,
the cherry and oracle cherry must return to the bounty creator.

If the bounty the "Working Period" expires and there are no active entries,
the cherry is divided between the workers, and the oracle cherry goes to the creator.

if an oracle submits a judgement, he gets the oracle cherry, even if It's a negative judgement.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201703380142370/1201703509272676) by [Unito](https://www.unito.io)
