### PR TITLE
Migration scripts: allow non-sudo transactions

### DIFF
--- a/utils/migration-scripts/src/commands/sumer-giza/migrateContent.ts
+++ b/utils/migration-scripts/src/commands/sumer-giza/migrateContent.ts
@@ -63,6 +63,11 @@ export class MigrateContentCommand extends Command {
       required: false,
       default: [],
     }),
+    logLevel: flags.string({
+      char: 'l',
+      description: 'Set log level: [error|warn|info|debug] [default: info]',
+      default: process.env.DEBUG ? 'debug' : 'info',
+    }),
   }
 
   async run(): Promise<void> {

--- a/utils/migration-scripts/src/commands/sumer-giza/migrateContent.ts
+++ b/utils/migration-scripts/src/commands/sumer-giza/migrateContent.ts
@@ -13,8 +13,8 @@ export class MigrateContentCommand extends Command {
       description: 'WS provider endpoint uri (Giza)',
       default: 'ws://localhost:9944',
     }),
-    sudoUri: flags.string({
-      description: 'Sudo key Substrate uri',
+    senderUri: flags.string({
+      description: '(Sudo) key Substrate uri. If not sudo, membership is required.',
       default: '//Alice',
     }),
     channelIds: flags.integer({

--- a/utils/migration-scripts/src/commands/sumer-giza/retryFailedUploads.ts
+++ b/utils/migration-scripts/src/commands/sumer-giza/retryFailedUploads.ts
@@ -28,6 +28,11 @@ export class RetryFailedUploadsCommand extends Command {
       description: 'Path to failed uploads file',
       required: true,
     }),
+    logLevel: flags.string({
+      char: 'l',
+      description: 'Set log level: [error|warn|info|debug] [default: info]',
+      default: process.env.DEBUG ? 'debug' : 'info',
+    }),
   }
 
   async run(): Promise<void> {

--- a/utils/migration-scripts/src/logging.ts
+++ b/utils/migration-scripts/src/logging.ts
@@ -10,7 +10,7 @@ winston.addColors(colors)
 
 export function createLogger(label: string): Logger {
   return winston.createLogger({
-    level: 'debug',
+    level: process.env.DEBUG ? 'debug' : 'info',
     transports: [new winston.transports.Console()],
     defaultMeta: { label },
     format: winston.format.combine(

--- a/utils/migration-scripts/src/logging.ts
+++ b/utils/migration-scripts/src/logging.ts
@@ -8,9 +8,9 @@ const colors = {
 }
 winston.addColors(colors)
 
-export function createLogger(label: string): Logger {
+export function createLogger(label: string, level: string = 'debug'): Logger {
   return winston.createLogger({
-    level: process.env.DEBUG ? 'debug' : 'info',
+    level,
     transports: [new winston.transports.Console()],
     defaultMeta: { label },
     format: winston.format.combine(

--- a/utils/migration-scripts/src/sumer-giza/AssetsManager.ts
+++ b/utils/migration-scripts/src/sumer-giza/AssetsManager.ts
@@ -202,9 +202,11 @@ export class AssetsManager {
     let lastError: Error | undefined
     for (const endpoint of endpoints) {
       try {
+        this.logger.debug(`Trying to fetch asset ${contentId} from ${endpoint}...`)
         const tmpAssetPath = await this.fetchAsset(endpoint, contentId, expectedSize)
         return tmpAssetPath
       } catch (e) {
+        this.logger.debug(`Fetching ${contentId} from ${endpoint} failed: ${(e as Error).message}`)
         lastError = e as Error
         continue
       }

--- a/utils/migration-scripts/src/sumer-giza/ChannelsMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/ChannelsMigration.ts
@@ -39,7 +39,7 @@ export class ChannelMigration extends AssetsMigration {
     super(params)
     this.config = params.config
     this.forcedChannelOwner = params.forcedChannelOwner
-    this.logger = createLogger(this.name)
+    this.logger = createLogger(this.name, this.config.logLevel)
   }
 
   private getChannelOwnerMember({ id, ownerMember }: ChannelFieldsFragment): AccoundId | number {
@@ -90,7 +90,7 @@ export class ChannelMigration extends AssetsMigration {
     const ids = channelIds.sort((a, b) => a - b)
     while (ids.length) {
       const idsBatch = ids.splice(0, channelBatchSize)
-      this.logger.info(`Fetching a batch of ${idsBatch.length} channels...`)
+      this.logger.info(`Fetching ${idsBatch.length} channel(s)`)
       const channelsBatch = (await this.queryNodeApi.getChannelsByIds(idsBatch)).sort(
         (a, b) => parseInt(a.id) - parseInt(b.id)
       )

--- a/utils/migration-scripts/src/sumer-giza/ChannelsMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/ChannelsMigration.ts
@@ -42,8 +42,9 @@ export class ChannelMigration extends AssetsMigration {
     this.logger = createLogger(this.name)
   }
 
-  private getChannelOwnerMember({ id, ownerMember }: ChannelFieldsFragment) {
-    if (this.member) return this.member
+  private getChannelOwnerMember({ id, ownerMember }: ChannelFieldsFragment): AccoundId | number {
+    if (!this.isSudo) return this.member
+
     if (!ownerMember) {
       throw new Error(`Chanel ownerMember missing: ${id}. Only member-owned channels are supported!`)
     }
@@ -57,7 +58,7 @@ export class ChannelMigration extends AssetsMigration {
 
   protected async migrateBatch(tx: SubmittableExtrinsic<'promise'>, channels: ChannelFieldsFragment[]): Promise<void> {
     const { api } = this
-    const result = await api.sendExtrinsic(this.sudo, tx)
+    const result = await api.sendExtrinsic(this.key, tx)
     const channelCreatedEvents = api.findEvents(result, 'content', 'ChannelCreated')
     const newChannelIds: ChannelId[] = channelCreatedEvents.map((e) => e.data[1])
     if (channelCreatedEvents.length !== channels.length) {

--- a/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/ContentMigration.ts
@@ -55,6 +55,7 @@ export class ContentMigration {
     const forcedChannelOwner = await this.getForcedChannelOwner()
     const assetsManager = await AssetsManager.create({
       api,
+      queryNodeApi,
       config,
     })
     const { idsMap: channelsMap, videoIds } = await new ChannelMigration({

--- a/utils/migration-scripts/src/sumer-giza/VideosMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/VideosMigration.ts
@@ -50,7 +50,7 @@ export class VideosMigration extends AssetsMigration {
 
   protected async migrateBatch(tx: SubmittableExtrinsic<'promise'>, videos: VideoFieldsFragment[]): Promise<void> {
     const { api } = this
-    const result = await api.sendExtrinsic(this.sudo, tx)
+    const result = await api.sendExtrinsic(this.key, tx)
     const videoCreatedEvents = api.findEvents(result, 'content', 'VideoCreated')
     const newVideoIds: VideoId[] = videoCreatedEvents.map((e) => e.data[2])
     if (videoCreatedEvents.length !== videos.length) {

--- a/utils/migration-scripts/src/sumer-giza/VideosMigration.ts
+++ b/utils/migration-scripts/src/sumer-giza/VideosMigration.ts
@@ -37,7 +37,7 @@ export class VideosMigration extends AssetsMigration {
     this.channelsMap = params.channelsMap
     this.videoIds = params.videoIds
     this.forcedChannelOwner = params.forcedChannelOwner
-    this.logger = createLogger(this.name)
+    this.logger = createLogger(this.name, this.config.logLevel)
   }
 
   private getNewChannelId(oldChannelId: number): number {
@@ -85,12 +85,12 @@ export class VideosMigration extends AssetsMigration {
       const alreadyMigratedVideosNum = videoIds.length - idsToMigrate.length
       this.logger.info(
         (idsToMigrate.length ? `${alreadyMigratedVideosNum}/${videoIds.length}` : 'All') +
-          ' videos already migrated, skippping...'
+          ' videos already migrated.'
       )
     }
     while (idsToMigrate.length) {
       const idsBatch = idsToMigrate.splice(0, videoBatchSize)
-      this.logger.info(`Fetching a batch of ${idsBatch.length} videos...`)
+      this.logger.info(`Fetching ${idsBatch.length} video(s)`)
       const videosBatch = (await this.queryNodeApi.getVideosByIds(idsBatch)).sort(
         (a, b) => parseInt(a.id) - parseInt(b.id)
       )


### PR DESCRIPTION
For the ongoing the [Giza test](https://github.com/traumschule/community-repo/tree/giza-testing/working-groups/operations-group/Giza-testing#storage-1) i tried to use #2819.

Because it requires a `sudo` key i modified `ChannelsMigration.ts` and `VideosMigration.ts` to let a member perform the transactions.


```
$ /root/joystream/node_modules/.bin/migration-scripts sumer-giza:migrateContent -c 2 3
Sudo key: 5Ev8KjT9UYvi1Joe8vvDCuK4YvFFSBH5MZQpKGzrcjLF5CLy
Our key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY (member 207)
Fetching a batch of 2 channels...
All channels in this batch were already migrated (2/2)
Added 39 video ids to the list of videos to migrate
Sudo key: 5Ev8KjT9UYvi1Joe8vvDCuK4YvFFSBH5MZQpKGzrcjLF5CLy
Our key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY (member 207)
Fetching a batch of 20 videos...
Sending utility.batch extrinsic from 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
Video map entries added! [
  [ 1, 807 ],   [ 2, 808 ],
  [ 3, 809 ],   [ 4, 810 ],
  [ 5, 811 ],   [ 12, 812 ],
  [ 13, 813 ],  [ 14, 814 ],
  [ 15, 815 ],  [ 16, 816 ],
  [ 17, 817 ],  [ 18, 818 ],
  [ 19, 819 ],  [ 20, 820 ],
  [ 21, 821 ],  [ 275, 822 ],
  [ 484, 823 ], [ 948, 824 ],
  [ 981, 825 ], [ 1266, 826 ]
]
Uploading 40 data objects...
Upload of object 2192 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
...
Upload of object 2221 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
Fetching a batch of 19 videos...
Sending utility.batch extrinsic from 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
Video map entries added! [
  [ 6495, 827 ], [ 6814, 828 ],
  [ 6854, 829 ], [ 6920, 830 ],
  [ 7048, 831 ], [ 7410, 832 ],
  [ 7411, 833 ], [ 7412, 834 ],
  [ 7413, 835 ], [ 7652, 836 ],
  [ 8139, 837 ], [ 8140, 838 ],
  [ 8141, 839 ], [ 8162, 840 ],
  [ 8443, 841 ], [ 8827, 842 ],
  [ 8848, 843 ], [ 8849, 844 ],
  [ 8850, 845 ]
]
Uploading 78 data objects...
Upload of object 2192 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
...
Upload of object 2219 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
  C-c                                                                              

$ /root/joystream/node_modules/.bin/migration-scripts sumer-giza:migrateContent -c 2 3
Sudo key: 5Ev8KjT9UYvi1Joe8vvDCuK4YvFFSBH5MZQpKGzrcjLF5CLy
Our key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY (member 207)
Fetching a batch of 2 channels...
All channels in this batch were already migrated (2/2)
Added 39 video ids to the list of videos to migrate
Sudo key: 5Ev8KjT9UYvi1Joe8vvDCuK4YvFFSBH5MZQpKGzrcjLF5CLy
Our key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY (member 207)
All videos already migrated, skippping...
Done in 8.83s.


# yarn migration-scripts sumer-giza:retryFailedUploads -f utils/migration-scripts/results/sumer-giza/channelsMigrationFailedUploads_1642061324133.json 
yarn run v1.22.4
$ /root/joystream/node_modules/.bin/migration-scripts sumer-giza:retryFailedUploads -f utils/migration-scripts/results/sumer-giza/channelsMigrationFailedUploads_1642061324133.json
Uploading 4 data objects...
Upload of object 2188 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
Upload of object 2189 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
Upload of object 2190 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
Upload of object 2191 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
Done in 6.69s.
```

The updated version behaves a bit differently:


```
$ /root/joystream/node_modules/.bin/migration-scripts sumer-giza:migrateContent -c 4 5 6
2022-01-13 09:54:32:5432 Assets Manager [info]: Failed/pending uploads will be saved to /root/joystream/utils/migration-scripts/results/sumer-giza/unprocessedUploads_1642067672225.json
Sudo key: 5Ev8KjT9UYvi1Joe8vvDCuK4YvFFSBH5MZQpKGzrcjLF5CLy
Our key: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY (member 207)
2022-01-13 09:54:32:5432 Channels migration [info]: Fetching a batch of 3 channels...
Error: Could not fetch asset 5DSuctx2Tu4fHo66pYBmEh5HBV8PZiLHebDdTtN6KNforip7 from any provider. Last error: timeout of 5000ms exceeded
    at AssetsManager.fetchAssetWithRetry (/root/joystream/utils/migration-scripts/src/sumer-giza/AssetsManager.ts:212:11)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at runNextTicks (internal/process/task_queues.js:64:3)
    at listOnTimeout (internal/timers.js:526:9)
    at processTimers (internal/timers.js:500:7)
    at AssetsManager.prepareAsset (/root/joystream/utils/migration-scripts/src/sumer-giza/AssetsManager.ts:133:18)
    at /root/joystream/utils/migration-scripts/src/sumer-giza/AssetsManager.ts:164:24
    at async Promise.all (index 0)
    at AssetsManager.prepareAssets (/root/joystream/utils/migration-scripts/src/sumer-giza/AssetsManager.ts:159:5)
    at ChannelMigration.prepareChannel (/root/joystream/utils/migration-scripts/src/sumer-giza/ChannelsMigration.ts:145:28)

# yarn migration-scripts sumer-giza:retryFailedUploads -f utils/migration-scripts/results/sumer-giza/videosMigrationFailedUploads_1642065850907.json 
yarn run v1.22.4
$ /root/joystream/node_modules/.bin/migration-scripts sumer-giza:retryFailedUploads -f utils/migration-scripts/results/sumer-giza/videosMigrationFailedUploads_1642065850907.json
2022-01-13 09:56:42:5642 Assets Manager [info]: Failed/pending uploads will be saved to utils/migration-scripts/results/sumer-giza/unprocessedUploads_1642067802456.json
2022-01-13 09:56:42:5642 Assets Manager [info]: Uploading 78 data objects...
2022-01-13 09:56:42:5642 Assets Manager [error]: Upload of object 2192 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
...
2022-01-13 09:57:02:572 Assets Manager [error]: Upload of object 2213 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
2022-01-13 09:57:03:573 Assets Manager [error]: Upload of object 2219 to http://localhost:3333 failed: {"type":"upload","message":"Error: Incorrect storage bucket ID."}
Killed
error Command failed with exit code 137.
```

Maybe i do not understand the new system enough but the script seems to assume that the local provider holds the same bucket the new assets get assigned to?

Creation of channels (https://giza-l1dev.joystream.app/#/explorer/query/315051) and videos (https://giza-l1dev.joystream.app/#/explorer/query/315762) works, just the uploads fail.

I did not try to apply f6bd4c9871f1491bd0d781560c947c95781c1aec yet.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201703380142370/1201703600079292) by [Unito](https://www.unito.io)
