### PR TITLE
Query node: Fix expectedEndingTimestamp / expectedStart

### DIFF
--- a/query-node/mappings/src/workingGroups.ts
+++ b/query-node/mappings/src/workingGroups.ts
@@ -249,7 +249,7 @@ async function handleAddUpcomingOpeningAction(
     metadata: openingMeta,
     group,
     rewardPerBlock: isSet(rewardPerBlock) && parseInt(rewardPerBlock) ? new BN(rewardPerBlock) : undefined,
-    expectedStart: expectedStart ? new Date(expectedStart) : undefined,
+    expectedStart: expectedStart ? new Date(expectedStart * 1000) : undefined,
     stakeAmount: isSet(minApplicationStake) && parseInt(minApplicationStake) ? new BN(minApplicationStake) : undefined,
     createdInEvent: statusChangedEvent,
   })

--- a/query-node/mappings/src/workingGroups.ts
+++ b/query-node/mappings/src/workingGroups.ts
@@ -177,7 +177,7 @@ export async function createWorkingGroupOpeningMetadata(
     description: description || undefined,
     shortDescription: shortDescription || undefined,
     hiringLimit: hiringLimit || undefined,
-    expectedEnding: expectedEndingTimestamp ? new Date(expectedEndingTimestamp) : undefined,
+    expectedEnding: expectedEndingTimestamp ? new Date(expectedEndingTimestamp * 1000) : undefined,
     applicationFormQuestions: [],
   })
 

--- a/tests/integration-tests/src/fixtures/workingGroups/CreateUpcomingOpeningsFixture.ts
+++ b/tests/integration-tests/src/fixtures/workingGroups/CreateUpcomingOpeningsFixture.ts
@@ -103,7 +103,7 @@ export class CreateUpcomingOpeningsFixture extends BaseWorkingGroupFixture {
         Utils.assert(qUpcomingOpening)
         assert.equal(
           qUpcomingOpening.expectedStart
-            ? new Date(qUpcomingOpening.expectedStart).getTime()
+            ? moment(qUpcomingOpening.expectedStart).unix()
             : qUpcomingOpening.expectedStart,
           expectedMeta.expectedStart || null
         )

--- a/tests/integration-tests/src/fixtures/workingGroups/utils.ts
+++ b/tests/integration-tests/src/fixtures/workingGroups/utils.ts
@@ -29,7 +29,9 @@ export const assertQueriedOpeningMetadataIsValid = (
   assert.equal(qOpeningMeta.shortDescription, shortDescription || null)
   assert.equal(qOpeningMeta.description, description || null)
   assert.equal(
-    qOpeningMeta.expectedEnding ? new Date(qOpeningMeta.expectedEnding).getTime() : qOpeningMeta.expectedEnding,
+    qOpeningMeta.expectedEnding
+      ? Math.floor(new Date(qOpeningMeta.expectedEnding).getTime() / 1000)
+      : qOpeningMeta.expectedEnding,
     expectedEndingTimestamp || null
   )
   assert.equal(qOpeningMeta.hiringLimit, hiringLimit || null)

--- a/tests/integration-tests/src/fixtures/workingGroups/utils.ts
+++ b/tests/integration-tests/src/fixtures/workingGroups/utils.ts
@@ -1,7 +1,7 @@
 import { IOpeningMetadata, OpeningMetadata } from '@joystream/metadata-protobuf'
 import { assert } from 'chai'
 import { OpeningMetadataFieldsFragment } from '../../graphql/generated/queries'
-
+import moment from 'moment'
 import { ApplicationFormQuestionType } from '../../graphql/generated/schema'
 
 export const queryNodeQuestionTypeToMetadataQuestionType = (
@@ -29,9 +29,7 @@ export const assertQueriedOpeningMetadataIsValid = (
   assert.equal(qOpeningMeta.shortDescription, shortDescription || null)
   assert.equal(qOpeningMeta.description, description || null)
   assert.equal(
-    qOpeningMeta.expectedEnding
-      ? Math.floor(new Date(qOpeningMeta.expectedEnding).getTime() / 1000)
-      : qOpeningMeta.expectedEnding,
+    qOpeningMeta.expectedEnding ? moment(qOpeningMeta.expectedEnding).unix() : qOpeningMeta.expectedEnding,
     expectedEndingTimestamp || null
   )
   assert.equal(qOpeningMeta.hiringLimit, hiringLimit || null)


### PR DESCRIPTION
Small fix for working-groups mappings - the timestamp should be provided in seconds, but was treated as miliseconds when converted to `Date`