### PR TITLE
Rhodes. Runtime. Refactor the council budget handling.

### DIFF
--- a/runtime-modules/bounty/src/actors.rs
+++ b/runtime-modules/bounty/src/actors.rs
@@ -9,7 +9,6 @@ use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_support::ensure;
 use frame_support::traits::Currency;
 use frame_system::ensure_root;
-use sp_arithmetic::traits::Saturating;
 
 use common::council::CouncilBudgetManager;
 use common::membership::{MemberId, MemberOriginValidator, MembershipInfoProvider};
@@ -149,13 +148,8 @@ impl<T: Trait> BountyActorManager<T> {
 
     // Remove some balance from the council budget and transfer it to the bounty account.
     fn transfer_balance_from_council_budget(bounty_id: T::BountyId, amount: BalanceOf<T>) {
-        let budget = T::CouncilBudgetManager::get_budget();
-        let new_budget = budget.saturating_sub(amount);
-
-        T::CouncilBudgetManager::set_budget(new_budget);
-
         let bounty_account_id = Module::<T>::bounty_account_id(bounty_id);
-        let _ = balances::Module::<T>::deposit_creating(&bounty_account_id, amount);
+        T::CouncilBudgetManager::transfer(&bounty_account_id, amount);
     }
 
     // Add some balance from the council budget and slash from the bounty account.
@@ -163,9 +157,6 @@ impl<T: Trait> BountyActorManager<T> {
         let bounty_account_id = Module::<T>::bounty_account_id(bounty_id);
         let _ = balances::Module::<T>::slash(&bounty_account_id, amount);
 
-        let budget = T::CouncilBudgetManager::get_budget();
-        let new_budget = budget.saturating_add(amount);
-
-        T::CouncilBudgetManager::set_budget(new_budget);
+        T::CouncilBudgetManager::increase_budget(amount);
     }
 }

--- a/runtime-modules/bounty/src/actors.rs
+++ b/runtime-modules/bounty/src/actors.rs
@@ -149,7 +149,7 @@ impl<T: Trait> BountyActorManager<T> {
     // Remove some balance from the council budget and transfer it to the bounty account.
     fn transfer_balance_from_council_budget(bounty_id: T::BountyId, amount: BalanceOf<T>) {
         let bounty_account_id = Module::<T>::bounty_account_id(bounty_id);
-        T::CouncilBudgetManager::transfer(&bounty_account_id, amount);
+        T::CouncilBudgetManager::withdraw(&bounty_account_id, amount);
     }
 
     // Add some balance from the council budget and slash from the bounty account.

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -129,7 +129,7 @@ pub trait Trait:
     type WeightInfo: WeightInfo;
 
     /// Provides an access for the council budget.
-    type CouncilBudgetManager: CouncilBudgetManager<BalanceOf<Self>>;
+    type CouncilBudgetManager: CouncilBudgetManager<Self::AccountId, BalanceOf<Self>>;
 
     /// Provides stake logic implementation.
     type StakingHandler: StakingHandler<

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -26,11 +26,11 @@ pub fn run_to_block(n: u64) {
 }
 
 pub fn set_council_budget(new_budget: u64) {
-    <super::mocks::CouncilBudgetManager as CouncilBudgetManager<u64>>::set_budget(new_budget);
+    <super::mocks::CouncilBudgetManager as CouncilBudgetManager<u128, u64>>::set_budget(new_budget);
 }
 
 pub fn get_council_budget() -> u64 {
-    <super::mocks::CouncilBudgetManager as CouncilBudgetManager<u64>>::get_budget()
+    <super::mocks::CouncilBudgetManager as CouncilBudgetManager<u128, u64>>::get_budget()
 }
 
 pub fn increase_total_balance_issuance_using_account_id(account_id: u128, balance: u64) {

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -146,7 +146,7 @@ impl common::council::CouncilBudgetManager<u128, u64> for CouncilBudgetManager {
         }
     }
 
-    fn try_transfer(account_id: &u128, amount: u64) -> DispatchResult {
+    fn try_withdraw(account_id: &u128, amount: u64) -> DispatchResult {
         let _ = Balances::deposit_creating(account_id, amount);
 
         let current_budget = Self::get_budget();

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -146,16 +146,14 @@ impl common::council::CouncilBudgetManager<u128, u64> for CouncilBudgetManager {
         }
     }
 
-    fn try_transfer(_account_id: &u128, _amount: u64) -> DispatchResult {
-        todo!()
-    }
+    fn try_transfer(account_id: &u128, amount: u64) -> DispatchResult {
+        let _ = Balances::deposit_creating(account_id, amount);
 
-    fn transfer(_account_id: &u128, _amount: u64) {
-        todo!()
-    }
+        let current_budget = Self::get_budget();
+        let new_budget = current_budget.saturating_sub(amount);
+        Self::set_budget(new_budget);
 
-    fn increase_budget(_amount: u64) {
-        todo!()
+        Ok(())
     }
 }
 

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -125,7 +125,7 @@ impl common::membership::MembershipInfoProvider<Test> for () {
 
 pub const COUNCIL_BUDGET_ACCOUNT_ID: u128 = 90000000;
 pub struct CouncilBudgetManager;
-impl common::council::CouncilBudgetManager<u64> for CouncilBudgetManager {
+impl common::council::CouncilBudgetManager<u128, u64> for CouncilBudgetManager {
     fn get_budget() -> u64 {
         balances::Module::<Test>::usable_balance(&COUNCIL_BUDGET_ACCOUNT_ID)
     }
@@ -144,6 +144,18 @@ impl common::council::CouncilBudgetManager<u64> for CouncilBudgetManager {
             let _ =
                 balances::Module::<Test>::slash(&COUNCIL_BUDGET_ACCOUNT_ID, old_budget - budget);
         }
+    }
+
+    fn try_transfer(_account_id: &u128, _amount: u64) -> DispatchResult {
+        todo!()
+    }
+
+    fn transfer(_account_id: &u128, _amount: u64) {
+        todo!()
+    }
+
+    fn increase_budget(_amount: u64) {
+        todo!()
     }
 }
 

--- a/runtime-modules/common/src/council.rs
+++ b/runtime-modules/common/src/council.rs
@@ -10,11 +10,12 @@ pub trait CouncilBudgetManager<AccountId, Balance: Saturating> {
     fn set_budget(budget: Balance);
 
     /// Remove some balance from the council budget and transfer it to the account. Fallible.
-    fn try_transfer(account_id: &AccountId, amount: Balance) -> DispatchResult;
+    fn try_withdraw(account_id: &AccountId, amount: Balance) -> DispatchResult;
 
     /// Remove some balance from the council budget and transfer it to the account. Infallible.
-    fn transfer(account_id: &AccountId, amount: Balance) {
-        let _ = Self::try_transfer(account_id, amount);
+    /// No side-effects on insufficient council balance.
+    fn withdraw(account_id: &AccountId, amount: Balance) {
+        let _ = Self::try_withdraw(account_id, amount);
     }
 
     /// Increase the current budget value up to specified amount.

--- a/runtime-modules/common/src/council.rs
+++ b/runtime-modules/common/src/council.rs
@@ -1,12 +1,21 @@
 use frame_support::dispatch::DispatchResult;
 
 /// Provides an interface for the council budget.
-pub trait CouncilBudgetManager<Balance> {
+pub trait CouncilBudgetManager<AccountId, Balance> {
     /// Returns the current council balance.
     fn get_budget() -> Balance;
 
     /// Set the current budget value.
     fn set_budget(budget: Balance);
+
+    /// Remove some balance from the council budget and transfer it to the account. Fallible.
+    fn try_transfer(account_id: &AccountId, amount: Balance) -> DispatchResult;
+
+    /// Remove some balance from the council budget and transfer it to the account. Infallible.
+    fn transfer(account_id: &AccountId, amount: Balance);
+
+    /// Increase the current budget value up to specified amount.
+    fn increase_budget(amount: Balance);
 }
 
 /// Council validator for the origin(account_id) and member_id.

--- a/runtime-modules/common/src/council.rs
+++ b/runtime-modules/common/src/council.rs
@@ -1,7 +1,8 @@
 use frame_support::dispatch::DispatchResult;
+use sp_arithmetic::traits::Saturating;
 
 /// Provides an interface for the council budget.
-pub trait CouncilBudgetManager<AccountId, Balance> {
+pub trait CouncilBudgetManager<AccountId, Balance: Saturating> {
     /// Returns the current council balance.
     fn get_budget() -> Balance;
 
@@ -12,10 +13,17 @@ pub trait CouncilBudgetManager<AccountId, Balance> {
     fn try_transfer(account_id: &AccountId, amount: Balance) -> DispatchResult;
 
     /// Remove some balance from the council budget and transfer it to the account. Infallible.
-    fn transfer(account_id: &AccountId, amount: Balance);
+    fn transfer(account_id: &AccountId, amount: Balance) {
+        let _ = Self::try_transfer(account_id, amount);
+    }
 
     /// Increase the current budget value up to specified amount.
-    fn increase_budget(amount: Balance);
+    fn increase_budget(amount: Balance) {
+        let current_budget = Self::get_budget();
+        let new_budget = current_budget.saturating_add(amount);
+
+        Self::set_budget(new_budget);
+    }
 }
 
 /// Council validator for the origin(account_id) and member_id.

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -66,6 +66,8 @@ mod benchmarking;
 mod mock;
 mod tests;
 
+type Balances<T> = balances::Module<T>;
+
 /////////////////// Data Structures ////////////////////////////////////////////
 
 /// Information about council's current state and when it changed the last time.

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -1742,17 +1742,4 @@ impl<T: Trait + balances::Trait> common::council::CouncilBudgetManager<T::Accoun
 
         Ok(())
     }
-
-    fn transfer(account_id: &T::AccountId, amount: Balance<T>) {
-        let _ = Self::try_transfer(account_id, amount);
-    }
-
-    fn increase_budget(amount: Balance<T>) {
-        let current_budget = Self::get_budget();
-        let new_budget = current_budget.saturating_add(amount);
-
-        <Self as common::council::CouncilBudgetManager<T::AccountId, Balance<T>>>::set_budget(
-            new_budget,
-        );
-    }
 }

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -1726,7 +1726,7 @@ impl<T: Trait + balances::Trait> common::council::CouncilBudgetManager<T::Accoun
         Mutations::<T>::set_budget(budget);
     }
 
-    fn try_transfer(account_id: &T::AccountId, amount: Balance<T>) -> DispatchResult {
+    fn try_withdraw(account_id: &T::AccountId, amount: Balance<T>) -> DispatchResult {
         ensure!(
             Self::get_budget() >= amount,
             Error::<T>::InsufficientBalanceForTransfer

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -476,6 +476,9 @@ decl_error! {
 
         /// Candidate id not found
         CandidateDoesNotExist,
+
+        /// Cannot transfer: insufficient budget balance.
+        InsufficientBalanceForTransfer,
     }
 }
 
@@ -1712,12 +1715,44 @@ impl<T: Trait + common::membership::MembershipTypes>
     }
 }
 
-impl<T: Trait + balances::Trait> common::council::CouncilBudgetManager<Balance<T>> for Module<T> {
+impl<T: Trait + balances::Trait> common::council::CouncilBudgetManager<T::AccountId, Balance<T>>
+    for Module<T>
+{
     fn get_budget() -> Balance<T> {
         Self::budget()
     }
 
     fn set_budget(budget: Balance<T>) {
         Mutations::<T>::set_budget(budget);
+    }
+
+    fn try_transfer(account_id: &T::AccountId, amount: Balance<T>) -> DispatchResult {
+        ensure!(
+            Self::get_budget() >= amount,
+            Error::<T>::InsufficientBalanceForTransfer
+        );
+
+        let _ = Balances::<T>::deposit_creating(account_id, amount);
+
+        let current_budget = Self::get_budget();
+        let new_budget = current_budget.saturating_sub(amount);
+        <Self as common::council::CouncilBudgetManager<T::AccountId, Balance<T>>>::set_budget(
+            new_budget,
+        );
+
+        Ok(())
+    }
+
+    fn transfer(account_id: &T::AccountId, amount: Balance<T>) {
+        let _ = Self::try_transfer(account_id, amount);
+    }
+
+    fn increase_budget(amount: Balance<T>) {
+        let current_budget = Self::get_budget();
+        let new_budget = current_budget.saturating_add(amount);
+
+        <Self as common::council::CouncilBudgetManager<T::AccountId, Balance<T>>>::set_budget(
+            new_budget,
+        );
     }
 }

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1793,14 +1793,14 @@ fn test_council_budget_manager_works_correctlyl() {
         Mocks::set_budget(origin.clone(), initial_budget, Ok(()));
 
         assert_eq!(
-            <Module<Runtime> as CouncilBudgetManager<u64>>::get_budget(),
+            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
             initial_budget
         );
 
         let new_budget = 200;
-        <Module<Runtime> as CouncilBudgetManager<u64>>::set_budget(new_budget);
+        <Module<Runtime> as CouncilBudgetManager<u64, u64>>::set_budget(new_budget);
         assert_eq!(
-            <Module<Runtime> as CouncilBudgetManager<u64>>::get_budget(),
+            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
             new_budget
         );
     });

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1813,13 +1813,13 @@ fn test_council_budget_manager_works_correctly() {
 
         let account_id = 11;
         let transfer_amount = 100;
-        <Module<Runtime> as CouncilBudgetManager<u64, u64>>::transfer(&account_id, transfer_amount);
+        <Module<Runtime> as CouncilBudgetManager<u64, u64>>::withdraw(&account_id, transfer_amount);
         assert_eq!(
             <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
             new_budget + increase_amount - transfer_amount
         );
 
-        let res = <Module<Runtime> as CouncilBudgetManager<u64, u64>>::try_transfer(
+        let res = <Module<Runtime> as CouncilBudgetManager<u64, u64>>::try_withdraw(
             &account_id,
             transfer_amount,
         );
@@ -1830,7 +1830,7 @@ fn test_council_budget_manager_works_correctly() {
         );
 
         let incorrect_amount = 1000;
-        let res = <Module<Runtime> as CouncilBudgetManager<u64, u64>>::try_transfer(
+        let res = <Module<Runtime> as CouncilBudgetManager<u64, u64>>::try_withdraw(
             &account_id,
             incorrect_amount,
         );

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1783,7 +1783,7 @@ fn test_funding_request_succeeds() {
 }
 
 #[test]
-fn test_council_budget_manager_works_correctlyl() {
+fn test_council_budget_manager_works_correctly() {
     let config = default_genesis_config();
 
     build_test_externalities(config).execute_with(|| {
@@ -1802,6 +1802,45 @@ fn test_council_budget_manager_works_correctlyl() {
         assert_eq!(
             <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
             new_budget
+        );
+
+        let increase_amount = 100;
+        <Module<Runtime> as CouncilBudgetManager<u64, u64>>::increase_budget(increase_amount);
+        assert_eq!(
+            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
+            new_budget + increase_amount
+        );
+
+        let account_id = 11;
+        let transfer_amount = 100;
+        <Module<Runtime> as CouncilBudgetManager<u64, u64>>::transfer(&account_id, transfer_amount);
+        assert_eq!(
+            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
+            new_budget + increase_amount - transfer_amount
+        );
+
+        let res = <Module<Runtime> as CouncilBudgetManager<u64, u64>>::try_transfer(
+            &account_id,
+            transfer_amount,
+        );
+        assert!(res.is_ok());
+        assert_eq!(
+            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
+            new_budget + increase_amount - transfer_amount - transfer_amount
+        );
+
+        let incorrect_amount = 1000;
+        let res = <Module<Runtime> as CouncilBudgetManager<u64, u64>>::try_transfer(
+            &account_id,
+            incorrect_amount,
+        );
+        assert_eq!(
+            res,
+            Err(Error::<Runtime>::InsufficientBalanceForTransfer.into())
+        );
+        assert_eq!(
+            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
+            new_budget + increase_amount - transfer_amount - transfer_amount
         );
     });
 }


### PR DESCRIPTION
We need to refactor the council budget handling to reduce code duplication.

#### Changes
- added new methods for the `CouncilBudgetManager` trait:
  - try_transfer
  - transfer
  - increase_budget
- changed the `bounty` palelt to use new methods

[Original issue](https://github.com/Joystream/joystream/issues/3496) 