### PR TITLE
query node - run tests script improvements

### DIFF
--- a/query-node/run-tests.sh
+++ b/query-node/run-tests.sh
@@ -20,7 +20,9 @@ function cleanup() {
     docker-compose down -v
 }
 
-trap cleanup EXIT
+if [ -z "$DEBUG" ]; then
+  trap cleanup EXIT
+fi
 
 # Clean start
 docker-compose down -v
@@ -28,9 +30,12 @@ docker-compose down -v
 docker-compose -f ../docker-compose.yml up -d joystream-node
 ./start.sh
 
+../tests/network-tests/start-storage.sh
+export REUSE_KEYS=true
+
 # pass the scenario name without .ts extension
 SCENARIO=$1
 # fallback if scenario if not specified
-SCENARIO=${SCENARIO:=full}
+SCENARIO=${SCENARIO:="content-directory"}
 
 time yarn workspace network-tests run-test-scenario ${SCENARIO}


### PR DESCRIPTION
This PR fixes and improves script for running only query node related network tests. 
Use
```
./query-node/run-tests.sh

# don't destroy docker containers after tests finish; allows debugging in graphql playground, etc.
DEBUG=true ./query-node/run-tests.sh 
```