### PR TITLE
DevOps - Orion deployment using Kubernetes and Pulumi

### DIFF
--- a/devops/kubernetes/orion/.gitignore
+++ b/devops/kubernetes/orion/.gitignore
@@ -1,0 +1,5 @@
+/bin/
+/node_modules/
+kubeconfig*
+package-lock.json
+Pulumi.*.yaml

--- a/devops/kubernetes/orion/Pulumi.yaml
+++ b/devops/kubernetes/orion/Pulumi.yaml
@@ -1,0 +1,23 @@
+name: orion
+runtime: nodejs
+description: A Pulumi program to deploy Orion service to Kubernetes
+template:
+  config:
+    aws:profile:
+      default: joystream-user
+    aws:region:
+      default: us-east-1
+    isMinikube:
+      description: Whether you are deploying to minikube
+      default: false
+    queryNodeEndpoint:
+      description: Full URL for Query node endpoint
+    isLoadBalancerReady:
+      description: Whether the load balancer service is ready and has been assigned an IP
+      default: false
+    storage:
+      description: Amount of storage in gigabytes for ipfs volume
+      default: 40
+    orionImage:
+      description: The Orion image to use for running the orion node
+      default: joystream/orion:latest

--- a/devops/kubernetes/orion/Pulumi.yaml
+++ b/devops/kubernetes/orion/Pulumi.yaml
@@ -21,3 +21,6 @@ template:
     orionImage:
       description: The Orion image to use for running the orion node
       default: joystream/orion:latest
+    contentSecret:
+      description: Orion featured content secret
+      default: password123

--- a/devops/kubernetes/orion/Pulumi.yaml
+++ b/devops/kubernetes/orion/Pulumi.yaml
@@ -23,4 +23,3 @@ template:
       default: joystream/orion:latest
     contentSecret:
       description: Orion featured content secret
-      default: password123

--- a/devops/kubernetes/orion/README.md
+++ b/devops/kubernetes/orion/README.md
@@ -39,6 +39,7 @@ After cloning this repo, from this working directory, run these commands:
    ```bash
    $ pulumi config set-all --plaintext queryNodeEndpoint='http://host.minikube.internal:8081/graphql' \
     --plaintext isMinikube=true --plaintext orionImage='joystream/orion:latest' \
+    --plaintext contentSecret='password123' \
     --plaintext aws:region=us-east-1 --plaintext aws:profile=joystream-user
    ```
 
@@ -48,7 +49,7 @@ After cloning this repo, from this working directory, run these commands:
    $ pulumi config set isMinikube false
    ```
 
-   You can also set the `storage` and `contentSecret` config parameters if required. Check `Pulumi.yaml` file for additional parameters.
+   You can also set the `storage` config parameter if required. Check `Pulumi.yaml` file for additional parameters.
 
 1. Stand up the EKS cluster:
 

--- a/devops/kubernetes/orion/README.md
+++ b/devops/kubernetes/orion/README.md
@@ -1,0 +1,118 @@
+# Amazon Kubernetes Cluster: Orion
+
+Deploy Orion to a Kubernetes cluster
+
+## Deploying the App
+
+To deploy your infrastructure, follow the below steps.
+
+### Prerequisites
+
+1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+1. [Install Node.js](https://nodejs.org/en/download/)
+1. Install a package manager for Node.js, such as [npm](https://www.npmjs.com/get-npm) or [Yarn](https://yarnpkg.com/en/docs/install).
+1. [Configure AWS Credentials](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
+1. Optional (for debugging): [Install kubectl](https://kubernetes.io/docs/tasks/tools/)
+
+### Steps
+
+After cloning this repo, from this working directory, run these commands:
+
+1. Install the required Node.js packages:
+
+   This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
+
+   ```bash
+   $ npm install
+   ```
+
+1. Create a new stack, which is an isolated deployment target for this example:
+
+   This will initialize the Pulumi program in TypeScript.
+
+   ```bash
+   $ pulumi stack init
+   ```
+
+1. Set the required configuration variables in `Pulumi.<stack>.yaml`
+
+   ```bash
+   $ pulumi config set-all --plaintext queryNodeEndpoint='http://host.minikube.internal:8081/graphql' \
+    --plaintext isMinikube=true --plaintext orionImage='joystream/orion:latest' \
+    --plaintext aws:region=us-east-1 --plaintext aws:profile=joystream-user
+   ```
+
+   If you want to build the stack on AWS set the `isMinikube` config to `false`
+
+   ```bash
+   $ pulumi config set isMinikube false
+   ```
+
+   You can also set the `storage` config parameter if required. Check `Pulumi.yaml` file for additional parameters.
+
+1. Stand up the EKS cluster:
+
+   Running `pulumi up -y` will deploy the EKS cluster. Note, provisioning a
+   new EKS cluster takes between 10-15 minutes.
+
+1. Once the stack if up and running, we will modify the Caddy config to get SSL certificate for the load balancer
+
+   Modify the config variable `isLoadBalancerReady`
+
+   ```bash
+   $ pulumi config set isLoadBalancerReady true
+   ```
+
+   Run `pulumi up -y` to update the Caddy config
+
+1. Access the Kubernetes Cluster using `kubectl`
+
+   To access your new Kubernetes cluster using `kubectl`, we need to set up the
+   `kubeconfig` file and download `kubectl`. We can leverage the Pulumi
+   stack output in the CLI, as Pulumi facilitates exporting these objects for us.
+
+   ```bash
+   $ pulumi stack output kubeconfig --show-secrets > kubeconfig
+   $ export KUBECONFIG=$PWD/kubeconfig
+   $ kubectl get nodes
+   ```
+
+   We can also use the stack output to query the cluster for our newly created Deployment:
+
+   ```bash
+   $ kubectl get deployment $(pulumi stack output deploymentName) --namespace=$(pulumi stack output namespaceName)
+   $ kubectl get service $(pulumi stack output serviceName) --namespace=$(pulumi stack output namespaceName)
+   ```
+
+   To get logs
+
+   ```bash
+   $ kubectl config set-context --current --namespace=$(pulumi stack output namespaceName)
+   $ kubectl get pods
+   $ kubectl logs <PODNAME> --all-containers
+   ```
+
+   To run a command on a pod
+
+   ```bash
+   $ kubectl exec ${POD_NAME} -c ${CONTAINER_NAME} -- ${CMD} ${ARG1}
+   ```
+
+   To see complete pulumi stack output
+
+   ```bash
+   $ pulumi stack output
+   ```
+
+   To execute a command
+
+   ```bash
+   $ kubectl exec --stdin --tty <PODNAME> -c colossus -- /bin/bash
+   ```
+
+1. Once you've finished experimenting, tear down your stack's resources by destroying and removing it:
+
+   ```bash
+   $ pulumi destroy --yes
+   $ pulumi stack rm --yes
+   ```

--- a/devops/kubernetes/orion/README.md
+++ b/devops/kubernetes/orion/README.md
@@ -48,7 +48,7 @@ After cloning this repo, from this working directory, run these commands:
    $ pulumi config set isMinikube false
    ```
 
-   You can also set the `storage` config parameter if required. Check `Pulumi.yaml` file for additional parameters.
+   You can also set the `storage` and `contentSecret` config parameters if required. Check `Pulumi.yaml` file for additional parameters.
 
 1. Stand up the EKS cluster:
 

--- a/devops/kubernetes/orion/index.ts
+++ b/devops/kubernetes/orion/index.ts
@@ -1,0 +1,153 @@
+import * as awsx from '@pulumi/awsx'
+import * as eks from '@pulumi/eks'
+import * as k8s from '@pulumi/kubernetes'
+import * as pulumi from '@pulumi/pulumi'
+import { CaddyServiceDeployment } from 'pulumi-common'
+import { MongoDBServiceDeployment } from './mongo'
+
+const awsConfig = new pulumi.Config('aws')
+const config = new pulumi.Config()
+
+const name = 'orion'
+
+const queryNodeHost = config.require('queryNodeEndpoint')
+const lbReady = config.get('isLoadBalancerReady') === 'true'
+const orionImage = config.get('orionImage') || `joystream/orion:latest`
+const storage = parseInt(config.get('storage') || '40')
+const isMinikube = config.getBoolean('isMinikube')
+
+export let kubeconfig: pulumi.Output<any>
+let provider: k8s.Provider
+
+if (isMinikube) {
+  provider = new k8s.Provider('local', {})
+} else {
+  // Create a VPC for our cluster.
+  const vpc = new awsx.ec2.Vpc('orion-vpc', { numberOfAvailabilityZones: 2, numberOfNatGateways: 1 })
+
+  // Create an EKS cluster with the default configuration.
+  const cluster = new eks.Cluster('eksctl-orion-node', {
+    vpcId: vpc.id,
+    subnetIds: vpc.publicSubnetIds,
+    instanceType: 't2.medium',
+    providerCredentialOpts: {
+      profileName: awsConfig.get('profile'),
+    },
+  })
+  provider = cluster.provider
+
+  // Export the cluster's kubeconfig.
+  kubeconfig = cluster.kubeconfig
+}
+
+const resourceOptions = { provider: provider }
+
+// Create a Kubernetes Namespace
+const ns = new k8s.core.v1.Namespace(name, {}, resourceOptions)
+
+// Export the Namespace name
+export const namespaceName = ns.metadata.name
+
+const appLabels = { appClass: name }
+
+const mongoDb = new MongoDBServiceDeployment(
+  'mongo-db',
+  {
+    namespaceName: namespaceName,
+    storage: storage,
+  },
+  resourceOptions
+)
+
+// Create a Deployment
+const deployment = new k8s.apps.v1.Deployment(
+  name,
+  {
+    metadata: {
+      namespace: namespaceName,
+      labels: appLabels,
+    },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: appLabels },
+      template: {
+        metadata: {
+          labels: appLabels,
+        },
+        spec: {
+          containers: [
+            {
+              name: 'orion',
+              image: orionImage,
+              imagePullPolicy: 'IfNotPresent',
+              env: [
+                {
+                  name: 'ORION_PORT',
+                  value: '6116',
+                },
+                {
+                  name: 'ORION_MONGO_HOSTNAME',
+                  value: mongoDb.service.metadata.name,
+                },
+                {
+                  name: 'ORION_FEATURED_CONTENT_SECRET',
+                  value: 'password123',
+                },
+                {
+                  name: 'ORION_QUERY_NODE_URL',
+                  value: queryNodeHost,
+                },
+              ],
+              ports: [{ containerPort: 6116 }],
+            },
+          ],
+        },
+      },
+    },
+  },
+  resourceOptions
+)
+
+// Create a LoadBalancer Service for the Deployment
+const service = new k8s.core.v1.Service(
+  name,
+  {
+    metadata: {
+      labels: appLabels,
+      namespace: namespaceName,
+      name: 'orion-node',
+    },
+    spec: {
+      type: isMinikube ? 'NodePort' : 'ClusterIP',
+      ports: [{ name: 'port-1', port: 6116 }],
+      selector: appLabels,
+    },
+  },
+  resourceOptions
+)
+
+// Export the Service name
+export const serviceName = service.metadata.name
+
+// Export the Deployment name
+export const deploymentName = deployment.metadata.name
+
+const caddyEndpoints = [
+  ` {
+    reverse_proxy orion-node:6116
+}`,
+]
+
+export let endpoint1: pulumi.Output<string> = pulumi.interpolate``
+export let endpoint2: pulumi.Output<string> = pulumi.interpolate``
+
+if (!isMinikube) {
+  const caddy = new CaddyServiceDeployment(
+    'caddy-proxy',
+    { lbReady, namespaceName: namespaceName, caddyEndpoints },
+    resourceOptions
+  )
+
+  endpoint1 = pulumi.interpolate`${caddy.primaryEndpoint}`
+  endpoint2 = pulumi.interpolate`${caddy.secondaryEndpoint}`
+}

--- a/devops/kubernetes/orion/index.ts
+++ b/devops/kubernetes/orion/index.ts
@@ -13,7 +13,7 @@ const name = 'orion'
 const queryNodeHost = config.require('queryNodeEndpoint')
 const lbReady = config.get('isLoadBalancerReady') === 'true'
 const orionImage = config.get('orionImage') || `joystream/orion:latest`
-const contentSecret = config.get('contentSecret') || `password123`
+const contentSecret = config.require('contentSecret')
 const storage = parseInt(config.get('storage') || '40')
 const isMinikube = config.getBoolean('isMinikube')
 

--- a/devops/kubernetes/orion/index.ts
+++ b/devops/kubernetes/orion/index.ts
@@ -13,6 +13,7 @@ const name = 'orion'
 const queryNodeHost = config.require('queryNodeEndpoint')
 const lbReady = config.get('isLoadBalancerReady') === 'true'
 const orionImage = config.get('orionImage') || `joystream/orion:latest`
+const contentSecret = config.get('contentSecret') || `password123`
 const storage = parseInt(config.get('storage') || '40')
 const isMinikube = config.getBoolean('isMinikube')
 
@@ -91,7 +92,7 @@ const deployment = new k8s.apps.v1.Deployment(
                 },
                 {
                   name: 'ORION_FEATURED_CONTENT_SECRET',
-                  value: 'password123',
+                  value: contentSecret,
                 },
                 {
                   name: 'ORION_QUERY_NODE_URL',

--- a/devops/kubernetes/orion/mongo.ts
+++ b/devops/kubernetes/orion/mongo.ts
@@ -1,0 +1,100 @@
+import * as k8s from '@pulumi/kubernetes'
+import * as pulumi from '@pulumi/pulumi'
+
+/**
+ * ServiceDeployment is an example abstraction that uses a class to fold together the common pattern of a
+ * Kubernetes Deployment and its associated Service object.
+ * This class delpoys a Mongo DB instance on a Persistent Volume
+ */
+export class MongoDBServiceDeployment extends pulumi.ComponentResource {
+  public readonly deployment: k8s.apps.v1.Deployment
+  public readonly service: k8s.core.v1.Service
+
+  constructor(name: string, args: ServiceDeploymentArgs, opts?: pulumi.ComponentResourceOptions) {
+    super('mongodb:service:PostgresServiceDeployment', name, {}, opts)
+
+    const databaseLabels = { app: name }
+    const pvcName = `${name}-pvc`
+
+    const pvc = new k8s.core.v1.PersistentVolumeClaim(
+      pvcName,
+      {
+        metadata: {
+          labels: databaseLabels,
+          namespace: args.namespaceName,
+          name: pvcName,
+        },
+        spec: {
+          accessModes: ['ReadWriteOnce'],
+          resources: {
+            requests: {
+              storage: `${args.storage}Gi`,
+            },
+          },
+        },
+      },
+      { parent: this }
+    )
+
+    this.deployment = new k8s.apps.v1.Deployment(
+      name,
+      {
+        metadata: {
+          namespace: args.namespaceName,
+          labels: databaseLabels,
+        },
+        spec: {
+          selector: { matchLabels: databaseLabels },
+          template: {
+            metadata: { labels: databaseLabels },
+            spec: {
+              containers: [
+                {
+                  name: 'mongo-db',
+                  image: 'library/mongo:4.4',
+                  volumeMounts: [
+                    {
+                      name: 'mongo-data',
+                      mountPath: '/data/db',
+                      subPath: 'mongo',
+                    },
+                  ],
+                },
+              ],
+              volumes: [
+                {
+                  name: 'mongo-data',
+                  persistentVolumeClaim: {
+                    claimName: pvcName,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      { parent: this }
+    )
+
+    this.service = new k8s.core.v1.Service(
+      name,
+      {
+        metadata: {
+          namespace: args.namespaceName,
+          labels: this.deployment.metadata.labels,
+          name: name,
+        },
+        spec: {
+          ports: [{ port: 27017 }],
+          selector: this.deployment.spec.template.metadata.labels,
+        },
+      },
+      { parent: this }
+    )
+  }
+}
+
+export interface ServiceDeploymentArgs {
+  namespaceName: pulumi.Output<string>
+  storage: Number
+}

--- a/devops/kubernetes/orion/package.json
+++ b/devops/kubernetes/orion/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "eks-cluster",
+  "devDependencies": {
+    "@types/node": "^10.0.0"
+  },
+  "dependencies": {
+    "@pulumi/awsx": "^0.30.0",
+    "@pulumi/eks": "^0.31.0",
+    "@pulumi/kubernetes": "^3.0.0",
+    "@pulumi/pulumi": "^3.0.0",
+    "pulumi-common": "file:../pulumi-common"
+  }
+}

--- a/devops/kubernetes/orion/tsconfig.json
+++ b/devops/kubernetes/orion/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This PR adds the Pulumi stack to deploy an Orion node with MongoDB.

![Screenshot 2022-01-20 at 6 22 26 PM](https://user-images.githubusercontent.com/7795956/150484997-53d2181f-69ff-4fc8-aa35-528630a8a5b8.png)

![Screenshot 2022-01-20 at 6 22 21 PM](https://user-images.githubusercontent.com/7795956/150485007-8fbfb527-25de-4a6e-96f4-7a02e1faf06d.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201703380142370/1201703508484325) by [Unito](https://www.unito.io)
