### PR TITLE
DevOps: update aws cloudformation sample configs for giza

### DIFF
--- a/.pipelines/deploy-node-network-inputs.json
+++ b/.pipelines/deploy-node-network-inputs.json
@@ -28,8 +28,8 @@
     "value": "t2.micro"
   },
   "ec2AMI": {
-    "description": "Pre-built AMI ID (ami-0090c9c49dc765fbb)",
-    "value": "ami-0090c9c49dc765fbb"
+    "description": "Pre-built AMI ID (ami-095792100b6e43a67)",
+    "value": "ami-095792100b6e43a67"
   },
   "networkSuffix": {
     "description": "Network suffix that will be added to the network name",

--- a/devops/aws/deploy-infra.sample.cfg
+++ b/devops/aws/deploy-infra.sample.cfg
@@ -5,13 +5,13 @@ REGION=us-east-1
 CLI_PROFILE=joystream-user
 KEY_PATH="/Users/joystream/Joystream/joystream-key.pem"
 AWS_KEY_PAIR_NAME="joystream-key"
-DEFAULT_EC2_INSTANCE_TYPE=t2.micro
-VALIDATOR_EC2_INSTANCE_TYPE=t2.micro
-BUILD_EC2_INSTANCE_TYPE=t2.xlarge
-RPC_EC2_INSTANCE_TYPE=t2.micro
+DEFAULT_EC2_INSTANCE_TYPE=t2.medium
+VALIDATOR_EC2_INSTANCE_TYPE=t2.medium
+BUILD_EC2_INSTANCE_TYPE=t2.large
+RPC_EC2_INSTANCE_TYPE=t2.medium
 
 # prebuilt AMI with joystream-node, chain-spec and subkey already built
-EC2_AMI_ID="ami-08ffec5991ca99db9"
+EC2_AMI_ID="ami-095792100b6e43a67"
 
 ACCOUNT_ID=$(aws sts get-caller-identity --profile $CLI_PROFILE --query Account --output text)
 
@@ -28,12 +28,12 @@ NUMBER_OF_VALIDATORS=2
 LOCAL_CODE_PATH="~/Joystream/joystream"
 NETWORK_SUFFIX=7891
 
-DEPLOYMENT_TYPE=live
+DEPLOYMENT_TYPE=staging
 INITIAL_MEMBERS_PATH=""
 INITIAL_BALANCES_PATH=""
 
 GIT_REPO="https://github.com/Joystream/joystream.git"
-BRANCH_NAME=sumer
+BRANCH_NAME=master
 
 # If true will build LOCAL_CODE_PATH otherwise will pull from GIT_REPO:BRANCH_NAME
 BUILD_LOCAL_CODE=false

--- a/devops/aws/deploy-single-node.sample.cfg
+++ b/devops/aws/deploy-single-node.sample.cfg
@@ -12,8 +12,11 @@ DATE_TIME=$(date +"%d-%b-%Y-%H-%M-%S")
 
 SINGLE_NODE_STACK_NAME="joystream-node-$DATE_TIME"
 
-BINARY_FILE="https://github.com/Joystream/joystream/releases/download/v9.3.0/joystream-node-5.1.0-9d9e77751-x86_64-linux-gnu.tar.gz"
-CHAIN_SPEC_FILE="https://github.com/Joystream/joystream/releases/download/v9.3.0/joy-testnet-5.json"
+# For deploy single node playbook only
+# GIZA
+BINARY_FILE="https://github.com/Joystream/joystream/releases/download/v9.14.0/joystream-node-5.14.0-feb3930-x86_64-linux-gnu.tar.gz"
+CHAIN_SPEC_FILE="https://github.com/Joystream/joystream/releases/download/v9.14.0/joy-testnet-5.json"
 
+# For deploy playground playbook only
 GIT_REPO="https://github.com/Joystream/joystream.git"
 BRANCH_NAME="master"


### PR DESCRIPTION
Update default AMI in sample config to use Giza release.

cc: @ahhda 