### PR TITLE
query node - fix for auction whitelist

### DIFF
--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -43,7 +43,7 @@ import {
 } from 'query-node/dist/model'
 import * as joystreamTypes from '@joystream/types/augment/all/types'
 import { Content } from '../../generated/types'
-import { FindConditions } from 'typeorm'
+import { FindConditions, In } from 'typeorm'
 import BN from 'bn.js'
 import { PERBILL_ONE_PERCENT } from '../temporaryConstants'
 
@@ -168,7 +168,7 @@ async function getRequiredExistingEntites<Type extends Video | Membership>(
   errorMessage: string
 ): Promise<Type[]> {
   // load entities
-  const entities = await store.getMany(entityType, { where: { id: ids } })
+  const entities = await store.getMany(entityType, { where: { id: In(ids) } })
 
   // assess loaded entity ids
   const loadedEntityIds = entities.map((item) => item.id.toString())


### PR DESCRIPTION
The same fix as in https://github.com/Joystream/joystream/pull/3467, but targeting rhodes.