### PR TITLE
Rhodes.Runtime: revert council budget refactoring.

### DIFF
--- a/runtime-modules/bounty/src/actors.rs
+++ b/runtime-modules/bounty/src/actors.rs
@@ -9,6 +9,7 @@ use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_support::ensure;
 use frame_support::traits::Currency;
 use frame_system::ensure_root;
+use sp_arithmetic::traits::Saturating;
 
 use common::council::CouncilBudgetManager;
 use common::membership::{MemberId, MemberOriginValidator, MembershipInfoProvider};
@@ -148,8 +149,13 @@ impl<T: Trait> BountyActorManager<T> {
 
     // Remove some balance from the council budget and transfer it to the bounty account.
     fn transfer_balance_from_council_budget(bounty_id: T::BountyId, amount: BalanceOf<T>) {
+        let budget = T::CouncilBudgetManager::get_budget();
+        let new_budget = budget.saturating_sub(amount);
+
+        T::CouncilBudgetManager::set_budget(new_budget);
+
         let bounty_account_id = Module::<T>::bounty_account_id(bounty_id);
-        T::CouncilBudgetManager::withdraw(&bounty_account_id, amount);
+        let _ = balances::Module::<T>::deposit_creating(&bounty_account_id, amount);
     }
 
     // Add some balance from the council budget and slash from the bounty account.
@@ -157,6 +163,9 @@ impl<T: Trait> BountyActorManager<T> {
         let bounty_account_id = Module::<T>::bounty_account_id(bounty_id);
         let _ = balances::Module::<T>::slash(&bounty_account_id, amount);
 
-        T::CouncilBudgetManager::increase_budget(amount);
+        let budget = T::CouncilBudgetManager::get_budget();
+        let new_budget = budget.saturating_add(amount);
+
+        T::CouncilBudgetManager::set_budget(new_budget);
     }
 }

--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -129,7 +129,7 @@ pub trait Trait:
     type WeightInfo: WeightInfo;
 
     /// Provides an access for the council budget.
-    type CouncilBudgetManager: CouncilBudgetManager<Self::AccountId, BalanceOf<Self>>;
+    type CouncilBudgetManager: CouncilBudgetManager<BalanceOf<Self>>;
 
     /// Provides stake logic implementation.
     type StakingHandler: StakingHandler<

--- a/runtime-modules/bounty/src/tests/fixtures.rs
+++ b/runtime-modules/bounty/src/tests/fixtures.rs
@@ -26,11 +26,11 @@ pub fn run_to_block(n: u64) {
 }
 
 pub fn set_council_budget(new_budget: u64) {
-    <super::mocks::CouncilBudgetManager as CouncilBudgetManager<u128, u64>>::set_budget(new_budget);
+    <super::mocks::CouncilBudgetManager as CouncilBudgetManager<u64>>::set_budget(new_budget);
 }
 
 pub fn get_council_budget() -> u64 {
-    <super::mocks::CouncilBudgetManager as CouncilBudgetManager<u128, u64>>::get_budget()
+    <super::mocks::CouncilBudgetManager as CouncilBudgetManager<u64>>::get_budget()
 }
 
 pub fn increase_total_balance_issuance_using_account_id(account_id: u128, balance: u64) {

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -125,7 +125,7 @@ impl common::membership::MembershipInfoProvider<Test> for () {
 
 pub const COUNCIL_BUDGET_ACCOUNT_ID: u128 = 90000000;
 pub struct CouncilBudgetManager;
-impl common::council::CouncilBudgetManager<u128, u64> for CouncilBudgetManager {
+impl common::council::CouncilBudgetManager<u64> for CouncilBudgetManager {
     fn get_budget() -> u64 {
         balances::Module::<Test>::usable_balance(&COUNCIL_BUDGET_ACCOUNT_ID)
     }
@@ -144,16 +144,6 @@ impl common::council::CouncilBudgetManager<u128, u64> for CouncilBudgetManager {
             let _ =
                 balances::Module::<Test>::slash(&COUNCIL_BUDGET_ACCOUNT_ID, old_budget - budget);
         }
-    }
-
-    fn try_withdraw(account_id: &u128, amount: u64) -> DispatchResult {
-        let _ = Balances::deposit_creating(account_id, amount);
-
-        let current_budget = Self::get_budget();
-        let new_budget = current_budget.saturating_sub(amount);
-        Self::set_budget(new_budget);
-
-        Ok(())
     }
 }
 

--- a/runtime-modules/common/src/council.rs
+++ b/runtime-modules/common/src/council.rs
@@ -2,29 +2,12 @@ use frame_support::dispatch::DispatchResult;
 use sp_arithmetic::traits::Saturating;
 
 /// Provides an interface for the council budget.
-pub trait CouncilBudgetManager<AccountId, Balance: Saturating> {
+pub trait CouncilBudgetManager<Balance> {
     /// Returns the current council balance.
     fn get_budget() -> Balance;
 
     /// Set the current budget value.
     fn set_budget(budget: Balance);
-
-    /// Remove some balance from the council budget and transfer it to the account. Fallible.
-    fn try_withdraw(account_id: &AccountId, amount: Balance) -> DispatchResult;
-
-    /// Remove some balance from the council budget and transfer it to the account. Infallible.
-    /// No side-effects on insufficient council balance.
-    fn withdraw(account_id: &AccountId, amount: Balance) {
-        let _ = Self::try_withdraw(account_id, amount);
-    }
-
-    /// Increase the current budget value up to specified amount.
-    fn increase_budget(amount: Balance) {
-        let current_budget = Self::get_budget();
-        let new_budget = current_budget.saturating_add(amount);
-
-        Self::set_budget(new_budget);
-    }
 }
 
 /// Council validator for the origin(account_id) and member_id.

--- a/runtime-modules/common/src/council.rs
+++ b/runtime-modules/common/src/council.rs
@@ -1,5 +1,4 @@
 use frame_support::dispatch::DispatchResult;
-use sp_arithmetic::traits::Saturating;
 
 /// Provides an interface for the council budget.
 pub trait CouncilBudgetManager<Balance> {

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -1722,4 +1722,17 @@ impl<T: Trait + balances::Trait> common::council::CouncilBudgetManager<Balance<T
     fn set_budget(budget: Balance<T>) {
         Mutations::<T>::set_budget(budget);
     }
+
+    fn transfer(account_id: &T::AccountId, amount: Balance<T>) {
+        let _ = Self::try_transfer(account_id, amount);
+    }
+
+    fn increase_budget(amount: Balance<T>) {
+        let current_budget = Self::get_budget();
+        let new_budget = current_budget.saturating_add(amount);
+
+        <Self as common::council::CouncilBudgetManager<T::AccountId, Balance<T>>>::set_budget(
+            new_budget,
+        );
+    }
 }

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -1723,9 +1723,11 @@ impl<T: Trait + balances::Trait> common::council::CouncilBudgetManager<Balance<T
         Mutations::<T>::set_budget(budget);
     }
 
-    fn transfer(account_id: &T::AccountId, amount: Balance<T>) {
-        let _ = Self::try_transfer(account_id, amount);
-    }
+    fn try_transfer(account_id: &T::AccountId, amount: Balance<T>) -> DispatchResult {
+        ensure!(
+            Self::get_budget() >= amount,
+            Error::<T>::InsufficientBalanceForTransfer
+        );
 
     fn increase_budget(amount: Balance<T>) {
         let current_budget = Self::get_budget();

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -478,9 +478,6 @@ decl_error! {
 
         /// Candidate id not found
         CandidateDoesNotExist,
-
-        /// Cannot transfer: insufficient budget balance.
-        InsufficientBalanceForTransfer,
     }
 }
 
@@ -1717,31 +1714,12 @@ impl<T: Trait + common::membership::MembershipTypes>
     }
 }
 
-impl<T: Trait + balances::Trait> common::council::CouncilBudgetManager<T::AccountId, Balance<T>>
-    for Module<T>
-{
+impl<T: Trait + balances::Trait> common::council::CouncilBudgetManager<Balance<T>> for Module<T> {
     fn get_budget() -> Balance<T> {
         Self::budget()
     }
 
     fn set_budget(budget: Balance<T>) {
         Mutations::<T>::set_budget(budget);
-    }
-
-    fn try_withdraw(account_id: &T::AccountId, amount: Balance<T>) -> DispatchResult {
-        ensure!(
-            Self::get_budget() >= amount,
-            Error::<T>::InsufficientBalanceForTransfer
-        );
-
-        let _ = Balances::<T>::deposit_creating(account_id, amount);
-
-        let current_budget = Self::get_budget();
-        let new_budget = current_budget.saturating_sub(amount);
-        <Self as common::council::CouncilBudgetManager<T::AccountId, Balance<T>>>::set_budget(
-            new_budget,
-        );
-
-        Ok(())
     }
 }

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -66,8 +66,6 @@ mod benchmarking;
 mod mock;
 mod tests;
 
-type Balances<T> = balances::Module<T>;
-
 /////////////////// Data Structures ////////////////////////////////////////////
 
 /// Information about council's current state and when it changed the last time.

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -1720,19 +1720,4 @@ impl<T: Trait + balances::Trait> common::council::CouncilBudgetManager<Balance<T
     fn set_budget(budget: Balance<T>) {
         Mutations::<T>::set_budget(budget);
     }
-
-    fn try_transfer(account_id: &T::AccountId, amount: Balance<T>) -> DispatchResult {
-        ensure!(
-            Self::get_budget() >= amount,
-            Error::<T>::InsufficientBalanceForTransfer
-        );
-
-    fn increase_budget(amount: Balance<T>) {
-        let current_budget = Self::get_budget();
-        let new_budget = current_budget.saturating_add(amount);
-
-        <Self as common::council::CouncilBudgetManager<T::AccountId, Balance<T>>>::set_budget(
-            new_budget,
-        );
-    }
 }

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1793,14 +1793,14 @@ fn test_council_budget_manager_works_correctly() {
         Mocks::set_budget(origin.clone(), initial_budget, Ok(()));
 
         assert_eq!(
-            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
+            <Module<Runtime> as CouncilBudgetManager<u64>>::get_budget(),
             initial_budget
         );
 
         let new_budget = 200;
-        <Module<Runtime> as CouncilBudgetManager<u64, u64>>::set_budget(new_budget);
+        <Module<Runtime> as CouncilBudgetManager<u64>>::set_budget(new_budget);
         assert_eq!(
-            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
+            <Module<Runtime> as CouncilBudgetManager<u64>>::get_budget(),
             new_budget
         );
 

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -1783,7 +1783,7 @@ fn test_funding_request_succeeds() {
 }
 
 #[test]
-fn test_council_budget_manager_works_correctly() {
+fn test_council_budget_manager_works_correctlyl() {
     let config = default_genesis_config();
 
     build_test_externalities(config).execute_with(|| {
@@ -1802,45 +1802,6 @@ fn test_council_budget_manager_works_correctly() {
         assert_eq!(
             <Module<Runtime> as CouncilBudgetManager<u64>>::get_budget(),
             new_budget
-        );
-
-        let increase_amount = 100;
-        <Module<Runtime> as CouncilBudgetManager<u64, u64>>::increase_budget(increase_amount);
-        assert_eq!(
-            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
-            new_budget + increase_amount
-        );
-
-        let account_id = 11;
-        let transfer_amount = 100;
-        <Module<Runtime> as CouncilBudgetManager<u64, u64>>::withdraw(&account_id, transfer_amount);
-        assert_eq!(
-            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
-            new_budget + increase_amount - transfer_amount
-        );
-
-        let res = <Module<Runtime> as CouncilBudgetManager<u64, u64>>::try_withdraw(
-            &account_id,
-            transfer_amount,
-        );
-        assert!(res.is_ok());
-        assert_eq!(
-            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
-            new_budget + increase_amount - transfer_amount - transfer_amount
-        );
-
-        let incorrect_amount = 1000;
-        let res = <Module<Runtime> as CouncilBudgetManager<u64, u64>>::try_withdraw(
-            &account_id,
-            incorrect_amount,
-        );
-        assert_eq!(
-            res,
-            Err(Error::<Runtime>::InsufficientBalanceForTransfer.into())
-        );
-        assert_eq!(
-            <Module<Runtime> as CouncilBudgetManager<u64, u64>>::get_budget(),
-            new_budget + increase_amount - transfer_amount - transfer_amount
         );
     });
 }


### PR DESCRIPTION
This PR reverts the changes of the council budget refactoring [PR](https://github.com/Joystream/joystream/pull/3518).