### PR TITLE
increase voting and revealing periods and longer council idle time

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -481,14 +481,14 @@ pub type CouncilModule = council::Module<Runtime>;
 parameter_types! {
     // referendum parameters
     pub const MaxSaltLength: u64 = 32;
-    pub const VoteStageDuration: BlockNumber = 5;
-    pub const RevealStageDuration: BlockNumber = 7;
+    pub const VoteStageDuration: BlockNumber = 50;
+    pub const RevealStageDuration: BlockNumber = 50;
     pub const MinimumVotingStake: u64 = 10000;
 
     // council parameteres
     pub const MinNumberOfExtraCandidates: u64 = 1;
-    pub const AnnouncingPeriodDuration: BlockNumber = 15;
-    pub const IdlePeriodDuration: BlockNumber = 27;
+    pub const AnnouncingPeriodDuration: BlockNumber = 50;
+    pub const IdlePeriodDuration: BlockNumber = 500;
     pub const CouncilSize: u64 = 3;
     pub const MinCandidateStake: u64 = 11000;
     pub const ElectedMemberRewardPeriod: BlockNumber = 10;


### PR DESCRIPTION
We are using adjusted periods for testing in playground. But with these values, council mappings seems to break:

```
ERROR: Stopping the proccessor due to errors: {} name: Error, message: No stage update found., stack: Error: No stage update found.
    at getCurrentStageUpdate (/joystream/query-node/mappings/lib/src/council.js:72:15)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async council_NewCandidate (/joystream/query-node/mappings/lib/src/council.js:244:29)
    at async MappingsLookupService.call (/joystream/node_modules/@joystream/hydra-processor/lib/executor/MappingsLookupService.js:80:9)
    at async /joystream/node_modules/@joystream/hydra-processor/lib/executor/TransactionalExecutor.js:40:17
ERROR: {} name: Error, message: Error: No stage update found., stack: Error: Error: No stage update found.
    at MappingsProcessor.processingLoop (/joystream/node_modules/@joystream/hydra-processor/lib/process/MappingsProcessor.js:75:23)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Promise.all (index 1)
    at async MappingsProcessor.start (/joystream/node_modules/@joystream/hydra-processor/lib/process/MappingsProcessor.js:25:9)
    at async ProcessorRunner.process (/joystream/node_modules/@joystream/hydra-processor/lib/start/ProcessorRunner.js:47:9)
    at async Run.run (/joystream/node_modules/@joystream/hydra-processor/lib/commands/run.js:27:13)
    at async Run._run (/joystream/node_modules/@oclif/command/lib/command.js:43:20)
    at async Config.runCommand (/joystream/node_modules/@oclif/config/lib/config.js:173:24)
    at async Main.run (/joystream/node_modules/@oclif/command/lib/main.js:27:9)
    at async Main._run (/joystream/node_modules/@oclif/command/lib/command.js:43:20)
INFO: Shutting down...
INFO: Closing the database connection...
error Command failed with exit code 1.
```

The chain is started up with setupNewChain scenario which is electing the council.

Is this only an issue in the mappings, or potentially indication of a bug in the council runtime module?

To replicate the issue, simply build joystream-node and start local playground with `yarn start`, then look at the processor logs with `docker logs processor`