### PR TITLE
playground: enable CORS for config url

### DIFF
--- a/devops/aws/templates/Playground-Caddyfile.j2
+++ b/devops/aws/templates/Playground-Caddyfile.j2
@@ -49,6 +49,9 @@ wss://{{ nip_domain }}/query-node/server* {
 }
 
 {{ nip_domain }}/config.json {
+    header /* {
+      Access-Control-Allow-Origin *
+    }
     root * /home/ubuntu
     rewrite * /config.json
     file_server


### PR DESCRIPTION
Add CORS header when serving the playground config.json to allow Pioneer to properly fetch it.

cc: @ahhda 