### PR TITLE
runtime code shasum: different tag scheme for test node

### DIFF
--- a/scripts/runtime-code-shasum.sh
+++ b/scripts/runtime-code-shasum.sh
@@ -14,6 +14,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   SED=gsed
 fi
 
+# Make sure same default value is set in joystream-node.Dockerfile
+TEST_NODE_BLOCKTIME=1000
 TEST_PROPOSALS_PARAMETERS_PATH="./tests/integration-tests/proposal-parameters.json"
 
 # sort/owner/group/mtime arguments only work with gnu version of tar!
@@ -32,6 +34,6 @@ HASH=$(
     | cut -d " " -f 1
 )
 
-if [[ -n "$TEST_NODE" ]]; then SUFFIX=-test; else SUFFIX= ; fi
+if [[ -n "$TEST_NODE" ]]; then SUFFIX=-test-${TEST_NODE_BLOCKTIME}; else SUFFIX= ; fi
 
 echo ${HASH}${SUFFIX}

--- a/scripts/runtime-code-shasum.sh
+++ b/scripts/runtime-code-shasum.sh
@@ -14,11 +14,11 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   SED=gsed
 fi
 
-export TEST_NODE_BLOCKTIME=1000
-export TEST_PROPOSALS_PARAMETERS_PATH="./tests/integration-tests/proposal-parameters.json"
+TEST_PROPOSALS_PARAMETERS_PATH="./tests/integration-tests/proposal-parameters.json"
 
 # sort/owner/group/mtime arguments only work with gnu version of tar!
-${TAR} -c --sort=name --owner=root:0 --group=root:0 --mode 644 --mtime='UTC 2020-01-01' \
+HASH=$(
+  ${TAR} -c --sort=name --owner=root:0 --group=root:0 --mode 644 --mtime='UTC 2020-01-01' \
     Cargo.lock \
     Cargo.toml \
     runtime \
@@ -28,6 +28,10 @@ ${TAR} -c --sort=name --owner=root:0 --group=root:0 --mode 644 --mtime='UTC 2020
     joystream-node-armv7.Dockerfile \
     node \
     $(test -n "$TEST_NODE" && echo "$TEST_PROPOSALS_PARAMETERS_PATH") \
-    | if [[ -n "$TEST_NODE" ]]; then ${SED} '$a'"$TEST_NODE_BLOCKTIME"; else tee; fi \
     | shasum \
     | cut -d " " -f 1
+)
+
+if [[ -n "$TEST_NODE" ]]; then SUFFIX=-test; else SUFFIX= ; fi
+
+echo ${HASH}${SUFFIX}


### PR DESCRIPTION
Testing a new approach to add `-test` suffix to docker image tag computed, to avoid use of sed which is giving some inconsistent results between local machine and github runner. see: https://github.com/Joystream/joystream/pull/3164#issuecomment-1029354574