### PR TITLE
Print seeds yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "chain-spec-builder"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "ansi_term 0.12.1",
  "enum-utils",

--- a/utils/chain-spec-builder/Cargo.toml
+++ b/utils/chain-spec-builder/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'chain-spec-builder'
-version = '5.0.0'
+version = '5.1.0'
 
 [dependencies]
 enum-utils = "0.1.2"

--- a/utils/chain-spec-builder/src/main.rs
+++ b/utils/chain-spec-builder/src/main.rs
@@ -19,7 +19,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ansi_term::Style;
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use structopt::StructOpt;
 
@@ -322,28 +321,25 @@ fn generate_authority_keys_and_store(seeds: &[String], keystore_path: &Path) -> 
 }
 
 fn print_seeds(authority_seeds: &[String], endowed_seeds: &[String], sudo_seed: &str) {
-    let header = Style::new().bold().underline();
-    let entry = Style::new().bold();
-
-    println!("{}", header.paint("Authority seeds"));
+    println!("{}", "# Authority seeds");
 
     for (n, seed) in authority_seeds.iter().enumerate() {
-        println!("{} //{}", entry.paint(format!("auth-{}:", n)), seed,);
+        println!("{}//{}", format!("auth_{}=", n), seed);
     }
 
     println!();
 
     if !endowed_seeds.is_empty() {
-        println!("{}", header.paint("Endowed seeds"));
+        println!("{}", "# Endowed seeds");
         for (n, seed) in endowed_seeds.iter().enumerate() {
-            println!("{} //{}", entry.paint(format!("endowed-{}:", n)), seed,);
+            println!("{}//{}", format!("endowed_{}=", n), seed);
         }
 
         println!();
     }
 
-    println!("{}", header.paint("Sudo seed"));
-    println!("//{}", sudo_seed);
+    println!("{}", "# Sudo seed");
+    println!("sudo=//{}", sudo_seed);
 }
 
 fn main() -> Result<(), String> {

--- a/utils/chain-spec-builder/src/main.rs
+++ b/utils/chain-spec-builder/src/main.rs
@@ -321,7 +321,7 @@ fn generate_authority_keys_and_store(seeds: &[String], keystore_path: &Path) -> 
 }
 
 fn print_seeds(authority_seeds: &[String], endowed_seeds: &[String], sudo_seed: &str) {
-    println!("{}", "# Authority seeds");
+    println!("# Authority seeds");
 
     for (n, seed) in authority_seeds.iter().enumerate() {
         println!("{}//{}", format!("auth_{}=", n), seed);
@@ -330,7 +330,7 @@ fn print_seeds(authority_seeds: &[String], endowed_seeds: &[String], sudo_seed: 
     println!();
 
     if !endowed_seeds.is_empty() {
-        println!("{}", "# Endowed seeds");
+        println!("# Endowed seeds");
         for (n, seed) in endowed_seeds.iter().enumerate() {
             println!("{}//{}", format!("endowed_{}=", n), seed);
         }
@@ -338,7 +338,7 @@ fn print_seeds(authority_seeds: &[String], endowed_seeds: &[String], sudo_seed: 
         println!();
     }
 
-    println!("{}", "# Sudo seed");
+    println!("# Sudo seed");
     println!("sudo=//{}", sudo_seed);
 }
 


### PR DESCRIPTION
Print the seeds generated from chainspec-builder tool in  yaml format to be easy to parse from devops deployment scripts. Also dropped ansi color formatting which was also problematic.

The output used to look like this:
```
Authority seeds
auth-0: //7QwlgAgGezfgS3iyBrAiA97DNvLo7Wxg

Endowed seeds
endowed-0: //PkorJt9n7jzVyXqebeloUc4SCsRaw0hM

Sudo seed
//GCUegR3jemautaGERbw0ze5r4T46M5ll
```

new output will look like this:

```
# Authority seeds
auth_0=//7QwlgAgGezfgS3iyBrAiA97DNvLo7Wxg

# Endowed seeds
endowed_0=//PkorJt9n7jzVyXqebeloUc4SCsRaw0hM

# Sudo seed
sudo=//GCUegR3jemautaGERbw0ze5r4T46M5ll
```

Example use, the seeds are printed to stdout:
```
yarn cargo-build
mkdir -p ~/tmp
./target/release/chain-spec-builder generate -a 1 -e 1 -k ~/tmp -c ~/tmp/spec.json
```

you can then do cool stuff like pick-out values with `jo` and `jq`. Example to get the sudo seed:
`./target/release/chain-spec-builder generate -a 1 -e 1 -k ~/tmp -c ~/tmp/spec.json | jo | jq .sudo -r`
 
cc: @ahhda 