### PR TITLE
DevOps - Add async to node docker build

### DIFF
--- a/devops/aws/deploy-playground-playbook.yml
+++ b/devops/aws/deploy-playground-playbook.yml
@@ -55,6 +55,19 @@
       command: yarn build:node:docker
       args:
         chdir: '{{ remote_code_path }}'
+      async: 3600
+      poll: 0
+      register: node_build_result
+
+    - name: Check on build node image async task
+      async_status:
+        jid: '{{ node_build_result.ansible_job_id }}'
+      register: job_result
+      until: job_result.finished
+      # Max number of times to check for status
+      retries: 36
+      # Check for the status every 100s
+      delay: 100
 
     - name: Run docker-compose
       command: yarn start


### PR DESCRIPTION
Github action runs are currently failing for Olympia as Github cannot maintain long-running SSH sessions with ansible.

This PR resolves that issue.

Github action result: https://github.com/ahhda/joystream/runs/5034276309?check_suite_focus=true