### PR TITLE
Integration tests: Run CLI tests after workerPayoutsJob

### DIFF
--- a/tests/network-tests/src/scenarios/combined.ts
+++ b/tests/network-tests/src/scenarios/combined.ts
@@ -26,7 +26,11 @@ scenario(async ({ job }) => {
   job('at least value bug', atLeastValueBug).requires(leadSetupJob)
 
   // tests minting payouts (requires council to set mint capacity)
-  job('worker payouts', [workerPayout.storage, workerPayout.content, workerPayout.distribution]).requires(leadSetupJob)
+  const workerPayoutsJob = job('worker payouts', [
+    workerPayout.storage,
+    workerPayout.content,
+    workerPayout.distribution,
+  ]).requires(leadSetupJob)
 
   job('working group tests', [
     manageWorkerFlow(WorkingGroups.Storage),
@@ -37,7 +41,8 @@ scenario(async ({ job }) => {
     manageWorkerAsWorker.distribution,
   ]).requires(leadSetupJob)
 
-  const createChannelJob = job('create channel via CLI', createChannel)
+  // Run CLI tests after workerPayoutsJob as they may lock Sender for too long and cause FillOpeningInvalidNextPaymentBlock
+  const createChannelJob = job('create channel via CLI', createChannel).after(workerPayoutsJob)
   job('init storage and distribution buckets via CLI', [initDistributionBucket, initStorageBucket]).after(
     createChannelJob
   )


### PR DESCRIPTION
Fixes occasionally failing integration tests, ie.: https://github.com/Joystream/joystream/runs/4983207184?check_suite_focus=true

When `workerPayoutsJob` is executed in parallel to `createChannelJob`, there may be a significant delay between [getting the current block number](https://github.com/Lezek123/substrate-runtime-joystream/blob/integration-tests-fix/tests/network-tests/src/fixtures/workingGroupModule.ts#L347) and [sending the `fillOpening` tx with `nextPaymentBlock === now.add(this.firstPayoutInterval`](https://github.com/Lezek123/substrate-runtime-joystream/blob/integration-tests-fix/tests/network-tests/src/fixtures/workingGroupModule.ts#L353) which may cause `FillOpeningInvalidNextPaymentBlock`