### PR TITLE
query node - temporary fix for auction in transactional status being empty

### DIFF
--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -486,6 +486,7 @@ export async function convertTransactionalStatus(
 
     const status = new TransactionalStatusAuction()
     status.auctionId = auction.id
+    status.tmpAuctionId = auction.id
 
     return status
   }
@@ -524,6 +525,7 @@ export async function contentNft_OpenAuctionStarted({ event, store }: EventConte
   // update NFT transactional status
   const transactionalStatus = new TransactionalStatusAuction()
   transactionalStatus.auctionId = auction.id
+  transactionalStatus.tmpAuctionId = auction.id
   await setNewNftTransactionalStatus(store, nft, transactionalStatus, event.blockNumber)
 
   // common event processing - second
@@ -569,6 +571,7 @@ export async function contentNft_EnglishAuctionStarted({ event, store }: EventCo
   // update NFT transactional status
   const transactionalStatus = new TransactionalStatusAuction()
   transactionalStatus.auctionId = auction.id
+  transactionalStatus.tmpAuctionId = auction.id
   await setNewNftTransactionalStatus(store, nft, transactionalStatus, event.blockNumber)
 
   // common event processing - second

--- a/query-node/schemas/contentNft.graphql
+++ b/query-node/schemas/contentNft.graphql
@@ -128,6 +128,9 @@ type TransactionalStatusAuction @variant {
 
   "Auction"
   auction: Auction!
+
+  "Auction Id - temporary variable that helps to workaround a bug" # see https://github.com/Joystream/joystream/issues/3342
+  tmpAuctionId: String!
 }
 
 "Represents TransactionalStatus BuyNow"


### PR DESCRIPTION
Temporary workaround for https://github.com/Joystream/joystream/issues/3342 . 

Can be used in query like this:
```
videos {
    id
    nft {
      id
      transactionalStatus {
        __typename
        ... on TransactionalStatusAuction {
          dummy
          tmpAuctionId # this will be properly set
          auction { # this will be null
            id
          }
        }
      }
    }
  }
```