### PR TITLE
build-node-docker without docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -62,4 +62,6 @@ DISTRIBUTOR_2_WORKER_ID=1
 DISTRIBUTOR_2_ACCOUNT_URI=//testing//worker//Distribution//${DISTRIBUTOR_2_WORKER_ID}
 
 # joystream/node docker image tag
-JOYSTREAM_NODE_TAG=latest
+# We do not provide a default value - scripts that startup a joystream-node service
+# Should be explicit about what version to use.
+# JOYSTREAM_NODE_TAG=latest

--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -112,6 +112,7 @@ jobs:
           mkdir -p ${HOME}/.local/share/joystream-cli
           joystream-cli api:setUri ws://localhost:9944
           export RUNTIME=sumer
+          export TARGET_RUNTIME_TAG=latest
           tests/network-tests/run-migration-tests.sh
 
   basic_runtime:
@@ -140,7 +141,9 @@ jobs:
       - name: Ensure tests are runnable
         run: yarn workspace network-tests build
       - name: Execute network tests
-        run: tests/network-tests/run-full-tests.sh
+        run: |
+          export RUNTIME=latest
+          tests/network-tests/run-full-tests.sh
 
   new_chain_setup:
     name: Initialize new chain
@@ -172,5 +175,7 @@ jobs:
       # Bring up hydra query-node development instance, then run content directory
       # integration tests
       - name: Execute Tests
-        run: tests/network-tests/test-setup-new-chain.sh
+        run: |
+          export RUNTIME=latest
+          tests/network-tests/test-setup-new-chain.sh
 

--- a/build-node-docker.sh
+++ b/build-node-docker.sh
@@ -2,23 +2,31 @@
 
 set -e
 
-if ! command -v docker-compose &> /dev/null
-then
-  echo "docker-compose not found. Skipping docker image builds."
-  exit 0
-fi
+# Looks for a cached joystream/node image matching code shasum.
+# Search order: local repo then dockerhub. If no cached image is found we build it.
+# Finally image is tagged as "latest"
 
-# Fetch a cached joystream/node image if one is found matching code shasum instead of building
 CODE_HASH=`scripts/runtime-code-shasum.sh`
 IMAGE=joystream/node:${CODE_HASH}
-echo "Trying to fetch cached ${IMAGE} image"
-docker pull ${IMAGE} || :
+LATEST=joystream/node:latest
 
+# Look for image locally
 if ! docker inspect ${IMAGE} > /dev/null;
 then
-  echo "Fetch failed, building image locally"
-  docker-compose build joystream-node
+  # Not found, try to fetch from remote repo
+  echo "Trying to fetch cached ${IMAGE} image"
+  docker pull ${IMAGE} || :
+
+  # If we didn't find it, build it
+  if ! docker inspect ${IMAGE} > /dev/null;
+  then
+    echo "Building ${IMAGE}.."
+    docker build . --file joystream-node.Dockerfile --tag ${IMAGE}
+  fi
 else
-  echo "Tagging cached image as 'latest'"
-  docker image tag ${IMAGE} joystream/node:latest
+  echo "Found ${IMAGE} in local repo"
 fi
+
+# At this point image should be in local repo
+echo "Tagging ${IMAGE} as ${LATEST}"
+docker image tag ${IMAGE} ${LATEST}

--- a/build-node-docker.sh
+++ b/build-node-docker.sh
@@ -28,5 +28,5 @@ else
 fi
 
 # At this point image should be in local repo
-echo "Tagging ${IMAGE} as ${LATEST}"
-docker image tag ${IMAGE} ${LATEST}
+# echo "Tagging ${IMAGE} as ${LATEST}"
+# docker image tag ${IMAGE} ${LATEST}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,9 @@
-# Compiles new joystream/node and joystream/apps images if local images not found
-# and runs a complete joystream development network
-# To prevent build of docker images run docker-compose with "--no-build" arg
+# Complete joystream development network
 version: '3.4'
 services:
   joystream-node:
     image: joystream/node:$JOYSTREAM_NODE_TAG
     restart: unless-stopped
-    build:
-      # context is relative to the compose file
-      context: .
-      # dockerfile is relative to the context
-      dockerfile: joystream-node.Dockerfile
     container_name: joystream-node
     volumes:
       - chain-data:/data

--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Run a complete joystream development network on your machine using docker
+export JOYSTREAM_NODE_TAG=${JOYSTREAM_NODE_TAG:=$(./scripts/runtime-code-shasum.sh)}
 
 INIT_CHAIN_SCENARIO=${INIT_CHAIN_SCENARIO:=setup-new-chain}
 
@@ -22,8 +23,7 @@ else
 fi
 
 ## Run a local development chain
-JOYSTREAM_NODE_TAG=${JOYSTREAM_NODE_TAG:=$(scripts/runtime-code-shasum.sh)} \
-  docker-compose up -d joystream-node
+docker-compose up -d joystream-node
 
 ## Init the chain with some state
 export SKIP_MOCK_CONTENT=true

--- a/start.sh
+++ b/start.sh
@@ -22,7 +22,8 @@ else
 fi
 
 ## Run a local development chain
-docker-compose up -d joystream-node
+JOYSTREAM_NODE_TAG=${JOYSTREAM_NODE_TAG:=$(scripts/runtime-code-shasum.sh)} \
+  docker-compose up -d joystream-node
 
 ## Init the chain with some state
 export SKIP_MOCK_CONTENT=true

--- a/tests/network-tests/run-migration-tests.sh
+++ b/tests/network-tests/run-migration-tests.sh
@@ -5,7 +5,7 @@ SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
 cd $SCRIPT_PATH
 
 # The joystream/node docker image tag which contains WASM runtime to upgrade chain with
-TARGET_RUNTIME_TAG=${TARGET_RUNTIME_TAG:=latest}
+TARGET_RUNTIME_TAG=${TARGET_RUNTIME_TAG:=$(../../scripts/runtime-code-shasum.sh)}
 # The joystream/node docker image tag to start the chain with
 RUNTIME_TAG=${RUNTIME_TAG:=sumer}
 # Post migration assertions by means of typescript scenarios required

--- a/tests/network-tests/run-test-node-docker.sh
+++ b/tests/network-tests/run-test-node-docker.sh
@@ -26,7 +26,7 @@ TREASURY_ACCOUNT=$(docker run --rm --pull=always docker.io/parity/subkey:2.0.1 i
 >&2 echo "treasury account from suri: ${TREASURY_ACCOUNT}"
 
 # The docker image tag to use for joystream/node
-RUNTIME=${RUNTIME:=latest}
+RUNTIME=${RUNTIME:=$(../../scripts/runtime-code-shasum.sh)}
 
 echo "{
   \"balances\":[


### PR DESCRIPTION
- build script checks local repo before fetching from docker-hub
- immediately tags image with code hash
- build without docker-compose, remove build directive in docker-compose. benefits:
   -  on mac if local image not found, docker pulls but doesn't use the pulled image and proceeds to build
   - avoid tagging arbitrary image through docker-compose build that doesn't match code hash