### PR TITLE
Small CLI improvements, and added staking.validate

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -125,6 +125,9 @@
       },
       "forum": {
         "description": "Forum working group activities (moderation, category management)"
+      },
+      "staking": {
+        "description": "Staking and validation commands"
       }
     }
   },

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -415,7 +415,7 @@ export default class Api {
     return await this.entriesByAccountIds(this._api.query.staking.ledger)
   }
 
-  async isControllerValid(account: string) {
+  async isControllerValid(account: string): Promise<Option<StakingLedger>> {
     return await this._api.query.staking.ledger(account)
   }
 

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -152,8 +152,6 @@ export default class Api {
     return entries
   }
 
-
-
   protected async blockHash(height: number): Promise<string> {
     const blockHash = await this._api.rpc.chain.getBlockHash(height)
 

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -415,7 +415,7 @@ export default class Api {
     return await this.entriesByAccountIds(this._api.query.staking.ledger)
   }
 
-  async isControllerValid(account: string): Promise<Option<StakingLedger>> {
+  async getStakingLedger(account: string): Promise<Option<StakingLedger>> {
     return await this._api.query.staking.ledger(account)
   }
 

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -3,10 +3,10 @@ import { createType, types } from '@joystream/types'
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { SubmittableExtrinsic, AugmentedQuery } from '@polkadot/api/types'
 import { formatBalance } from '@polkadot/util'
-import { Balance, LockIdentifier } from '@polkadot/types/interfaces'
+import { Balance, LockIdentifier, StakingLedger, ElectionStatus } from '@polkadot/types/interfaces'
 import { KeyringPair } from '@polkadot/keyring/types'
 import { Codec, Observable } from '@polkadot/types/types'
-import { UInt } from '@polkadot/types'
+import { UInt, Option } from '@polkadot/types'
 import {
   AccountSummary,
   WorkingGroups,
@@ -48,9 +48,9 @@ export const apiModuleByGroup = {
   [WorkingGroups.Forum]: 'forumWorkingGroup',
   [WorkingGroups.Membership]: 'membershipWorkingGroup',
   [WorkingGroups.Gateway]: 'gatewayWorkingGroup',
-  [WorkingGroups.OperationsAlpha]: 'operationsWorkingGroupAlpha',
-  [WorkingGroups.OperationsBeta]: 'operationsWorkingGroupBeta',
-  [WorkingGroups.OperationsGamma]: 'operationsWorkingGroupGamma',
+  [WorkingGroups.Builders]: 'operationsWorkingGroupAlpha',
+  [WorkingGroups.HumanResources]: 'operationsWorkingGroupBeta',
+  [WorkingGroups.Marketing]: 'operationsWorkingGroupGamma',
   [WorkingGroups.Distribution]: 'distributionWorkingGroup',
 } as const
 
@@ -140,6 +140,19 @@ export default class Api {
 
     return entries.sort((a, b) => a[0].toNumber() - b[0].toNumber())
   }
+
+  async entriesByAccountIds<AccountType extends AccountId, ValueType extends Codec>(
+    apiMethod: AugmentedQuery<'promise', (key: AccountType) => Observable<ValueType>, [AccountType]>
+  ): Promise<[AccountType, ValueType][]> {
+    const entries: [AccountType, ValueType][] = (await apiMethod.entries()).map(([storageKey, value]) => [
+      storageKey.args[0] as AccountType,
+      value,
+    ])
+
+    return entries
+  }
+
+
 
   protected async blockHash(height: number): Promise<string> {
     const blockHash = await this._api.rpc.chain.getBlockHash(height)
@@ -398,6 +411,18 @@ export default class Api {
 
   availableCuratorGroups(): Promise<[CuratorGroupId, CuratorGroup][]> {
     return this.entriesByIds(this._api.query.content.curatorGroupById)
+  }
+
+  async allStakingLedgers(): Promise<[AccountId, Option<StakingLedger>][]> {
+    return await this.entriesByAccountIds(this._api.query.staking.ledger)
+  }
+
+  async isControllerValid(account: string) {
+    return await this._api.query.staking.ledger(account)
+  }
+
+  async getEraElectionStatus(): Promise<ElectionStatus> {
+    return await this._api.query.staking.eraElectionStatus()
   }
 
   async curatorGroupById(id: number): Promise<CuratorGroup | null> {

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -55,9 +55,9 @@ export enum WorkingGroups {
   Curators = 'curators',
   Forum = 'forum',
   Membership = 'membership',
-  OperationsAlpha = 'operationsAlpha',
-  OperationsBeta = 'operationsBeta',
-  OperationsGamma = 'operationsGamma',
+  Builders = 'builders',
+  HumanResources = 'humanResources',
+  Marketing = 'marketing',
   Gateway = 'gateway',
   Distribution = 'distributors',
 }
@@ -68,9 +68,9 @@ export const AvailableGroups: readonly WorkingGroups[] = [
   WorkingGroups.Forum,
   WorkingGroups.Membership,
   WorkingGroups.Gateway,
-  WorkingGroups.OperationsAlpha,
-  WorkingGroups.OperationsBeta,
-  WorkingGroups.OperationsGamma,
+  WorkingGroups.Builders,
+  WorkingGroups.HumanResources,
+  WorkingGroups.Marketing,
   WorkingGroups.Distribution,
 ] as const
 

--- a/cli/src/base/ApiCommandBase.ts
+++ b/cli/src/base/ApiCommandBase.ts
@@ -140,8 +140,8 @@ export default abstract class ApiCommandBase extends StateAwareCommandBase {
           value: 'ws://localhost:9944',
         },
         {
-          name: 'Current Testnet official Joystream node (wss://rome-rpc-endpoint.joystream.org:9944/)',
-          value: 'wss://rome-rpc-endpoint.joystream.org:9944/',
+          name: 'Current Testnet official Joystream node (wss://rpc.joystream.org:9944/)',
+          value: 'wss://rpc.joystream.org:9944/',
         },
         {
           name: 'Custom endpoint',

--- a/cli/src/base/ApiCommandBase.ts
+++ b/cli/src/base/ApiCommandBase.ts
@@ -174,8 +174,8 @@ export default abstract class ApiCommandBase extends StateAwareCommandBase {
         value: 'http://localhost:8081/graphql',
       },
       {
-        name: 'Jsgenesis-hosted query node (https://hydra.joystream.org/graphql)',
-        value: 'https://hydra.joystream.org/graphql',
+        name: 'Jsgenesis-hosted query node (https://query.joystream.org/graphql)',
+        value: 'https://query.joystream.org/graphql',
       },
       {
         name: 'Custom endpoint',

--- a/cli/src/base/StakingCommandBase.ts
+++ b/cli/src/base/StakingCommandBase.ts
@@ -7,14 +7,9 @@ import { formatBalance } from '@polkadot/util'
 export default abstract class StakingCommandBase extends AccountsCommandBase {
   private async availableControllers(): Promise<[AccountId, StakingLedger][]> {
     const controllers = await this.getStakingLedgers()
-    const stakerMap: [AccountId, StakingLedger][] = []
-    controllers.forEach(([key, value]) => {
-      const ledger = value.unwrapOr(undefined)
-      if (!!ledger && this.isKeyAvailable(key)) {
-        stakerMap.push([key, ledger])
-      }
-    })
-    return stakerMap
+    return controllers
+      .filter(([key, value]) => value.isSome && this.isKeyAvailable(key))
+      .map(([key, value]) => [key, value.unwrap()])
   }
 
   private async getStakingLedgers() {
@@ -74,7 +69,7 @@ export default abstract class StakingCommandBase extends AccountsCommandBase {
     return await this.simplePrompt<number>({ message, type: 'number' })
   }
 
-  async electionStatus() {
+  async checkElectionStatus() {
     const electionStatus = await this.getApi().getEraElectionStatus()
     if (electionStatus.isOpen === true) {
       this.warn(

--- a/cli/src/base/StakingCommandBase.ts
+++ b/cli/src/base/StakingCommandBase.ts
@@ -1,0 +1,91 @@
+import ExitCodes from '../ExitCodes'
+import { AccountId } from "@joystream/types/common"
+import { StakingLedger } from '@polkadot/types/interfaces'
+import AccountsCommandBase from "./AccountsCommandBase"
+import { formatBalance } from '@polkadot/util'
+
+export default abstract class StakingCommandBase extends AccountsCommandBase {
+  
+  private async availableControllers(): Promise<[AccountId,StakingLedger][]> {
+    const controllers = await this.getStakingLedgers()
+    const stakerMap: [AccountId,StakingLedger][] = []
+    controllers.forEach(([key,value]) => {
+      const ledger = value.unwrapOr(undefined)
+      if (!!ledger && this.isKeyAvailable(key)) {
+        stakerMap.push([key,ledger])
+      }
+    })
+    return stakerMap
+  }
+ 
+
+
+  private async getStakingLedgers() {
+    const controllers = await this.getApi().allStakingLedgers()
+    return controllers
+  }
+
+  async getController():Promise<string> {
+    const availableControllers = await this.availableControllers()
+    const selectedValidator = await this.promptForController('No controller input',availableControllers)
+    return availableControllers[selectedValidator][0].toString()
+  }
+
+  async promptForController(message = 'Choose your controller account', stakingAlternatives: [AccountId,StakingLedger][]): Promise<number> {
+    if (!stakingAlternatives.length) {
+      this.warn('No controller accounts to choose from!')
+      this.exit(ExitCodes.NoAccountFound)
+    }
+    const selectedController = await this.simplePrompt<number>({
+      message,
+      type: 'list',
+      choices: stakingAlternatives.map((a) => ({
+        name: `Controller: ${a[0].toString()}, with Stash ${a[1].stash.toString()} with an active stake: ${formatBalance(a[1].active)}`,
+        value: stakingAlternatives.indexOf(a),
+      })), 
+    })
+    return selectedController
+  }
+
+  async isController(controllerInput:string) {
+    if (this.isKeyAvailable(controllerInput)) {
+      const info = (await this.getApi().isControllerValid(controllerInput)).unwrapOr(undefined)
+      if (!!info) {
+        this.log(`Your controller ${controllerInput} with stash ${info.stash.toString()} is actively staking ${formatBalance(info.active)}`)
+      } else {
+        this.warn('Your account is not a controller!')
+        this.exit(ExitCodes.InvalidInput)
+      }
+    } else {
+      this.warn(`You don't have this account imported!`)
+      this.exit(ExitCodes.NoAccountFound)
+    }
+  }
+
+  async promptForCommission(message = 'Choose how much you reqiure as commission (between 0% and 100%'): Promise<number> {
+    return await this.simplePrompt<number>({ message, type: 'number'})
+  }
+
+  async electionStatus() {
+    const electionStatus = await this.getApi().getEraElectionStatus()
+    if (electionStatus.isOpen === true) {
+      this.warn('There is currently an ongoing election for new validator candidates. As such staking operations are not permitted. You need to wait')
+      this.exit(ExitCodes.ActionCurrentlyUnavailable)
+    }
+  }
+
+  async getValidatorPrefs(commission: number | undefined): Promise<any> {
+    let validatorPrefs = {'commission': 0}
+    if (!commission) {
+      commission = await this.promptForCommission()
+    }
+    if (commission >= 0 && commission <= 100) {
+      validatorPrefs = {'commission': commission*10**7}
+    } else {
+      this.warn('Invalid commission input!')
+      this.exit(ExitCodes.InvalidInput)
+    }
+    return validatorPrefs
+  }
+
+}

--- a/cli/src/base/StakingCommandBase.ts
+++ b/cli/src/base/StakingCommandBase.ts
@@ -1,37 +1,37 @@
 import ExitCodes from '../ExitCodes'
-import { AccountId } from "@joystream/types/common"
+import { AccountId } from '@joystream/types/common'
 import { StakingLedger } from '@polkadot/types/interfaces'
-import AccountsCommandBase from "./AccountsCommandBase"
+import AccountsCommandBase from './AccountsCommandBase'
 import { formatBalance } from '@polkadot/util'
 
 export default abstract class StakingCommandBase extends AccountsCommandBase {
-  
-  private async availableControllers(): Promise<[AccountId,StakingLedger][]> {
+  private async availableControllers(): Promise<[AccountId, StakingLedger][]> {
     const controllers = await this.getStakingLedgers()
-    const stakerMap: [AccountId,StakingLedger][] = []
-    controllers.forEach(([key,value]) => {
+    const stakerMap: [AccountId, StakingLedger][] = []
+    controllers.forEach(([key, value]) => {
       const ledger = value.unwrapOr(undefined)
       if (!!ledger && this.isKeyAvailable(key)) {
-        stakerMap.push([key,ledger])
+        stakerMap.push([key, ledger])
       }
     })
     return stakerMap
   }
- 
-
 
   private async getStakingLedgers() {
     const controllers = await this.getApi().allStakingLedgers()
     return controllers
   }
 
-  async getController():Promise<string> {
+  async getController(): Promise<string> {
     const availableControllers = await this.availableControllers()
-    const selectedValidator = await this.promptForController('No controller input',availableControllers)
+    const selectedValidator = await this.promptForController('No controller input', availableControllers)
     return availableControllers[selectedValidator][0].toString()
   }
 
-  async promptForController(message = 'Choose your controller account', stakingAlternatives: [AccountId,StakingLedger][]): Promise<number> {
+  async promptForController(
+    message = 'Choose your controller account',
+    stakingAlternatives: [AccountId, StakingLedger][]
+  ): Promise<number> {
     if (!stakingAlternatives.length) {
       this.warn('No controller accounts to choose from!')
       this.exit(ExitCodes.NoAccountFound)
@@ -40,18 +40,24 @@ export default abstract class StakingCommandBase extends AccountsCommandBase {
       message,
       type: 'list',
       choices: stakingAlternatives.map((a) => ({
-        name: `Controller: ${a[0].toString()}, with Stash ${a[1].stash.toString()} with an active stake: ${formatBalance(a[1].active)}`,
+        name: `Controller: ${a[0].toString()}, with Stash ${a[1].stash.toString()} with an active stake: ${formatBalance(
+          a[1].active
+        )}`,
         value: stakingAlternatives.indexOf(a),
-      })), 
+      })),
     })
     return selectedController
   }
 
-  async isController(controllerInput:string) {
+  async isController(controllerInput: string) {
     if (this.isKeyAvailable(controllerInput)) {
       const info = (await this.getApi().isControllerValid(controllerInput)).unwrapOr(undefined)
       if (!!info) {
-        this.log(`Your controller ${controllerInput} with stash ${info.stash.toString()} is actively staking ${formatBalance(info.active)}`)
+        this.log(
+          `Your controller ${controllerInput} with stash ${info.stash.toString()} is actively staking ${formatBalance(
+            info.active
+          )}`
+        )
       } else {
         this.warn('Your account is not a controller!')
         this.exit(ExitCodes.InvalidInput)
@@ -62,30 +68,33 @@ export default abstract class StakingCommandBase extends AccountsCommandBase {
     }
   }
 
-  async promptForCommission(message = 'Choose how much you reqiure as commission (between 0% and 100%'): Promise<number> {
-    return await this.simplePrompt<number>({ message, type: 'number'})
+  async promptForCommission(
+    message = 'Choose how much you reqiure as commission (between 0% and 100%'
+  ): Promise<number> {
+    return await this.simplePrompt<number>({ message, type: 'number' })
   }
 
   async electionStatus() {
     const electionStatus = await this.getApi().getEraElectionStatus()
     if (electionStatus.isOpen === true) {
-      this.warn('There is currently an ongoing election for new validator candidates. As such staking operations are not permitted. You need to wait')
+      this.warn(
+        'There is currently an ongoing election for new validator candidates. As such staking operations are not permitted. You need to wait'
+      )
       this.exit(ExitCodes.ActionCurrentlyUnavailable)
     }
   }
 
   async getValidatorPrefs(commission: number | undefined): Promise<any> {
-    let validatorPrefs = {'commission': 0}
+    let validatorPrefs = { 'commission': 0 }
     if (!commission) {
       commission = await this.promptForCommission()
     }
     if (commission >= 0 && commission <= 100) {
-      validatorPrefs = {'commission': commission*10**7}
+      validatorPrefs = { 'commission': commission * 10 ** 7 }
     } else {
       this.warn('Invalid commission input!')
       this.exit(ExitCodes.InvalidInput)
     }
     return validatorPrefs
   }
-
 }

--- a/cli/src/base/StakingCommandBase.ts
+++ b/cli/src/base/StakingCommandBase.ts
@@ -46,8 +46,8 @@ export default abstract class StakingCommandBase extends AccountsCommandBase {
 
   async isController(controllerInput: string) {
     if (this.isKeyAvailable(controllerInput)) {
-      const info = (await this.getApi().isControllerValid(controllerInput)).unwrapOr(undefined)
-      if (!!info) {
+      const info = (await this.getApi().getStakingLedger(controllerInput)).unwrapOr(undefined)
+      if (info) {
         this.log(
           `Your controller ${controllerInput} with stash ${info.stash.toString()} is actively staking ${formatBalance(
             info.active
@@ -64,7 +64,7 @@ export default abstract class StakingCommandBase extends AccountsCommandBase {
   }
 
   async promptForCommission(
-    message = 'Choose how much you reqiure as commission (between 0% and 100%'
+    message = 'Choose how much you reqiure as commission (between 0% and 100%)'
   ): Promise<number> {
     return await this.simplePrompt<number>({ message, type: 'number' })
   }

--- a/cli/src/commands/staking/validate.ts
+++ b/cli/src/commands/staking/validate.ts
@@ -3,25 +3,21 @@ import { flags } from '@oclif/command'
 
 export default class StakingValidateCommand extends StakingCommandBase {
   static description = 'Start validating. Takes the controller key.'
-  static args = [
-    {
-      name: 'commission',
+
+  static flags = {
+    commission: flags.integer({
       required: false,
       description:
         'Set a commission (0-100), which is deducted from all rewards before the remainder is split with nominator',
-    },
-  ]
-  static flags = {
+    }),
     controller: flags.string({
       required: false,
-      description: `The controller key you want to validate with.`,
+      description: 'The controller key you want to validate with.',
     }),
   }
 
   async run(): Promise<void> {
-    let { commission } = this.parse(StakingValidateCommand).args
-    let { controller } = this.parse(StakingValidateCommand).flags
-    await this.electionStatus()
+    let { commission, controller } = this.parse(StakingValidateCommand).flags
     const validatorPrefs = await this.getValidatorPrefs(commission)
 
     if (controller === undefined) {
@@ -29,7 +25,7 @@ export default class StakingValidateCommand extends StakingCommandBase {
     } else {
       await this.isController(controller)
     }
-    await this.electionStatus()
+    await this.checkElectionStatus()
     await this.sendAndFollowNamedTx(await this.getDecodedPair(controller), 'staking', 'validate', [validatorPrefs])
   }
 }

--- a/cli/src/commands/staking/validate.ts
+++ b/cli/src/commands/staking/validate.ts
@@ -1,14 +1,14 @@
 import StakingCommandBase from '../../base/StakingCommandBase'
 import { flags } from '@oclif/command'
 
-
 export default class StakingValidateCommand extends StakingCommandBase {
   static description = 'Start validating. Takes the controller key.'
   static args = [
     {
       name: 'commission',
       required: false,
-      description: 'Set a commission (0-100), which is deducted from all rewards before the remainder is split with nominator',
+      description:
+        'Set a commission (0-100), which is deducted from all rewards before the remainder is split with nominator',
     },
   ]
   static flags = {
@@ -17,7 +17,7 @@ export default class StakingValidateCommand extends StakingCommandBase {
       description: `The controller key you want to validate with.`,
     }),
   }
-  
+
   async run(): Promise<void> {
     let { commission } = this.parse(StakingValidateCommand).args
     let { controller } = this.parse(StakingValidateCommand).flags
@@ -33,5 +33,3 @@ export default class StakingValidateCommand extends StakingCommandBase {
     await this.sendAndFollowNamedTx(await this.getDecodedPair(controller), 'staking', 'validate', [validatorPrefs])
   }
 }
-    
-    

--- a/cli/src/commands/staking/validate.ts
+++ b/cli/src/commands/staking/validate.ts
@@ -1,0 +1,37 @@
+import StakingCommandBase from '../../base/StakingCommandBase'
+import { flags } from '@oclif/command'
+
+
+export default class StakingValidateCommand extends StakingCommandBase {
+  static description = 'Start validating. Takes the controller key.'
+  static args = [
+    {
+      name: 'commission',
+      required: false,
+      description: 'Set a commission (0-100), which is deducted from all rewards before the remainder is split with nominator',
+    },
+  ]
+  static flags = {
+    controller: flags.string({
+      required: false,
+      description: `The controller key you want to validate with.`,
+    }),
+  }
+  
+  async run(): Promise<void> {
+    let { commission } = this.parse(StakingValidateCommand).args
+    let { controller } = this.parse(StakingValidateCommand).flags
+    await this.electionStatus()
+    const validatorPrefs = await this.getValidatorPrefs(commission)
+
+    if (controller === undefined) {
+      controller = await this.getController()
+    } else {
+      await this.isController(controller)
+    }
+    await this.electionStatus()
+    await this.sendAndFollowNamedTx(await this.getDecodedPair(controller), 'staking', 'validate', [validatorPrefs])
+  }
+}
+    
+    

--- a/cli/src/schemas/WorkingGroups.ts
+++ b/cli/src/schemas/WorkingGroups.ts
@@ -49,7 +49,7 @@ export const WorkingGroupOpeningInputSchema: JsonSchema<WorkingGroupOpeningInput
       required: ['amount', 'unstakingPeriod'],
       properties: {
         amount: { type: 'integer', minimum: 2000 },
-        unstakingPeriod: { type: 'integer', minimum: 43201 },
+        unstakingPeriod: { type: 'integer', minimum: 43200 },
       },
     },
     rewardPerBlock: {


### PR DESCRIPTION
Changes:
- Renamed the Operations Working Group in the CLI
- Added `validate.staking`, as I was under the impression this would not work in `polkadot-js`
   - If the code is ok, I suggest we can keep it, as I'm planning to have the community expand on this
- Changed the minimum unstaking period to `43200` to be in line with the runtime.
   - Note that these should ideally be read from the state, but I don't think I would be able to add that in a good way