### PR TITLE
Fix runtime proposal integration cargo tests

### DIFF
--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -219,7 +219,7 @@ pub(crate) fn set_council_budget_increment_proposal() -> ProposalParameters<Bloc
 pub(crate) fn set_councilor_reward_proposal() -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
         voting_period: 200,
-        grace_period: 201600, // A council term
+        grace_period: 100, // A council term
         approval_quorum_percentage: 66,
         approval_threshold_percentage: 80,
         slashing_quorum_percentage: 60,
@@ -249,8 +249,8 @@ pub(crate) fn set_initial_invitation_balance_proposal() -> ProposalParameters<Bl
 pub(crate) fn set_membership_lead_invitation_quota_proposal(
 ) -> ProposalParameters<BlockNumber, Balance> {
     ProposalParameters {
-        voting_period: 72000,
-        grace_period: 43200,
+        voting_period: 200,
+        grace_period: 100,
         approval_quorum_percentage: 60,
         approval_threshold_percentage: 75,
         slashing_quorum_percentage: 60,

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -255,3 +255,57 @@ pub(crate) fn increase_total_balance_issuance_using_account_id(
     }
     assert_eq!(Balances::total_issuance(), initial_balance + balance);
 }
+
+pub(crate) fn max_proposal_stake() -> u128 {
+    let mut stakes = vec![];
+    stakes.push(<Runtime as proposals_codex::Trait>::SetMaxValidatorCountProposalParameters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::RuntimeUpgradeProposalParameters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::SignalProposalParameters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::FundingRequestProposalParameters::get());
+    stakes.push(
+        <Runtime as proposals_codex::Trait>::CreateWorkingGroupLeadOpeningProposalParameters::get(),
+    );
+    stakes.push(
+        <Runtime as proposals_codex::Trait>::FillWorkingGroupLeadOpeningProposalParameters::get(),
+    );
+    stakes.push(
+        <Runtime as proposals_codex::Trait>::UpdateWorkingGroupBudgetProposalParameters::get(),
+    );
+    stakes.push(
+        <Runtime as proposals_codex::Trait>::DecreaseWorkingGroupLeadStakeProposalParameters::get(),
+    );
+    stakes
+        .push(<Runtime as proposals_codex::Trait>::SlashWorkingGroupLeadProposalParameters::get());
+    stakes.push(
+        <Runtime as proposals_codex::Trait>::SetWorkingGroupLeadRewardProposalParameters::get(),
+    );
+    stakes.push(
+        <Runtime as proposals_codex::Trait>::TerminateWorkingGroupLeadProposalParameters::get(),
+    );
+    stakes.push(<Runtime as proposals_codex::Trait>::AmendConstitutionProposalParameters::get());
+    stakes.push(
+        <Runtime as proposals_codex::Trait>::CancelWorkingGroupLeadOpeningProposalParameters::get(),
+    );
+    stakes.push(<Runtime as proposals_codex::Trait>::SetMembershipPriceProposalParameters::get());
+    stakes.push(
+        <Runtime as proposals_codex::Trait>::SetCouncilBudgetIncrementProposalParameters::get(),
+    );
+    stakes.push(<Runtime as proposals_codex::Trait>::SetCouncilorRewardProposalParameters::get());
+    stakes.push(
+        <Runtime as proposals_codex::Trait>::SetInitialInvitationBalanceProposalParameters::get(),
+    );
+    stakes.push(<Runtime as proposals_codex::Trait>::SetInvitationCountProposalParameters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::SetMembershipLeadInvitationQuotaProposalParameters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::SetReferralCutProposalParameters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::CreateBlogPostProposalParameters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::EditBlogPostProoposalParamters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::LockBlogPostProposalParameters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::UnlockBlogPostProposalParameters::get());
+    stakes.push(<Runtime as proposals_codex::Trait>::VetoProposalProposalParameters::get());
+
+    stakes
+        .iter()
+        .map(|p| p.required_stake.unwrap_or(0))
+        .max_by(|s1, s2| s1.cmp(s2))
+        .unwrap()
+}

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -97,12 +97,6 @@ pub(crate) fn setup_new_council(cycle_id: u64) {
     for member_id in extra_candidate_ids.clone() {
         let extra_councilor = account_from_member_id(member_id);
 
-        // new members so we don't need to release any stake?
-        // Council::release_candidacy_stake(
-        //     RawOrigin::Signed(extra_councilor.clone()).into(),
-        //     member_id,
-        // )
-        // .unwrap_or_else(|err| assert_eq!(err, council::Error::NoStake));
         increase_total_balance_issuance_using_account_id(
             extra_councilor.clone(),
             councilor_stake + 1,

--- a/runtime/src/tests/mod.rs
+++ b/runtime/src/tests/mod.rs
@@ -1,10 +1,8 @@
 //! The Joystream Substrate Node runtime integration tests.
 #![cfg(test)]
-// TODO: Fix broken tests, partial fix done in - https://github.com/Joystream/joystream/pull/3252
-// Remove allow dead_code directive when re-enabling these tests
-#![allow(dead_code)]
-// #[macro_use]
-// mod proposals_integration;
+
+#[macro_use]
+mod proposals_integration;
 
 mod locks;
 
@@ -12,6 +10,7 @@ mod locks;
 // TODO: Restore after the Olympia release
 //mod fee_tests;
 
+use crate::primitives::MemberId;
 use crate::{BlockNumber, ReferendumInstance, Runtime};
 use frame_support::traits::{Currency, OnFinalize, OnInitialize};
 use frame_system::RawOrigin;
@@ -39,31 +38,52 @@ pub(crate) fn initial_test_ext() -> sp_io::TestExternalities {
     t.into()
 }
 
-fn get_account_membership(account: AccountId32, i: usize) -> u64 {
-    let member_id = i as u64;
-    if Membership::membership(member_id).controller_account != account {
-        insert_member(account.clone());
-        set_staking_account(account.clone(), account, member_id);
-    }
-
-    member_id
+// Simple unique account derived from member id
+pub(crate) fn account_from_member_id(member_id: MemberId) -> AccountId32 {
+    let b1: u8 = ((member_id >> 24) & 0xff) as u8;
+    let b2: u8 = ((member_id >> 16) & 0xff) as u8;
+    let b3: u8 = ((member_id >> 8) & 0xff) as u8;
+    let b4: u8 = (member_id & 0xff) as u8;
+    let mut account: [u8; 32] = AccountId32::default().into();
+    account[0] = b1;
+    account[1] = b2;
+    account[2] = b3;
+    account[3] = b4;
+    account.into()
 }
 
-// council = Vec<(ID - membership handle helper, ACCOUNT_ID)>
-pub(crate) fn elect_council(council: Vec<(u8, AccountId32)>, cycle_id: u64) {
-    let mut voters = Vec::<AccountId32>::new();
+// Create a new set of members
+pub(crate) fn create_new_members(count: u64) -> Vec<MemberId> {
+    // get next member id (u64)
+    let first_member_id = Membership::members_created();
 
+    (0..count)
+        .map(|i| {
+            let member_id = first_member_id + i as u64;
+            let account_id = account_from_member_id(member_id);
+            insert_member(account_id.clone());
+            set_staking_account(account_id.clone(), account_id, member_id);
+            member_id
+        })
+        .collect()
+}
+
+pub(crate) fn setup_new_council(cycle_id: u64) {
+    let council_size = <Runtime as council::Trait>::CouncilSize::get();
+    let num_extra_candidates = <Runtime as council::Trait>::MinNumberOfExtraCandidates::get() + 1;
     let councilor_stake: u128 = <Runtime as council::Trait>::MinCandidateStake::get().into();
-    let extra_candidates = <Runtime as council::Trait>::MinNumberOfExtraCandidates::get() + 1;
-    let mut council_member_ids = Vec::new();
 
-    for (i, councilor) in council.iter() {
-        increase_total_balance_issuance_using_account_id(
-            councilor.clone().into(),
-            councilor_stake + 1,
-        );
+    // council members that will be elected
+    let council_member_ids = create_new_members(council_size);
+    // one new voter for each candidate that will be elected
+    let voter_ids = create_new_members(council_size);
+    // additional candidates that will receive no votes
+    let extra_candidate_ids = create_new_members(num_extra_candidates);
 
-        let member_id = get_account_membership(councilor.clone(), *i as usize);
+    for member_id in council_member_ids.clone() {
+        let councilor = account_from_member_id(member_id);
+        increase_total_balance_issuance_using_account_id(councilor.clone(), councilor_stake + 1);
+
         Council::announce_candidacy(
             RawOrigin::Signed(councilor.clone()).into(),
             member_id,
@@ -72,26 +92,19 @@ pub(crate) fn elect_council(council: Vec<(u8, AccountId32)>, cycle_id: u64) {
             councilor_stake,
         )
         .unwrap();
-        // Make sure to use different voters in each election cycle to prevent problems with
-        // staking
-        voters.push(
-            [(council.len() as u8 + extra_candidates as u8) * (cycle_id as u8 + 1) + *i; 32].into(),
-        );
-        council_member_ids.push(member_id);
     }
 
-    let council_index = (council.clone().last().unwrap().0 + 10) as usize;
-    for i in council_index..(council_index + extra_candidates as usize) {
-        let extra_councilor: AccountId32 = [i as u8; 32].into();
+    for member_id in extra_candidate_ids.clone() {
+        let extra_councilor = account_from_member_id(member_id);
 
-        let member_id = get_account_membership(extra_councilor.clone(), i);
-        Council::release_candidacy_stake(
-            RawOrigin::Signed(extra_councilor.clone()).into(),
-            member_id,
-        )
-        .unwrap_or_else(|err| assert_eq!(err, council::Error::NoStake));
+        // new members so we don't need to release any stake?
+        // Council::release_candidacy_stake(
+        //     RawOrigin::Signed(extra_councilor.clone()).into(),
+        //     member_id,
+        // )
+        // .unwrap_or_else(|err| assert_eq!(err, council::Error::NoStake));
         increase_total_balance_issuance_using_account_id(
-            extra_councilor.clone().into(),
+            extra_councilor.clone(),
             councilor_stake + 1,
         );
         Council::announce_candidacy(
@@ -109,14 +122,16 @@ pub(crate) fn elect_council(council: Vec<(u8, AccountId32)>, cycle_id: u64) {
 
     let voter_stake: u128 =
         <Runtime as referendum::Trait<ReferendumInstance>>::MinimumStake::get().into();
-    for (i, voter) in voters.iter().enumerate() {
-        increase_total_balance_issuance_using_account_id(voter.clone().into(), voter_stake + 1);
+
+    for (i, member_id) in voter_ids.clone().iter().enumerate() {
+        let voter = account_from_member_id(*member_id);
+        increase_total_balance_issuance_using_account_id(voter.clone(), voter_stake + 1);
 
         let commitment = Referendum::calculate_commitment(
-            voter.into(),
+            &voter,
             &[0u8],
             &cycle_id,
-            &council_member_ids[i],
+            &council_member_ids[i as usize],
         );
 
         Referendum::vote(
@@ -133,11 +148,12 @@ pub(crate) fn elect_council(council: Vec<(u8, AccountId32)>, cycle_id: u64) {
             + <Runtime as referendum::Trait<ReferendumInstance>>::VoteStageDuration::get(),
     );
 
-    for (i, voter) in voters.iter().enumerate() {
+    for (i, member_id) in voter_ids.iter().enumerate() {
+        let voter = account_from_member_id(*member_id);
         Referendum::reveal_vote(
             RawOrigin::Signed(voter.clone()).into(),
             vec![0u8],
-            council_member_ids[i].clone(),
+            council_member_ids[i as usize].clone(),
         )
         .unwrap();
     }

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -4,7 +4,7 @@
 
 mod working_group_proposals;
 
-use crate::tests::run_to_block;
+use crate::tests::{account_from_member_id, create_new_members, run_to_block, setup_new_council};
 use crate::{BlogInstance, MembershipWorkingGroupInstance, ProposalCancellationFee, Runtime};
 use codec::Encode;
 use proposals_codex::{GeneralProposalParameters, ProposalDetails};
@@ -22,11 +22,9 @@ use sp_runtime::AccountId32;
 use sp_std::collections::btree_set::BTreeSet;
 
 use super::{
-    increase_total_balance_issuance_using_account_id, initial_test_ext, insert_member,
-    set_staking_account,
+    increase_total_balance_issuance_using_account_id, initial_test_ext, set_staking_account,
 };
 
-use crate::tests::elect_council;
 use crate::CouncilManager;
 
 pub type Balances = pallet_balances::Module<Runtime>;
@@ -38,42 +36,11 @@ pub type Membership = membership::Module<Runtime>;
 pub type MembershipWorkingGroup = working_group::Module<Runtime, MembershipWorkingGroupInstance>;
 pub type Blog = blog::Module<Runtime, BlogInstance>;
 
-fn setup_members(count: u8) {
-    for i in 0..count {
-        let account_id: [u8; 32] = [i; 32];
-        let account_id_converted: AccountId32 = account_id.clone().into();
-        insert_member(account_id_converted.clone());
-        set_staking_account(account_id_converted.clone(), account_id_converted, i as u64);
-    }
-}
-
-fn setup_council(cycle_id: u64) {
-    let council_size = <Runtime as council::Trait>::CouncilSize::get() as u8;
-
-    let mut council = vec![];
-    for id in 0..council_size {
-        council.push((id, [id; 32].into()));
-    }
-
-    elect_council(council, cycle_id);
-}
-
-fn setup_different_council(cycle_id: u64) {
-    let council_size = <Runtime as council::Trait>::CouncilSize::get() as u8;
-
-    let mut council = vec![];
-    for id in council_size..(2 * council_size) {
-        council.push((id, [id; 32].into()));
-    }
-
-    elect_council(council, cycle_id);
-}
-
 struct VoteGenerator {
     proposal_id: u32,
-    current_account_id: AccountId32,
-    current_account_id_seed: u8,
-    current_voter_id: u64,
+    // index into council seats
+    current_voter_index: usize,
+    last_voter_id: u64,
     pub auto_increment_voter_id: bool,
 }
 
@@ -81,14 +48,22 @@ impl VoteGenerator {
     fn new(proposal_id: u32) -> Self {
         VoteGenerator {
             proposal_id,
-            current_voter_id: 0,
-            current_account_id_seed: 0,
-            current_account_id: AccountId32::default(),
+            current_voter_index: 0,
+            last_voter_id: 0,
             auto_increment_voter_id: true,
         }
     }
+
+    fn last_voter(&self) -> u64 {
+        self.last_voter_id
+    }
+
     fn vote_and_assert_ok(&mut self, vote_kind: VoteKind) {
-        self.vote_and_assert(vote_kind, Ok(()));
+        self.vote_and_assert(vote_kind.clone(), Ok(()));
+        assert_eq!(
+            ProposalsEngine::vote_by_proposal_by_voter(self.proposal_id, self.last_voter_id),
+            vote_kind
+        );
     }
 
     fn vote_and_assert(&mut self, vote_kind: VoteKind, expected_result: DispatchResult) {
@@ -96,19 +71,21 @@ impl VoteGenerator {
     }
 
     fn vote(&mut self, vote_kind: VoteKind) -> DispatchResult {
+        let council_members = council::Module::<Runtime>::council_members();
+        let voter = council_members[self.current_voter_index].clone();
+        let voter_member_id = voter.member_id();
+        let account_id = account_from_member_id(*voter_member_id);
         let vote_result = ProposalsEngine::vote(
-            frame_system::RawOrigin::Signed(self.current_account_id.clone()).into(),
-            self.current_voter_id,
+            frame_system::RawOrigin::Signed(account_id).into(),
+            *voter_member_id,
             self.proposal_id,
             vote_kind,
             Vec::new(),
         );
 
+        self.last_voter_id = *voter_member_id;
         if self.auto_increment_voter_id {
-            self.current_account_id_seed += 1;
-            self.current_voter_id += 1;
-            let account_id: [u8; 32] = [self.current_account_id_seed; 32];
-            self.current_account_id = account_id.into();
+            self.current_voter_index += 1;
         }
 
         vote_result
@@ -257,10 +234,8 @@ impl CancelProposalFixture {
 #[test]
 fn proposal_cancellation_with_slashes_with_balance_checks_succeeds() {
     initial_test_ext().execute_with(|| {
-        let account_id = <Runtime as frame_system::Trait>::AccountId::default();
-
-        setup_members(2);
-        let member_id = 0; // newly created member_id
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
 
         let stake_amount = 20000u128;
         let parameters = ProposalParameters {
@@ -289,7 +264,10 @@ fn proposal_cancellation_with_slashes_with_balance_checks_succeeds() {
             account_balance - <Runtime as membership::Trait>::CandidateStake::get()
         );
 
-        let proposal_id = dummy_proposal.create_proposal_and_assert(Ok(1)).unwrap();
+        let expected_proposal_id = 1;
+        let proposal_id = dummy_proposal
+            .create_proposal_and_assert(Ok(expected_proposal_id))
+            .unwrap();
 
         // Only the biggest locked stake count, we don't need to substract the stake candidate here
         assert_eq!(
@@ -333,12 +311,15 @@ fn proposal_cancellation_with_slashes_with_balance_checks_succeeds() {
 #[test]
 fn proposal_reset_succeeds() {
     initial_test_ext().execute_with(|| {
-        setup_members(30);
-        setup_council(0);
-        let council_size = <Runtime as council::Trait>::CouncilSize::get() as u32;
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
+        setup_new_council(0);
 
         // create proposal
-        let dummy_proposal = DummyProposalFixture::default().with_voting_period(100);
+        let dummy_proposal = DummyProposalFixture::default()
+            .with_voting_period(100)
+            .with_account_id(account_id)
+            .with_proposer(member_id);
         let proposal_id = dummy_proposal.create_proposal_and_assert(Ok(1)).unwrap();
 
         // create some votes
@@ -359,31 +340,8 @@ fn proposal_reset_succeeds() {
             }
         );
 
-        // Ensure council was elected
-        assert_eq!(
-            CouncilManager::<Runtime>::total_voters_count(),
-            council_size
-        );
-
-        // Check for votes.
-        assert_eq!(
-            ProposalsEngine::vote_by_proposal_by_voter(proposal_id, 0),
-            VoteKind::Reject
-        );
-        assert_eq!(
-            ProposalsEngine::vote_by_proposal_by_voter(proposal_id, 1),
-            VoteKind::Abstain
-        );
-        assert_eq!(
-            ProposalsEngine::vote_by_proposal_by_voter(proposal_id, 2),
-            VoteKind::Slash
-        );
-
-        // Check proposals CouncilElected hook just trigger the election hook (empty council).
-        //<Runtime as governance::election::Trait>::CouncilElected::council_elected(Vec::new(), 10);
-
         end_idle_period();
-        setup_different_council(1);
+        setup_new_council(1);
 
         let updated_proposal = ProposalsEngine::proposals(proposal_id);
 
@@ -399,14 +357,8 @@ fn proposal_reset_succeeds() {
 
         // No votes could survive cleaning: should be default value.
         assert_eq!(
-            ProposalsEngine::vote_by_proposal_by_voter(proposal_id, 2),
+            ProposalsEngine::vote_by_proposal_by_voter(proposal_id, vote_generator.last_voter()),
             VoteKind::default()
-        );
-
-        // Check council CouncilElected hook. It should set current council.
-        assert_eq!(
-            CouncilManager::<Runtime>::total_voters_count(),
-            council_size
         );
     });
 }
@@ -526,24 +478,23 @@ where
     SuccessfulCall: Fn() -> DispatchResult,
 {
     fn call_extrinsic_and_assert(&self) {
-        let account_id: [u8; 32] = [self.member_id as u8; 32];
+        let account_id = account_from_member_id(self.member_id);
 
         if self.setup_environment {
-            setup_members(15);
-            setup_council(0);
+            setup_new_council(0);
             if self.set_member_lead {
-                let lead_account_id = [self.lead_id as u8; 32];
+                let lead_account_id = account_from_member_id(self.lead_id);
 
                 increase_total_balance_issuance_using_account_id(
-                    lead_account_id.clone().into(),
+                    lead_account_id.clone(),
                     1_500_000,
                 );
 
-                set_membership_leader(lead_account_id.into(), self.lead_id);
+                set_membership_leader(lead_account_id, self.lead_id);
             }
         }
 
-        increase_total_balance_issuance_using_account_id(account_id.clone().into(), 1_500_000);
+        increase_total_balance_issuance_using_account_id(account_id.clone(), 1_500_000);
 
         assert_eq!((self.successful_call)(), Ok(()));
 
@@ -561,20 +512,20 @@ where
 #[test]
 fn text_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::Signal(b"signal".to_vec()),
             )
@@ -588,27 +539,26 @@ fn text_proposal_execution_succeeds() {
 #[test]
 fn funding_request_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let council_budget = 5_000_000;
         let funding = 5000;
 
-        let target_account_id: [u8; 32] = [111; 32];
-        let target_account_id: AccountId32 = target_account_id.clone().into();
+        let target_account_id = account_from_member_id(create_new_members(1)[0]);
 
         assert!(Council::set_budget(RawOrigin::Root.into(), council_budget).is_ok());
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.clone().into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::FundingRequest(vec![common::FundingRequestParameters {
                     amount: funding,
@@ -618,35 +568,38 @@ fn funding_request_proposal_execution_succeeds() {
         })
         .with_member_id(member_id as u64);
 
-        assert_eq!(Balances::usable_balance(target_account_id.clone()), 0);
+        let starting_balance = Balances::usable_balance(target_account_id.clone());
 
         codex_extrinsic_test_fixture.call_extrinsic_and_assert();
         run_to_block(86410);
 
-        assert_eq!(Balances::usable_balance(target_account_id), funding);
+        assert_eq!(
+            Balances::usable_balance(target_account_id),
+            starting_balance + funding
+        );
     });
 }
 
 #[test]
 fn create_blog_post_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let council_budget = 5_000_000;
 
         assert!(Council::set_budget(RawOrigin::Root.into(), council_budget).is_ok());
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.clone().into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::CreateBlogPost(vec![0u8], vec![0u8]),
             )
@@ -665,8 +618,8 @@ fn create_blog_post_proposal_execution_succeeds() {
 #[test]
 fn edit_blog_post_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let council_budget = 5_000_000;
 
         assert!(Council::set_budget(RawOrigin::Root.into(), council_budget).is_ok());
@@ -676,15 +629,15 @@ fn edit_blog_post_proposal_execution_succeeds() {
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.clone().into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::EditBlogPost(post_id, Some(vec![1u8]), None),
             )
@@ -701,8 +654,8 @@ fn edit_blog_post_proposal_execution_succeeds() {
 #[test]
 fn lock_blog_post_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let council_budget = 5_000_000;
 
         assert!(Council::set_budget(RawOrigin::Root.into(), council_budget).is_ok());
@@ -712,15 +665,15 @@ fn lock_blog_post_proposal_execution_succeeds() {
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.clone().into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::LockBlogPost(post_id),
             )
@@ -739,8 +692,8 @@ fn lock_blog_post_proposal_execution_succeeds() {
 #[test]
 fn unlock_blog_post_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let council_budget = 5_000_000;
 
         assert!(Council::set_budget(RawOrigin::Root.into(), council_budget).is_ok());
@@ -751,15 +704,15 @@ fn unlock_blog_post_proposal_execution_succeeds() {
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.clone().into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::UnlockBlogPost(post_id),
             )
@@ -778,23 +731,23 @@ fn unlock_blog_post_proposal_execution_succeeds() {
 #[test]
 fn veto_proposal_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let council_budget = 5_000_000;
         assert!(Council::set_budget(RawOrigin::Root.into(), council_budget).is_ok());
 
         let proposal_id = ProposalsEngine::proposal_count() + 1;
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.clone().into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::AmendConstitution(vec![0u8]),
             )
@@ -805,20 +758,21 @@ fn veto_proposal_proposal_execution_succeeds() {
 
         assert!(proposals_engine::Proposals::<Runtime>::contains_key(1));
 
-        let member_id = 14;
-        let account_id: [u8; 32] = [member_id; 32];
+        // new member that will propose veto
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
                 member_id: member_id.into(),
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.clone().into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::VetoProposal(proposal_id),
             )
@@ -838,27 +792,26 @@ fn veto_proposal_proposal_execution_succeeds() {
 #[test]
 fn set_validator_count_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 1;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
 
         let new_validator_count = 8;
         assert_eq!(<pallet_staking::ValidatorCount>::get(), 0);
 
-        setup_members(100);
-        setup_council(0);
+        setup_new_council(0);
         increase_total_balance_issuance_using_account_id(account_id.clone().into(), 1_500_000);
 
         let staking_account_id: [u8; 32] = [225u8; 32];
         increase_total_balance_issuance_using_account_id(staking_account_id.into(), 1_500_000);
         set_staking_account(
-            account_id.into(),
+            account_id.clone(),
             staking_account_id.into(),
             member_id as u64,
         );
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
                 staking_account_id: Some(staking_account_id.into()),
@@ -866,7 +819,7 @@ fn set_validator_count_proposal_execution_succeeds() {
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.clone().into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::SetMaxValidatorCount(new_validator_count),
             )
@@ -883,20 +836,20 @@ fn set_validator_count_proposal_execution_succeeds() {
 #[test]
 fn amend_constitution_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::AmendConstitution(b"Constitution text".to_vec()),
             )
@@ -910,21 +863,21 @@ fn amend_constitution_proposal_execution_succeeds() {
 #[test]
 fn set_membership_price_proposal_execution_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let membership_price = 100;
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::SetMembershipPrice(membership_price),
             )
@@ -940,21 +893,21 @@ fn set_membership_price_proposal_execution_succeeds() {
 #[test]
 fn set_initial_invitation_balance_proposal_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let initial_invitation_balance = 100;
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::SetInitialInvitationBalance(initial_invitation_balance),
             )
@@ -973,21 +926,21 @@ fn set_initial_invitation_balance_proposal_succeeds() {
 #[test]
 fn set_initial_invitation_count_proposal_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let new_default_invite_count = 50;
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::SetInitialInvitationCount(new_default_invite_count),
             )
@@ -1008,22 +961,22 @@ fn set_initial_invitation_count_proposal_succeeds() {
 #[test]
 fn set_membership_leader_invitation_quota_proposal_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let new_invite_count = 30;
-        let lead_id = 11;
+        let lead_id = create_new_members(1)[0];
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::SetMembershipLeadInvitationQuota(new_invite_count),
             )
@@ -1043,21 +996,21 @@ fn set_membership_leader_invitation_quota_proposal_succeeds() {
 #[test]
 fn set_referral_cut_proposal_succeeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let referral_cut = 30;
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::SetReferralCut(referral_cut),
             )
@@ -1075,21 +1028,21 @@ fn set_referral_cut_proposal_succeeds() {
 #[test]
 fn set_budget_increment_proposal_succeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let budget_increment = 500;
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::SetCouncilBudgetIncrement(budget_increment),
             )
@@ -1110,21 +1063,21 @@ fn set_budget_increment_proposal_succeds() {
 #[test]
 fn set_councilor_reward_proposal_succeds() {
     initial_test_ext().execute_with(|| {
-        let member_id = 10;
-        let account_id: [u8; 32] = [member_id; 32];
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
         let councilor_reward = 100;
 
         let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
             let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
-                member_id: member_id.into(),
+                member_id: member_id,
                 title: b"title".to_vec(),
                 description: b"body".to_vec(),
-                staking_account_id: Some(account_id.into()),
+                staking_account_id: Some(account_id.clone()),
                 exact_execution_block: None,
             };
 
             ProposalCodex::create_proposal(
-                RawOrigin::Signed(account_id.into()).into(),
+                RawOrigin::Signed(account_id.clone()).into(),
                 general_proposal_parameters,
                 ProposalDetails::SetCouncilorReward(councilor_reward),
             )
@@ -1142,15 +1095,19 @@ fn set_councilor_reward_proposal_succeds() {
 #[test]
 fn proposal_reactivation_succeeds() {
     initial_test_ext().execute_with(|| {
-        setup_members(25);
-        setup_council(0);
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
+
+        setup_new_council(0);
         let council_size = <Runtime as council::Trait>::CouncilSize::get() as u32;
 
         let starting_block = System::block_number();
         // create proposal
         let dummy_proposal = DummyProposalFixture::default()
             .with_voting_period(100)
-            .with_constitutionality(2);
+            .with_constitutionality(2)
+            .with_account_id(account_id)
+            .with_proposer(member_id);
         let proposal_id = dummy_proposal.create_proposal_and_assert(Ok(1)).unwrap();
 
         // Approve Proposal
@@ -1178,16 +1135,15 @@ fn proposal_reactivation_succeeds() {
         );
 
         end_idle_period();
-        setup_different_council(1);
+        setup_new_council(1);
 
-        // Why this jump to arbitrary blocknumber potentially in the past..?!
-        // run_to_block(10);
+        run_to_block(System::block_number() + 1);
 
         let updated_proposal = ProposalsEngine::proposals(proposal_id);
 
         assert_eq!(updated_proposal.status, ProposalStatus::Active);
 
-        // Check council CouncilElected hook. It should set current council. And we elected single councilor.
+        // Ensure council was elected
         assert_eq!(
             CouncilManager::<Runtime>::total_voters_count(),
             council_size

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -4,7 +4,9 @@
 
 mod working_group_proposals;
 
-use crate::tests::{account_from_member_id, create_new_members, run_to_block, setup_new_council};
+use crate::tests::{
+    account_from_member_id, create_new_members, max_proposal_stake, run_to_block, setup_new_council,
+};
 use crate::{BlogInstance, MembershipWorkingGroupInstance, ProposalCancellationFee, Runtime};
 use codec::Encode;
 use proposals_codex::{GeneralProposalParameters, ProposalDetails};
@@ -485,16 +487,18 @@ where
             if self.set_member_lead {
                 let lead_account_id = account_from_member_id(self.lead_id);
 
+                let min_stake = <Runtime as working_group::Trait<MembershipWorkingGroupInstance>>::MinimumApplicationStake::get();
+
                 increase_total_balance_issuance_using_account_id(
                     lead_account_id.clone(),
-                    1_500_000,
+                    min_stake * 2,
                 );
 
                 set_membership_leader(lead_account_id, self.lead_id);
             }
         }
 
-        increase_total_balance_issuance_using_account_id(account_id.clone(), 1_500_000);
+        increase_total_balance_issuance_using_account_id(account_id.clone(), max_proposal_stake());
 
         assert_eq!((self.successful_call)(), Ok(()));
 

--- a/runtime/src/tests/proposals_integration/working_group_proposals.rs
+++ b/runtime/src/tests/proposals_integration/working_group_proposals.rs
@@ -490,8 +490,8 @@ fn run_create_add_working_group_leader_opening_proposal_execution_succeeds<
     <T as common::membership::MembershipTypes>::MemberId: From<u64>,
 {
     initial_test_ext().execute_with(|| {
-        let member_id: MemberId = 1;
-        let account_id: [u8; 32] = [member_id as u8; 32];
+        let member_id: MemberId = create_new_members(1)[0];
+        let account_id: [u8; 32] = account_from_member_id(member_id).into();
 
         let next_opening_id = WorkingGroupInstance::<T, I>::next_opening_id();
 
@@ -596,8 +596,8 @@ fn run_create_fill_working_group_leader_opening_proposal_execution_succeeds<
     common::MemberId<T>: From<u64>,
 {
     initial_test_ext().execute_with(|| {
-        let member_id: u64 = 14;
-        let account_id: [u8; 32] = [member_id as u8; 32];
+        let member_id: u64 = create_new_members(1)[0];
+        let account_id: [u8; 32] = account_from_member_id(member_id).into();
 
         increase_total_balance_issuance_using_account_id(account_id.clone().into(), 1_500_000);
 
@@ -755,10 +755,8 @@ fn run_create_decrease_group_leader_stake_proposal_execution_succeeds<
     <T as pallet_balances::Trait>::Balance: From<u128>,
 {
     initial_test_ext().execute_with(|| {
-        // Don't use the same member id as a councilor, can lead to conflicting stakes
-        let member_id: MemberId = 14;
-
-        let account_id: [u8; 32] = [member_id as u8; 32];
+        let member_id: u64 = create_new_members(1)[0];
+        let account_id: [u8; 32] = account_from_member_id(member_id).into();
         let stake_amount: Balance = 10_000;
 
         increase_total_balance_issuance_using_account_id(account_id.into(), 1_500_000);
@@ -937,10 +935,8 @@ fn run_create_slash_group_leader_stake_proposal_execution_succeeds<
     <T as pallet_balances::Trait>::Balance: From<u128>,
 {
     initial_test_ext().execute_with(|| {
-        // Don't use the same member id as a councilor, can lead to conflicting stakes
-        let member_id: MemberId = 14;
-
-        let account_id: [u8; 32] = [member_id as u8; 32];
+        let member_id: u64 = create_new_members(1)[0];
+        let account_id: [u8; 32] = account_from_member_id(member_id).into();
         let stake_amount: Balance = 10_000;
 
         let stake_policy = working_group::StakePolicy {
@@ -1107,13 +1103,12 @@ fn run_create_set_working_group_mint_capacity_proposal_execution_succeeds<
     working_group::BalanceOf<T>: From<u128>,
 {
     initial_test_ext().execute_with(|| {
-        let member_id: MemberId = 1;
-        let account_id: [u8; 32] = [member_id as u8; 32];
+        setup_new_council(0);
+
+        let member_id: MemberId = create_new_members(1)[0];
+        let account_id: [u8; 32] = account_from_member_id(member_id).into();
 
         let mint_capacity = 999999;
-
-        setup_members(15);
-        setup_council(0);
 
         increase_total_balance_issuance_using_account_id(account_id.clone().into(), 1_500_000);
 
@@ -1147,8 +1142,8 @@ fn run_create_syphon_working_group_mint_capacity_proposal_execution_succeeds<
     working_group::BalanceOf<T>: From<u128>,
 {
     initial_test_ext().execute_with(|| {
-        let member_id: MemberId = 14;
-        let account_id: [u8; 32] = [member_id as u8; 32];
+        let member_id: u64 = create_new_members(1)[0];
+        let account_id: [u8; 32] = account_from_member_id(member_id).into();
 
         increase_total_balance_issuance_using_account_id(account_id.clone().into(), 1_500_000);
 
@@ -1355,8 +1350,8 @@ fn run_create_set_group_leader_reward_proposal_execution_succeeds<
     working_group::BalanceOf<T>: From<u128>,
 {
     initial_test_ext().execute_with(|| {
-        let member_id: MemberId = 14;
-        let account_id: [u8; 32] = [member_id as u8; 32];
+        let member_id: u64 = create_new_members(1)[0];
+        let account_id: [u8; 32] = account_from_member_id(member_id).into();
 
         increase_total_balance_issuance_using_account_id(account_id.clone().into(), 1_500_000);
 
@@ -1531,10 +1526,8 @@ fn run_create_terminate_group_leader_role_proposal_execution_succeeds<
     <T as pallet_balances::Trait>::Balance: From<u128>,
 {
     initial_test_ext().execute_with(|| {
-        // Don't use the same member id as a councilor, can lead to conflicting stakes
-        let member_id: MemberId = 14;
-
-        let account_id: [u8; 32] = [member_id as u8; 32];
+        let member_id: u64 = create_new_members(1)[0];
+        let account_id: [u8; 32] = account_from_member_id(member_id).into();
         let stake_amount = 100_000_u128;
 
         let stake_policy = working_group::StakePolicy {
@@ -1708,10 +1701,8 @@ fn run_create_terminate_group_leader_role_proposal_with_slashing_execution_succe
     <T as pallet_balances::Trait>::Balance: From<u128>,
 {
     initial_test_ext().execute_with(|| {
-        // Don't use the same member id as a councilor, can lead to conflicting stakes
-        let member_id: MemberId = 14;
-
-        let account_id: [u8; 32] = [member_id as u8; 32];
+        let member_id: u64 = create_new_members(1)[0];
+        let account_id: [u8; 32] = account_from_member_id(member_id).into();
         let stake_amount = 100_000_u128;
 
         let stake_policy = working_group::StakePolicy {


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/3288

- [x] Fix issues with false assumptions about size of council and member account re-use causing staking conflict issues
- [x] Make tests sensitive to real values of required stakes
- [x] Make tests sensitive to change in proposal grace periods
  - didn't change working group related proposals assuming they will always be 0 grace period
- [x] Ensure proposed changes are indeed different than current values?
- [x] Fixed one proposal default parameter values as per https://github.com/Joystream/joystream/issues/3242