### PR TITLE
devops: no cache header when serving network config.json

### DIFF
--- a/devops/aws/templates/Playground-Caddyfile.j2
+++ b/devops/aws/templates/Playground-Caddyfile.j2
@@ -51,6 +51,7 @@ wss://{{ nip_domain }}/query-node/server* {
 {{ nip_domain }}/network/config.json {
     header /* {
       Access-Control-Allow-Origin *
+      Cache-Control: no-cache
     }
     root * /home/ubuntu
     rewrite * /config.json


### PR DESCRIPTION
Prevent browsers caching network config file so it can be updated after deployment.