### PR TITLE
Olympia. Runtime. Fix default invitation balance bug in the membership pallet.

### DIFF
--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -711,10 +711,10 @@ decl_module! {
             )?;
 
             let current_wg_budget = T::WorkingGroup::get_budget();
-            let default_invitation_balance = T::DefaultInitialInvitationBalance::get();
+            let invitation_balance = Self::initial_invitation_balance();
 
             ensure!(
-                default_invitation_balance <= current_wg_budget,
+                invitation_balance <= current_wg_budget,
                 Error::<T>::WorkingGroupBudgetIsNotSufficientForInviting
             );
 
@@ -743,19 +743,19 @@ decl_module! {
             });
 
             // Decrease the working group balance.
-            let new_wg_budget = current_wg_budget.saturating_sub(default_invitation_balance);
+            let new_wg_budget = current_wg_budget.saturating_sub(invitation_balance);
             T::WorkingGroup::set_budget(new_wg_budget);
 
             // Create default balance for the invited member.
             let _ = balances::Module::<T>::deposit_creating(
                 &params.controller_account,
-                default_invitation_balance
+                invitation_balance
             );
 
             // Lock invitation balance. Allow only transaction payments.
             T::InvitedMemberStakingHandler::lock_with_reasons(
                 &params.controller_account,
-                default_invitation_balance,
+                invitation_balance,
                 WithdrawReasons::except(WithdrawReason::TransactionPayment)
             );
 

--- a/runtime-modules/membership/src/tests/fixtures.rs
+++ b/runtime-modules/membership/src/tests/fixtures.rs
@@ -495,6 +495,13 @@ impl Default for SetInitialInvitationBalanceFixture {
 }
 
 impl SetInitialInvitationBalanceFixture {
+    pub fn with_initial_balance(self, new_initial_balance: u64) -> Self {
+        Self {
+            new_initial_balance,
+            ..self
+        }
+    }
+
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Membership::set_initial_invitation_balance(
             self.origin.clone().into(),


### PR DESCRIPTION
The membership pallet had a bug related to the initial invitation balance for members. We assigned the value of the default runtime constant instead of the dedicated changeable storage value. The tests contained the same bug. This PR fixes it.

[Original issue](https://github.com/Joystream/joystream/issues/3357)