### PR TITLE
runtime - removal of obsolete boundaries for auction starting in future

### DIFF
--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -185,9 +185,6 @@ decl_storage! {
         /// Platform fee percentage
         pub PlatfromFeePercentage get(fn platform_fee_percentage) config(): Perbill;
 
-        /// Max delta between current block and starts at
-        pub AuctionStartsAtMaxDelta get(fn auction_starts_at_max_delta) config(): T::BlockNumber;
-
         /// Max nft auction whitelist length
         pub MaxAuctionWhiteListLength get(fn max_auction_whitelist_length) config(): MaxNumber;
 

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -406,7 +406,6 @@ pub struct ExtBuilder {
     min_bid_step: u64,
     max_bid_step: u64,
     platform_fee_percentage: Perbill,
-    auction_starts_at_max_delta: u64,
     max_auction_whitelist_length: u32,
 }
 
@@ -435,7 +434,6 @@ impl Default for ExtBuilder {
             min_bid_step: 10,
             max_bid_step: 100,
             platform_fee_percentage: Perbill::from_percent(1),
-            auction_starts_at_max_delta: 90_000,
             max_auction_whitelist_length: 4,
         }
     }
@@ -470,7 +468,6 @@ impl ExtBuilder {
             min_bid_step: self.min_bid_step,
             max_bid_step: self.max_bid_step,
             platform_fee_percentage: self.platform_fee_percentage,
-            auction_starts_at_max_delta: self.auction_starts_at_max_delta,
             max_auction_whitelist_length: self.max_auction_whitelist_length,
         }
         .assimilate_storage(&mut t)


### PR DESCRIPTION
After runtime changes to how auctions work https://github.com/Joystream/joystream/pull/3353, a now obsolote storage variable `auction_starts_at_max_delta` has been left behind. This PR removes it.