### PR TITLE
Giza: Playground fix

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -19,7 +19,14 @@ on:
         description: 'AWS EC2 instance type (t2.micro, t2.large)'
         required: false
         default: 't2.micro'
-
+      stackName:
+        description: 'AWS CloudFormation Stack Name'
+        required: true
+      # TODO: customDomain instead of ip_address.nip.io
+      # customDomain:
+      #   description: 'DNS hostname to use for deployment'
+      #   required: false
+      #   default: ''
 defaults:
   run:
     working-directory: devops/aws
@@ -28,8 +35,8 @@ jobs:
   deploy-playground:
     name: Create an EC2 instance and configure docker-compose stack
     runs-on: ubuntu-latest
-    env:
-      STACK_NAME: joystream-playground-${{ github.event.inputs.branchName }}-${{ github.run_number }}
+    # env:
+    #   STACK_NAME: joystream-playground-${{ github.event.inputs.branchName }}-${{ github.run_number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -48,7 +55,8 @@ jobs:
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         id: deploy_stack
         with:
-          name: ${{ env.STACK_NAME }}
+          # name: ${{ env.STACK_NAME }}
+          name: ${{ github.event.inputs.stackName }}
           template: devops/aws/cloudformation/single-instance-docker.yml
           no-fail-on-empty-changeset: '1'
           parameter-overrides: 'KeyName=${{ github.event.inputs.keyName }},EC2InstanceType=${{ github.event.inputs.instanceType }}'

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -19,9 +19,10 @@ on:
         description: 'AWS EC2 instance type (t2.micro, t2.large)'
         required: false
         default: 't2.micro'
-      stackName:
-        description: 'AWS CloudFormation Stack Name'
-        required: true
+      stackNamePrefix:
+        description: 'Additional identifier to include in stack name'
+        required: false
+        default: 'playground'
       # TODO: customDomain instead of ip_address.nip.io
       # customDomain:
       #   description: 'DNS hostname to use for deployment'
@@ -35,8 +36,8 @@ jobs:
   deploy-playground:
     name: Create an EC2 instance and configure docker-compose stack
     runs-on: ubuntu-latest
-    # env:
-    #   STACK_NAME: joystream-playground-${{ github.event.inputs.branchName }}-${{ github.run_number }}
+    env:
+      STACK_NAME: ${{ github.event.inputs.stackNamePrefix }}-${{ github.event.inputs.branchName }}-${{ github.run_number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -55,8 +56,7 @@ jobs:
         uses: aws-actions/aws-cloudformation-github-deploy@v1
         id: deploy_stack
         with:
-          # name: ${{ env.STACK_NAME }}
-          name: ${{ github.event.inputs.stackName }}
+          name: ${{ env.STACK_NAME }}
           template: devops/aws/cloudformation/single-instance-docker.yml
           no-fail-on-empty-changeset: '1'
           parameter-overrides: 'KeyName=${{ github.event.inputs.keyName }},EC2InstanceType=${{ github.event.inputs.instanceType }}'

--- a/devops/aws/deploy-playground-playbook.yml
+++ b/devops/aws/deploy-playground-playbook.yml
@@ -62,8 +62,8 @@
         chdir: '{{ remote_code_path }}'
       environment:
         PERSIST: 'true'
-        COLOSSUS_1_NODE_URI: 'https://{{ inventory_hostname }}.nip.io/colossus-1/'
-        DISTRIBUTOR_1_NODE_URI: 'https://{{ inventory_hostname }}.nip.io/distributor-1/'
+        COLOSSUS_1_URL: 'https://{{ inventory_hostname }}.nip.io/colossus-1/'
+        DISTRIBUTOR_1_URL: 'https://{{ inventory_hostname }}.nip.io/distributor-1/'
       async: 1800
       poll: 0
       register: compose_result

--- a/start.sh
+++ b/start.sh
@@ -27,9 +27,9 @@ docker-compose up -d joystream-node
 ## Init the chain with some state
 export SKIP_MOCK_CONTENT=true
 HOST_IP=$(tests/network-tests/get-host-ip.sh)
-export COLOSSUS_1_URL="http://${HOST_IP}:3333"
+export COLOSSUS_1_URL=${COLOSSUS_1_URL:="http://${HOST_IP}:3333"}
 export COLOSSUS_1_TRANSACTOR_KEY=$(docker run --rm --pull=always docker.io/parity/subkey:2.0.1 inspect ${COLOSSUS_1_TRANSACTOR_URI} --output-type json | jq .ss58Address -r)
-export DISTRIBUTOR_1_URL="http://${HOST_IP}:3334"
+export DISTRIBUTOR_1_URL=${DISTRIBUTOR_1_URL:="http://${HOST_IP}:3334"}
 ./tests/network-tests/run-test-scenario.sh ${INIT_CHAIN_SCENARIO}
 
 ## Set sudo as the membership screening authority


### PR DESCRIPTION
- Allows COLOSSUS_1_URL and DISTRIBUTOR_1_URL to be configured outside of start.sh
- Fix renamed env variables above in github workflow playground deployment
- Allow custom prefix to be added to cloud formation stack name for playground deployment to more easily identify it in list of stacks in aws console.