### PR TITLE
Integration tests: Forum moderation: Reverse threads vs posts order

### DIFF
--- a/tests/integration-tests/src/flows/forum/moderation.ts
+++ b/tests/integration-tests/src/flows/forum/moderation.ts
@@ -56,13 +56,13 @@ export default async function threads({ api, query }: FlowProps): Promise<void> 
   })
 
   // Run fixtures
-  const moderateThreadsFixture = new ModerateThreadsFixture(api, query, threadModerations)
-  const moderateThreadsRunner = new FixtureRunner(moderateThreadsFixture)
-  await moderateThreadsRunner.run()
-
   const moderatePostsFixture = new ModeratePostsFixture(api, query, postModerations)
   const moderatePostsRunner = new FixtureRunner(moderatePostsFixture)
   await moderatePostsRunner.run()
+
+  const moderateThreadsFixture = new ModerateThreadsFixture(api, query, threadModerations)
+  const moderateThreadsRunner = new FixtureRunner(moderateThreadsFixture)
+  await moderateThreadsRunner.run()
 
   // Run query-node checks
   await Promise.all([moderateThreadsFixture.runQueryNodeChecks(), moderatePostsFixture.runQueryNodeChecks()])


### PR DESCRIPTION
In case https://github.com/Joystream/joystream/pull/3125 gets merged, it will no longer be possible to moderate threads first and then posts inside those threads, therefore the order needs to be reversed in the integration tests.