### PR TITLE
Fix new marketing and HR names 

### DIFF
--- a/pioneer/packages/joy-proposals/src/forms/GenericWorkingGroupProposalForm.tsx
+++ b/pioneer/packages/joy-proposals/src/forms/GenericWorkingGroupProposalForm.tsx
@@ -45,7 +45,7 @@ type ExportComponentProps = ProposalFormExportProps<FormAdditionalProps, FormVal
 type FormContainerProps = ProposalFormContainerProps<ExportComponentProps>;
 export type FormInnerProps = ProposalFormInnerProps<FormContainerProps, FormValues>;
 
-const OPERATIONS_GROUP_NAMES = { Alpha: 'Builders', Beta: 'Human Resources', Gamma: 'Marketing' };
+const OPERATIONS_GROUP_NAMES = { Alpha: 'Builders', Beta: 'Marketing', Gamma: 'Human Resources' };
 
 const OperationsGroupSubtext = styled('p')`
   font-size: 11px !important;

--- a/pioneer/packages/joy-roles/src/tabs/Opportunities.tsx
+++ b/pioneer/packages/joy-roles/src/tabs/Opportunities.tsx
@@ -490,11 +490,11 @@ const renderWorkingGroupName = (workingGroup: WorkingGroups) => {
   }
 
   if (workingGroup === WorkingGroups.OperationsBeta) {
-    return { text: 'Human Resources', subtext: 'Operations Working Group Beta' };
+    return { text: 'Marketing', subtext: 'Operations Working Group Beta' };
   }
 
   if (workingGroup === WorkingGroups.OperationsGamma) {
-    return { text: 'Marketing', subtext: 'Operations Working Group Gamma' };
+    return { text: 'Human Resources', subtext: 'Operations Working Group Gamma' };
   }
 
   return { text: workingGroup };

--- a/pioneer/packages/joy-roles/src/tabs/WorkingGroup.tsx
+++ b/pioneer/packages/joy-roles/src/tabs/WorkingGroup.tsx
@@ -180,13 +180,13 @@ export const OperationsGroupAlpha = (props: GroupOverviewOuterProps) => (
 export const OperationsGroupBeta = (props: GroupOverviewOuterProps) => (
   <OperationsGroup
     group={WorkingGroups.OperationsBeta}
-    customGroupName='Human Resources'
+    customGroupName='Marketing'
     description={
       <>
         <OperationsGroupName>Operations Group Beta</OperationsGroupName>
         <span>
-          The Human Resources working group is responsible for the Human Resources tasks required
-          for the operation and growth of the platform and community.
+          The Marketing working group is responsible for developing and executing strategies to
+          promote the Joystream platform.
         </span>
       </>
     }
@@ -197,13 +197,13 @@ export const OperationsGroupBeta = (props: GroupOverviewOuterProps) => (
 export const OperationsGroupGamma = (props: GroupOverviewOuterProps) => (
   <OperationsGroup
     group={WorkingGroups.OperationsGamma}
-    customGroupName='Marketing'
+    customGroupName='Human Resources'
     description={
       <>
         <OperationsGroupName>Operations Group Gamma</OperationsGroupName>
         <span>
-          The Marketing working group is responsible for developing and executing strategies to
-          promote the Joystream platform.
+          The Human Resources working group is responsible for the Human Resources tasks required
+          for the operation and growth of the platform and community.
         </span>
       </>
     }

--- a/pioneer/packages/joy-roles/src/working_groups.ts
+++ b/pioneer/packages/joy-roles/src/working_groups.ts
@@ -20,7 +20,7 @@ export const workerRoleNameByGroup: { [key in WorkingGroups]: string } = {
   [WorkingGroups.ContentCurators]: 'Content Curator',
   [WorkingGroups.StorageProviders]: 'Storage Provider',
   [WorkingGroups.OperationsAlpha]: 'Builder',
-  [WorkingGroups.OperationsBeta]: 'HR Worker',
-  [WorkingGroups.OperationsGamma]: 'Marketer',
+  [WorkingGroups.OperationsBeta]: 'Marketer',
+  [WorkingGroups.OperationsGamma]: 'HR Worker',
   [WorkingGroups.Distribution]: 'Distributor'
 };

--- a/pioneer/packages/joy-tokenomics/src/tokenomicsGroupsData.ts
+++ b/pioneer/packages/joy-tokenomics/src/tokenomicsGroupsData.ts
@@ -72,9 +72,9 @@ export const WORKING_GROUPS = [
   {
     groupType: 'operationsBeta' as const,
     titleCutoff: 1050,
-    shortTitle: 'Human Res.',
-    title: 'Human Resources',
-    helpText: 'The current Human Resources (Operations Group Beta) Workers, and the sum of their projected rewards and stakes.',
+    shortTitle: 'Marketing',
+    title: 'Marketing',
+    helpText: 'The current Marketers (Operations Group Beta), and the sum of their projected rewards and stakes.',
     color: '#03a9f4',
     extraInfo: {
       full: 'Operations Working Group Beta',
@@ -82,18 +82,18 @@ export const WORKING_GROUPS = [
     },
     lead: {
       titleCutoff: 1015,
-      shortTitle: 'HR Lead',
-      title: 'Human Res. Lead',
-      helpText: 'Current Human Resources (Operations Group Beta) Lead, and their projected reward and stake.',
+      shortTitle: 'Marketing Lead',
+      title: 'Marketing Lead',
+      helpText: 'Current Marketing Lead (Operations Group Beta), and their projected reward and stake.',
       color: '#2196f3'
     }
   },
   {
     groupType: 'operationsGamma' as const,
     titleCutoff: 1050,
-    shortTitle: 'Marketing',
-    title: 'Marketing',
-    helpText: 'The current Marketers (Operations Group Gamma), and the sum of their projected rewards and stakes.',
+    shortTitle: 'Human Res.',
+    title: 'Human Resources',
+    helpText: 'The current Human Resources (Operations Group Gamma) Workers, and the sum of their projected rewards and stakes.',
     color: '#3f51b5',
     extraInfo: {
       full: 'Operations Working Group Gamma',
@@ -101,9 +101,9 @@ export const WORKING_GROUPS = [
     },
     lead: {
       titleCutoff: 1015,
-      shortTitle: 'Marketing Lead',
-      title: 'Marketing Lead',
-      helpText: 'Current Marketing Lead (Operations Group Gamma), and their projected reward and stake.',
+      shortTitle: 'HR Lead',
+      title: 'Human Res. Lead',
+      helpText: 'Current Human Resources (Operations Group Gamma) Lead, and their projected reward and stake.',
       color: '#673ab7'
     }
   },


### PR DESCRIPTION
As was pointed out in the previous PR (https://github.com/Joystream/joystream/pull/3136#issuecomment-1033595381), Marketing and HR have been swapped compared to what was written in the original document. This PR addresses that.

Thank you @freakstatic for pointing it out :)