### PR TITLE
Referendum-related test

### DIFF
--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -38,6 +38,8 @@ pub const USER_REGULAR: u64 = 2;
 pub const USER_REGULAR_POWER_VOTES: u64 = 3;
 pub const USER_REGULAR_2: u64 = 4;
 pub const USER_REGULAR_3: u64 = 5;
+pub const USER_REGULAR_4: u64 = 6;
+pub const USER_REGULAR_5: u64 = 7;
 
 pub const POWER_VOTE_STRENGTH: u64 = 10;
 
@@ -450,6 +452,8 @@ pub fn build_test_externalities(
         topup_account(USER_REGULAR, amount);
         topup_account(USER_REGULAR_2, amount);
         topup_account(USER_REGULAR_3, amount);
+        topup_account(USER_REGULAR_4, amount);
+        topup_account(USER_REGULAR_5, amount);
         topup_account(USER_REGULAR_POWER_VOTES, amount);
 
         InstanceMockUtils::<Runtime, DefaultInstance>::increase_block_number(1)


### PR DESCRIPTION
Added a simple (failing) test that illustrated my concerns described here: https://github.com/Joystream/joystream/issues/3530

        // This is how the referendum goes:
        // 1. Candidate 1 gets a vote = 100
        // 2. Candidate 2 gets a vote = 50
        // 3. Candidate 3 gets a vote = 30
        // 4. Candidate 3 gets a vote = 30
        // 5. Candidate 3 gets a vote = 30
        // 6. Votes from 1-5 are revealed one after another
        // Expected outcome: winners are Candidate 1 (100), Candidate 3 (90)
        // Actual outcome: winners are Candidate 1 (100), Candidate 2 (50)
