### PR TITLE
query node - NFT royalty overflow hotfix

### DIFF
--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -345,7 +345,9 @@ export async function createNft(
 
   // calculate some values
   const creatorRoyalty = nftIssuanceParameters.royalty.isSome
-    ? nftIssuanceParameters.royalty.unwrap().toNumber()
+    ? // TODO: this is causing number overload and needs to be divided by magic constant seen in tests
+      // ? nftIssuanceParameters.royalty.unwrap().toNumber()
+      1
     : undefined
   const decodedMetadata = nftIssuanceParameters.nft_metadata.toString()
 


### PR DESCRIPTION
This PR contains a hotfix for `royalty` value, causing a number overflow error. It discards actual royalty value and sets dummy value (`1`). It will need a proper fix after some testing is done (the actual number must be divided by proper constant).