### PR TITLE
Audit3. Runtime: Add swap channel price to the content pallet.

### DIFF
--- a/runtime-modules/content/src/errors.rs
+++ b/runtime-modules/content/src/errors.rs
@@ -289,5 +289,8 @@ decl_error! {
         /// Cannot accept the channel transfer: provided commitment parameters doesn't match with
         /// channel pending transfer parameters.
         InvalidChannelTransferCommitmentParams,
+
+        /// Cannot transfer the channel: channel owner has insufficient balance (budget for WGs)
+        InsufficientBalanceForTransfer,
     }
 }

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -28,7 +28,9 @@ pub use storage::{
 };
 
 pub use common::{
-    currency::GovernanceCurrency, membership::MembershipInfoProvider, working_group::WorkingGroup,
+    currency::GovernanceCurrency,
+    membership::MembershipInfoProvider,
+    working_group::{WorkingGroup, WorkingGroupBudgetHandler},
     MembershipTypes, StorageOwnership, Url,
 };
 use frame_support::{
@@ -52,6 +54,7 @@ use sp_runtime::{
     ModuleId,
 };
 use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
+
 /// Module configuration trait for Content Directory Module
 pub trait Trait:
     frame_system::Trait
@@ -125,6 +128,9 @@ pub trait Trait:
         + Copy
         + MaybeSerializeDeserialize
         + PartialEq;
+
+    /// Content working group pallet integration.
+    type ContentWorkingGroup: common::working_group::WorkingGroupBudgetHandler<Self>;
 }
 
 decl_storage! {
@@ -2372,22 +2378,25 @@ decl_module! {
             commitment_params: TransferParameters<T::MemberId, BalanceOf<T>>
         ) {
             let channel = Self::ensure_channel_exists(&channel_id)?;
-            ensure_actor_authorized_to_accept_channel::<T>(origin, &actor, &channel.owner)?;
 
             if let ChannelTransferStatus::PendingTransfer(ref params) = channel.transfer_status {
-                ensure!(
-                    params.transfer_params == commitment_params,
-                    Error::<T>::InvalidChannelTransferCommitmentParams
-                );
+                ensure_actor_authorized_to_accept_channel::<T>(origin, &actor, &params.new_owner)?;
+                Self::validate_channel_transfer_acceptance(&actor, &commitment_params, params)?;
             } else {
-                return Err(Error::<T>::InvalidChannelTransferStatus.into())
+                return Err(Error::<T>::InvalidChannelTransferStatus.into());
             }
+
+            let new_owner = actor_to_channel_owner::<T>(&actor)?;
 
             //
             // == MUTATION SAFE ==
             //
 
             if let ChannelTransferStatus::PendingTransfer(params) = channel.transfer_status {
+                if !params.transfer_params.is_free_of_charge() {
+                    Self::pay_for_channel_swap(&channel.owner, &new_owner, commitment_params.price)?;
+                }
+
                 ChannelById::<T>::mutate(&channel_id, |channel| {
                     channel.transfer_status = ChannelTransferStatus::NoActiveTransfer;
                     channel.owner = params.new_owner.clone();
@@ -2780,6 +2789,87 @@ impl<T: Trait> Module<T> {
             .difference(&ids_to_remove)
             .cloned()
             .collect::<BTreeSet<_>>()
+    }
+
+    fn ensure_sufficient_balance_for_channel_transfer(
+        owner: &ChannelOwner<T::MemberId, T::CuratorGroupId>,
+        transfer_cost: BalanceOf<T>,
+    ) -> DispatchResult {
+        let balance = match owner {
+            ChannelOwner::Member(member_id) => {
+                let controller_account_id =
+                    T::MemberAuthenticator::controller_account_id(*member_id)?;
+
+                Balances::<T>::usable_balance(&controller_account_id)
+            }
+            ChannelOwner::CuratorGroup(_) => T::ContentWorkingGroup::get_budget(),
+        };
+
+        ensure!(
+            balance >= transfer_cost,
+            Error::<T>::InsufficientBalanceForTransfer
+        );
+        Ok(())
+    }
+
+    // Validates channel transfer acceptance parameters: commitment params, new owner balance.
+    fn validate_channel_transfer_acceptance(
+        actor: &ContentActor<T::CuratorGroupId, T::CuratorId, T::MemberId>,
+        commitment_params: &TransferParameters<T::MemberId, BalanceOf<T>>,
+        params: &PendingTransfer<T::MemberId, T::CuratorGroupId, BalanceOf<T>>,
+    ) -> DispatchResult {
+        ensure!(
+            params.transfer_params == *commitment_params,
+            Error::<T>::InvalidChannelTransferCommitmentParams
+        );
+
+        // Check for new owner balance only if the transfer is not free.
+        if !params.transfer_params.is_free_of_charge() {
+            let owner = actor_to_channel_owner::<T>(actor)?;
+
+            Self::ensure_sufficient_balance_for_channel_transfer(
+                &owner,
+                params.transfer_params.price,
+            )?;
+        }
+
+        Ok(())
+    }
+    // Transfers balance from the new channel owner to the old channel owner.
+    fn pay_for_channel_swap(
+        old_owner: &ChannelOwner<T::MemberId, T::CuratorGroupId>,
+        new_owner: &ChannelOwner<T::MemberId, T::CuratorGroupId>,
+        price: BalanceOf<T>,
+    ) -> DispatchResult {
+        // Decrease (or slash) balance for the new owner
+        match new_owner {
+            ChannelOwner::Member(member_id) => {
+                let controller_account_id =
+                    T::MemberAuthenticator::controller_account_id(*member_id)?;
+
+                let _ = Balances::<T>::slash(&controller_account_id, price);
+            }
+            ChannelOwner::CuratorGroup(_) => {
+                let new_budget = T::ContentWorkingGroup::get_budget().saturating_sub(price);
+                T::ContentWorkingGroup::set_budget(new_budget);
+            }
+        };
+
+        // Increase (deposit) balance for the old owner
+        match old_owner {
+            ChannelOwner::Member(member_id) => {
+                let controller_account_id =
+                    T::MemberAuthenticator::controller_account_id(*member_id)?;
+
+                let _ = Balances::<T>::deposit_creating(&controller_account_id, price);
+            }
+            ChannelOwner::CuratorGroup(_) => {
+                let new_budget = T::ContentWorkingGroup::get_budget().saturating_add(price);
+                T::ContentWorkingGroup::set_budget(new_budget);
+            }
+        };
+
+        Ok(())
     }
 }
 

--- a/runtime-modules/content/src/tests/channels.rs
+++ b/runtime-modules/content/src/tests/channels.rs
@@ -427,7 +427,7 @@ fn unsuccessful_channel_update_with_pending_status_transfer() {
         create_default_member_owned_channel();
 
         UpdateChannelTransferStatusFixture::default()
-            .with_transfer_status_by_member_id(DEFAULT_MEMBER_ID)
+            .with_new_member_channel_owner(DEFAULT_MEMBER_ID)
             .call_and_assert(Ok(()));
 
         UpdateChannelFixture::default()

--- a/runtime-modules/content/src/tests/merkle.rs
+++ b/runtime-modules/content/src/tests/merkle.rs
@@ -301,7 +301,7 @@ fn successful_reward_claim_with_member_owned_channel_no_reward_account_found() {
         update_commit_value_with_payments_helper(&payments);
 
         UpdateChannelTransferStatusFixture::default()
-            .with_transfer_status_by_member_id(DEFAULT_MEMBER_ID)
+            .with_new_member_channel_owner(DEFAULT_MEMBER_ID)
             .call_and_assert(Ok(()));
 
         ClaimChannelRewardFixture::default()

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -386,6 +386,26 @@ impl Trait for Test {
 
     /// channel privilege level
     type ChannelPrivilegeLevel = u8;
+
+    /// content working group
+    type ContentWorkingGroup = ContentWG;
+}
+
+thread_local! {
+    pub static CONTENT_WG_BUDGET: RefCell<u64> = RefCell::new(WORKING_GROUP_BUDGET);
+}
+
+pub struct ContentWG;
+impl common::working_group::WorkingGroupBudgetHandler<Test> for ContentWG {
+    fn get_budget() -> u64 {
+        CONTENT_WG_BUDGET.with(|val| *val.borrow())
+    }
+
+    fn set_budget(new_value: u64) {
+        CONTENT_WG_BUDGET.with(|val| {
+            *val.borrow_mut() = new_value;
+        });
+    }
 }
 
 // #[derive (Default)]

--- a/runtime-modules/content/src/tests/posts.rs
+++ b/runtime-modules/content/src/tests/posts.rs
@@ -478,7 +478,7 @@ pub fn unsuccessful_comment_update_with_pending_active_transfers() {
         create_default_member_owned_channel_with_video_and_comment();
 
         UpdateChannelTransferStatusFixture::default()
-            .with_transfer_status_by_member_id(DEFAULT_MEMBER_ID)
+            .with_new_member_channel_owner(DEFAULT_MEMBER_ID)
             .call_and_assert(Ok(()));
 
         EditPostTextFixture::default()
@@ -854,7 +854,7 @@ pub fn unsuccessful_post_deletion_with_active_channel_transfer() {
         create_default_member_owned_channel_with_video_and_comment();
 
         UpdateChannelTransferStatusFixture::default()
-            .with_transfer_status_by_member_id(DEFAULT_MEMBER_ID)
+            .with_new_member_channel_owner(DEFAULT_MEMBER_ID)
             .call_and_assert(Ok(()));
 
         DeletePostFixture::default()
@@ -1164,7 +1164,7 @@ pub fn successful_moderators_update_by_member_owner() {
         create_default_member_owned_channel();
 
         UpdateChannelTransferStatusFixture::default()
-            .with_transfer_status_by_member_id(DEFAULT_MEMBER_ID)
+            .with_new_member_channel_owner(DEFAULT_MEMBER_ID)
             .call_and_assert(Ok(()));
 
         UpdateModeratorSetFixture::default()

--- a/runtime-modules/content/src/tests/videos.rs
+++ b/runtime-modules/content/src/tests/videos.rs
@@ -95,7 +95,7 @@ fn unuccessful_video_creation_with_pending_channel_transfer() {
         create_default_member_owned_channel();
 
         UpdateChannelTransferStatusFixture::default()
-            .with_transfer_status_by_member_id(DEFAULT_MEMBER_ID)
+            .with_new_member_channel_owner(DEFAULT_MEMBER_ID)
             .call_and_assert(Ok(()));
 
         CreateVideoFixture::default()
@@ -592,7 +592,7 @@ fn unsuccessful_video_update_with_pending_channel_transfer() {
             .collect::<BTreeSet<_>>();
 
         UpdateChannelTransferStatusFixture::default()
-            .with_transfer_status_by_member_id(DEFAULT_MEMBER_ID)
+            .with_new_member_channel_owner(DEFAULT_MEMBER_ID)
             .call_and_assert(Ok(()));
 
         UpdateVideoFixture::default()
@@ -980,7 +980,7 @@ fn unsuccessful_video_deletion_with_pending_transfer() {
         create_default_member_owned_channel_with_video();
 
         UpdateChannelTransferStatusFixture::default()
-            .with_transfer_status_by_member_id(DEFAULT_MEMBER_ID)
+            .with_new_member_channel_owner(DEFAULT_MEMBER_ID)
             .call_and_assert(Ok(()));
 
         DeleteVideoFixture::default()

--- a/runtime-modules/content/src/types.rs
+++ b/runtime-modules/content/src/types.rs
@@ -75,7 +75,7 @@ pub struct ChannelCategoryUpdateParameters {
 pub struct ChannelRecord<
     MemberId: Ord + PartialEq,
     CuratorGroupId: PartialEq,
-    Balance: PartialEq,
+    Balance: PartialEq + Zero,
     ChannelPrivilegeLevel,
     DataObjectId: Ord,
 > {
@@ -105,16 +105,16 @@ pub struct ChannelRecord<
 pub enum ChannelTransferStatus<
     MemberId: Ord + PartialEq,
     CuratorGroupId: PartialEq,
-    Balance: PartialEq,
+    Balance: PartialEq + Zero,
 > {
-    /// Default transfer status: no pending tranfers.
+    /// Default transfer status: no pending transfers.
     NoActiveTransfer,
 
     /// There is ongoing transfer with parameters.
     PendingTransfer(PendingTransfer<MemberId, CuratorGroupId, Balance>),
 }
 
-impl<MemberId: Ord + PartialEq, CuratorGroupId: PartialEq, Balance: PartialEq> Default
+impl<MemberId: Ord + PartialEq, CuratorGroupId: PartialEq, Balance: PartialEq + Zero> Default
     for ChannelTransferStatus<MemberId, CuratorGroupId, Balance>
 {
     fn default() -> Self {
@@ -125,7 +125,7 @@ impl<MemberId: Ord + PartialEq, CuratorGroupId: PartialEq, Balance: PartialEq> D
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
 /// Contains parameters for the pending transfer.
-pub struct PendingTransfer<MemberId: Ord, CuratorGroupId, Balance> {
+pub struct PendingTransfer<MemberId: Ord, CuratorGroupId, Balance: Zero> {
     /// New channel owner.
     pub new_owner: ChannelOwner<MemberId, CuratorGroupId>,
     /// Transfer parameters.
@@ -135,17 +135,24 @@ pub struct PendingTransfer<MemberId: Ord, CuratorGroupId, Balance> {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
 /// Contains parameters for the pending transfer.
-pub struct TransferParameters<MemberId: Ord, Balance> {
+pub struct TransferParameters<MemberId: Ord, Balance: Zero> {
     /// New set of the channel's collaborators.
     pub new_collaborators: BTreeSet<MemberId>,
     /// Transfer price: can be 0, which means free.
     pub price: Balance,
 }
 
+impl<MemberId: Ord, Balance: Zero> TransferParameters<MemberId, Balance> {
+    // Defines whether the transfer is free.
+    pub(crate) fn is_free_of_charge(&self) -> bool {
+        self.price.is_zero()
+    }
+}
+
 impl<
         MemberId: Ord + PartialEq,
         CuratorGroupId: PartialEq,
-        Balance: PartialEq,
+        Balance: PartialEq + Zero,
         ChannelPrivilegeLevel,
         DataObjectId: Ord,
     > ChannelRecord<MemberId, CuratorGroupId, Balance, ChannelPrivilegeLevel, DataObjectId>

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -505,6 +505,7 @@ impl content::Trait for Runtime {
     type MemberAuthenticator = Members;
     type MaxKeysPerCuratorGroupPermissionsByLevelMap = MaxKeysPerCuratorGroupPermissionsByLevelMap;
     type ChannelPrivilegeLevel = ChannelPrivilegeLevel;
+    type ContentWorkingGroup = ContentWorkingGroup;
 }
 
 // The referendum instance alias.


### PR DESCRIPTION
This PR implements paid channel transfer. It supports members and curator groups.

#### Changes
- integrated content working group's budget manager
- added balances' checks  and transfers for members and curator groups

[Original issue](https://github.com/Joystream/joystream/issues/3437)