### PR TITLE
Ephesus. Runtime. Working group budget refactoring

### DIFF
--- a/runtime-modules/blog/src/mock.rs
+++ b/runtime-modules/blog/src/mock.rs
@@ -124,16 +124,6 @@ impl staking_handler::LockComparator<u64> for Runtime {
     }
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Runtime> for () {
-    fn get_budget() -> u64 {
-        unimplemented!();
-    }
-
-    fn set_budget(_: u64) {
-        unimplemented!()
-    }
-}
-
 impl common::working_group::WorkingGroupAuthenticator<Runtime> for () {
     fn ensure_worker_origin(
         _origin: <Runtime as frame_system::Trait>::Origin,

--- a/runtime-modules/blog/src/mock.rs
+++ b/runtime-modules/blog/src/mock.rs
@@ -99,7 +99,7 @@ impl membership::Trait for Runtime {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type WeightInfo = Weights;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InviteMemberLockId>;
     type ReferralCutMaximumPercent = ReferralCutMaximumPercent;
@@ -124,7 +124,21 @@ impl staking_handler::LockComparator<u64> for Runtime {
     }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Runtime> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u128, u64> for Wg {
+    fn get_budget() -> u64 {
+        unimplemented!()
+    }
+
+    fn set_budget(_new_value: u64) {
+        unimplemented!()
+    }
+
+    fn try_withdraw(_account_id: &u128, _amount: u64) -> DispatchResult {
+        unimplemented!()
+    }
+}
+impl common::working_group::WorkingGroupAuthenticator<Runtime> for Wg {
     fn ensure_worker_origin(
         _origin: <Runtime as frame_system::Trait>::Origin,
         _worker_id: &<Runtime as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/bounty/src/tests/mocks.rs
+++ b/runtime-modules/bounty/src/tests/mocks.rs
@@ -328,7 +328,7 @@ impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type ReferralCutMaximumPercent = ReferralCutMaximumPercent;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
     type StakingCandidateStakingHandler =
@@ -347,7 +347,8 @@ impl LockComparator<<Test as balances::Trait>::Balance> for Test {
     }
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u128, u64> for Wg {
     fn get_budget() -> u64 {
         unimplemented!()
     }
@@ -355,9 +356,13 @@ impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
     fn set_budget(_new_value: u64) {
         unimplemented!()
     }
+
+    fn try_withdraw(_account_id: &u128, _amount: u64) -> DispatchResult {
+        unimplemented!()
+    }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Test> for () {
+impl common::working_group::WorkingGroupAuthenticator<Test> for Wg {
     fn ensure_worker_origin(
         _origin: <Test as frame_system::Trait>::Origin,
         _worker_id: &<Test as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/common/src/council.rs
+++ b/runtime-modules/common/src/council.rs
@@ -1,31 +1,7 @@
 use frame_support::dispatch::DispatchResult;
-use sp_arithmetic::traits::Saturating;
 
 /// Provides an interface for the council budget.
-pub trait CouncilBudgetManager<AccountId, Balance: Saturating> {
-    /// Returns the current council balance.
-    fn get_budget() -> Balance;
-
-    /// Set the current budget value.
-    fn set_budget(budget: Balance);
-
-    /// Remove some balance from the council budget and transfer it to the account. Fallible.
-    fn try_withdraw(account_id: &AccountId, amount: Balance) -> DispatchResult;
-
-    /// Remove some balance from the council budget and transfer it to the account. Infallible.
-    /// No side-effects on insufficient council balance.
-    fn withdraw(account_id: &AccountId, amount: Balance) {
-        let _ = Self::try_withdraw(account_id, amount);
-    }
-
-    /// Increase the current budget value up to specified amount.
-    fn increase_budget(amount: Balance) {
-        let current_budget = Self::get_budget();
-        let new_budget = current_budget.saturating_add(amount);
-
-        Self::set_budget(new_budget);
-    }
-}
+pub use crate::BudgetManager as CouncilBudgetManager;
 
 /// Council validator for the origin(account_id) and member_id.
 pub trait CouncilOriginValidator<Origin, MemberId, AccountId> {

--- a/runtime-modules/common/src/working_group.rs
+++ b/runtime-modules/common/src/working_group.rs
@@ -60,11 +60,5 @@ pub trait WorkingGroupAuthenticator<T: crate::MembershipTypes> {
     fn ensure_worker_exists(worker_id: &T::ActorId) -> DispatchResult;
 }
 
-/// Working group interface to work with the its budget.
-pub trait WorkingGroupBudgetHandler<T: balances::Trait> {
-    /// Returns current working group balance.
-    fn get_budget() -> T::Balance;
-
-    /// Sets new working broup balance
-    fn set_budget(new_value: T::Balance);
-}
+/// Provides an interface for the working group budget.
+pub use crate::BudgetManager as WorkingGroupBudgetHandler;

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -10,7 +10,6 @@ use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup},
     ModuleId, Perbill,
 };
-use sp_std::cell::RefCell;
 use staking_handler::LockComparator;
 
 use crate::ContentActorAuthenticator;
@@ -537,7 +536,7 @@ impl membership::Trait for Test {
     type Event = MetaEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type ReferralCutMaximumPercent = ReferralCutMaximumPercent;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
     type StakingCandidateStakingHandler =
@@ -546,26 +545,22 @@ impl membership::Trait for Test {
     type WeightInfo = ();
 }
 
-pub const WORKING_GROUP_BUDGET: u64 = 100;
-
-thread_local! {
-    pub static WG_BUDGET: RefCell<u64> = RefCell::new(WORKING_GROUP_BUDGET);
-    pub static LEAD_SET: RefCell<bool> = RefCell::new(bool::default());
-}
-
-impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for Wg {
     fn get_budget() -> u64 {
-        WG_BUDGET.with(|val| *val.borrow())
+        unimplemented!()
     }
 
-    fn set_budget(new_value: u64) {
-        WG_BUDGET.with(|val| {
-            *val.borrow_mut() = new_value;
-        });
+    fn set_budget(_new_value: u64) {
+        unimplemented!()
+    }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
+        unimplemented!()
     }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Test> for () {
+impl common::working_group::WorkingGroupAuthenticator<Test> for Wg {
     fn ensure_worker_origin(
         _origin: <Test as frame_system::Trait>::Origin,
         _worker_id: &<Test as common::membership::MembershipTypes>::ActorId,
@@ -635,6 +630,34 @@ impl MembershipInfoProvider<Test> for MemberInfoProvider {
 // working group integration
 pub struct StorageWG;
 pub struct DistributionWG;
+
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for StorageWG {
+    fn get_budget() -> u64 {
+        unimplemented!()
+    }
+
+    fn set_budget(_new_value: u64) {
+        unimplemented!()
+    }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
+        unimplemented!()
+    }
+}
+
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for DistributionWG {
+    fn get_budget() -> u64 {
+        unimplemented!()
+    }
+
+    fn set_budget(_new_value: u64) {
+        unimplemented!()
+    }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
+        unimplemented!()
+    }
+}
 
 impl common::working_group::WorkingGroupAuthenticator<Test> for StorageWG {
     fn ensure_worker_origin(
@@ -743,25 +766,5 @@ impl common::working_group::WorkingGroupAuthenticator<Test> for DistributionWG {
             DispatchError::Other("Invailid worker"),
         );
         Ok(())
-    }
-}
-
-impl common::working_group::WorkingGroupBudgetHandler<Test> for StorageWG {
-    fn get_budget() -> u64 {
-        unimplemented!()
-    }
-
-    fn set_budget(_new_value: u64) {
-        unimplemented!()
-    }
-}
-
-impl common::working_group::WorkingGroupBudgetHandler<Test> for DistributionWG {
-    fn get_budget() -> u64 {
-        unimplemented!()
-    }
-
-    fn set_budget(_new_value: u64) {
-        unimplemented!()
     }
 }

--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -479,7 +479,7 @@ decl_error! {
         /// Candidate id not found
         CandidateDoesNotExist,
 
-        /// Cannot transfer: insufficient budget balance.
+        /// Cannot withdraw: insufficient budget balance.
         InsufficientBalanceForTransfer,
     }
 }

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -461,12 +461,16 @@ impl membership::Trait for Runtime {
     type CandidateStake = CandidateStake;
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Runtime> for () {
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for () {
     fn get_budget() -> u64 {
         unimplemented!()
     }
 
     fn set_budget(_new_value: u64) {
+        unimplemented!()
+    }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
         unimplemented!()
     }
 }

--- a/runtime-modules/council/src/mock.rs
+++ b/runtime-modules/council/src/mock.rs
@@ -451,7 +451,7 @@ impl balances::Trait for Runtime {
 impl membership::Trait for Runtime {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
@@ -461,7 +461,8 @@ impl membership::Trait for Runtime {
     type CandidateStake = CandidateStake;
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for Wg {
     fn get_budget() -> u64 {
         unimplemented!()
     }
@@ -475,7 +476,7 @@ impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for () {
     }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Runtime> for () {
+impl common::working_group::WorkingGroupAuthenticator<Runtime> for Wg {
     fn ensure_worker_origin(
         _origin: <Runtime as frame_system::Trait>::Origin,
         _worker_id: &<Runtime as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -298,7 +298,11 @@ thread_local! {
     pub static WG_BUDGET: RefCell<u64> = RefCell::new(WORKING_GROUP_BUDGET);
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Runtime> for () {
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for () {
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
+        unimplemented!()
+    }
+
     fn get_budget() -> u64 {
         WG_BUDGET.with(|val| *val.borrow())
     }

--- a/runtime-modules/forum/src/mock.rs
+++ b/runtime-modules/forum/src/mock.rs
@@ -298,8 +298,9 @@ thread_local! {
     pub static WG_BUDGET: RefCell<u64> = RefCell::new(WORKING_GROUP_BUDGET);
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for () {
-    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u128, u64> for Wg {
+    fn try_withdraw(_account_id: &u128, _amount: u64) -> DispatchResult {
         unimplemented!()
     }
 
@@ -318,7 +319,7 @@ impl membership::Trait for Runtime {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type WeightInfo = Weights;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InviteMemberLockId>;
     type ReferralCutMaximumPercent = ReferralCutMaximumPercent;
@@ -359,7 +360,7 @@ impl Trait for Runtime {
     type PostLifeTime = PostLifeTime;
 
     type MapLimits = MapLimits;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type MemberOriginValidator = ();
     type ThreadDeposit = ThreadDeposit;
     type PostDeposit = PostDeposit;
@@ -404,7 +405,7 @@ impl common::membership::MemberOriginValidator<Origin, u128, u128> for () {
     }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Runtime> for () {
+impl common::working_group::WorkingGroupAuthenticator<Runtime> for Wg {
     fn ensure_worker_origin(
         _origin: <Runtime as frame_system::Trait>::Origin,
         _worker_id: &<Runtime as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/membership/src/benchmarking.rs
+++ b/runtime-modules/membership/src/benchmarking.rs
@@ -14,7 +14,7 @@ use frame_system::Module as System;
 use frame_system::{EventRecord, RawOrigin};
 use sp_arithmetic::traits::One;
 use sp_arithmetic::Perbill;
-use sp_runtime::traits::Bounded;
+use sp_runtime::traits::{Bounded, Saturating};
 use sp_std::prelude::*;
 use sp_std::vec;
 

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -114,7 +114,7 @@ pub trait Trait:
 
     /// Working group pallet integration.
     type WorkingGroup: common::working_group::WorkingGroupAuthenticator<Self>
-        + common::working_group::WorkingGroupBudgetHandler<Self>;
+        + common::working_group::WorkingGroupBudgetHandler<Self::AccountId, BalanceOf<Self>>;
 
     /// Defines the default balance for the invited member.
     type DefaultInitialInvitationBalance: Get<BalanceOf<Self>>;

--- a/runtime-modules/membership/src/lib.rs
+++ b/runtime-modules/membership/src/lib.rs
@@ -57,7 +57,7 @@ use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure};
 use frame_system::{ensure_root, ensure_signed};
 use sp_arithmetic::traits::{One, Zero};
 use sp_arithmetic::Perbill;
-use sp_runtime::traits::{Hash, Saturating};
+use sp_runtime::traits::Hash;
 use sp_runtime::SaturatedConversion;
 use sp_std::vec::Vec;
 
@@ -745,15 +745,8 @@ decl_module! {
                 membership.invites = membership.invites.saturating_sub(1);
             });
 
-            // Decrease the working group balance.
-            let new_wg_budget = current_wg_budget.saturating_sub(invitation_balance);
-            T::WorkingGroup::set_budget(new_wg_budget);
-
-            // Create default balance for the invited member.
-            let _ = balances::Module::<T>::deposit_creating(
-                &params.controller_account,
-                invitation_balance
-            );
+            // Transfer the balance from tne WG budget to the controller account.
+            T::WorkingGroup::withdraw(&params.controller_account, invitation_balance);
 
             // Lock invitation balance. Allow only transaction payments.
             T::InvitedMemberStakingHandler::lock_with_reasons(

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -314,7 +314,7 @@ impl Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
     type ReferralCutMaximumPercent = ReferralCutMaximumPercent;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
     type StakingCandidateStakingHandler =
@@ -330,7 +330,8 @@ thread_local! {
     pub static LEAD_SET: RefCell<bool> = RefCell::new(bool::default());
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for Wg {
     fn get_budget() -> u64 {
         WG_BUDGET.with(|val| *val.borrow())
     }
@@ -340,9 +341,13 @@ impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
             *val.borrow_mut() = new_value;
         });
     }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> frame_support::dispatch::DispatchResult {
+        todo!()
+    }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Test> for () {
+impl common::working_group::WorkingGroupAuthenticator<Test> for Wg {
     fn ensure_worker_origin(
         origin: <Test as frame_system::Trait>::Origin,
         worker_id: &<Test as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -144,7 +144,7 @@ impl membership::WeightInfo for Weights {
 impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
@@ -154,7 +154,8 @@ impl membership::Trait for Test {
     type CandidateStake = CandidateStake;
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for Wg {
     fn get_budget() -> u64 {
         unimplemented!()
     }
@@ -162,9 +163,13 @@ impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
     fn set_budget(_new_value: u64) {
         unimplemented!()
     }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
+        unimplemented!()
+    }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Test> for () {
+impl common::working_group::WorkingGroupAuthenticator<Test> for Wg {
     fn ensure_worker_origin(
         _origin: <Test as frame_system::Trait>::Origin,
         _worker_id: &<Test as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/proposals/discussion/src/tests/mock.rs
+++ b/runtime-modules/proposals/discussion/src/tests/mock.rs
@@ -167,7 +167,7 @@ parameter_types! {
 impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
@@ -186,7 +186,8 @@ impl LockComparator<<Test as balances::Trait>::Balance> for Test {
     }
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u128, u64> for Wg {
     fn get_budget() -> u64 {
         unimplemented!()
     }
@@ -194,9 +195,13 @@ impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
     fn set_budget(_new_value: u64) {
         unimplemented!()
     }
+
+    fn try_withdraw(_account_id: &u128, _amount: u64) -> DispatchResult {
+        unimplemented!()
+    }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Test> for () {
+impl common::working_group::WorkingGroupAuthenticator<Test> for Wg {
     fn ensure_worker_origin(
         _origin: <Test as frame_system::Trait>::Origin,
         _worker_id: &<Test as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/proposals/engine/src/tests/mock/mod.rs
+++ b/runtime-modules/proposals/engine/src/tests/mock/mod.rs
@@ -256,7 +256,7 @@ impl membership::WeightInfo for Weights {
 impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
@@ -266,7 +266,8 @@ impl membership::Trait for Test {
     type CandidateStake = CandidateStake;
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for Wg {
     fn get_budget() -> u64 {
         unimplemented!()
     }
@@ -274,9 +275,13 @@ impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
     fn set_budget(_new_value: u64) {
         unimplemented!()
     }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
+        unimplemented!()
+    }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Test> for () {
+impl common::working_group::WorkingGroupAuthenticator<Test> for Wg {
     fn ensure_worker_origin(
         _origin: <Test as frame_system::Trait>::Origin,
         _worker_id: &<Test as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -262,12 +262,16 @@ impl pallet_timestamp::Trait for Runtime {
     type WeightInfo = ();
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Runtime> for () {
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for () {
     fn get_budget() -> u64 {
         unimplemented!()
     }
 
     fn set_budget(_new_value: u64) {
+        unimplemented!()
+    }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
         unimplemented!()
     }
 }

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -245,7 +245,7 @@ parameter_types! {
 impl membership::Trait for Runtime {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = DefaultInitialInvitationBalance;
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
@@ -262,7 +262,8 @@ impl pallet_timestamp::Trait for Runtime {
     type WeightInfo = ();
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for Wg {
     fn get_budget() -> u64 {
         unimplemented!()
     }
@@ -276,7 +277,7 @@ impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for () {
     }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Runtime> for () {
+impl common::working_group::WorkingGroupAuthenticator<Runtime> for Wg {
     fn ensure_worker_origin(
         _origin: <Runtime as frame_system::Trait>::Origin,
         _worker_id: &<Runtime as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -353,10 +353,10 @@ pub trait Trait: frame_system::Trait + balances::Trait + common::MembershipTypes
 
     /// Storage working group pallet integration.
     type StorageWorkingGroup: common::working_group::WorkingGroupAuthenticator<Self>
-        + common::working_group::WorkingGroupBudgetHandler<Self>;
+        + common::working_group::WorkingGroupBudgetHandler<Self::AccountId, BalanceOf<Self>>;
 
     type DistributionWorkingGroup: common::working_group::WorkingGroupAuthenticator<Self>
-        + common::working_group::WorkingGroupBudgetHandler<Self>;
+        + common::working_group::WorkingGroupBudgetHandler<Self::AccountId, BalanceOf<Self>>;
 }
 
 /// Operations with local pallet account.

--- a/runtime-modules/storage/src/tests/mocks.rs
+++ b/runtime-modules/storage/src/tests/mocks.rs
@@ -296,22 +296,30 @@ impl common::working_group::WorkingGroupAuthenticator<Test> for DistributionWG {
     }
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Test> for StorageWG {
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for StorageWG {
     fn get_budget() -> u64 {
         unimplemented!()
     }
 
     fn set_budget(_new_value: u64) {
+        unimplemented!()
+    }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
         unimplemented!()
     }
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Test> for DistributionWG {
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for DistributionWG {
     fn get_budget() -> u64 {
         unimplemented!()
     }
 
     fn set_budget(_new_value: u64) {
+        unimplemented!()
+    }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
         unimplemented!()
     }
 }

--- a/runtime-modules/utility/src/tests/mocks.rs
+++ b/runtime-modules/utility/src/tests/mocks.rs
@@ -113,28 +113,28 @@ macro_rules! call_wg {
     ($working_group:ident<$T:ty>, $function:ident $(,$x:expr)*) => {{
         match $working_group {
             WorkingGroup::Content =>
-                <working_group::Module::<$T, ContentWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+                <working_group::Module::<$T, ContentWorkingGroupInstance> as WorkingGroupBudgetHandler<u64, u64>>::$function($($x,)*),
 
             WorkingGroup::Storage =>
-                <working_group::Module::<$T, StorageWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+                <working_group::Module::<$T, StorageWorkingGroupInstance> as WorkingGroupBudgetHandler<u64, u64>>::$function($($x,)*),
 
             WorkingGroup::Forum =>
-                <working_group::Module::<$T, ForumWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+                <working_group::Module::<$T, ForumWorkingGroupInstance> as WorkingGroupBudgetHandler<u64, u64>>::$function($($x,)*),
 
             WorkingGroup::Membership =>
-                <working_group::Module::<$T, MembershipWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+                <working_group::Module::<$T, MembershipWorkingGroupInstance> as WorkingGroupBudgetHandler<u64, u64>>::$function($($x,)*),
 
             WorkingGroup::Gateway =>
-                <working_group::Module::<$T, GatewayWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+                <working_group::Module::<$T, GatewayWorkingGroupInstance> as WorkingGroupBudgetHandler<u64, u64>>::$function($($x,)*),
 
             WorkingGroup::Distribution =>
-                <working_group::Module::<$T, DistributionWorkingGroupInstance> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+                <working_group::Module::<$T, DistributionWorkingGroupInstance> as WorkingGroupBudgetHandler<u64, u64>>::$function($($x,)*),
             WorkingGroup::OperationsAlpha =>
-                <working_group::Module::<$T, OperationsWorkingGroupInstanceAlpha> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+                <working_group::Module::<$T, OperationsWorkingGroupInstanceAlpha> as WorkingGroupBudgetHandler<u64, u64>>::$function($($x,)*),
             WorkingGroup::OperationsBeta =>
-                <working_group::Module::<$T, OperationsWorkingGroupInstanceAlpha> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+                <working_group::Module::<$T, OperationsWorkingGroupInstanceAlpha> as WorkingGroupBudgetHandler<u64, u64>>::$function($($x,)*),
             WorkingGroup::OperationsGamma =>
-                <working_group::Module::<$T, OperationsWorkingGroupInstanceAlpha> as WorkingGroupBudgetHandler<Test>>::$function($($x,)*),
+                <working_group::Module::<$T, OperationsWorkingGroupInstanceAlpha> as WorkingGroupBudgetHandler<u64, u64>>::$function($($x,)*),
         }
     }};
 }
@@ -245,7 +245,7 @@ parameter_types! {
 impl membership::Trait for Test {
     type Event = TestEvent;
     type DefaultMembershipPrice = DefaultMembershipPrice;
-    type WorkingGroup = ();
+    type WorkingGroup = Wg;
     type WeightInfo = Weights;
     type DefaultInitialInvitationBalance = ();
     type InvitedMemberStakingHandler = staking_handler::StakingManager<Self, InvitedMemberLockId>;
@@ -255,7 +255,8 @@ impl membership::Trait for Test {
     type CandidateStake = CandidateStake;
 }
 
-impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
+pub struct Wg;
+impl common::working_group::WorkingGroupBudgetHandler<u64, u64> for Wg {
     fn get_budget() -> u64 {
         unimplemented!()
     }
@@ -263,9 +264,13 @@ impl common::working_group::WorkingGroupBudgetHandler<Test> for () {
     fn set_budget(_new_value: u64) {
         unimplemented!()
     }
+
+    fn try_withdraw(_account_id: &u64, _amount: u64) -> DispatchResult {
+        unimplemented!()
+    }
 }
 
-impl common::working_group::WorkingGroupAuthenticator<Test> for () {
+impl common::working_group::WorkingGroupAuthenticator<Test> for Wg {
     fn ensure_worker_origin(
         _origin: <Test as frame_system::Trait>::Origin,
         _worker_id: &<Test as common::membership::MembershipTypes>::ActorId,

--- a/runtime-modules/working-group/src/errors.rs
+++ b/runtime-modules/working-group/src/errors.rs
@@ -89,5 +89,8 @@ decl_error! {
 
         /// Worker storage text is too long.
         WorkerStorageValueTooLong,
+
+        /// Cannot withdraw: insufficient budget balance.
+        InsufficientBalanceForTransfer,
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1022,15 +1022,15 @@ parameter_types! {
 macro_rules! call_wg {
     ($working_group:ident, $function:ident $(,$x:expr)*) => {{
         match $working_group {
-            WorkingGroup::Content => <ContentWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
-            WorkingGroup::Storage => <StorageWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
-            WorkingGroup::Forum => <ForumWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
-            WorkingGroup::Membership => <MembershipWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
-            WorkingGroup::Gateway => <GatewayWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
-            WorkingGroup::Distribution => <DistributionWorkingGroup as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
-            WorkingGroup::OperationsAlpha => <OperationsWorkingGroupAlpha as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
-            WorkingGroup::OperationsBeta => <OperationsWorkingGroupBeta as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
-            WorkingGroup::OperationsGamma => <OperationsWorkingGroupGamma as WorkingGroupBudgetHandler<Runtime>>::$function($($x,)*),
+            WorkingGroup::Content => <ContentWorkingGroup as WorkingGroupBudgetHandler<AccountId, Balance>>::$function($($x,)*),
+            WorkingGroup::Storage => <StorageWorkingGroup as WorkingGroupBudgetHandler<AccountId, Balance>>::$function($($x,)*),
+            WorkingGroup::Forum => <ForumWorkingGroup as WorkingGroupBudgetHandler<AccountId, Balance>>::$function($($x,)*),
+            WorkingGroup::Membership => <MembershipWorkingGroup as WorkingGroupBudgetHandler<AccountId, Balance>>::$function($($x,)*),
+            WorkingGroup::Gateway => <GatewayWorkingGroup as WorkingGroupBudgetHandler<AccountId, Balance>>::$function($($x,)*),
+            WorkingGroup::Distribution => <DistributionWorkingGroup as WorkingGroupBudgetHandler<AccountId, Balance>>::$function($($x,)*),
+            WorkingGroup::OperationsAlpha => <OperationsWorkingGroupAlpha as WorkingGroupBudgetHandler<AccountId, Balance>>::$function($($x,)*),
+            WorkingGroup::OperationsBeta => <OperationsWorkingGroupBeta as WorkingGroupBudgetHandler<AccountId, Balance>>::$function($($x,)*),
+            WorkingGroup::OperationsGamma => <OperationsWorkingGroupGamma as WorkingGroupBudgetHandler<AccountId, Balance>>::$function($($x,)*),
         }
     }};
 }


### PR DESCRIPTION
The PR refactors the working group budget handler. It continues the work started in the [council refactoring PR](https://github.com/Joystream/joystream/pull/3518).

#### Changes
- reintroduced `WorkingGroupBudgetHandler` as an alias for the `BudgetManager` trait:
- implemented `try_withdraw` method for the working-group pallet
- changed the `membership` pallet to use new methods
- changed multiple mocks across the pallets

[Original issue](https://github.com/Joystream/joystream/issues/3496) 