### PR TITLE
setup.sh: install newer version of docker-compose on linux

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,9 +9,11 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     sudo apt-get update
     sudo apt-get install -y coreutils clang llvm jq curl gcc xz-utils sudo pkg-config unzip libc6-dev make libssl-dev python
     # docker
-    sudo apt-get install -y docker.io docker-compose containerd runc
-    # older linux distro may install old version of docker-compose
-    # Minimum required v1.29 - see https://docs.docker.com/compose/install/
+    sudo apt-get install -y docker.io containerd runc
+    # docker-compose
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+    sudo ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # install brew package manager
     if ! which brew >/dev/null 2>&1; then


### PR DESCRIPTION
Avoid installing older version of docker-compose with apt-get and instead install newer version 1.29 directly from official docker github repo.