### PR TITLE
Olympia. Runtime: fix create_thread bug - check the category existence.

### DIFF
--- a/runtime-modules/forum/src/lib.rs
+++ b/runtime-modules/forum/src/lib.rs
@@ -2219,6 +2219,8 @@ impl<T: Trait> Module<T> {
         // Check that account is forum member
         Self::ensure_is_forum_user(account_id, &forum_user_id)?;
 
+        Self::ensure_category_exists(category_id)?;
+
         let category = Self::ensure_category_is_mutable(category_id)?;
 
         // The balance for creation of thread is the base cost plus the cost of a single post

--- a/runtime-modules/forum/src/tests.rs
+++ b/runtime-modules/forum/src/tests.rs
@@ -1049,6 +1049,32 @@ fn edit_thread_metadata() {
     });
 }
 
+#[test]
+fn create_thread_fails_on_non_existing_category() {
+    let forum_lead = FORUM_LEAD_ORIGIN_ID;
+    let initial_balance = 10_000_000;
+
+    with_test_externalities(|| {
+        balances::Module::<Runtime>::make_free_balance_be(&forum_lead, initial_balance);
+
+        assert_eq!(
+            balances::Module::<Runtime>::free_balance(&forum_lead),
+            initial_balance
+        );
+        let invalid_category_id = 100;
+        create_thread_mock(
+            FORUM_LEAD_ORIGIN,
+            FORUM_LEAD_ORIGIN_ID,
+            FORUM_LEAD_ORIGIN_ID,
+            invalid_category_id,
+            good_thread_metadata(),
+            good_thread_text(),
+            None,
+            Err(Error::<Runtime>::CategoryDoesNotExist.into()),
+        );
+    });
+}
+
 /*
  ** update_category
  */


### PR DESCRIPTION
The `create_thread` didn’t check the category existence. This PR fixes it. [Original issue](https://github.com/Joystream/joystream/issues/3270)