### PR TITLE
Integration tests: Separate council and proposals tests

### DIFF
--- a/tests/integration-tests/src/scenarios/full.ts
+++ b/tests/integration-tests/src/scenarios/full.ts
@@ -51,6 +51,10 @@ scenario(async ({ job, env }) => {
   job('transferring invites', transferringInvites).after(membershipSystemJob)
   job('managing staking accounts', managingStakingAccounts).after(membershipSystemJob)
 
+  // Council (should not interrupt proposalsJob!)
+  const secondCouncilJob = job('electing second council', electCouncil).requires(membershipSystemJob)
+  const councilFailuresJob = job('council election failures', failToElect).requires(secondCouncilJob)
+
   // Proposals:
   const proposalsJob = job('proposals & proposal discussion', [
     proposals,
@@ -59,7 +63,7 @@ scenario(async ({ job, env }) => {
     exactExecutionBlock,
     expireProposal,
     proposalsDiscussion,
-  ]).requires(membershipSystemJob)
+  ]).requires(councilFailuresJob)
 
   // Working groups
   const sudoHireLead = job('sudo lead opening', leadOpening).after(proposalsJob)
@@ -76,8 +80,4 @@ scenario(async ({ job, env }) => {
   job('forum polls', polls).requires(sudoHireLead)
   job('forum posts', posts).requires(sudoHireLead)
   job('forum moderation', moderation).requires(sudoHireLead)
-
-  // Council
-  const secondCouncilJob = job('electing second council', electCouncil).requires(membershipSystemJob)
-  job('council election failures', failToElect).requires(secondCouncilJob)
 })


### PR DESCRIPTION
Council and proposals tests should not be executed in parallel, since proposals tests make some assumptions about council and also re-elect council for the purpose of testing proposals with `constitutionality` > 1 