### PR TITLE
DevOps - Fix Raspberry build

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           export WORKSPACE_ROOT=`cargo metadata --offline --no-deps --format-version 1 | jq .workspace_root -r`
           sudo chmod a+w $WORKSPACE_ROOT
+          sudo chmod -R a+w $HOME/.cargo/registry
           ./scripts/raspberry-cross-build.sh
 
       - name: Tar the binary

--- a/scripts/raspberry-cross-build.sh
+++ b/scripts/raspberry-cross-build.sh
@@ -12,5 +12,5 @@ docker run \
     -e WASM_BUILD_TOOLCHAIN=nightly-2021-02-20 \
     --volume ${WORKSPACE_ROOT}/:/home/cross/project \
     --volume ${HOME}/.cargo/registry:/home/cross/.cargo/registry \
-    joystream/rust-raspberry \
+    joystream/rust-raspberry:nightly-2021-02-20 \
     build --release -p joystream-node


### PR DESCRIPTION
The `create-release` workflow is failing because an error in `build-rpi-binary` task. This PR resolved the issue by changing the registry directory permissions so that the docker run command can write to it.

Successful run: https://github.com/ahhda/joystream/runs/4963207079?check_suite_focus=true