### PR TITLE
Audit3. Runtime: Add initial balance to the module account of the storage pallet.

### DIFF
--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -275,6 +275,7 @@ pub fn testnet_genesis(
         membership: Some(MembersConfig { members }),
         forum: Some(forum_config),
         content: Some(content_config),
+        storage: Some(Default::default()),
     }
 }
 

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -309,9 +309,9 @@ impl storage::Trait for Test {
         MaxNumberOfPendingInvitationsPerDistributionBucket;
     type ContentId = u64;
     type MaxDataObjectSize = MaxDataObjectSize;
-
     type StorageWorkingGroup = StorageWG;
     type DistributionWorkingGroup = DistributionWG;
+    type ModuleAccountInitialBalance = ExistentialDeposit;
 }
 
 // Anyone can upload and delete without restriction

--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -1229,6 +1229,14 @@ decl_storage! {
     }
     add_extra_genesis {
         build(|_| {
+            // We deposit some initial balance to the pallet's module account on the genesis block
+            // to protect the account from being deleted ("dusted") on early stages of pallet's work
+            // by the "garbage collector" of the balances pallet.
+            // It should be equal to at least `ExistentialDeposit` from the balances pallet setting.
+            // Original issues:
+            // - https://github.com/Joystream/joystream/issues/3497
+            // - https://github.com/Joystream/joystream/issues/3510
+
             let module_account_id = StorageTreasury::<T>::module_account_id();
             let deposit: BalanceOf<T> = T::ModuleAccountInitialBalance::get();
 

--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -394,6 +394,9 @@ pub trait Trait: frame_system::Trait + balances::Trait + common::MembershipTypes
 
     type DistributionWorkingGroup: common::working_group::WorkingGroupAuthenticator<Self>
         + common::working_group::WorkingGroupBudgetHandler<Self>;
+
+    /// Module account initial balance (existential deposit).
+    type ModuleAccountInitialBalance: Get<BalanceOf<Self>>;
 }
 
 /// Operations with local pallet account.
@@ -1223,6 +1226,14 @@ decl_storage! {
 
         /// "Distribution buckets per bag" number limit.
         pub DistributionBucketsPerBagLimit get (fn distribution_buckets_per_bag_limit): u64;
+    }
+    add_extra_genesis {
+        build(|_| {
+            let module_account_id = StorageTreasury::<T>::module_account_id();
+            let deposit: BalanceOf<T> = T::ModuleAccountInitialBalance::get();
+
+            let _ = Balances::<T>::deposit_creating(&module_account_id, deposit);
+        });
     }
 }
 

--- a/runtime-modules/storage/src/tests/mocks.rs
+++ b/runtime-modules/storage/src/tests/mocks.rs
@@ -36,7 +36,7 @@ impl_outer_event! {
 }
 
 parameter_types! {
-    pub const ExistentialDeposit: u32 = 0;
+    pub const ExistentialDeposit: u32 = 1;
 }
 
 impl balances::Trait for Test {
@@ -103,6 +103,7 @@ impl crate::Trait for Test {
     type ContentId = u64;
     type StorageWorkingGroup = StorageWG;
     type DistributionWorkingGroup = DistributionWG;
+    type ModuleAccountInitialBalance = ExistentialDeposit;
 }
 
 pub const DEFAULT_MEMBER_ID: u64 = 100;
@@ -167,6 +168,18 @@ impl frame_system::Trait for Test {
 pub fn build_test_externalities() -> sp_io::TestExternalities {
     let t = frame_system::GenesisConfig::default()
         .build_storage::<Test>()
+        .unwrap();
+
+    t.into()
+}
+
+pub fn build_test_externalities_with_genesis() -> sp_io::TestExternalities {
+    let mut t = frame_system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap();
+
+    crate::GenesisConfig::default()
+        .assimilate_storage::<Test>(&mut t)
         .unwrap();
 
     t.into()

--- a/runtime-modules/storage/src/tests/mod.rs
+++ b/runtime-modules/storage/src/tests/mod.rs
@@ -7,6 +7,7 @@ use frame_support::dispatch::DispatchError;
 use frame_support::traits::Currency;
 use frame_support::{assert_err, assert_ok, StorageDoubleMap, StorageMap, StorageValue};
 use frame_system::RawOrigin;
+use sp_runtime::SaturatedConversion;
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use sp_std::convert::TryInto;
@@ -21,9 +22,9 @@ use crate::{
 };
 
 use mocks::{
-    build_test_externalities, Balances, BlacklistSizeLimit,
+    build_test_externalities, build_test_externalities_with_genesis, Balances, BlacklistSizeLimit,
     DefaultChannelDynamicBagNumberOfStorageBuckets, DefaultMemberDynamicBagNumberOfStorageBuckets,
-    MaxDataObjectSize, MaxDistributionBucketFamilyNumber, Storage, Test,
+    ExistentialDeposit, MaxDataObjectSize, MaxDistributionBucketFamilyNumber, Storage, Test,
     ANOTHER_DISTRIBUTION_PROVIDER_ID, ANOTHER_STORAGE_PROVIDER_ID, BAG_DELETION_PRIZE_VALUE,
     DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID, DEFAULT_DISTRIBUTION_PROVIDER_ID,
     DEFAULT_MEMBER_ACCOUNT_ID, DEFAULT_MEMBER_ID, DEFAULT_STORAGE_BUCKETS_NUMBER,
@@ -6012,6 +6013,18 @@ fn distribution_operator_remark_unsuccessful_with_invalid_origin() {
                 msg
             ),
             DispatchError::BadOrigin,
+        );
+    })
+}
+
+#[test]
+fn initial_module_account_balance_set() {
+    build_test_externalities_with_genesis().execute_with(|| {
+        run_to_block(1);
+
+        assert_eq!(
+            Balances::usable_balance(&crate::StorageTreasury::<Test>::module_account_id()),
+            ExistentialDeposit::get().saturated_into::<u64>()
         );
     })
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -646,6 +646,7 @@ impl storage::Trait for Runtime {
     type ContentId = ContentId;
     type StorageWorkingGroup = StorageWorkingGroup;
     type DistributionWorkingGroup = DistributionWorkingGroup;
+    type ModuleAccountInitialBalance = ExistentialDeposit;
 }
 
 impl common::membership::MembershipTypes for Runtime {
@@ -1159,7 +1160,7 @@ construct_runtime!(
         Blog: blog::<Instance1>::{Module, Call, Storage, Event<T>},
         JoystreamUtility: joystream_utility::{Module, Call, Event<T>},
         Content: content::{Module, Call, Storage, Event<T>, Config<T>},
-        Storage: storage::{Module, Call, Storage, Event<T>},
+        Storage: storage::{Module, Call, Storage, Event<T>, Config},
         // --- Proposals
         ProposalsEngine: proposals_engine::{Module, Call, Storage, Event<T>},
         ProposalsDiscussion: proposals_discussion::{Module, Call, Storage, Event<T>},


### PR DESCRIPTION
We need to deposit some initial balance to the module account of the storage pallet to prevent accounts from deletion because of the existential deposit requirements.

#### Changes
- new field `ModuleAccountInitialBalance` in the `pallet_storage::Trait`
- new genesis code for the storage pallet
- `ModuleAccountInitialBalance` is set to the `ExistentialDeposit` in the runtime configuration
- updated tests and chain-spec

[Original issue](https://github.com/Joystream/joystream/issues/3510)