### PR TITLE
Olympia: Fix QueryNode build

### DIFF
--- a/query-node/manifest.yml
+++ b/query-node/manifest.yml
@@ -88,9 +88,6 @@ typegen:
     - content.ChannelUpdated
     - content.ChannelAssetsRemoved
     - content.ChannelCensorshipStatusUpdated
-    - content.ChannelOwnershipTransferRequested
-    - content.ChannelOwnershipTransferRequestWithdrawn
-    - content.ChannelOwnershipTransferred
     - content.ChannelCategoryCreated
     - content.ChannelCategoryUpdated
     - content.ChannelCategoryDeleted


### PR DESCRIPTION
Drop events from manifest which are no longer in runtime following merge of https://github.com/Joystream/joystream/pull/3137 to unbreak build of query-node.

```
  hydra-typegen:extract Validated types: ContentActor,ChannelId,Channel,ChannelUpdateParameters +1ms
  hydra-typegen:extract Validated types: ContentActor,ChannelId,BTreeSet,DataObjectId,Channel +0ms
  hydra-typegen:extract Validated types: ContentActor,ChannelId,IsCensored,Bytes +0ms
    Error: No metadata found for the event content.ChannelOwnershipTransferRequested
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
```