### PR TITLE
Giza CLI: Fix package.json resolutions and missing dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -7,10 +7,6 @@
     "joystream-cli": "./bin/run"
   },
   "bugs": "https://github.com/Joystream/joystream/issues",
-  "resolutions": {
-    "@polkadot/util": "7.3.1",
-    "@polkadot/util-crypto": "7.3.1"
-  },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
     "@ffprobe-installer/ffprobe": "^1.1.0",
@@ -23,6 +19,9 @@
     "@oclif/plugin-not-found": "^1.2.4",
     "@oclif/plugin-warn-if-update-available": "^1.7.0",
     "@polkadot/api": "5.9.1",
+    "@polkadot/keyring": "7.3.1",
+    "@polkadot/util": "7.3.1",
+    "@polkadot/util-crypto": "7.3.1",
     "@types/cli-progress": "^3.9.1",
     "@types/fluent-ffmpeg": "^2.1.16",
     "@types/inquirer": "^6.5.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -7,6 +7,10 @@
     "joystream-cli": "./bin/run"
   },
   "bugs": "https://github.com/Joystream/joystream/issues",
+  "resolutions": {
+    "@polkadot/util": "7.3.1",
+    "@polkadot/util-crypto": "7.3.1"
+  },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
     "@ffprobe-installer/ffprobe": "^1.1.0",
@@ -48,7 +52,8 @@
     "multihashes": "^4.0.3",
     "@apollo/client": "^3.2.5",
     "cross-fetch": "^3.0.6",
-    "form-data": "^4.0.0"
+    "form-data": "^4.0.0",
+    "graphql": "^14.7.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.22.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3131,7 +3131,7 @@
     yaml-validator "^3.0.0"
 
 "@joystream/types@link:types":
-  version "0.17.1"
+  version "0.17.2"
   dependencies:
     "@polkadot/api" "5.9.1"
     "@polkadot/keyring" "7.3.1"


### PR DESCRIPTION
Fixes issues with CLI dependencies identified by @mnaamani while testing `npm pack`'ed version of the CLI:
```
Mokhtars-MBP:package mokhtar$ ./bin/run account:list
@polkadot/util has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	7.9.2	/Users/mokhtar/tmp/package/node_modules/@polkadot/util
	7.3.1	/Users/mokhtar/tmp/package/node_modules/@polkadot/keyring/node_modules/@polkadot/util
@polkadot/util-crypto has multiple versions, ensure that there is only one installed.
Either remove and explicitly install matching versions or dedupe using your package manager.
The following conflicting packages were found:
	7.9.2	/Users/mokhtar/tmp/package/node_modules/@polkadot/util-crypto
	7.3.1	/Users/mokhtar/tmp/package/node_modules/@polkadot/keyring/node_modules/@polkadot/util-crypto
    Error: Cannot find module 'graphql'
    Require stack:
    - /Users/mokhtar/tmp/package/node_modules/@apollo/client/utilities/globals/globals.cjs
    - /Users/mokhtar/tmp/package/node_modules/@apollo/client/core/core.cjs
    - /Users/mokhtar/tmp/package/lib/QueryNodeApi.js
    - /Users/mokhtar/tmp/package/lib/base/ApiCommandBase.js
    - /Users/mokhtar/tmp/package/lib/base/AccountsCommandBase.js
    - /Users/mokhtar/tmp/package/lib/commands/account/list.js
    - /Users/mokhtar/tmp/package/node_modules/@oclif/config/lib/plugin.js
    - /Users/mokhtar/tmp/package/node_modules/@oclif/config/lib/config.js
    - /Users/mokhtar/tmp/package/node_modules/@oclif/config/lib/index.js
    - /Users/mokhtar/tmp/package/node_modules/@oclif/command/lib/command.js
    - /Users/mokhtar/tmp/package/node_modules/@oclif/command/lib/index.js
    - /Users/mokhtar/tmp/package/bin/run
    Code: MODULE_NOT_FOUND
```