### PR TITLE
Bounty perpetual working period, closes #2821, closes #2947, closes #3193, fixes #3446, fixes #3447, fixes #3329;

### DIFF
--- a/runtime-modules/bounty/src/actors.rs
+++ b/runtime-modules/bounty/src/actors.rs
@@ -58,7 +58,7 @@ impl<T: Trait> BountyActorManager<T> {
         }
     }
 
-    // Validate balance is sufficient for the bounty
+    /// Validate balance is sufficient for the bounty
     pub(crate) fn validate_balance_sufficiency(
         &self,
         required_balance: BalanceOf<T>,
@@ -85,7 +85,7 @@ impl<T: Trait> BountyActorManager<T> {
         T::CouncilBudgetManager::get_budget() >= amount
     }
 
-    // Validate that provided actor relates to the initial BountyActor.
+    /// Validate that provided actor relates to the initial BountyActor.
     pub(crate) fn validate_actor(&self, actor: &BountyActor<MemberId<T>>) -> DispatchResult {
         let initial_actor = match self {
             BountyActorManager::Council => BountyActor::Council,
@@ -97,7 +97,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    // Transfer funds for the bounty creation.
+    /// Transfer funds for the bounty creation.
     pub(crate) fn transfer_funds_to_bounty_account(
         &self,
         bounty_id: T::BountyId,
@@ -122,7 +122,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    // Restore a balance for the bounty creator.
+    /// Restore a balance for the bounty creator.
     pub(crate) fn transfer_funds_from_bounty_account(
         &self,
         bounty_id: T::BountyId,

--- a/runtime-modules/bounty/src/actors.rs
+++ b/runtime-modules/bounty/src/actors.rs
@@ -85,18 +85,6 @@ impl<T: Trait> BountyActorManager<T> {
         T::CouncilBudgetManager::get_budget() >= amount
     }
 
-    // Validate that provided actor relates to the initial BountyActor.
-    pub(crate) fn validate_actor(&self, actor: &BountyActor<MemberId<T>>) -> DispatchResult {
-        let initial_actor = match self {
-            BountyActorManager::Council => BountyActor::Council,
-            BountyActorManager::Member(_, member_id) => BountyActor::Member(*member_id),
-        };
-
-        ensure!(initial_actor == actor.clone(), Error::<T>::NotBountyActor);
-
-        Ok(())
-    }
-
     // Transfer funds for the bounty creation.
     pub(crate) fn transfer_funds_to_bounty_account(
         &self,

--- a/runtime-modules/bounty/src/actors.rs
+++ b/runtime-modules/bounty/src/actors.rs
@@ -58,7 +58,7 @@ impl<T: Trait> BountyActorManager<T> {
         }
     }
 
-    /// Validate balance is sufficient for the bounty
+    // Validate balance is sufficient for the bounty
     pub(crate) fn validate_balance_sufficiency(
         &self,
         required_balance: BalanceOf<T>,
@@ -85,7 +85,7 @@ impl<T: Trait> BountyActorManager<T> {
         T::CouncilBudgetManager::get_budget() >= amount
     }
 
-    /// Validate that provided actor relates to the initial BountyActor.
+    // Validate that provided actor relates to the initial BountyActor.
     pub(crate) fn validate_actor(&self, actor: &BountyActor<MemberId<T>>) -> DispatchResult {
         let initial_actor = match self {
             BountyActorManager::Council => BountyActor::Council,
@@ -97,7 +97,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    /// Transfer funds for the bounty creation.
+    // Transfer funds for the bounty creation.
     pub(crate) fn transfer_funds_to_bounty_account(
         &self,
         bounty_id: T::BountyId,
@@ -122,7 +122,7 @@ impl<T: Trait> BountyActorManager<T> {
         Ok(())
     }
 
-    /// Restore a balance for the bounty creator.
+    // Restore a balance for the bounty creator.
     pub(crate) fn transfer_funds_from_bounty_account(
         &self,
         bounty_id: T::BountyId,

--- a/runtime-modules/bounty/src/benchmarking.rs
+++ b/runtime-modules/bounty/src/benchmarking.rs
@@ -992,6 +992,121 @@ benchmarks! {
         );
         assert_last_event::<T>(Event::<T>::BountyRemoved(bounty_id).into());
     }
+    oracle_council_switch_to_oracle_member {
+
+        let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
+
+        let oracle = BountyActor::Council;
+
+        let (new_oracle_account_id, new_oracle_member_id) = member_funded_account::<T>("new_oracle", 2);
+        let new_oracle = BountyActor::Member(new_oracle_member_id);
+
+        let creator = BountyActor::Council;
+
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
+
+        let params = BountyCreationParameters::<T>{
+            creator,
+            cherry,
+            oracle_cherry,
+            oracle: oracle.clone(),
+            work_period: One::one(),
+            judging_period: One::one(),
+            funding_type: FundingType::Perpetual{ target: 100u32.into() },
+            entrant_stake: 100u32.into(),
+            ..Default::default()
+        };
+
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params.clone(), Vec::new()).unwrap();
+
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
+
+    }: switch_oracle (RawOrigin::Root, new_oracle.clone(), bounty_id)
+    verify {
+        let bounty_id: T::BountyId = 1u32.into();
+
+        assert!(Bounties::<T>::contains_key(bounty_id));
+        assert_eq!(Bounty::<T>::bounty_count(), 1); // Bounty counter was updated.
+        assert_last_event::<T>(Event::<T>::BountyOracleSwitched(bounty_id, oracle, new_oracle).into());
+    }
+    oracle_member_switch_to_oracle_member{
+
+        let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
+
+        let (current_oracle_account_id, current_oracle_member_id) = member_funded_account::<T>("current_oracle", 1);
+        let oracle = BountyActor::Member(current_oracle_member_id);
+
+        let (new_oracle_account_id, new_oracle_member_id) = member_funded_account::<T>("new_oracle", 2);
+        let new_oracle = BountyActor::Member(new_oracle_member_id);
+
+        let creator = BountyActor::Council;
+
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
+
+        let params = BountyCreationParameters::<T>{
+            creator,
+            cherry,
+            oracle_cherry,
+            oracle: oracle.clone(),
+            work_period: One::one(),
+            judging_period: One::one(),
+            funding_type: FundingType::Perpetual{ target: 100u32.into() },
+            entrant_stake: 100u32.into(),
+            ..Default::default()
+        };
+
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params.clone(), Vec::new()).unwrap();
+
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
+
+    }: switch_oracle (RawOrigin::Signed(current_oracle_account_id), new_oracle.clone(), bounty_id)
+    verify {
+        let bounty_id: T::BountyId = 1u32.into();
+
+        assert!(Bounties::<T>::contains_key(bounty_id));
+        assert_eq!(Bounty::<T>::bounty_count(), 1); // Bounty counter was updated.
+        assert_last_event::<T>(Event::<T>::BountyOracleSwitched(bounty_id, oracle, new_oracle).into());
+    }
+    oracle_member_switch_to_oracle_council {
+
+        let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
+
+        let (current_oracle_account_id, current_oracle_member_id) = member_funded_account::<T>("current_oracle", 1);
+        let oracle = BountyActor::Member(current_oracle_member_id);
+
+        let new_oracle = BountyActor::Council;
+
+        let creator = BountyActor::Council;
+
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
+
+        let params = BountyCreationParameters::<T>{
+            creator,
+            cherry,
+            oracle_cherry,
+            oracle: oracle.clone(),
+            work_period: One::one(),
+            judging_period: One::one(),
+            funding_type: FundingType::Perpetual{ target: 100u32.into() },
+            entrant_stake: 100u32.into(),
+            ..Default::default()
+        };
+
+        Bounty::<T>::create_bounty(RawOrigin::Root.into(), params.clone(), Vec::new()).unwrap();
+
+        let bounty_id: T::BountyId = Bounty::<T>::bounty_count().into();
+
+    }: switch_oracle (RawOrigin::Signed(current_oracle_account_id), new_oracle.clone(), bounty_id)
+    verify {
+        let bounty_id: T::BountyId = 1u32.into();
+
+        assert!(Bounties::<T>::contains_key(bounty_id));
+        assert_eq!(Bounty::<T>::bounty_count(), 1); // Bounty counter was updated.
+        assert_last_event::<T>(Event::<T>::BountyOracleSwitched(bounty_id, oracle, new_oracle).into());
+    }
 }
 
 #[cfg(test)]
@@ -1116,6 +1231,27 @@ mod tests {
     fn withdraw_work_entrant_funds() {
         build_test_externalities().execute_with(|| {
             assert_ok!(test_benchmark_withdraw_work_entrant_funds::<Test>());
+        });
+    }
+
+    #[test]
+    fn oracle_council_switch_to_oracle_member() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_oracle_council_switch_to_oracle_member::<Test>());
+        });
+    }
+
+    #[test]
+    fn oracle_member_switch_to_oracle_member() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_oracle_member_switch_to_oracle_member::<Test>());
+        });
+    }
+
+    #[test]
+    fn oracle_member_switch_to_oracle_council() {
+        build_test_externalities().execute_with(|| {
+            assert_ok!(test_benchmark_oracle_member_switch_to_oracle_council::<Test>());
         });
     }
 }

--- a/runtime-modules/bounty/src/benchmarking.rs
+++ b/runtime-modules/bounty/src/benchmarking.rs
@@ -170,7 +170,7 @@ fn create_funded_bounty<T: Trait>(
     params: BountyCreationParameters<T>,
     funding_amount: BalanceOf<T>,
 ) -> T::BountyId {
-    T::CouncilBudgetManager::set_budget(params.cherry + funding_amount);
+    T::CouncilBudgetManager::set_budget(params.cherry + params.oracle_cherry + funding_amount);
 
     Bounty::<T>::create_bounty(RawOrigin::Root.into(), params, Vec::new()).unwrap();
 
@@ -208,10 +208,11 @@ benchmarks! {
 
         let metadata = vec![0u8].repeat(i as usize);
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
         let max_amount: BalanceOf<T> = 1000u32.into();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let members = (1..=j)
             .map(|id| id.saturated_into())
@@ -221,6 +222,7 @@ benchmarks! {
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: max_amount },
             contract_type: AssuranceContractType::Closed(members),
@@ -242,6 +244,7 @@ benchmarks! {
 
         let metadata = vec![0u8].repeat(i as usize);
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
         let max_amount: BalanceOf<T> = 1000u32.into();
 
@@ -257,6 +260,7 @@ benchmarks! {
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             entrant_stake,
             creator: BountyActor::Member(member_id),
             funding_type: FundingType::Perpetual{ target: max_amount },
@@ -275,16 +279,18 @@ benchmarks! {
 
     cancel_bounty_by_council {
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let max_amount: BalanceOf<T> = 1000u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let creator = BountyActor::Council;
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             creator: creator.clone(),
             // same complexity with limited funding and FundingExpired stage.
             funding_type: FundingType::Perpetual{ target: max_amount },
@@ -305,12 +311,13 @@ benchmarks! {
 
     cancel_bounty_by_member {
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let max_amount: BalanceOf<T> = 1000u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
         let (account_id, member_id) = member_funded_account::<T>("member1", 0);
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let creator = BountyActor::Member(member_id);
 
@@ -318,6 +325,7 @@ benchmarks! {
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             creator: creator.clone(),
             // same complexity with limited funding and FundingExpired stage.
             funding_type: FundingType::Perpetual{ target: max_amount },
@@ -343,15 +351,17 @@ benchmarks! {
     veto_bounty {
         let max_amount: BalanceOf<T> = 1000u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
             judging_period: One::one(),
             funding_type: FundingType::Perpetual{ target: max_amount },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -370,15 +380,17 @@ benchmarks! {
     fund_bounty_by_member {
         let max_amount: BalanceOf<T> = 100u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
             judging_period: One::one(),
             funding_type: FundingType::Perpetual{ target: max_amount },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -405,15 +417,17 @@ benchmarks! {
     fund_bounty_by_council {
         let max_amount: BalanceOf<T> = 100u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry + max_amount);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry + max_amount);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
             judging_period: One::one(),
             funding_type: FundingType::Perpetual{ target: max_amount },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -435,9 +449,10 @@ benchmarks! {
         let funding_period = 1u32;
         let bounty_amount: BalanceOf<T> = 200u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
@@ -448,6 +463,7 @@ benchmarks! {
                 funding_period: funding_period.into(),
             },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -488,10 +504,11 @@ benchmarks! {
         let funding_period = 1u32;
         let bounty_amount: BalanceOf<T> = 200u32.into();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
 
-        T::CouncilBudgetManager::set_budget(cherry + funding_amount);
+        T::CouncilBudgetManager::set_budget(cherry + oracle_cherry + funding_amount);
 
         let params = BountyCreationParameters::<T>{
             work_period: One::one(),
@@ -502,6 +519,7 @@ benchmarks! {
                 funding_period: funding_period.into(),
             },
             cherry,
+            oracle_cherry,
             entrant_stake,
             ..Default::default()
         };
@@ -525,7 +543,7 @@ benchmarks! {
 
     }: withdraw_funding(RawOrigin::Root, funder, bounty_id)
     verify {
-        assert_eq!(T::CouncilBudgetManager::get_budget(), cherry + funding_amount);
+        assert_eq!(T::CouncilBudgetManager::get_budget(), cherry + oracle_cherry + funding_amount);
         assert_last_event::<T>(Event::<T>::BountyRemoved(bounty_id).into());
     }
 
@@ -533,6 +551,7 @@ benchmarks! {
         let i in 1 .. T::ClosedContractSizeLimit::get();
 
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let stake: BalanceOf<T> = 100u32.into();
 
@@ -548,6 +567,7 @@ benchmarks! {
             judging_period: One::one(),
             funding_type: FundingType::Perpetual{ target: funding_amount },
             cherry,
+            oracle_cherry,
             contract_type,
             entrant_stake: stake,
             ..Default::default()
@@ -579,6 +599,7 @@ benchmarks! {
 
     withdraw_work_entry {
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let stake: BalanceOf<T> = 100u32.into();
 
@@ -586,6 +607,7 @@ benchmarks! {
             work_period: One::one(),
             judging_period: One::one(),
             cherry,
+            oracle_cherry,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             entrant_stake: stake,
             ..Default::default()
@@ -617,6 +639,7 @@ benchmarks! {
         let work_data = vec![0u8].repeat(i as usize);
 
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let max_amount: BalanceOf<T> = 10000u32.into();
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
@@ -628,6 +651,7 @@ benchmarks! {
             work_period,
             judging_period,
             cherry,
+            oracle_cherry,
             funding_type: FundingType::Limited{
                 min_funding_amount: funding_amount,
                 max_funding_amount: max_amount,
@@ -670,6 +694,7 @@ benchmarks! {
 
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 10000000u32.into();
         let oracle = BountyActor::Council;
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
@@ -679,6 +704,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: BountyActor::Council,
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
@@ -733,6 +759,7 @@ benchmarks! {
 
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let oracle = BountyActor::Council;
         let entrant_stake: BalanceOf<T> = T::MinWorkEntrantStake::get();
@@ -742,6 +769,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: BountyActor::Council,
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
@@ -776,6 +804,7 @@ benchmarks! {
 
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 10000000u32.into();
         let work_period: T::BlockNumber = One::one();
         let (oracle_account_id, oracle_member_id) = member_funded_account::<T>("oracle", 1);
@@ -787,6 +816,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: BountyActor::Council,
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
@@ -846,6 +876,7 @@ benchmarks! {
 
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let work_period: T::BlockNumber = One::one();
         let (oracle_account_id, oracle_member_id) = member_funded_account::<T>("oracle", 1);
@@ -857,6 +888,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: BountyActor::Council,
             cherry,
+            oracle_cherry,
             entrant_stake,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
@@ -894,6 +926,7 @@ benchmarks! {
     withdraw_work_entrant_funds {
         let work_period: T::BlockNumber = One::one();
         let cherry: BalanceOf<T> = 100u32.into();
+        let oracle_cherry: BalanceOf<T> = 100u32.into();
         let funding_amount: BalanceOf<T> = 100u32.into();
         let work_period: T::BlockNumber = One::one();
         let (oracle_account_id, oracle_member_id) = member_funded_account::<T>("oracle", 1);
@@ -906,6 +939,7 @@ benchmarks! {
             judging_period: One::one(),
             creator: creator.clone(),
             cherry,
+            oracle_cherry,
             funding_type: FundingType::Perpetual{ target: funding_amount },
             oracle: oracle.clone(),
             entrant_stake: stake,

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -786,7 +786,10 @@ decl_error! {
 
         ///Council cannot terminate a bounty when there are active entries still left
         ///Call Switch oracle and then judge those entries, or submit Judgment if you already an oracle
-        AllWorkEntriesMustBeJudgedBeforeTerminatingBounty
+        AllWorkEntriesMustBeJudgedBeforeTerminatingBounty,
+
+        ///Worker tried to access a work entry that doesn't belong to him
+        WorkEntryDoesntBelongToWorker
     }
 }
 
@@ -1283,8 +1286,10 @@ decl_module! {
             let current_bounty_stage = Self::get_bounty_stage(&bounty);
 
             Self::ensure_bounty_stage(current_bounty_stage, BountyStage::WorkSubmission)?;
-            Self::ensure_work_entry_exists(&entry_id)?;
+            let entry = Self::ensure_work_entry_exists(&entry_id)?;
 
+            ensure!(entry.member_id == member_id,
+                Error::<T>::WorkEntryDoesntBelongToWorker);
             //
             // == MUTATION SAFE ==
             //
@@ -1495,6 +1500,9 @@ decl_module! {
             );
 
             let entry = Self::ensure_work_entry_exists(&entry_id)?;
+
+            ensure!(entry.member_id == member_id,
+                Error::<T>::WorkEntryDoesntBelongToWorker);
             //
             // == MUTATION SAFE ==
             //

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -1061,7 +1061,7 @@ decl_module! {
             ensure_root(origin)?;
 
             let bounty = Self::ensure_bounty_exists(&bounty_id)?;
-            let oracle_reward = bounty.creation_params.oracle_reward.clone();
+            let oracle_reward = bounty.creation_params.oracle_reward;
             let current_bounty_stage = Self::get_bounty_stage(&bounty);
 
             ensure!(matches!(current_bounty_stage,
@@ -1363,7 +1363,7 @@ decl_module! {
             <Bounties<T>>::mutate(bounty_id, |bounty| {
                 bounty.milestone = BountyMilestone::WorkSubmitted;
             });
-            Self::deposit_event(RawEvent::WorkSubmissionPeriodEnded(bounty_id, current_oracle.clone()));
+            Self::deposit_event(RawEvent::WorkSubmissionPeriodEnded(bounty_id, current_oracle));
         }
 
         /// Submits an oracle judgment for a bounty, slashing the entries rejected
@@ -1425,7 +1425,7 @@ decl_module! {
             // Update bounty record.
             <Bounties<T>>::mutate(bounty_id, |bounty| {
                 bounty.milestone = BountyMilestone::JudgmentSubmitted{
-                    successful_bounty: successful_bounty
+                    successful_bounty
                 };
             });
 

--- a/runtime-modules/bounty/src/stages.rs
+++ b/runtime-modules/bounty/src/stages.rs
@@ -19,7 +19,9 @@ impl<'a, T: Trait> BountyStageCalculator<'a, T> {
             .or_else(|| self.is_work_submission_stage())
             .or_else(|| self.is_judgment_stage())
             .or_else(|| self.is_successful_bounty_withdrawal_stage())
-            .unwrap_or(BountyStage::FailedBountyWithdrawal)
+            .unwrap_or(BountyStage::FailedBountyWithdrawal {
+                judgment_submitted: false,
+            })
     }
 
     // Calculates funding stage of the bounty.
@@ -131,15 +133,20 @@ impl<'a, T: Trait> BountyStageCalculator<'a, T> {
         None
     }
 
-    // Calculates withdrawal stage for the successful bounty.
+    // Calculates withdrawal stage for the bounty.
     // Returns None if conditions are not met.
     fn is_successful_bounty_withdrawal_stage(&self) -> Option<BountyStage> {
-        // The bounty judgment was submitted and the bounty is successful (there are some winners).
+        //The bounty judgment was submitted and is successful (there are some winners)
+        //or unsuccessful (all entries rejected).
         if let BountyMilestone::JudgmentSubmitted { successful_bounty } =
             self.bounty.milestone.clone()
         {
             if successful_bounty {
                 return Some(BountyStage::SuccessfulBountyWithdrawal);
+            } else {
+                return Some(BountyStage::FailedBountyWithdrawal {
+                    judgment_submitted: true,
+                });
             }
         }
 

--- a/runtime-modules/bounty/src/stages.rs
+++ b/runtime-modules/bounty/src/stages.rs
@@ -93,10 +93,10 @@ impl<'a, T: Trait> BountyStageCalculator<'a, T> {
     // Returns None if conditions are not met.
     fn is_judgment_stage(&self) -> Option<BountyStage> {
         // Can be judged only if there are work submissions.
-        if self.bounty.active_work_entry_count > 0 {
-            if BountyMilestone::WorkSubmitted == self.bounty.milestone {
-                return Some(BountyStage::Judgment);
-            }
+        if self.bounty.active_work_entry_count > 0
+            && BountyMilestone::WorkSubmitted == self.bounty.milestone
+        {
+            return Some(BountyStage::Judgment);
         }
 
         None

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -830,3 +830,39 @@ impl WithdrawWorkEntrantFundsFixture {
         }
     }
 }
+
+pub struct SwitchOracleFixture {
+    origin: RawOrigin<u128>,
+    new_oracle: BountyActor<u64>,
+    bounty_id: u64,
+}
+
+impl SwitchOracleFixture {
+    pub fn default() -> Self {
+        Self {
+            origin: RawOrigin::Root,
+            new_oracle: BountyActor::Member(2),
+            bounty_id: 1,
+        }
+    }
+    pub fn with_origin(self, origin: RawOrigin<u128>) -> Self {
+        Self { origin, ..self }
+    }
+
+    pub fn with_new_oracle_member_id(self, bounty_actor: BountyActor<u64>) -> Self {
+        Self {
+            new_oracle: bounty_actor,
+            ..self
+        }
+    }
+
+    pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let actual_result = Bounty::switch_oracle(
+            self.origin.clone().into(),
+            self.new_oracle.clone(),
+            self.bounty_id,
+        );
+
+        assert_eq!(actual_result, expected_result);
+    }
+}

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -547,7 +547,6 @@ impl AnnounceWorkEntryFixture {
                 staking_account_id: self.staking_account_id,
                 submitted_at: System::current_block_number(),
                 work_submitted: false,
-                oracle_judgment_result: None,
             };
 
             assert_eq!(expected_entry, Bounty::entries(entry_id));
@@ -677,64 +676,6 @@ impl SubmitJudgmentFixture {
             );
         } else {
             assert_eq!(new_bounty, old_bounty);
-        }
-    }
-}
-
-pub struct WithdrawWorkEntrantFundsFixture {
-    origin: RawOrigin<u128>,
-    entry_id: u64,
-    bounty_id: u64,
-    member_id: u64,
-}
-
-impl WithdrawWorkEntrantFundsFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(1),
-            entry_id: 1,
-            bounty_id: 1,
-            member_id: 1,
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u128>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_member_id(self, member_id: u64) -> Self {
-        Self { member_id, ..self }
-    }
-
-    pub fn with_bounty_id(self, bounty_id: u64) -> Self {
-        Self { bounty_id, ..self }
-    }
-
-    pub fn with_entry_id(self, entry_id: u64) -> Self {
-        Self { entry_id, ..self }
-    }
-
-    pub fn call_and_assert(&self, expected_result: DispatchResult) {
-        let old_bounty = Bounty::bounties(self.bounty_id);
-        let actual_result = Bounty::withdraw_work_entrant_funds(
-            self.origin.clone().into(),
-            self.member_id,
-            self.bounty_id,
-            self.entry_id,
-        );
-
-        assert_eq!(actual_result, expected_result);
-
-        if actual_result.is_ok() {
-            assert!(!<crate::Entries<Test>>::contains_key(&self.entry_id));
-
-            if <crate::Bounties<Test>>::contains_key(self.bounty_id) {
-                let new_bounty = Bounty::bounties(self.bounty_id);
-                assert_eq!(
-                    new_bounty.active_work_entry_count,
-                    old_bounty.active_work_entry_count - 1
-                );
-            }
         }
     }
 }

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -45,6 +45,11 @@ pub fn increase_account_balance(account_id: &u128, balance: u64) {
     let _ = Balances::deposit_creating(&account_id, balance);
 }
 
+pub fn decrease_bounty_account_balance(bounty_id: u64, amount: u64) {
+    let account_id = Bounty::bounty_account_id(bounty_id);
+    let _ = Balances::slash(&account_id, amount);
+}
+
 pub struct EventFixture;
 impl EventFixture {
     pub fn assert_last_crate_event(

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -101,6 +101,7 @@ impl EventFixture {
 }
 
 pub const DEFAULT_BOUNTY_CHERRY: u64 = 10;
+pub const DEFAULT_BOUNTY_ORACLE_CHERRY: u64 = 10;
 pub const DEFAULT_BOUNTY_ENTRANT_STAKE: u64 = 10;
 pub const DEFAULT_BOUNTY_MAX_AMOUNT: u64 = 1000;
 pub const DEFAULT_BOUNTY_MIN_AMOUNT: u64 = 1;
@@ -114,6 +115,7 @@ pub struct CreateBountyFixture {
     work_period: u64,
     judging_period: u64,
     cherry: u64,
+    oracle_cherry: u64,
     expected_milestone: Option<BountyMilestone<u64>>,
     entrant_stake: u64,
     contract_type: AssuranceContractType<u64>,
@@ -132,6 +134,7 @@ impl CreateBountyFixture {
             work_period: 1,
             judging_period: 1,
             cherry: DEFAULT_BOUNTY_CHERRY,
+            oracle_cherry: DEFAULT_BOUNTY_ORACLE_CHERRY,
             expected_milestone: None,
             entrant_stake: DEFAULT_BOUNTY_ENTRANT_STAKE,
             contract_type: AssuranceContractType::Open,
@@ -224,6 +227,13 @@ impl CreateBountyFixture {
         Self { cherry, ..self }
     }
 
+    pub fn with_oracle_cherry(self, oracle_cherry: u64) -> Self {
+        Self {
+            oracle_cherry,
+            ..self
+        }
+    }
+
     pub fn with_entrant_stake(self, entrant_stake: u64) -> Self {
         Self {
             entrant_stake,
@@ -247,6 +257,7 @@ impl CreateBountyFixture {
             work_period: self.work_period.clone(),
             judging_period: self.judging_period.clone(),
             cherry: self.cherry,
+            oracle_cherry: self.oracle_cherry,
             entrant_stake: self.entrant_stake,
             contract_type: self.contract_type.clone(),
             oracle: self.oracle.clone(),

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -121,6 +121,7 @@ pub struct CreateBountyFixture {
     judging_period: u64,
     cherry: u64,
     oracle_cherry: u64,
+    allow_council_switch_inactive_oracle: bool,
     expected_milestone: Option<BountyMilestone<u64>>,
     entrant_stake: u64,
     contract_type: AssuranceContractType<u64>,
@@ -140,6 +141,7 @@ impl CreateBountyFixture {
             judging_period: 1,
             cherry: DEFAULT_BOUNTY_CHERRY,
             oracle_cherry: DEFAULT_BOUNTY_ORACLE_CHERRY,
+            allow_council_switch_inactive_oracle: false,
             expected_milestone: None,
             entrant_stake: DEFAULT_BOUNTY_ENTRANT_STAKE,
             contract_type: AssuranceContractType::Open,
@@ -161,6 +163,13 @@ impl CreateBountyFixture {
     pub fn with_oracle_member_id(self, member_id: u64) -> Self {
         Self {
             oracle: BountyActor::Member(member_id),
+            ..self
+        }
+    }
+
+    pub fn with_allow_council_switch_oracle(self) -> Self {
+        Self {
+            allow_council_switch_inactive_oracle: true,
             ..self
         }
     }
@@ -266,6 +275,7 @@ impl CreateBountyFixture {
             entrant_stake: self.entrant_stake,
             contract_type: self.contract_type.clone(),
             oracle: self.oracle.clone(),
+            allow_council_switch_inactive_oracle: self.allow_council_switch_inactive_oracle,
             ..Default::default()
         }
     }

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -113,10 +113,10 @@ impl common::StakingAccountValidator<Test> for () {
         *account_id != STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER
     }
 }
-
+pub const MAX_MEMBERS: u32 = 150;
 impl common::membership::MembershipInfoProvider<Test> for () {
     fn controller_account_id(member_id: u64) -> Result<u128, DispatchError> {
-        if member_id < 10 {
+        if member_id < MAX_MEMBERS.into() {
             return Ok(member_id as u128); // similar account_id
         }
 
@@ -213,9 +213,6 @@ impl crate::WeightInfo for () {
         0
     }
     fn submit_oracle_judgment_by_member_all_rejected(_i: u32, _j: u32) -> u64 {
-        0
-    }
-    fn withdraw_work_entrant_funds() -> u64 {
         0
     }
     fn unlock_work_entrant_stake() -> u64 {

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -59,6 +59,7 @@ parameter_types! {
     pub const BountyLockId: [u8; 8] = [12; 8];
     pub const ClosedContractSizeLimit: u32 = 3;
     pub const MinCherryLimit: u64 = 10;
+    pub const MinOracleCherryLimit: u64 = 10;
     pub const MinFundingLimit: u64 = 50;
     pub const MinWorkEntrantStake: u64 = 10;
 }
@@ -102,6 +103,7 @@ impl Trait for Test {
     type EntryId = u64;
     type ClosedContractSizeLimit = ClosedContractSizeLimit;
     type MinCherryLimit = MinCherryLimit;
+    type MinOracleCherryLimit = MinOracleCherryLimit;
     type MinFundingLimit = MinFundingLimit;
     type MinWorkEntrantStake = MinWorkEntrantStake;
 }

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -46,7 +46,6 @@ impl_outer_event! {
         referendum_mod Instance1 <T>,
     }
 }
-
 // Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Test;
@@ -220,6 +219,12 @@ impl crate::WeightInfo for () {
         0
     }
     fn unlock_work_entrant_stake() -> u64 {
+        0
+    }
+    fn withdraw_state_bloat_bond_by_council() -> u64 {
+        0
+    }
+    fn withdraw_state_bloat_bond_by_member() -> u64 {
         0
     }
 }

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -59,7 +59,7 @@ parameter_types! {
     pub const BountyLockId: [u8; 8] = [12; 8];
     pub const ClosedContractSizeLimit: u32 = 3;
     pub const MinCherryLimit: u64 = 10;
-    pub const MinOracleCherryLimit: u64 = 10;
+    pub const MinOracleRewardLimit: u64 = 10;
     pub const MinFundingLimit: u64 = 50;
     pub const MinWorkEntrantStake: u64 = 10;
 }
@@ -103,7 +103,7 @@ impl Trait for Test {
     type EntryId = u64;
     type ClosedContractSizeLimit = ClosedContractSizeLimit;
     type MinCherryLimit = MinCherryLimit;
-    type MinOracleCherryLimit = MinOracleCherryLimit;
+    type MinOracleRewardLimit = MinOracleRewardLimit;
     type MinFundingLimit = MinFundingLimit;
     type MinWorkEntrantStake = MinWorkEntrantStake;
 }
@@ -162,13 +162,22 @@ impl crate::WeightInfo for () {
     fn cancel_bounty_by_council() -> u64 {
         0
     }
-    fn oracle_council_switch_to_oracle_member() -> u64 {
+    fn terminate_bounty() -> u64 {
         0
     }
-    fn oracle_member_switch_to_oracle_member() -> u64 {
+    fn end_working_period() -> u64 {
         0
     }
-    fn oracle_member_switch_to_oracle_council() -> u64 {
+    fn switch_oracle_to_council_by_oracle_member() -> u64 {
+        0
+    }
+    fn switch_oracle_to_member_by_oracle_member() -> u64 {
+        0
+    }
+    fn switch_oracle_to_member_by_oracle_council() -> u64 {
+        0
+    }
+    fn switch_oracle_to_member_by_not_oracle_council() -> u64 {
         0
     }
     fn veto_bounty() -> u64 {
@@ -208,6 +217,9 @@ impl crate::WeightInfo for () {
         0
     }
     fn withdraw_work_entrant_funds() -> u64 {
+        0
+    }
+    fn work_entrants_stake_account_action(_i: u32, _j: u32) -> u64 {
         0
     }
 }

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -162,6 +162,15 @@ impl crate::WeightInfo for () {
     fn cancel_bounty_by_council() -> u64 {
         0
     }
+    fn oracle_council_switch_to_oracle_member() -> u64 {
+        0
+    }
+    fn oracle_member_switch_to_oracle_member() -> u64 {
+        0
+    }
+    fn oracle_member_switch_to_oracle_council() -> u64 {
+        0
+    }
     fn veto_bounty() -> u64 {
         0
     }

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -168,6 +168,9 @@ impl crate::WeightInfo for () {
     fn end_working_period() -> u64 {
         0
     }
+    fn switch_oracle_to_council_by_council_approval_successful() -> u64 {
+        0
+    }
     fn switch_oracle_to_council_by_oracle_member() -> u64 {
         0
     }
@@ -198,28 +201,25 @@ impl crate::WeightInfo for () {
     fn announce_work_entry(_i: u32) -> u64 {
         0
     }
-    fn withdraw_work_entry() -> u64 {
-        0
-    }
     fn submit_work(_i: u32) -> u64 {
         0
     }
     fn submit_oracle_judgment_by_council_all_winners(_i: u32) -> u64 {
         0
     }
-    fn submit_oracle_judgment_by_council_all_rejected(_i: u32) -> u64 {
+    fn submit_oracle_judgment_by_council_all_rejected(_i: u32, _j: u32) -> u64 {
         0
     }
     fn submit_oracle_judgment_by_member_all_winners(_i: u32) -> u64 {
         0
     }
-    fn submit_oracle_judgment_by_member_all_rejected(_i: u32) -> u64 {
+    fn submit_oracle_judgment_by_member_all_rejected(_i: u32, _j: u32) -> u64 {
         0
     }
     fn withdraw_work_entrant_funds() -> u64 {
         0
     }
-    fn work_entrants_stake_account_action(_i: u32, _j: u32) -> u64 {
+    fn unlock_work_entrant_stake() -> u64 {
         0
     }
 }

--- a/runtime-modules/bounty/src/tests/mod.rs
+++ b/runtime-modules/bounty/src/tests/mod.rs
@@ -4126,7 +4126,7 @@ fn withdraw_work_entrant_funds_fails_with_invalid_stage() {
 }
 
 #[test]
-fn oracle_council_switch_to_oracle_member_successfull() {
+fn oracle_council_switch_to_oracle_member_successful() {
     build_test_externalities().execute_with(|| {
         let starting_block = 1;
         run_to_block(starting_block);
@@ -4160,7 +4160,7 @@ fn oracle_council_switch_to_oracle_member_successfull() {
 }
 
 #[test]
-fn council_switch_by_approval_new_oracle_member_successfull() {
+fn council_switch_by_approval_new_oracle_member_successful() {
     build_test_externalities().execute_with(|| {
         let starting_block = 1;
         run_to_block(starting_block);
@@ -4199,7 +4199,7 @@ fn council_switch_by_approval_new_oracle_member_successfull() {
 }
 
 #[test]
-fn oracle_member_switch_to_oracle_council_successfull() {
+fn oracle_member_switch_to_oracle_council_successful() {
     build_test_externalities().execute_with(|| {
         let starting_block = 1;
         run_to_block(starting_block);
@@ -4236,7 +4236,7 @@ fn oracle_member_switch_to_oracle_council_successfull() {
 }
 
 #[test]
-fn oracle_member_switch_to_oracle_member_successfull() {
+fn oracle_member_switch_to_oracle_member_successful() {
     build_test_externalities().execute_with(|| {
         let starting_block = 1;
         run_to_block(starting_block);

--- a/runtime-modules/membership/src/benchmarking.rs
+++ b/runtime-modules/membership/src/benchmarking.rs
@@ -16,7 +16,7 @@ use sp_arithmetic::traits::One;
 use sp_arithmetic::Perbill;
 use sp_runtime::traits::Bounded;
 use sp_std::prelude::*;
-
+use sp_std::vec;
 /// Balance alias for `balances` module.
 pub type BalanceOf<T> = <T as balances::Trait>::Balance;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -929,7 +929,7 @@ parameter_types! {
     pub const BountyModuleId: ModuleId = ModuleId(*b"m:bounty"); // module : bounty
     pub const ClosedContractSizeLimit: u32 = 50;
     pub const MinCherryLimit: Balance = 10;
-    pub const MinOracleCherryLimit: Balance = 10;
+    pub const MinOracleRewardLimit: Balance = 10;
     pub const MinFundingLimit: Balance = 10;
     pub const MinWorkEntrantStake: Balance = 100;
 }
@@ -945,7 +945,7 @@ impl bounty::Trait for Runtime {
     type EntryId = u64;
     type ClosedContractSizeLimit = ClosedContractSizeLimit;
     type MinCherryLimit = MinCherryLimit;
-    type MinOracleCherryLimit = MinOracleCherryLimit;
+    type MinOracleRewardLimit = MinOracleRewardLimit;
     type MinFundingLimit = MinFundingLimit;
     type MinWorkEntrantStake = MinWorkEntrantStake;
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -929,6 +929,7 @@ parameter_types! {
     pub const BountyModuleId: ModuleId = ModuleId(*b"m:bounty"); // module : bounty
     pub const ClosedContractSizeLimit: u32 = 50;
     pub const MinCherryLimit: Balance = 10;
+    pub const MinOracleCherryLimit: Balance = 10;
     pub const MinFundingLimit: Balance = 10;
     pub const MinWorkEntrantStake: Balance = 100;
 }
@@ -944,6 +945,7 @@ impl bounty::Trait for Runtime {
     type EntryId = u64;
     type ClosedContractSizeLimit = ClosedContractSizeLimit;
     type MinCherryLimit = MinCherryLimit;
+    type MinOracleCherryLimit = MinOracleCherryLimit;
     type MinFundingLimit = MinFundingLimit;
     type MinWorkEntrantStake = MinWorkEntrantStake;
 }

--- a/runtime/src/weights/bounty.rs
+++ b/runtime/src/weights/bounty.rs
@@ -8,120 +8,120 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl bounty::WeightInfo for WeightInfo {
     fn create_bounty_by_council(i: u32, j: u32) -> Weight {
-        (642_459_000 as Weight)
-            .saturating_add((177_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((4_148_000 as Weight).saturating_mul(j as Weight))
+        (614_460_000 as Weight)
+            .saturating_add((179_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((1_128_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn create_bounty_by_member(i: u32, j: u32) -> Weight {
-        (753_803_000 as Weight)
-            .saturating_add((178_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((6_539_000 as Weight).saturating_mul(j as Weight))
+        (692_262_000 as Weight)
+            .saturating_add((179_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((6_101_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn cancel_bounty_by_council() -> Weight {
-        (763_334_000 as Weight)
+        (866_290_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn cancel_bounty_by_member() -> Weight {
-        (1_387_193_000 as Weight)
+        (1_419_401_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn veto_bounty() -> Weight {
-        (767_493_000 as Weight)
+        (774_515_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn fund_bounty_by_member() -> Weight {
-        (940_458_000 as Weight)
+        (872_342_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn fund_bounty_by_council() -> Weight {
-        (574_726_000 as Weight)
+        (579_089_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn withdraw_funding_by_member() -> Weight {
-        (1_236_102_000 as Weight)
+        (1_491_273_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn withdraw_funding_by_council() -> Weight {
-        (944_520_000 as Weight)
+        (999_985_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn announce_work_entry(i: u32) -> Weight {
-        (808_136_000 as Weight)
-            .saturating_add((9_176_000 as Weight).saturating_mul(i as Weight))
+        (821_081_000 as Weight)
+            .saturating_add((8_093_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn withdraw_work_entry() -> Weight {
-        (944_051_000 as Weight)
+        (956_896_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn submit_work(i: u32) -> Weight {
-        (589_391_000 as Weight)
-            .saturating_add((179_000 as Weight).saturating_mul(i as Weight))
+        (454_823_000 as Weight)
+            .saturating_add((182_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn submit_oracle_judgment_by_council_all_winners(i: u32) -> Weight {
-        (741_719_000 as Weight)
-            .saturating_add((125_997_000 as Weight).saturating_mul(i as Weight))
+        (759_626_000 as Weight)
+            .saturating_add((120_602_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_council_all_rejected(i: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((647_153_000 as Weight).saturating_mul(i as Weight))
+        (1_671_028_000 as Weight)
+            .saturating_add((585_998_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_member_all_winners(i: u32) -> Weight {
-        (1_129_839_000 as Weight)
-            .saturating_add((130_714_000 as Weight).saturating_mul(i as Weight))
+        (1_266_347_000 as Weight)
+            .saturating_add((120_584_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(4 as Weight))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_member_all_rejected(i: u32) -> Weight {
-        (1_282_401_000 as Weight)
-            .saturating_add((599_421_000 as Weight).saturating_mul(i as Weight))
+        (1_180_573_000 as Weight)
+            .saturating_add((583_466_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn withdraw_work_entrant_funds() -> Weight {
-        (1_388_099_000 as Weight)
+        (1_333_601_000 as Weight)
             .saturating_add(DbWeight::get().reads(8 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
     }
     fn oracle_council_switch_to_oracle_member() -> Weight {
-        (430_417_000 as Weight)
+        (418_226_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn oracle_member_switch_to_oracle_member() -> Weight {
-        (532_129_000 as Weight)
+        (518_000_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn oracle_member_switch_to_oracle_council() -> Weight {
-        (417_054_000 as Weight)
+        (433_247_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }

--- a/runtime/src/weights/bounty.rs
+++ b/runtime/src/weights/bounty.rs
@@ -8,153 +8,148 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl bounty::WeightInfo for WeightInfo {
     fn create_bounty_by_council(i: u32, j: u32) -> Weight {
-        (412_900_000 as Weight)
-            .saturating_add((160_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((4_983_000 as Weight).saturating_mul(j as Weight))
+        (5_809_000 as Weight)
+            .saturating_add((166_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((11_416_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn create_bounty_by_member(i: u32, j: u32) -> Weight {
-        (690_942_000 as Weight)
-            .saturating_add((160_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((4_366_000 as Weight).saturating_mul(j as Weight))
+        (814_964_000 as Weight)
+            .saturating_add((158_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((1_989_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn cancel_bounty_by_council() -> Weight {
-        (674_328_000 as Weight)
+        (674_766_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn cancel_bounty_by_member() -> Weight {
-        (1_246_773_000 as Weight)
+        (1_203_977_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn veto_bounty() -> Weight {
-        (672_526_000 as Weight)
+        (671_979_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn fund_bounty_by_member() -> Weight {
-        (759_718_000 as Weight)
+        (760_395_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn fund_bounty_by_council() -> Weight {
-        (509_844_000 as Weight)
+        (502_356_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn withdraw_funding_by_member() -> Weight {
-        (1_046_834_000 as Weight)
+        (1_048_377_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn withdraw_funding_by_council() -> Weight {
-        (795_375_000 as Weight)
+        (796_006_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn announce_work_entry(i: u32) -> Weight {
-        (697_940_000 as Weight)
-            .saturating_add((7_233_000 as Weight).saturating_mul(i as Weight))
+        (696_148_000 as Weight)
+            .saturating_add((7_144_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn submit_work(i: u32) -> Weight {
-        (373_557_000 as Weight)
-            .saturating_add((160_000 as Weight).saturating_mul(i as Weight))
+        (368_984_000 as Weight)
+            .saturating_add((157_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn submit_oracle_judgment_by_council_all_winners(i: u32) -> Weight {
-        (618_451_000 as Weight)
-            .saturating_add((288_896_000 as Weight).saturating_mul(i as Weight))
+        (381_535_000 as Weight)
+            .saturating_add((741_491_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().reads((4 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_council_all_rejected(i: u32, j: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((9_919_819_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((18_685_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((9_688_927_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((18_143_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_member_all_winners(i: u32) -> Weight {
-        (1_004_920_000 as Weight)
-            .saturating_add((308_786_000 as Weight).saturating_mul(i as Weight))
+        (521_821_000 as Weight)
+            .saturating_add((745_682_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().reads((4 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(4 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_member_all_rejected(i: u32, j: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((10_162_672_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((19_289_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((10_165_855_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((18_716_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
-    fn withdraw_work_entrant_funds() -> Weight {
-        (846_404_000 as Weight)
-            .saturating_add(DbWeight::get().reads(7 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
     fn switch_oracle_to_council_by_council_approval_successful() -> Weight {
-        (296_131_000 as Weight)
+        (299_853_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn switch_oracle_to_member_by_oracle_council() -> Weight {
-        (358_573_000 as Weight)
+        (378_133_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn switch_oracle_to_member_by_not_oracle_council() -> Weight {
-        (366_833_000 as Weight)
+        (387_960_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn switch_oracle_to_member_by_oracle_member() -> Weight {
-        (467_434_000 as Weight)
+        (472_810_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn switch_oracle_to_council_by_oracle_member() -> Weight {
-        (364_787_000 as Weight)
+        (379_825_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn end_working_period() -> Weight {
-        (380_423_000 as Weight)
+        (364_306_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn terminate_bounty() -> Weight {
-        (510_458_000 as Weight)
+        (509_163_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn unlock_work_entrant_stake() -> Weight {
-        (763_805_000 as Weight)
+        (738_681_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn withdraw_state_bloat_bond_by_council() -> Weight {
-        (565_575_000 as Weight)
+        (736_228_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn withdraw_state_bloat_bond_by_member() -> Weight {
-        (813_974_000 as Weight)
+        (992_363_000 as Weight)
             .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
     }
 }

--- a/runtime/src/weights/bounty.rs
+++ b/runtime/src/weights/bounty.rs
@@ -3,126 +3,150 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
+use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
 
 pub struct WeightInfo;
 impl bounty::WeightInfo for WeightInfo {
-    fn create_bounty_by_council(i: u32, j: u32) -> Weight {
-        (614_460_000 as Weight)
-            .saturating_add((179_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((1_128_000 as Weight).saturating_mul(j as Weight))
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn create_bounty_by_member(i: u32, j: u32) -> Weight {
-        (692_262_000 as Weight)
-            .saturating_add((179_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((6_101_000 as Weight).saturating_mul(j as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn cancel_bounty_by_council() -> Weight {
-        (866_290_000 as Weight)
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-    }
-    fn cancel_bounty_by_member() -> Weight {
-        (1_419_401_000 as Weight)
-            .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-    }
-    fn veto_bounty() -> Weight {
-        (774_515_000 as Weight)
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-    }
-    fn fund_bounty_by_member() -> Weight {
-        (872_342_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn fund_bounty_by_council() -> Weight {
-        (579_089_000 as Weight)
-            .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn withdraw_funding_by_member() -> Weight {
-        (1_491_273_000 as Weight)
-            .saturating_add(DbWeight::get().reads(7 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
-    }
-    fn withdraw_funding_by_council() -> Weight {
-        (999_985_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn announce_work_entry(i: u32) -> Weight {
-        (821_081_000 as Weight)
-            .saturating_add((8_093_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
-    }
-    fn withdraw_work_entry() -> Weight {
-        (956_896_000 as Weight)
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-    }
-    fn submit_work(i: u32) -> Weight {
-        (454_823_000 as Weight)
-            .saturating_add((182_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(2 as Weight))
-    }
-    fn submit_oracle_judgment_by_council_all_winners(i: u32) -> Weight {
-        (759_626_000 as Weight)
-            .saturating_add((120_602_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
-    }
-    fn submit_oracle_judgment_by_council_all_rejected(i: u32) -> Weight {
-        (1_671_028_000 as Weight)
-            .saturating_add((585_998_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-            .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
-    }
-    fn submit_oracle_judgment_by_member_all_winners(i: u32) -> Weight {
-        (1_266_347_000 as Weight)
-            .saturating_add((120_584_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(5 as Weight))
-            .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
-            .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
-    }
-    fn submit_oracle_judgment_by_member_all_rejected(i: u32) -> Weight {
-        (1_180_573_000 as Weight)
-            .saturating_add((583_466_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
-            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
-            .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
-    }
-    fn withdraw_work_entrant_funds() -> Weight {
-        (1_333_601_000 as Weight)
-            .saturating_add(DbWeight::get().reads(8 as Weight))
-            .saturating_add(DbWeight::get().writes(6 as Weight))
-    }
-    fn oracle_council_switch_to_oracle_member() -> Weight {
-        (418_226_000 as Weight)
-            .saturating_add(DbWeight::get().reads(2 as Weight))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
-    }
-    fn oracle_member_switch_to_oracle_member() -> Weight {
-        (518_000_000 as Weight)
-            .saturating_add(DbWeight::get().reads(3 as Weight))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
-    }
-    fn oracle_member_switch_to_oracle_council() -> Weight {
-        (433_247_000 as Weight)
-            .saturating_add(DbWeight::get().reads(2 as Weight))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
-    }
+	fn create_bounty_by_council(i: u32, j: u32, ) -> Weight {
+		(362_598_000 as Weight)
+			.saturating_add((168_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add((5_849_000 as Weight).saturating_mul(j as Weight))
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
+	}
+	fn create_bounty_by_member(i: u32, j: u32, ) -> Weight {
+		(613_607_000 as Weight)
+			.saturating_add((166_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add((6_524_000 as Weight).saturating_mul(j as Weight))
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
+	}
+	fn cancel_bounty_by_council() -> Weight {
+		(721_078_000 as Weight)
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+	}
+	fn cancel_bounty_by_member() -> Weight {
+		(1_248_464_000 as Weight)
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+	}
+	fn veto_bounty() -> Weight {
+		(687_556_000 as Weight)
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+	}
+	fn fund_bounty_by_member() -> Weight {
+		(784_240_000 as Weight)
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
+	}
+	fn fund_bounty_by_council() -> Weight {
+		(491_642_000 as Weight)
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
+	}
+	fn withdraw_funding_by_member() -> Weight {
+		(1_085_334_000 as Weight)
+			.saturating_add(DbWeight::get().reads(7 as Weight))
+			.saturating_add(DbWeight::get().writes(5 as Weight))
+	}
+	fn withdraw_funding_by_council() -> Weight {
+		(813_067_000 as Weight)
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
+	}
+	fn announce_work_entry(i: u32, ) -> Weight {
+		(708_853_000 as Weight)
+			.saturating_add((7_630_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add(DbWeight::get().reads(6 as Weight))
+			.saturating_add(DbWeight::get().writes(5 as Weight))
+	}
+	fn withdraw_work_entry() -> Weight {
+		(409_487_000 as Weight)
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(2 as Weight))
+	}
+	fn submit_work(i: u32, ) -> Weight {
+		(349_833_000 as Weight)
+			.saturating_add((165_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn submit_oracle_judgment_by_council_all_winners(i: u32, ) -> Weight {
+		(589_908_000 as Weight)
+			.saturating_add((299_820_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
+	}
+	fn submit_oracle_judgment_by_council_all_rejected(i: u32, ) -> Weight {
+		(506_207_000 as Weight)
+			.saturating_add((103_077_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+	}
+	fn submit_oracle_judgment_by_member_all_winners(i: u32, ) -> Weight {
+		(1_082_713_000 as Weight)
+			.saturating_add((298_068_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add(DbWeight::get().reads(5 as Weight))
+			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(DbWeight::get().writes(4 as Weight))
+			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
+	}
+	fn submit_oracle_judgment_by_member_all_rejected(i: u32, ) -> Weight {
+		(930_911_000 as Weight)
+			.saturating_add((102_491_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add(DbWeight::get().reads(4 as Weight))
+			.saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+	}
+	fn withdraw_work_entrant_funds() -> Weight {
+		(973_633_000 as Weight)
+			.saturating_add(DbWeight::get().reads(7 as Weight))
+			.saturating_add(DbWeight::get().writes(5 as Weight))
+	}
+	fn switch_oracle_to_member_by_oracle_council() -> Weight {
+		(368_036_000 as Weight)
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn switch_oracle_to_member_by_not_oracle_council() -> Weight {
+		(367_397_000 as Weight)
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn switch_oracle_to_member_by_oracle_member() -> Weight {
+		(438_778_000 as Weight)
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn switch_oracle_to_council_by_oracle_member() -> Weight {
+		(354_735_000 as Weight)
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn end_working_period() -> Weight {
+		(355_201_000 as Weight)
+			.saturating_add(DbWeight::get().reads(2 as Weight))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+	}
+	fn terminate_bounty() -> Weight {
+		(475_942_000 as Weight)
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().writes(3 as Weight))
+	}
+	fn work_entrants_stake_account_action(i: u32, j: u32, ) -> Weight {
+		(0 as Weight)
+			.saturating_add((6_333_016_000 as Weight).saturating_mul(i as Weight))
+			.saturating_add((11_000_000 as Weight).saturating_mul(j as Weight))
+			.saturating_add(DbWeight::get().reads(3 as Weight))
+			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(DbWeight::get().writes(1 as Weight))
+			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
+	}
 }

--- a/runtime/src/weights/bounty.rs
+++ b/runtime/src/weights/bounty.rs
@@ -3,150 +3,148 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 
-use frame_support::weights::{Weight, constants::RocksDbWeight as DbWeight};
+use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 
 pub struct WeightInfo;
 impl bounty::WeightInfo for WeightInfo {
-	fn create_bounty_by_council(i: u32, j: u32, ) -> Weight {
-		(362_598_000 as Weight)
-			.saturating_add((168_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add((5_849_000 as Weight).saturating_mul(j as Weight))
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(4 as Weight))
-	}
-	fn create_bounty_by_member(i: u32, j: u32, ) -> Weight {
-		(613_607_000 as Weight)
-			.saturating_add((166_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add((6_524_000 as Weight).saturating_mul(j as Weight))
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().writes(4 as Weight))
-	}
-	fn cancel_bounty_by_council() -> Weight {
-		(721_078_000 as Weight)
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
-	}
-	fn cancel_bounty_by_member() -> Weight {
-		(1_248_464_000 as Weight)
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
-	}
-	fn veto_bounty() -> Weight {
-		(687_556_000 as Weight)
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
-	}
-	fn fund_bounty_by_member() -> Weight {
-		(784_240_000 as Weight)
-			.saturating_add(DbWeight::get().reads(5 as Weight))
-			.saturating_add(DbWeight::get().writes(4 as Weight))
-	}
-	fn fund_bounty_by_council() -> Weight {
-		(491_642_000 as Weight)
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().writes(4 as Weight))
-	}
-	fn withdraw_funding_by_member() -> Weight {
-		(1_085_334_000 as Weight)
-			.saturating_add(DbWeight::get().reads(7 as Weight))
-			.saturating_add(DbWeight::get().writes(5 as Weight))
-	}
-	fn withdraw_funding_by_council() -> Weight {
-		(813_067_000 as Weight)
-			.saturating_add(DbWeight::get().reads(5 as Weight))
-			.saturating_add(DbWeight::get().writes(4 as Weight))
-	}
-	fn announce_work_entry(i: u32, ) -> Weight {
-		(708_853_000 as Weight)
-			.saturating_add((7_630_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(DbWeight::get().reads(6 as Weight))
-			.saturating_add(DbWeight::get().writes(5 as Weight))
-	}
-	fn withdraw_work_entry() -> Weight {
-		(409_487_000 as Weight)
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(2 as Weight))
-	}
-	fn submit_work(i: u32, ) -> Weight {
-		(349_833_000 as Weight)
-			.saturating_add((165_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
-	}
-	fn submit_oracle_judgment_by_council_all_winners(i: u32, ) -> Weight {
-		(589_908_000 as Weight)
-			.saturating_add((299_820_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
-			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
-	}
-	fn submit_oracle_judgment_by_council_all_rejected(i: u32, ) -> Weight {
-		(506_207_000 as Weight)
-			.saturating_add((103_077_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
-			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
-	}
-	fn submit_oracle_judgment_by_member_all_winners(i: u32, ) -> Weight {
-		(1_082_713_000 as Weight)
-			.saturating_add((298_068_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(DbWeight::get().reads(5 as Weight))
-			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
-			.saturating_add(DbWeight::get().writes(4 as Weight))
-			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
-	}
-	fn submit_oracle_judgment_by_member_all_rejected(i: u32, ) -> Weight {
-		(930_911_000 as Weight)
-			.saturating_add((102_491_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add(DbWeight::get().reads(4 as Weight))
-			.saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
-			.saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
-	}
-	fn withdraw_work_entrant_funds() -> Weight {
-		(973_633_000 as Weight)
-			.saturating_add(DbWeight::get().reads(7 as Weight))
-			.saturating_add(DbWeight::get().writes(5 as Weight))
-	}
-	fn switch_oracle_to_member_by_oracle_council() -> Weight {
-		(368_036_000 as Weight)
-			.saturating_add(DbWeight::get().reads(2 as Weight))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
-	}
-	fn switch_oracle_to_member_by_not_oracle_council() -> Weight {
-		(367_397_000 as Weight)
-			.saturating_add(DbWeight::get().reads(2 as Weight))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
-	}
-	fn switch_oracle_to_member_by_oracle_member() -> Weight {
-		(438_778_000 as Weight)
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
-	}
-	fn switch_oracle_to_council_by_oracle_member() -> Weight {
-		(354_735_000 as Weight)
-			.saturating_add(DbWeight::get().reads(2 as Weight))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
-	}
-	fn end_working_period() -> Weight {
-		(355_201_000 as Weight)
-			.saturating_add(DbWeight::get().reads(2 as Weight))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
-	}
-	fn terminate_bounty() -> Weight {
-		(475_942_000 as Weight)
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().writes(3 as Weight))
-	}
-	fn work_entrants_stake_account_action(i: u32, j: u32, ) -> Weight {
-		(0 as Weight)
-			.saturating_add((6_333_016_000 as Weight).saturating_mul(i as Weight))
-			.saturating_add((11_000_000 as Weight).saturating_mul(j as Weight))
-			.saturating_add(DbWeight::get().reads(3 as Weight))
-			.saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
-			.saturating_add(DbWeight::get().writes(1 as Weight))
-			.saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
-	}
+    fn create_bounty_by_council(i: u32, j: u32) -> Weight {
+        (416_534_000 as Weight)
+            .saturating_add((167_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((5_362_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+    fn create_bounty_by_member(i: u32, j: u32) -> Weight {
+        (695_781_000 as Weight)
+            .saturating_add((168_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((4_755_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+    fn cancel_bounty_by_council() -> Weight {
+        (701_131_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
+    fn cancel_bounty_by_member() -> Weight {
+        (1_302_327_000 as Weight)
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
+    fn veto_bounty() -> Weight {
+        (682_409_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
+    fn fund_bounty_by_member() -> Weight {
+        (865_019_000 as Weight)
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+    fn fund_bounty_by_council() -> Weight {
+        (516_434_000 as Weight)
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+    fn withdraw_funding_by_member() -> Weight {
+        (1_102_202_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
+    }
+    fn withdraw_funding_by_council() -> Weight {
+        (864_672_000 as Weight)
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+    fn announce_work_entry(i: u32) -> Weight {
+        (734_866_000 as Weight)
+            .saturating_add((8_316_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
+    }
+    fn submit_work(i: u32) -> Weight {
+        (405_782_000 as Weight)
+            .saturating_add((167_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn submit_oracle_judgment_by_council_all_winners(i: u32) -> Weight {
+        (680_191_000 as Weight)
+            .saturating_add((311_771_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
+    }
+    fn submit_oracle_judgment_by_council_all_rejected(i: u32, j: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((10_136_855_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((19_132_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
+    }
+    fn submit_oracle_judgment_by_member_all_winners(i: u32) -> Weight {
+        (797_988_000 as Weight)
+            .saturating_add((318_091_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+            .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
+    }
+    fn submit_oracle_judgment_by_member_all_rejected(i: u32, j: u32) -> Weight {
+        (0 as Weight)
+            .saturating_add((10_125_039_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((19_048_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
+            .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
+    }
+    fn withdraw_work_entrant_funds() -> Weight {
+        (962_354_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
+    }
+    fn switch_oracle_to_council_by_council_approval_successful() -> Weight {
+        (281_287_000 as Weight)
+            .saturating_add(DbWeight::get().reads(1 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn switch_oracle_to_member_by_oracle_council() -> Weight {
+        (360_377_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn switch_oracle_to_member_by_not_oracle_council() -> Weight {
+        (366_893_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn switch_oracle_to_member_by_oracle_member() -> Weight {
+        (443_217_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn switch_oracle_to_council_by_oracle_member() -> Weight {
+        (357_889_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn end_working_period() -> Weight {
+        (356_408_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn terminate_bounty() -> Weight {
+        (484_814_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
+    fn unlock_work_entrant_stake() -> Weight {
+        (700_261_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
 }

--- a/runtime/src/weights/bounty.rs
+++ b/runtime/src/weights/bounty.rs
@@ -8,69 +8,69 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl bounty::WeightInfo for WeightInfo {
     fn create_bounty_by_council(i: u32, j: u32) -> Weight {
-        (416_534_000 as Weight)
-            .saturating_add((167_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((5_362_000 as Weight).saturating_mul(j as Weight))
+        (412_900_000 as Weight)
+            .saturating_add((160_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((4_983_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn create_bounty_by_member(i: u32, j: u32) -> Weight {
-        (695_781_000 as Weight)
-            .saturating_add((168_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((4_755_000 as Weight).saturating_mul(j as Weight))
+        (690_942_000 as Weight)
+            .saturating_add((160_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((4_366_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn cancel_bounty_by_council() -> Weight {
-        (701_131_000 as Weight)
+        (674_328_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn cancel_bounty_by_member() -> Weight {
-        (1_302_327_000 as Weight)
+        (1_246_773_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn veto_bounty() -> Weight {
-        (682_409_000 as Weight)
+        (672_526_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn fund_bounty_by_member() -> Weight {
-        (865_019_000 as Weight)
+        (759_718_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn fund_bounty_by_council() -> Weight {
-        (516_434_000 as Weight)
+        (509_844_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn withdraw_funding_by_member() -> Weight {
-        (1_102_202_000 as Weight)
+        (1_046_834_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn withdraw_funding_by_council() -> Weight {
-        (864_672_000 as Weight)
+        (795_375_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn announce_work_entry(i: u32) -> Weight {
-        (734_866_000 as Weight)
-            .saturating_add((8_316_000 as Weight).saturating_mul(i as Weight))
+        (697_940_000 as Weight)
+            .saturating_add((7_233_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn submit_work(i: u32) -> Weight {
-        (405_782_000 as Weight)
-            .saturating_add((167_000 as Weight).saturating_mul(i as Weight))
+        (373_557_000 as Weight)
+            .saturating_add((160_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn submit_oracle_judgment_by_council_all_winners(i: u32) -> Weight {
-        (680_191_000 as Weight)
-            .saturating_add((311_771_000 as Weight).saturating_mul(i as Weight))
+        (618_451_000 as Weight)
+            .saturating_add((288_896_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
@@ -78,16 +78,16 @@ impl bounty::WeightInfo for WeightInfo {
     }
     fn submit_oracle_judgment_by_council_all_rejected(i: u32, j: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((10_136_855_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((19_132_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((9_919_819_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((18_685_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_member_all_winners(i: u32) -> Weight {
-        (797_988_000 as Weight)
-            .saturating_add((318_091_000 as Weight).saturating_mul(i as Weight))
+        (1_004_920_000 as Weight)
+            .saturating_add((308_786_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(4 as Weight))
@@ -95,56 +95,66 @@ impl bounty::WeightInfo for WeightInfo {
     }
     fn submit_oracle_judgment_by_member_all_rejected(i: u32, j: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((10_125_039_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((19_048_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((10_162_672_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((19_289_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn withdraw_work_entrant_funds() -> Weight {
-        (962_354_000 as Weight)
+        (846_404_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
-            .saturating_add(DbWeight::get().writes(5 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn switch_oracle_to_council_by_council_approval_successful() -> Weight {
-        (281_287_000 as Weight)
+        (296_131_000 as Weight)
             .saturating_add(DbWeight::get().reads(1 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn switch_oracle_to_member_by_oracle_council() -> Weight {
-        (360_377_000 as Weight)
+        (358_573_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn switch_oracle_to_member_by_not_oracle_council() -> Weight {
-        (366_893_000 as Weight)
+        (366_833_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn switch_oracle_to_member_by_oracle_member() -> Weight {
-        (443_217_000 as Weight)
+        (467_434_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn switch_oracle_to_council_by_oracle_member() -> Weight {
-        (357_889_000 as Weight)
+        (364_787_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn end_working_period() -> Weight {
-        (356_408_000 as Weight)
+        (380_423_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn terminate_bounty() -> Weight {
-        (484_814_000 as Weight)
+        (510_458_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn unlock_work_entrant_stake() -> Weight {
-        (700_261_000 as Weight)
+        (763_805_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
+    }
+    fn withdraw_state_bloat_bond_by_council() -> Weight {
+        (565_575_000 as Weight)
+            .saturating_add(DbWeight::get().reads(5 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
+    }
+    fn withdraw_state_bloat_bond_by_member() -> Weight {
+        (813_974_000 as Weight)
+            .saturating_add(DbWeight::get().reads(6 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
     }
 }

--- a/runtime/src/weights/bounty.rs
+++ b/runtime/src/weights/bounty.rs
@@ -1,4 +1,4 @@
-//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.0
+//! THIS FILE WAS AUTO-GENERATED USING THE SUBSTRATE BENCHMARK CLI VERSION 2.0.1
 
 #![allow(unused_parens)]
 #![allow(unused_imports)]
@@ -8,106 +8,121 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl bounty::WeightInfo for WeightInfo {
     fn create_bounty_by_council(i: u32, j: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((194_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((28_742_000 as Weight).saturating_mul(j as Weight))
+        (642_459_000 as Weight)
+            .saturating_add((177_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((4_148_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn create_bounty_by_member(i: u32, j: u32) -> Weight {
-        (843_057_000 as Weight)
-            .saturating_add((174_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((6_931_000 as Weight).saturating_mul(j as Weight))
+        (753_803_000 as Weight)
+            .saturating_add((178_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((6_539_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn cancel_bounty_by_council() -> Weight {
-        (527_000_000 as Weight)
+        (763_334_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn cancel_bounty_by_member() -> Weight {
-        (872_000_000 as Weight)
+        (1_387_193_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn veto_bounty() -> Weight {
-        (576_000_000 as Weight)
+        (767_493_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn fund_bounty_by_member() -> Weight {
-        (866_000_000 as Weight)
+        (940_458_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn fund_bounty_by_council() -> Weight {
-        (559_000_000 as Weight)
+        (574_726_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn withdraw_funding_by_member() -> Weight {
-        (939_000_000 as Weight)
-            .saturating_add(DbWeight::get().reads(6 as Weight))
-            .saturating_add(DbWeight::get().writes(4 as Weight))
+        (1_236_102_000 as Weight)
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn withdraw_funding_by_council() -> Weight {
-        (688_000_000 as Weight)
+        (944_520_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn announce_work_entry(i: u32) -> Weight {
-        (774_826_000 as Weight)
-            .saturating_add((10_400_000 as Weight).saturating_mul(i as Weight))
+        (808_136_000 as Weight)
+            .saturating_add((9_176_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(6 as Weight))
             .saturating_add(DbWeight::get().writes(5 as Weight))
     }
     fn withdraw_work_entry() -> Weight {
-        (911_000_000 as Weight)
+        (944_051_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(4 as Weight))
     }
     fn submit_work(i: u32) -> Weight {
-        (546_484_000 as Weight)
-            .saturating_add((171_000 as Weight).saturating_mul(i as Weight))
+        (589_391_000 as Weight)
+            .saturating_add((179_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn submit_oracle_judgment_by_council_all_winners(i: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((150_234_000 as Weight).saturating_mul(i as Weight))
+        (741_719_000 as Weight)
+            .saturating_add((125_997_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_council_all_rejected(i: u32) -> Weight {
-        (3_192_844_000 as Weight)
-            .saturating_add((552_887_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(1 as Weight))
+        (0 as Weight)
+            .saturating_add((647_153_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_member_all_winners(i: u32) -> Weight {
-        (317_671_000 as Weight)
-            .saturating_add((130_010_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(4 as Weight))
+        (1_129_839_000 as Weight)
+            .saturating_add((130_714_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(3 as Weight))
+            .saturating_add(DbWeight::get().writes(4 as Weight))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn submit_oracle_judgment_by_member_all_rejected(i: u32) -> Weight {
-        (261_974_000 as Weight)
-            .saturating_add((593_591_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add(DbWeight::get().reads(2 as Weight))
+        (1_282_401_000 as Weight)
+            .saturating_add((599_421_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((3 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(DbWeight::get().writes(1 as Weight))
+            .saturating_add(DbWeight::get().writes(3 as Weight))
             .saturating_add(DbWeight::get().writes((3 as Weight).saturating_mul(i as Weight)))
     }
     fn withdraw_work_entrant_funds() -> Weight {
-        (1_248_000_000 as Weight)
+        (1_388_099_000 as Weight)
             .saturating_add(DbWeight::get().reads(8 as Weight))
             .saturating_add(DbWeight::get().writes(6 as Weight))
+    }
+    fn oracle_council_switch_to_oracle_member() -> Weight {
+        (430_417_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn oracle_member_switch_to_oracle_member() -> Weight {
+        (532_129_000 as Weight)
+            .saturating_add(DbWeight::get().reads(3 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
+    }
+    fn oracle_member_switch_to_oracle_council() -> Weight {
+        (417_054_000 as Weight)
+            .saturating_add(DbWeight::get().reads(2 as Weight))
+            .saturating_add(DbWeight::get().writes(1 as Weight))
     }
 }


### PR DESCRIPTION
#2821 Built-in reward for bounty oracles

A new field was added to the bounty pallet "MinOracleRewardLimit"
When a creator creates a bounty he has to set a specific cherry and oracle reward,
This reward should be awarded to the oracle if he submits a judgment (with winners or not).

#2947 Bounty oracle switch

Bounty oracle can be switched by the current oracle or by the council
This can happen in the following stages  Funding, WorkSubmission, Judgment.

#3193 Flexible working period duration

working period and judging period have no longer a specific limit, after funding, workers can submit their work,
the oracle can end this period by calling ```end_working_period``` if there are no work submissions, the bounty fails and 
the oracle reward goes to the creator, on the opposite side if there are submissions, the bounty will advance to judgment.
In judgement, the oracle will select the winners, the losers and receive the oracle reward for that.
The winners will receive a reward and their stake accounts will be immediately unlocked.
The losers will have their stake accounts slashed (or not) by the oracle, a description can also be given, for example, with the reason for the slashing action.
It can be the case, the oracle becomes inactive and doesn't end the working period, if there are no entry submissions, the council can call ```terminate_bounty``` and the bounty fails. 
When work entries are present, the Council can switch the oracle and proceed with the normal process.

#3446 When a bounty succeeds, removing all BountyContributions by the last worker can be expensive.
#3447 Bounty blocked by T::MinFundingLimit in the funding period

If a bounty is successful all bounty contribution entries will be occupying space in the chain, if a funder starts sending a small amount from multiple accounts, he can perform a state bloat attack.  
The funder must have an incentive to delete those bounty contribution entries, a min fund limit doesn't work, a better solution is to use a state bloat bond, 
this is a quantity (at the time this is just a static variable) of joy the funder has to deposit (this is not stake) in the bounty. after the oracle successfully judges the work, each funder can 
call ```withdraw_state_bloat_bond_by_council``` and recover the state bloat bond.
A funder can make multiple contributions with the same membership and only has to deposit the bond once. 

#3329 Joystream/joystream Actor validation redundant 