### PR TITLE
Olympia: Disable nft tests

### DIFF
--- a/tests/network-tests/src/scenarios/full.ts
+++ b/tests/network-tests/src/scenarios/full.ts
@@ -31,7 +31,8 @@ import initStorageBucket from '../flows/clis/initStorageBucket'
 import createChannel from '../flows/clis/createChannel'
 import { scenario } from '../Scenario'
 import activeVideoCounters from '../flows/content/activeVideoCounters'
-import nftAuctionAndOffers from '../flows/content/nftAuctionAndOffers'
+// Disable nft tests until functionality re-activated in rhodes release
+// import nftAuctionAndOffers from '../flows/content/nftAuctionAndOffers'
 import updatingVerificationStatus from '../flows/membership/updateVerificationStatus'
 
 scenario('Full', async ({ job, env }) => {
@@ -94,7 +95,8 @@ scenario('Full', async ({ job, env }) => {
 
   // Content directory
   const videoCountersJob = job('check active video counters', activeVideoCounters).requires(sudoHireLead)
-  job('nft auction and offers', nftAuctionAndOffers).after(videoCountersJob)
+  // Disable nft tests until functionality re-activated in rhodes release
+  // job('nft auction and offers', nftAuctionAndOffers).after(videoCountersJob)
 
   // CLIs:
   const createChannelJob = job('create channel via CLI', createChannel).after(videoCountersJob)


### PR DESCRIPTION
Disable nft tests (they fail now because we disabled them in the runtime) from full scenario to be re-enabled in rhodes release.