### PR TITLE
Rhodes NFT bid tests fix

### DIFF
--- a/runtime-modules/content/src/tests/nft/make_bid.rs
+++ b/runtime-modules/content/src/tests/nft/make_bid.rs
@@ -64,9 +64,9 @@ fn setup_english_auction_scenario() {
         starting_price: Content::min_starting_price(),
         buy_now_price: Some(DEFAULT_BUY_NOW_PRICE),
         extension_period: Content::min_auction_extension_period(),
-        auction_duration: Content::min_auction_duration(),
         min_bid_step: Content::min_bid_step(),
-        end: DEFAULT_AUCTION_END,
+        starts_at: None,
+        duration: AUCTION_DURATION,
         whitelist: BTreeSet::new(),
     };
 


### PR DESCRIPTION
A recent PR https://github.com/Joystream/joystream/pull/3506 introduced a runtime module test that hadn't reflected changes regarding NFT auctions done in https://github.com/Joystream/joystream/pull/3490. It slipped into `rhodes` branch and breaks `content` runtime module tests. For example, see https://github.com/Joystream/joystream/runs/5758766706?check_suite_focus=true. This PR fixes the problem.