### PR TITLE
Runtime. Refactor test fixtures for the storage pallet.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4205,6 +4216,7 @@ name = "pallet-storage"
 version = "4.0.1"
 dependencies = [
  "derive-fixture",
+ "derive-new",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4204,6 +4204,7 @@ dependencies = [
 name = "pallet-storage"
 version = "4.0.1"
 dependencies = [
+ "derive-fixture",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
+name = "derive-fixture"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
 	"runtime-modules/utility",
 	"node",
 	"utils/chain-spec-builder/",
+	"runtime-modules/support/derive-fixture",
 ]
 exclude = [
     "analyses/bench"

--- a/runtime-modules/storage/Cargo.toml
+++ b/runtime-modules/storage/Cargo.toml
@@ -26,6 +26,8 @@ sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62'}
 randomness-collective-flip = { package = 'pallet-randomness-collective-flip', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group'}
+derive-fixture = { package = 'derive-fixture', default-features = false, path = '../support/derive-fixture'}
+
     
 [features]
 default = ['std']

--- a/runtime-modules/storage/Cargo.toml
+++ b/runtime-modules/storage/Cargo.toml
@@ -27,7 +27,7 @@ sp-core = { package = 'sp-core', default-features = false, git = 'https://github
 randomness-collective-flip = { package = 'pallet-randomness-collective-flip', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group'}
 derive-fixture = { package = 'derive-fixture', default-features = false, path = '../support/derive-fixture'}
-
+derive-new = "0.5"
     
 [features]
 default = ['std']

--- a/runtime-modules/storage/src/tests/fixtures.rs
+++ b/runtime-modules/storage/src/tests/fixtures.rs
@@ -1,3 +1,4 @@
+use derive_fixture::Fixture;
 use frame_support::dispatch::DispatchResult;
 use frame_support::storage::StorageMap;
 use frame_support::traits::{Currency, OnFinalize, OnInitialize};
@@ -110,6 +111,7 @@ pub const DEFAULT_DATA_OBJECTS_NUMBER: u64 = DEFAULT_STORAGE_BUCKET_OBJECTS_LIMI
 pub const DEFAULT_DATA_OBJECTS_SIZE: u64 =
     DEFAULT_STORAGE_BUCKET_SIZE_LIMIT / DEFAULT_DATA_OBJECTS_NUMBER - 1;
 
+#[derive(Fixture)]
 pub struct CreateStorageBucketFixture {
     origin: RawOrigin<u64>,
     invite_worker: Option<u64>,
@@ -126,35 +128,6 @@ impl CreateStorageBucketFixture {
             accepting_new_bags: true,
             size_limit: 0,
             objects_limit: 0,
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_invite_worker(self, invite_worker: Option<u64>) -> Self {
-        Self {
-            invite_worker,
-            ..self
-        }
-    }
-
-    pub fn with_accepting_new_bags(self, accepting_new_bags: bool) -> Self {
-        Self {
-            accepting_new_bags,
-            ..self
-        }
-    }
-
-    pub fn with_size_limit(self, size_limit: u64) -> Self {
-        Self { size_limit, ..self }
-    }
-
-    pub fn with_objects_limit(self, objects_limit: u64) -> Self {
-        Self {
-            objects_limit,
-            ..self
         }
     }
 
@@ -191,6 +164,7 @@ impl CreateStorageBucketFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct AcceptStorageBucketInvitationFixture {
     origin: RawOrigin<u64>,
     worker_id: u64,
@@ -205,27 +179,6 @@ impl AcceptStorageBucketInvitationFixture {
             worker_id: DEFAULT_WORKER_ID,
             storage_bucket_id: Default::default(),
             transactor_account_id: DEFAULT_ACCOUNT_ID,
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_worker_id(self, worker_id: u64) -> Self {
-        Self { worker_id, ..self }
-    }
-    pub fn with_transactor_account_id(self, transactor_account_id: u64) -> Self {
-        Self {
-            transactor_account_id,
-            ..self
-        }
-    }
-
-    pub fn with_storage_bucket_id(self, storage_bucket_id: u64) -> Self {
-        Self {
-            storage_bucket_id,
-            ..self
         }
     }
 
@@ -256,6 +209,7 @@ impl AcceptStorageBucketInvitationFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateStorageBucketForBagsFixture {
     origin: RawOrigin<u64>,
     bag_id: BagId<Test>,
@@ -273,28 +227,6 @@ impl UpdateStorageBucketForBagsFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_add_bucket_ids(self, add_bucket_ids: BTreeSet<u64>) -> Self {
-        Self {
-            add_bucket_ids,
-            ..self
-        }
-    }
-
-    pub fn with_remove_bucket_ids(self, remove_bucket_ids: BTreeSet<u64>) -> Self {
-        Self {
-            remove_bucket_ids,
-            ..self
-        }
-    }
-
-    pub fn with_bag_id(self, bag_id: BagId<Test>) -> Self {
-        Self { bag_id, ..self }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_storage_buckets_for_bag(
             self.origin.clone().into(),
@@ -307,21 +239,12 @@ impl UpdateStorageBucketForBagsFixture {
     }
 }
 
+#[derive(Fixture, Default)]
 pub struct UploadFixture {
     params: UploadParameters<Test>,
 }
 
 impl UploadFixture {
-    pub fn default() -> Self {
-        Self {
-            params: Default::default(),
-        }
-    }
-
-    pub fn with_params(self, params: UploadParameters<Test>) -> Self {
-        Self { params, ..self }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_next_data_object_id = Storage::next_data_object_id();
         let actual_result = Storage::upload_data_objects(self.params.clone());
@@ -359,6 +282,7 @@ pub fn create_single_data_object() -> Vec<DataObjectCreationParameters> {
     create_data_object_candidates(1, 1)
 }
 
+#[derive(Fixture)]
 pub struct SetStorageOperatorMetadataFixture {
     origin: RawOrigin<u64>,
     worker_id: u64,
@@ -376,25 +300,6 @@ impl SetStorageOperatorMetadataFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_worker_id(self, worker_id: u64) -> Self {
-        Self { worker_id, ..self }
-    }
-
-    pub fn with_storage_bucket_id(self, storage_bucket_id: u64) -> Self {
-        Self {
-            storage_bucket_id,
-            ..self
-        }
-    }
-
-    pub fn with_metadata(self, metadata: Vec<u8>) -> Self {
-        Self { metadata, ..self }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::set_storage_operator_metadata(
             self.origin.clone().into(),
@@ -407,6 +312,7 @@ impl SetStorageOperatorMetadataFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct AcceptPendingDataObjectsFixture {
     origin: RawOrigin<u64>,
     worker_id: u64,
@@ -426,32 +332,6 @@ impl AcceptPendingDataObjectsFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_worker_id(self, worker_id: u64) -> Self {
-        Self { worker_id, ..self }
-    }
-
-    pub fn with_bag_id(self, bag_id: BagId<Test>) -> Self {
-        Self { bag_id, ..self }
-    }
-
-    pub fn with_data_object_ids(self, data_object_ids: BTreeSet<u64>) -> Self {
-        Self {
-            data_object_ids,
-            ..self
-        }
-    }
-
-    pub fn with_storage_bucket_id(self, storage_bucket_id: u64) -> Self {
-        Self {
-            storage_bucket_id,
-            ..self
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::accept_pending_data_objects(
             self.origin.clone().into(),
@@ -465,6 +345,7 @@ impl AcceptPendingDataObjectsFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct CancelStorageBucketInvitationFixture {
     origin: RawOrigin<u64>,
     storage_bucket_id: u64,
@@ -475,17 +356,6 @@ impl CancelStorageBucketInvitationFixture {
         Self {
             origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
             storage_bucket_id: Default::default(),
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_storage_bucket_id(self, storage_bucket_id: u64) -> Self {
-        Self {
-            storage_bucket_id,
-            ..self
         }
     }
 
@@ -511,6 +381,7 @@ impl CancelStorageBucketInvitationFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct InviteStorageBucketOperatorFixture {
     origin: RawOrigin<u64>,
     operator_worker_id: u64,
@@ -523,24 +394,6 @@ impl InviteStorageBucketOperatorFixture {
             origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
             operator_worker_id: DEFAULT_WORKER_ID,
             storage_bucket_id: Default::default(),
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_operator_worker_id(self, operator_worker_id: u64) -> Self {
-        Self {
-            operator_worker_id,
-            ..self
-        }
-    }
-
-    pub fn with_storage_bucket_id(self, storage_bucket_id: u64) -> Self {
-        Self {
-            storage_bucket_id,
-            ..self
         }
     }
 
@@ -567,6 +420,7 @@ impl InviteStorageBucketOperatorFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateUploadingBlockedStatusFixture {
     origin: RawOrigin<u64>,
     new_status: bool,
@@ -578,14 +432,6 @@ impl UpdateUploadingBlockedStatusFixture {
             origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
             new_status: false,
         }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_new_status(self, new_status: bool) -> Self {
-        Self { new_status, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -604,6 +450,7 @@ impl UpdateUploadingBlockedStatusFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct MoveDataObjectsFixture {
     src_bag_id: BagId<Test>,
     dest_bag_id: BagId<Test>,
@@ -619,24 +466,6 @@ impl MoveDataObjectsFixture {
         }
     }
 
-    pub fn with_src_bag_id(self, src_bag_id: BagId<Test>) -> Self {
-        Self { src_bag_id, ..self }
-    }
-
-    pub fn with_dest_bag_id(self, dest_bag_id: BagId<Test>) -> Self {
-        Self {
-            dest_bag_id,
-            ..self
-        }
-    }
-
-    pub fn with_data_object_ids(self, data_object_ids: BTreeSet<u64>) -> Self {
-        Self {
-            data_object_ids,
-            ..self
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::move_data_objects(
             self.src_bag_id.clone(),
@@ -648,6 +477,7 @@ impl MoveDataObjectsFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct DeleteDataObjectsFixture {
     deletion_prize_account_id: u64,
     bag_id: BagId<Test>,
@@ -663,24 +493,6 @@ impl DeleteDataObjectsFixture {
         }
     }
 
-    pub fn with_bag_id(self, bag_id: BagId<Test>) -> Self {
-        Self { bag_id, ..self }
-    }
-
-    pub fn with_data_object_ids(self, data_object_ids: BTreeSet<u64>) -> Self {
-        Self {
-            data_object_ids,
-            ..self
-        }
-    }
-
-    pub fn with_deletion_account_id(self, deletion_prize_account_id: u64) -> Self {
-        Self {
-            deletion_prize_account_id,
-            ..self
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::delete_data_objects(
             self.deletion_prize_account_id,
@@ -692,6 +504,7 @@ impl DeleteDataObjectsFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateStorageBucketStatusFixture {
     origin: RawOrigin<u64>,
     storage_bucket_id: u64,
@@ -705,21 +518,6 @@ impl UpdateStorageBucketStatusFixture {
             storage_bucket_id: Default::default(),
             new_status: false,
         }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_storage_bucket_id(self, storage_bucket_id: u64) -> Self {
-        Self {
-            storage_bucket_id,
-            ..self
-        }
-    }
-
-    pub fn with_new_status(self, new_status: bool) -> Self {
-        Self { new_status, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -739,6 +537,7 @@ impl UpdateStorageBucketStatusFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateBlacklistFixture {
     origin: RawOrigin<u64>,
     remove_hashes: BTreeSet<Cid>,
@@ -754,21 +553,6 @@ impl UpdateBlacklistFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_add_hashes(self, add_hashes: BTreeSet<Cid>) -> Self {
-        Self { add_hashes, ..self }
-    }
-
-    pub fn with_remove_hashes(self, remove_hashes: BTreeSet<Cid>) -> Self {
-        Self {
-            remove_hashes,
-            ..self
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_blacklist(
             self.origin.clone().into(),
@@ -780,6 +564,7 @@ impl UpdateBlacklistFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct DeleteDynamicBagFixture {
     bag_id: DynamicBagId<Test>,
     deletion_account_id: u64,
@@ -793,17 +578,6 @@ impl DeleteDynamicBagFixture {
         }
     }
 
-    pub fn with_deletion_account_id(self, deletion_account_id: u64) -> Self {
-        Self {
-            deletion_account_id,
-            ..self
-        }
-    }
-
-    pub fn with_bag_id(self, bag_id: DynamicBagId<Test>) -> Self {
-        Self { bag_id, ..self }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result =
             Storage::delete_dynamic_bag(self.deletion_account_id, self.bag_id.clone());
@@ -812,21 +586,12 @@ impl DeleteDynamicBagFixture {
     }
 }
 
+#[derive(Fixture, Default)]
 pub struct CanDeleteDynamicBagWithObjectsFixture {
     bag_id: DynamicBagId<Test>,
 }
 
 impl CanDeleteDynamicBagWithObjectsFixture {
-    pub fn default() -> Self {
-        Self {
-            bag_id: Default::default(),
-        }
-    }
-
-    pub fn with_bag_id(self, bag_id: DynamicBagId<Test>) -> Self {
-        Self { bag_id, ..self }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::can_delete_dynamic_bag_with_objects(&self.bag_id.clone());
 
@@ -834,6 +599,7 @@ impl CanDeleteDynamicBagWithObjectsFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct DeleteStorageBucketFixture {
     origin: RawOrigin<u64>,
     storage_bucket_id: u64,
@@ -844,17 +610,6 @@ impl DeleteStorageBucketFixture {
         Self {
             origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
             storage_bucket_id: Default::default(),
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_storage_bucket_id(self, storage_bucket_id: u64) -> Self {
-        Self {
-            storage_bucket_id,
-            ..self
         }
     }
 
@@ -872,6 +627,7 @@ impl DeleteStorageBucketFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct RemoveStorageBucketOperatorFixture {
     origin: RawOrigin<u64>,
     storage_bucket_id: u64,
@@ -882,17 +638,6 @@ impl RemoveStorageBucketOperatorFixture {
         Self {
             origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
             storage_bucket_id: Default::default(),
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_storage_bucket_id(self, storage_bucket_id: u64) -> Self {
-        Self {
-            storage_bucket_id,
-            ..self
         }
     }
 
@@ -918,6 +663,7 @@ impl RemoveStorageBucketOperatorFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateDataObjectPerMegabyteFeeFixture {
     origin: RawOrigin<u64>,
     new_fee: u64,
@@ -929,14 +675,6 @@ impl UpdateDataObjectPerMegabyteFeeFixture {
             origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
             new_fee: 0,
         }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_new_fee(self, new_fee: u64) -> Self {
-        Self { new_fee, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -954,6 +692,7 @@ impl UpdateDataObjectPerMegabyteFeeFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateStorageBucketsPerBagLimitFixture {
     origin: RawOrigin<u64>,
     new_limit: u64,
@@ -965,14 +704,6 @@ impl UpdateStorageBucketsPerBagLimitFixture {
             origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
             new_limit: 0,
         }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_new_limit(self, new_limit: u64) -> Self {
-        Self { new_limit, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -993,6 +724,7 @@ impl UpdateStorageBucketsPerBagLimitFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct SetStorageBucketVoucherLimitsFixture {
     origin: RawOrigin<u64>,
     storage_bucket_id: u64,
@@ -1007,31 +739,6 @@ impl SetStorageBucketVoucherLimitsFixture {
             storage_bucket_id: Default::default(),
             new_objects_size_limit: 0,
             new_objects_number_limit: 0,
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_storage_bucket_id(self, storage_bucket_id: u64) -> Self {
-        Self {
-            storage_bucket_id,
-            ..self
-        }
-    }
-
-    pub fn with_new_objects_size_limit(self, new_objects_size_limit: u64) -> Self {
-        Self {
-            new_objects_size_limit,
-            ..self
-        }
-    }
-
-    pub fn with_new_objects_number_limit(self, new_objects_number_limit: u64) -> Self {
-        Self {
-            new_objects_number_limit,
-            ..self
         }
     }
 
@@ -1056,6 +763,8 @@ impl SetStorageBucketVoucherLimitsFixture {
         }
     }
 }
+
+#[derive(Fixture)]
 pub struct UpdateStorageBucketsVoucherMaxLimitsFixture {
     origin: RawOrigin<u64>,
     new_objects_size_limit: u64,
@@ -1068,24 +777,6 @@ impl UpdateStorageBucketsVoucherMaxLimitsFixture {
             origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
             new_objects_size_limit: 0,
             new_objects_number_limit: 0,
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_new_objects_size_limit(self, new_objects_size_limit: u64) -> Self {
-        Self {
-            new_objects_size_limit,
-            ..self
-        }
-    }
-
-    pub fn with_new_objects_number_limit(self, new_objects_number_limit: u64) -> Self {
-        Self {
-            new_objects_number_limit,
-            ..self
         }
     }
 
@@ -1120,28 +811,15 @@ impl UpdateStorageBucketsVoucherMaxLimitsFixture {
     }
 }
 
+#[derive(Fixture, Default)]
 pub struct CreateDynamicBagFixture {
     bag_id: DynamicBagId<Test>,
     deletion_prize: Option<DynamicBagDeletionPrize<Test>>,
 }
 
 impl CreateDynamicBagFixture {
-    pub fn default() -> Self {
-        Self {
-            bag_id: Default::default(),
-            deletion_prize: Default::default(),
-        }
-    }
-
-    pub fn with_bag_id(self, bag_id: DynamicBagId<Test>) -> Self {
-        Self { bag_id, ..self }
-    }
-
-    pub fn with_deletion_prize(self, deletion_prize: DynamicBagDeletionPrize<Test>) -> Self {
-        Self {
-            deletion_prize: Some(deletion_prize),
-            ..self
-        }
+    pub fn with_some_deletion_prize(self, deletion_prize: DynamicBagDeletionPrize<Test>) -> Self {
+        self.with_deletion_prize(Some(deletion_prize))
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -1157,6 +835,7 @@ impl CreateDynamicBagFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct CreateDynamicBagWithObjectsFixture {
     sender: u64,
     bag_id: DynamicBagId<Test>,
@@ -1214,33 +893,12 @@ impl CreateDynamicBagWithObjectsFixture {
         }
     }
 
-    pub fn with_upload_parameters(self, upload_parameters: UploadParameters<Test>) -> Self {
-        Self {
-            upload_parameters,
-            ..self
-        }
-    }
-
     pub fn with_objects_prize_source_account(self, deletion_prize_source_account_id: u64) -> Self {
         Self {
             upload_parameters: UploadParameters::<Test> {
                 deletion_prize_source_account_id,
                 ..self.upload_parameters
             },
-            ..self
-        }
-    }
-
-    pub fn with_bag_id(self, bag_id: DynamicBagId<Test>) -> Self {
-        Self { bag_id, ..self }
-    }
-
-    pub fn with_deletion_prize(
-        self,
-        deletion_prize: Option<DynamicBagDeletionPrize<Test>>,
-    ) -> Self {
-        Self {
-            deletion_prize: deletion_prize,
             ..self
         }
     }
@@ -1298,6 +956,7 @@ impl CreateDynamicBagWithObjectsFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture {
     origin: RawOrigin<u64>,
     new_storage_buckets_number: u64,
@@ -1310,24 +969,6 @@ impl UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture {
             origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
             new_storage_buckets_number: 0,
             dynamic_bag_type: Default::default(),
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_new_storage_buckets_number(self, new_storage_buckets_number: u64) -> Self {
-        Self {
-            new_storage_buckets_number,
-            ..self
-        }
-    }
-
-    pub fn with_dynamic_bag_type(self, dynamic_bag_type: DynamicBagType) -> Self {
-        Self {
-            dynamic_bag_type,
-            ..self
         }
     }
 
@@ -1355,6 +996,7 @@ impl UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct CreateDistributionBucketFamilyFixture {
     origin: RawOrigin<u64>,
 }
@@ -1364,10 +1006,6 @@ impl CreateDistributionBucketFamilyFixture {
         Self {
             origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
         }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) -> Option<u64> {
@@ -1406,6 +1044,7 @@ impl CreateDistributionBucketFamilyFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct DeleteDistributionBucketFamilyFixture {
     origin: RawOrigin<u64>,
     family_id: u64,
@@ -1417,14 +1056,6 @@ impl DeleteDistributionBucketFamilyFixture {
             origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
             family_id: Default::default(),
         }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -1448,6 +1079,7 @@ impl DeleteDistributionBucketFamilyFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct CreateDistributionBucketFixture {
     origin: RawOrigin<u64>,
     family_id: u64,
@@ -1460,21 +1092,6 @@ impl CreateDistributionBucketFixture {
             origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
             family_id: Default::default(),
             accept_new_bags: false,
-        }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_accept_new_bags(self, accept_new_bags: bool) -> Self {
-        Self {
-            accept_new_bags,
-            ..self
         }
     }
 
@@ -1517,6 +1134,7 @@ impl CreateDistributionBucketFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateDistributionBucketStatusFixture {
     origin: RawOrigin<u64>,
     family_id: u64,
@@ -1533,24 +1151,6 @@ impl UpdateDistributionBucketStatusFixture {
             new_status: false,
         }
     }
-    pub fn with_bucket_index(self, bucket_index: u64) -> Self {
-        Self {
-            distribution_bucket_index: bucket_index,
-            ..self
-        }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_new_status(self, new_status: bool) -> Self {
-        Self { new_status, ..self }
-    }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_distribution_bucket_status(
@@ -1563,6 +1163,7 @@ impl UpdateDistributionBucketStatusFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct DeleteDistributionBucketFixture {
     origin: RawOrigin<u64>,
     family_id: u64,
@@ -1578,21 +1179,6 @@ impl DeleteDistributionBucketFixture {
         }
     }
 
-    pub fn with_bucket_index(self, bucket_index: u64) -> Self {
-        Self {
-            distribution_bucket_index: bucket_index,
-            ..self
-        }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::delete_distribution_bucket(
             self.origin.clone().into(),
@@ -1603,6 +1189,7 @@ impl DeleteDistributionBucketFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateDistributionBucketForBagsFixture {
     origin: RawOrigin<u64>,
     bag_id: BagId<Test>,
@@ -1622,32 +1209,6 @@ impl UpdateDistributionBucketForBagsFixture {
         }
     }
 
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_add_bucket_indices(self, add_bucket_indices: BTreeSet<u64>) -> Self {
-        Self {
-            add_bucket_indices,
-            ..self
-        }
-    }
-
-    pub fn with_remove_bucket_indices(self, remove_bucket_indices: BTreeSet<u64>) -> Self {
-        Self {
-            remove_bucket_indices,
-            ..self
-        }
-    }
-
-    pub fn with_bag_id(self, bag_id: BagId<Test>) -> Self {
-        Self { bag_id, ..self }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_distribution_buckets_for_bag(
             self.origin.clone().into(),
@@ -1661,6 +1222,7 @@ impl UpdateDistributionBucketForBagsFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateDistributionBucketsPerBagLimitFixture {
     origin: RawOrigin<u64>,
     new_limit: u64,
@@ -1672,14 +1234,6 @@ impl UpdateDistributionBucketsPerBagLimitFixture {
             origin: RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID),
             new_limit: 0,
         }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_new_limit(self, new_limit: u64) -> Self {
-        Self { new_limit, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -1703,6 +1257,7 @@ impl UpdateDistributionBucketsPerBagLimitFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateDistributionBucketModeFixture {
     origin: RawOrigin<u64>,
     family_id: u64,
@@ -1719,27 +1274,6 @@ impl UpdateDistributionBucketModeFixture {
             distributing: true,
         }
     }
-    pub fn with_bucket_index(self, bucket_index: u64) -> Self {
-        Self {
-            distribution_bucket_index: bucket_index,
-            ..self
-        }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_distributing(self, distributing: bool) -> Self {
-        Self {
-            distributing,
-            ..self
-        }
-    }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_distribution_bucket_mode(
@@ -1752,6 +1286,7 @@ impl UpdateDistributionBucketModeFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct UpdateFamiliesInDynamicBagCreationPolicyFixture {
     origin: RawOrigin<u64>,
     dynamic_bag_type: DynamicBagType,
@@ -1764,21 +1299,6 @@ impl UpdateFamiliesInDynamicBagCreationPolicyFixture {
             origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
             dynamic_bag_type: Default::default(),
             families: Default::default(),
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_families(self, families: BTreeMap<u64, u32>) -> Self {
-        Self { families, ..self }
-    }
-
-    pub fn with_dynamic_bag_type(self, dynamic_bag_type: DynamicBagType) -> Self {
-        Self {
-            dynamic_bag_type,
-            ..self
         }
     }
 
@@ -1807,6 +1327,7 @@ impl UpdateFamiliesInDynamicBagCreationPolicyFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct InviteDistributionBucketOperatorFixture {
     origin: RawOrigin<u64>,
     operator_worker_id: u64,
@@ -1822,28 +1343,6 @@ impl InviteDistributionBucketOperatorFixture {
             bucket_index: Default::default(),
             family_id: Default::default(),
         }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_operator_worker_id(self, operator_worker_id: u64) -> Self {
-        Self {
-            operator_worker_id,
-            ..self
-        }
-    }
-
-    pub fn with_bucket_index(self, bucket_index: u64) -> Self {
-        Self {
-            bucket_index,
-            ..self
-        }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -1869,6 +1368,7 @@ impl InviteDistributionBucketOperatorFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct CancelDistributionBucketInvitationFixture {
     origin: RawOrigin<u64>,
     bucket_index: u64,
@@ -1883,28 +1383,6 @@ impl CancelDistributionBucketInvitationFixture {
             bucket_index: Default::default(),
             family_id: Default::default(),
             operator_worker_id: Default::default(),
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_bucket_index(self, bucket_index: u64) -> Self {
-        Self {
-            bucket_index,
-            ..self
-        }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
-    pub fn with_operator_worker_id(self, operator_worker_id: u64) -> Self {
-        Self {
-            operator_worker_id,
-            ..self
         }
     }
 
@@ -1931,6 +1409,7 @@ impl CancelDistributionBucketInvitationFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct AcceptDistributionBucketInvitationFixture {
     origin: RawOrigin<u64>,
     bucket_index: u64,
@@ -1946,25 +1425,6 @@ impl AcceptDistributionBucketInvitationFixture {
             family_id: Default::default(),
             worker_id: Default::default(),
         }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_bucket_index(self, bucket_index: u64) -> Self {
-        Self {
-            bucket_index,
-            ..self
-        }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
-    pub fn with_worker_id(self, worker_id: u64) -> Self {
-        Self { worker_id, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
@@ -1990,6 +1450,7 @@ impl AcceptDistributionBucketInvitationFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct SetDistributionBucketMetadataFixture {
     origin: RawOrigin<u64>,
     bucket_index: u64,
@@ -2009,29 +1470,6 @@ impl SetDistributionBucketMetadataFixture {
         }
     }
 
-    pub fn with_metadata(self, metadata: Vec<u8>) -> Self {
-        Self { metadata, ..self }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_bucket_index(self, bucket_index: u64) -> Self {
-        Self {
-            bucket_index,
-            ..self
-        }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
-    pub fn with_worker_id(self, worker_id: u64) -> Self {
-        Self { worker_id, ..self }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::set_distribution_operator_metadata(
             self.origin.clone().into(),
@@ -2044,6 +1482,7 @@ impl SetDistributionBucketMetadataFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct RemoveDistributionBucketOperatorFixture {
     origin: RawOrigin<u64>,
     bucket_index: u64,
@@ -2058,28 +1497,6 @@ impl RemoveDistributionBucketOperatorFixture {
             bucket_index: Default::default(),
             family_id: Default::default(),
             operator_worker_id: Default::default(),
-        }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_bucket_index(self, bucket_index: u64) -> Self {
-        Self {
-            bucket_index,
-            ..self
-        }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
-    }
-
-    pub fn with_operator_worker_id(self, operator_worker_id: u64) -> Self {
-        Self {
-            operator_worker_id,
-            ..self
         }
     }
 
@@ -2103,6 +1520,7 @@ impl RemoveDistributionBucketOperatorFixture {
     }
 }
 
+#[derive(Fixture)]
 pub struct SetDistributionBucketFamilyMetadataFixture {
     origin: RawOrigin<u64>,
     family_id: u64,
@@ -2116,18 +1534,6 @@ impl SetDistributionBucketFamilyMetadataFixture {
             family_id: Default::default(),
             metadata: Default::default(),
         }
-    }
-
-    pub fn with_metadata(self, metadata: Vec<u8>) -> Self {
-        Self { metadata, ..self }
-    }
-
-    pub fn with_origin(self, origin: RawOrigin<u64>) -> Self {
-        Self { origin, ..self }
-    }
-
-    pub fn with_family_id(self, family_id: u64) -> Self {
-        Self { family_id, ..self }
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {

--- a/runtime-modules/storage/src/tests/fixtures.rs
+++ b/runtime-modules/storage/src/tests/fixtures.rs
@@ -1,4 +1,5 @@
 use derive_fixture::Fixture;
+use derive_new::new;
 use frame_support::dispatch::DispatchResult;
 use frame_support::storage::StorageMap;
 use frame_support::traits::{Currency, OnFinalize, OnInitialize};
@@ -21,7 +22,7 @@ use crate::tests::mocks::{
 use crate::{
     BagId, Cid, DataObjectCreationParameters, DataObjectStorage, DistributionBucket,
     DistributionBucketId, DynamicBagDeletionPrize, DynamicBagId, DynamicBagType, RawEvent,
-    StaticBagId, StorageBucketOperatorStatus, UploadParameters,
+    StorageBucketOperatorStatus, UploadParameters,
 };
 
 // Recommendation from Parity on testing on_finalize
@@ -111,26 +112,25 @@ pub const DEFAULT_DATA_OBJECTS_NUMBER: u64 = DEFAULT_STORAGE_BUCKET_OBJECTS_LIMI
 pub const DEFAULT_DATA_OBJECTS_SIZE: u64 =
     DEFAULT_STORAGE_BUCKET_SIZE_LIMIT / DEFAULT_DATA_OBJECTS_NUMBER - 1;
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct CreateStorageBucketFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     invite_worker: Option<u64>,
+
+    #[new(value = "true")]
     accepting_new_bags: bool,
+
+    #[new(default)]
     size_limit: u64,
+
+    #[new(default)]
     objects_limit: u64,
 }
 
 impl CreateStorageBucketFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-            invite_worker: None,
-            accepting_new_bags: true,
-            size_limit: 0,
-            objects_limit: 0,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) -> Option<u64> {
         let next_storage_bucket_id = Storage::next_storage_bucket_id();
         let actual_result = Storage::create_storage_bucket(
@@ -164,24 +164,22 @@ impl CreateStorageBucketFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct AcceptStorageBucketInvitationFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(value = "DEFAULT_WORKER_ID")]
     worker_id: u64,
+
+    #[new(default)]
     storage_bucket_id: u64,
+
+    #[new(value = "DEFAULT_ACCOUNT_ID")]
     transactor_account_id: u64,
 }
 
 impl AcceptStorageBucketInvitationFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-            worker_id: DEFAULT_WORKER_ID,
-            storage_bucket_id: Default::default(),
-            transactor_account_id: DEFAULT_ACCOUNT_ID,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_bucket = Storage::storage_bucket_by_id(self.storage_bucket_id);
 
@@ -209,24 +207,22 @@ impl AcceptStorageBucketInvitationFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateStorageBucketForBagsFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     bag_id: BagId<Test>,
+
+    #[new(default)]
     add_bucket_ids: BTreeSet<u64>,
+
+    #[new(default)]
     remove_bucket_ids: BTreeSet<u64>,
 }
 
 impl UpdateStorageBucketForBagsFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-            bag_id: Default::default(),
-            add_bucket_ids: Default::default(),
-            remove_bucket_ids: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_storage_buckets_for_bag(
             self.origin.clone().into(),
@@ -282,24 +278,22 @@ pub fn create_single_data_object() -> Vec<DataObjectCreationParameters> {
     create_data_object_candidates(1, 1)
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct SetStorageOperatorMetadataFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(value = "DEFAULT_WORKER_ID")]
     worker_id: u64,
+
+    #[new(default)]
     storage_bucket_id: u64,
+
+    #[new(default)]
     metadata: Vec<u8>,
 }
 
 impl SetStorageOperatorMetadataFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            worker_id: DEFAULT_WORKER_ID,
-            storage_bucket_id: Default::default(),
-            metadata: Vec::new(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::set_storage_operator_metadata(
             self.origin.clone().into(),
@@ -312,26 +306,25 @@ impl SetStorageOperatorMetadataFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct AcceptPendingDataObjectsFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(value = "DEFAULT_WORKER_ID")]
     worker_id: u64,
+
+    #[new(default)]
     storage_bucket_id: u64,
+
+    #[new(default)]
     bag_id: BagId<Test>,
+
+    #[new(default)]
     data_object_ids: BTreeSet<u64>,
 }
 
 impl AcceptPendingDataObjectsFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID),
-            worker_id: DEFAULT_WORKER_ID,
-            storage_bucket_id: Default::default(),
-            data_object_ids: Default::default(),
-            bag_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::accept_pending_data_objects(
             self.origin.clone().into(),
@@ -345,20 +338,16 @@ impl AcceptPendingDataObjectsFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct CancelStorageBucketInvitationFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     storage_bucket_id: u64,
 }
 
 impl CancelStorageBucketInvitationFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
-            storage_bucket_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_bucket = Storage::storage_bucket_by_id(self.storage_bucket_id);
 
@@ -381,22 +370,19 @@ impl CancelStorageBucketInvitationFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct InviteStorageBucketOperatorFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(value = "DEFAULT_WORKER_ID")]
     operator_worker_id: u64,
+
+    #[new(default)]
     storage_bucket_id: u64,
 }
 
 impl InviteStorageBucketOperatorFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-            operator_worker_id: DEFAULT_WORKER_ID,
-            storage_bucket_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_bucket = Storage::storage_bucket_by_id(self.storage_bucket_id);
 
@@ -420,20 +406,16 @@ impl InviteStorageBucketOperatorFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateUploadingBlockedStatusFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     new_status: bool,
 }
 
 impl UpdateUploadingBlockedStatusFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
-            new_status: false,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_status = Storage::uploading_blocked();
 
@@ -450,7 +432,7 @@ impl UpdateUploadingBlockedStatusFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, Default)]
 pub struct MoveDataObjectsFixture {
     src_bag_id: BagId<Test>,
     dest_bag_id: BagId<Test>,
@@ -458,14 +440,6 @@ pub struct MoveDataObjectsFixture {
 }
 
 impl MoveDataObjectsFixture {
-    pub fn default() -> Self {
-        Self {
-            src_bag_id: BagId::<Test>::Static(StaticBagId::Council),
-            dest_bag_id: BagId::<Test>::Static(StaticBagId::Council),
-            data_object_ids: BTreeSet::new(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::move_data_objects(
             self.src_bag_id.clone(),
@@ -477,22 +451,19 @@ impl MoveDataObjectsFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct DeleteDataObjectsFixture {
+    #[new(value = "DEFAULT_ACCOUNT_ID")]
     deletion_prize_account_id: u64,
+
+    #[new(default)]
     bag_id: BagId<Test>,
+
+    #[new(default)]
     data_object_ids: BTreeSet<u64>,
 }
 
 impl DeleteDataObjectsFixture {
-    pub fn default() -> Self {
-        Self {
-            bag_id: Default::default(),
-            data_object_ids: Default::default(),
-            deletion_prize_account_id: DEFAULT_ACCOUNT_ID,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::delete_data_objects(
             self.deletion_prize_account_id,
@@ -504,22 +475,19 @@ impl DeleteDataObjectsFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateStorageBucketStatusFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     storage_bucket_id: u64,
+
+    #[new(default)]
     new_status: bool,
 }
 
 impl UpdateStorageBucketStatusFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            storage_bucket_id: Default::default(),
-            new_status: false,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_storage_bucket_status(
             self.origin.clone().into(),
@@ -537,22 +505,19 @@ impl UpdateStorageBucketStatusFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateBlacklistFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     remove_hashes: BTreeSet<Cid>,
+
+    #[new(default)]
     add_hashes: BTreeSet<Cid>,
 }
 
 impl UpdateBlacklistFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
-            remove_hashes: BTreeSet::new(),
-            add_hashes: BTreeSet::new(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_blacklist(
             self.origin.clone().into(),
@@ -564,20 +529,16 @@ impl UpdateBlacklistFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct DeleteDynamicBagFixture {
+    #[new(default)]
     bag_id: DynamicBagId<Test>,
+
+    #[new(value = "DEFAULT_ACCOUNT_ID")]
     deletion_account_id: u64,
 }
 
 impl DeleteDynamicBagFixture {
-    pub fn default() -> Self {
-        Self {
-            bag_id: Default::default(),
-            deletion_account_id: DEFAULT_ACCOUNT_ID,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result =
             Storage::delete_dynamic_bag(self.deletion_account_id, self.bag_id.clone());
@@ -599,20 +560,16 @@ impl CanDeleteDynamicBagWithObjectsFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct DeleteStorageBucketFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     storage_bucket_id: u64,
 }
 
 impl DeleteStorageBucketFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-            storage_bucket_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result =
             Storage::delete_storage_bucket(self.origin.clone().into(), self.storage_bucket_id);
@@ -627,20 +584,16 @@ impl DeleteStorageBucketFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct RemoveStorageBucketOperatorFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     storage_bucket_id: u64,
 }
 
 impl RemoveStorageBucketOperatorFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
-            storage_bucket_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_bucket = Storage::storage_bucket_by_id(self.storage_bucket_id);
 
@@ -663,20 +616,16 @@ impl RemoveStorageBucketOperatorFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateDataObjectPerMegabyteFeeFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     new_fee: u64,
 }
 
 impl UpdateDataObjectPerMegabyteFeeFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
-            new_fee: 0,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_fee = Storage::data_object_per_mega_byte_fee();
 
@@ -692,20 +641,16 @@ impl UpdateDataObjectPerMegabyteFeeFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateStorageBucketsPerBagLimitFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     new_limit: u64,
 }
 
 impl UpdateStorageBucketsPerBagLimitFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
-            new_limit: 0,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_fee = Storage::storage_buckets_per_bag_limit();
 
@@ -724,24 +669,22 @@ impl UpdateStorageBucketsPerBagLimitFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct SetStorageBucketVoucherLimitsFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     storage_bucket_id: u64,
+
+    #[new(default)]
     new_objects_size_limit: u64,
+
+    #[new(default)]
     new_objects_number_limit: u64,
 }
 
 impl SetStorageBucketVoucherLimitsFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            storage_bucket_id: Default::default(),
-            new_objects_size_limit: 0,
-            new_objects_number_limit: 0,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_voucher = Storage::storage_bucket_by_id(self.storage_bucket_id).voucher;
         let actual_result = Storage::set_storage_bucket_voucher_limits(
@@ -764,22 +707,19 @@ impl SetStorageBucketVoucherLimitsFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateStorageBucketsVoucherMaxLimitsFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     new_objects_size_limit: u64,
+
+    #[new(default)]
     new_objects_number_limit: u64,
 }
 
 impl UpdateStorageBucketsVoucherMaxLimitsFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
-            new_objects_size_limit: 0,
-            new_objects_number_limit: 0,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_size_limit = Storage::voucher_max_objects_size_limit();
         let old_number_limit = Storage::voucher_max_objects_number_limit();
@@ -956,22 +896,19 @@ impl CreateDynamicBagWithObjectsFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     new_storage_buckets_number: u64,
+
+    #[new(default)]
     dynamic_bag_type: DynamicBagType,
 }
 
 impl UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
-            new_storage_buckets_number: 0,
-            dynamic_bag_type: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_policy = Storage::get_dynamic_bag_creation_policy(self.dynamic_bag_type);
 
@@ -996,18 +933,13 @@ impl UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct CreateDistributionBucketFamilyFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
 }
 
 impl CreateDistributionBucketFamilyFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) -> Option<u64> {
         let next_family_id = Storage::next_distribution_bucket_family_id();
         let family_number = Storage::distribution_bucket_family_number();
@@ -1044,20 +976,16 @@ impl CreateDistributionBucketFamilyFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct DeleteDistributionBucketFamilyFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     family_id: u64,
 }
 
 impl DeleteDistributionBucketFamilyFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-            family_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let family_number = Storage::distribution_bucket_family_number();
         let actual_result =
@@ -1079,22 +1007,19 @@ impl DeleteDistributionBucketFamilyFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct CreateDistributionBucketFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     accept_new_bags: bool,
 }
 
 impl CreateDistributionBucketFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-            family_id: Default::default(),
-            accept_new_bags: false,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) -> Option<u64> {
         let next_bucket_index = Storage::distribution_bucket_family_by_id(self.family_id)
             .next_distribution_bucket_index;
@@ -1134,24 +1059,22 @@ impl CreateDistributionBucketFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateDistributionBucketStatusFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     distribution_bucket_index: u64,
+
+    #[new(default)]
     new_status: bool,
 }
 
 impl UpdateDistributionBucketStatusFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            family_id: Default::default(),
-            distribution_bucket_index: Default::default(),
-            new_status: false,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_distribution_bucket_status(
             self.origin.clone().into(),
@@ -1163,22 +1086,19 @@ impl UpdateDistributionBucketStatusFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct DeleteDistributionBucketFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     distribution_bucket_index: u64,
 }
 
 impl DeleteDistributionBucketFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            family_id: Default::default(),
-            distribution_bucket_index: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::delete_distribution_bucket(
             self.origin.clone().into(),
@@ -1189,26 +1109,25 @@ impl DeleteDistributionBucketFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateDistributionBucketForBagsFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     bag_id: BagId<Test>,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     add_bucket_indices: BTreeSet<u64>,
+
+    #[new(default)]
     remove_bucket_indices: BTreeSet<u64>,
 }
 
 impl UpdateDistributionBucketForBagsFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-            bag_id: Default::default(),
-            family_id: Default::default(),
-            add_bucket_indices: Default::default(),
-            remove_bucket_indices: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_distribution_buckets_for_bag(
             self.origin.clone().into(),
@@ -1222,20 +1141,16 @@ impl UpdateDistributionBucketForBagsFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateDistributionBucketsPerBagLimitFixture {
+    #[new(value = "RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     new_limit: u64,
 }
 
 impl UpdateDistributionBucketsPerBagLimitFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID),
-            new_limit: 0,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_limit = Storage::distribution_buckets_per_bag_limit();
 
@@ -1257,24 +1172,22 @@ impl UpdateDistributionBucketsPerBagLimitFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateDistributionBucketModeFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     distribution_bucket_index: u64,
+
+    #[new(value = "true")]
     distributing: bool,
 }
 
 impl UpdateDistributionBucketModeFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            family_id: Default::default(),
-            distribution_bucket_index: Default::default(),
-            distributing: true,
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::update_distribution_bucket_mode(
             self.origin.clone().into(),
@@ -1286,22 +1199,19 @@ impl UpdateDistributionBucketModeFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct UpdateFamiliesInDynamicBagCreationPolicyFixture {
+    #[new(value = "RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     dynamic_bag_type: DynamicBagType,
+
+    #[new(default)]
     families: BTreeMap<u64, u32>,
 }
 
 impl UpdateFamiliesInDynamicBagCreationPolicyFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID),
-            dynamic_bag_type: Default::default(),
-            families: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let old_policy = Storage::get_dynamic_bag_creation_policy(self.dynamic_bag_type);
 
@@ -1327,24 +1237,22 @@ impl UpdateFamiliesInDynamicBagCreationPolicyFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct InviteDistributionBucketOperatorFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(value = "DEFAULT_WORKER_ID")]
     operator_worker_id: u64,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     bucket_index: u64,
 }
 
 impl InviteDistributionBucketOperatorFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
-            operator_worker_id: DEFAULT_WORKER_ID,
-            bucket_index: Default::default(),
-            family_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::invite_distribution_bucket_operator(
             self.origin.clone().into(),
@@ -1368,24 +1276,22 @@ impl InviteDistributionBucketOperatorFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct CancelDistributionBucketInvitationFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     bucket_index: u64,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     operator_worker_id: u64,
 }
 
 impl CancelDistributionBucketInvitationFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID),
-            bucket_index: Default::default(),
-            family_id: Default::default(),
-            operator_worker_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::cancel_distribution_bucket_operator_invite(
             self.origin.clone().into(),
@@ -1409,24 +1315,22 @@ impl CancelDistributionBucketInvitationFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct AcceptDistributionBucketInvitationFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     bucket_index: u64,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     worker_id: u64,
 }
 
 impl AcceptDistributionBucketInvitationFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID),
-            bucket_index: Default::default(),
-            family_id: Default::default(),
-            worker_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::accept_distribution_bucket_invitation(
             self.origin.clone().into(),
@@ -1450,26 +1354,25 @@ impl AcceptDistributionBucketInvitationFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct SetDistributionBucketMetadataFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     bucket_index: u64,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     worker_id: u64,
+
+    #[new(default)]
     metadata: Vec<u8>,
 }
 
 impl SetDistributionBucketMetadataFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID),
-            bucket_index: Default::default(),
-            family_id: Default::default(),
-            worker_id: Default::default(),
-            metadata: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::set_distribution_operator_metadata(
             self.origin.clone().into(),
@@ -1482,24 +1385,22 @@ impl SetDistributionBucketMetadataFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(new, Fixture)]
 pub struct RemoveDistributionBucketOperatorFixture {
+    #[new(value = "RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     bucket_index: u64,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     operator_worker_id: u64,
 }
 
 impl RemoveDistributionBucketOperatorFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID),
-            bucket_index: Default::default(),
-            family_id: Default::default(),
-            operator_worker_id: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::remove_distribution_bucket_operator(
             self.origin.clone().into(),
@@ -1520,22 +1421,19 @@ impl RemoveDistributionBucketOperatorFixture {
     }
 }
 
-#[derive(Fixture)]
+#[derive(Fixture, new)]
 pub struct SetDistributionBucketFamilyMetadataFixture {
+    #[new(value = "RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID)")]
     origin: RawOrigin<u64>,
+
+    #[new(default)]
     family_id: u64,
+
+    #[new(default)]
     metadata: Vec<u8>,
 }
 
 impl SetDistributionBucketFamilyMetadataFixture {
-    pub fn default() -> Self {
-        Self {
-            origin: RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID),
-            family_id: Default::default(),
-            metadata: Default::default(),
-        }
-    }
-
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let actual_result = Storage::set_distribution_bucket_family_metadata(
             self.origin.clone().into(),

--- a/runtime-modules/storage/src/tests/mod.rs
+++ b/runtime-modules/storage/src/tests/mod.rs
@@ -2220,7 +2220,7 @@ fn delete_data_objects_succeeded() {
         DeleteDataObjectsFixture::default()
             .with_bag_id(bag_id.clone())
             .with_data_object_ids(data_object_ids.clone())
-            .with_deletion_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
+            .with_deletion_prize_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
             .call_and_assert(Ok(()));
 
         // post-checks
@@ -2262,7 +2262,7 @@ fn delete_data_objects_fails_with_non_existent_dynamic_bag() {
         DeleteDataObjectsFixture::default()
             .with_bag_id(bag_id.clone())
             .with_data_object_ids(data_object_ids.clone())
-            .with_deletion_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
+            .with_deletion_prize_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
             .call_and_assert(Err(Error::<Test>::DynamicBagDoesntExist.into()));
     });
 }
@@ -2310,7 +2310,7 @@ fn delete_data_objects_fails_with_invalid_treasury_balance() {
         DeleteDataObjectsFixture::default()
             .with_bag_id(council_bag_id.clone())
             .with_data_object_ids(data_object_ids.clone())
-            .with_deletion_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
+            .with_deletion_prize_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
             .call_and_assert(Err(Error::<Test>::InsufficientTreasuryBalance.into()));
     });
 }
@@ -2625,7 +2625,7 @@ fn delete_dynamic_bags_succeeded() {
         let dynamic_bag_id = DynamicBagId::<Test>::Member(DEFAULT_MEMBER_ID);
         CreateDynamicBagFixture::default()
             .with_bag_id(dynamic_bag_id.clone())
-            .with_deletion_prize(DynamicBagDeletionPrize::<Test> {
+            .with_some_deletion_prize(DynamicBagDeletionPrize::<Test> {
                 account_id: DEFAULT_MEMBER_ACCOUNT_ID,
                 prize: deletion_prize_value,
             })
@@ -2693,7 +2693,7 @@ fn delete_dynamic_bags_succeeded_with_assigned_distribution_buckets() {
         let dynamic_bag_id = DynamicBagId::<Test>::Member(DEFAULT_MEMBER_ID);
         CreateDynamicBagFixture::default()
             .with_bag_id(dynamic_bag_id.clone())
-            .with_deletion_prize(DynamicBagDeletionPrize::<Test> {
+            .with_some_deletion_prize(DynamicBagDeletionPrize::<Test> {
                 account_id: DEFAULT_MEMBER_ACCOUNT_ID,
                 prize: deletion_prize_value,
             })
@@ -2746,7 +2746,7 @@ fn delete_dynamic_bags_succeeded_with_assigned_storage_buckets() {
         let dynamic_bag_id = DynamicBagId::<Test>::Member(DEFAULT_MEMBER_ID);
         CreateDynamicBagFixture::default()
             .with_bag_id(dynamic_bag_id.clone())
-            .with_deletion_prize(DynamicBagDeletionPrize::<Test> {
+            .with_some_deletion_prize(DynamicBagDeletionPrize::<Test> {
                 account_id: DEFAULT_MEMBER_ACCOUNT_ID,
                 prize: deletion_prize_value,
             })
@@ -2798,7 +2798,7 @@ fn delete_dynamic_bags_fails_with_insufficient_balance_for_deletion_prize() {
         let dynamic_bag_id = DynamicBagId::<Test>::Member(DEFAULT_MEMBER_ID);
         CreateDynamicBagFixture::default()
             .with_bag_id(dynamic_bag_id.clone())
-            .with_deletion_prize(DynamicBagDeletionPrize::<Test> {
+            .with_some_deletion_prize(DynamicBagDeletionPrize::<Test> {
                 account_id: DEFAULT_MEMBER_ACCOUNT_ID,
                 prize: deletion_prize_value,
             })
@@ -3343,7 +3343,7 @@ fn create_dynamic_bag_succeeded() {
 
         CreateDynamicBagFixture::default()
             .with_bag_id(dynamic_bag_id.clone())
-            .with_deletion_prize(deletion_prize.clone())
+            .with_some_deletion_prize(deletion_prize.clone())
             .call_and_assert(Ok(()));
 
         let bag = Storage::dynamic_bag(&dynamic_bag_id);
@@ -3410,7 +3410,7 @@ fn create_dynamic_bag_fails_with_insufficient_balance() {
 
         CreateDynamicBagFixture::default()
             .with_bag_id(dynamic_bag_id.clone())
-            .with_deletion_prize(deletion_prize)
+            .with_some_deletion_prize(deletion_prize)
             .call_and_assert(Err(Error::<Test>::InsufficientBalance.into()));
     });
 }
@@ -3961,7 +3961,7 @@ fn update_distribution_bucket_status_succeeded() {
         let new_status = true;
         UpdateDistributionBucketStatusFixture::default()
             .with_family_id(family_id)
-            .with_bucket_index(bucket_index)
+            .with_distribution_bucket_index(bucket_index)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_new_status(new_status)
             .call_and_assert(Ok(()));
@@ -4021,7 +4021,7 @@ fn delete_distribution_bucket_succeeded() {
             .unwrap();
 
         DeleteDistributionBucketFixture::default()
-            .with_bucket_index(bucket_index)
+            .with_distribution_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()));
@@ -4069,7 +4069,7 @@ fn delete_distribution_bucket_fails_with_assgined_bags() {
         assert_eq!(bag.distributed_by, add_buckets);
 
         DeleteDistributionBucketFixture::default()
-            .with_bucket_index(bucket_index)
+            .with_distribution_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionBucketIsBoundToBag.into()));
@@ -4105,7 +4105,7 @@ fn delete_distribution_bucket_failed_with_existing_operators() {
             .call_and_assert(Ok(()));
 
         DeleteDistributionBucketFixture::default()
-            .with_bucket_index(bucket_index)
+            .with_distribution_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionProviderOperatorSet.into()));
@@ -4435,7 +4435,7 @@ fn update_distribution_bucket_mode_succeeded() {
         let distributing = false;
         UpdateDistributionBucketModeFixture::default()
             .with_family_id(family_id)
-            .with_bucket_index(bucket_index)
+            .with_distribution_bucket_index(bucket_index)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_distributing(distributing)
             .call_and_assert(Ok(()));
@@ -4585,7 +4585,7 @@ fn distribution_bucket_family_pick_during_dynamic_bag_creation_succeeded() {
         DeleteDistributionBucketFixture::default()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(deleted_bucket_id.distribution_bucket_family_id)
-            .with_bucket_index(deleted_bucket_id.distribution_bucket_index)
+            .with_distribution_bucket_index(deleted_bucket_id.distribution_bucket_index)
             .call_and_assert(Ok(()));
 
         let disabled_bucket_id = bucket_id6[0].clone();
@@ -4593,7 +4593,7 @@ fn distribution_bucket_family_pick_during_dynamic_bag_creation_succeeded() {
             .with_new_status(false)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(disabled_bucket_id.distribution_bucket_family_id)
-            .with_bucket_index(disabled_bucket_id.distribution_bucket_index)
+            .with_distribution_bucket_index(disabled_bucket_id.distribution_bucket_index)
             .call_and_assert(Ok(()));
 
         let families = BTreeMap::from_iter(vec![
@@ -4613,8 +4613,6 @@ fn distribution_bucket_family_pick_during_dynamic_bag_creation_succeeded() {
 
         let picked_bucket_ids =
             Storage::pick_distribution_buckets_for_dynamic_bag(dynamic_bag_type);
-
-        println!("{:?}", picked_bucket_ids);
 
         assert_eq!(picked_bucket_ids.len(), (new_bucket_number * 2) as usize); // buckets from two families
 

--- a/runtime-modules/storage/src/tests/mod.rs
+++ b/runtime-modules/storage/src/tests/mod.rs
@@ -41,7 +41,7 @@ use fixtures::*;
 
 fn create_storage_buckets(buckets_number: u64) -> BTreeSet<u64> {
     set_max_voucher_limits();
-    CreateStorageBucketFixture::default()
+    CreateStorageBucketFixture::new()
         .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
         .with_objects_limit(DEFAULT_STORAGE_BUCKET_OBJECTS_LIMIT)
         .with_size_limit(DEFAULT_STORAGE_BUCKET_SIZE_LIMIT)
@@ -79,7 +79,7 @@ fn create_storage_bucket_succeeded() {
 
         let invite_worker = None;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_accepting_new_bags(accepting_new_bags)
             .with_invite_worker(invite_worker)
@@ -111,12 +111,12 @@ fn create_storage_bucket_fails_with_invalid_voucher_params() {
         let size_limit = 2000;
         let objects_limit = 10;
 
-        CreateStorageBucketFixture::default()
+        CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_size_limit(size_limit)
             .call_and_assert(Err(Error::<Test>::VoucherMaxObjectSizeLimitExceeded.into()));
 
-        CreateStorageBucketFixture::default()
+        CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_objects_limit(objects_limit)
             .call_and_assert(Err(
@@ -132,7 +132,7 @@ fn create_storage_bucket_succeeded_with_invited_member() {
         let accepting_new_bags = true;
         let invite_worker = Some(invited_worker_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_accepting_new_bags(accepting_new_bags)
             .with_invite_worker(invite_worker)
@@ -151,7 +151,7 @@ fn create_storage_bucket_succeeded_with_invited_member() {
 #[test]
 fn create_storage_bucket_fails_with_non_signed_origin() {
     build_test_externalities().execute_with(|| {
-        CreateStorageBucketFixture::default()
+        CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::None)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -162,7 +162,7 @@ fn create_storage_bucket_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_account_id = 1;
 
-        CreateStorageBucketFixture::default()
+        CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_account_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -173,7 +173,7 @@ fn create_storage_bucket_fails_with_invalid_storage_provider_id() {
     build_test_externalities().execute_with(|| {
         let invalid_storage_provider_id = 155;
 
-        CreateStorageBucketFixture::default()
+        CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(Some(invalid_storage_provider_id))
             .call_and_assert(Err(Error::<Test>::StorageProviderOperatorDoesntExist.into()));
@@ -190,13 +190,13 @@ fn accept_storage_bucket_invitation_succeeded() {
         let invite_worker = Some(storage_provider_id);
         let transactor_id = DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -216,7 +216,7 @@ fn accept_storage_bucket_invitation_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_storage_provider_id = 1;
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(non_storage_provider_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -225,7 +225,7 @@ fn accept_storage_bucket_invitation_fails_with_non_leader_origin() {
 #[test]
 fn accept_storage_bucket_invitation_fails_with_non_existing_storage_bucket() {
     build_test_externalities().execute_with(|| {
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
     });
@@ -234,13 +234,13 @@ fn accept_storage_bucket_invitation_fails_with_non_existing_storage_bucket() {
 #[test]
 fn accept_storage_bucket_invitation_fails_with_non_invited_storage_provider() {
     build_test_externalities().execute_with(|| {
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(None)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::NoStorageBucketInvitation.into()));
@@ -252,13 +252,13 @@ fn accept_storage_bucket_invitation_fails_with_different_invited_storage_provide
     build_test_externalities().execute_with(|| {
         let different_storage_provider_id = ANOTHER_STORAGE_PROVIDER_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(Some(different_storage_provider_id))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::DifferentStorageProviderInvited.into()));
@@ -270,19 +270,19 @@ fn accept_storage_bucket_invitation_fails_with_already_set_storage_provider() {
     build_test_externalities().execute_with(|| {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(Some(storage_provider_id))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
             .call_and_assert(Ok(()));
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -304,7 +304,7 @@ fn update_storage_buckets_for_bags_succeeded() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
@@ -312,7 +312,7 @@ fn update_storage_buckets_for_bags_succeeded() {
 
         let add_buckets = BTreeSet::from_iter(vec![bucket_id]);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(add_buckets.clone())
@@ -337,14 +337,14 @@ fn update_storage_buckets_for_bags_succeeded_with_additioonal_checks_on_adding_a
         let static_bag_id = StaticBagId::Council;
         let bag_id: BagId<Test> = static_bag_id.into();
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
         let add_buckets_ids = BTreeSet::from_iter(vec![bucket_id]);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(add_buckets_ids.clone())
@@ -358,7 +358,7 @@ fn update_storage_buckets_for_bags_succeeded_with_additioonal_checks_on_adding_a
         assert_eq!(bucket.assigned_bags, 1);
 
         // ******
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_remove_bucket_ids(add_buckets_ids.clone())
@@ -381,7 +381,7 @@ fn update_storage_buckets_for_bags_fails_with_non_existing_dynamic_bag() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
@@ -389,7 +389,7 @@ fn update_storage_buckets_for_bags_fails_with_non_existing_dynamic_bag() {
 
         let add_buckets = BTreeSet::from_iter(vec![bucket_id]);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(add_buckets.clone())
@@ -405,7 +405,7 @@ fn update_storage_buckets_for_bags_fails_with_non_accepting_new_bags_bucket() {
 
         set_default_update_storage_buckets_per_bag_limit();
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(None)
             .with_accepting_new_bags(false)
@@ -414,7 +414,7 @@ fn update_storage_buckets_for_bags_fails_with_non_accepting_new_bags_bucket() {
 
         let add_buckets = BTreeSet::from_iter(vec![bucket_id]);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(add_buckets.clone())
@@ -449,7 +449,7 @@ fn update_storage_buckets_for_bags_succeeded_with_voucher_usage() {
         let objects_limit = 1;
         let size_limit = 100;
 
-        let new_bucket_id = CreateStorageBucketFixture::default()
+        let new_bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_objects_limit(objects_limit)
             .with_size_limit(size_limit)
@@ -462,7 +462,7 @@ fn update_storage_buckets_for_bags_succeeded_with_voucher_usage() {
         let bag = Storage::static_bag(&StaticBagId::Council);
         assert_eq!(bag.stored_by, old_buckets);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(new_buckets.clone())
@@ -511,7 +511,7 @@ fn update_storage_buckets_for_bags_fails_with_exceeding_the_voucher_objects_numb
 
         let new_bucket_objects_limit = 0;
         let new_bucket_size_limit = 100;
-        let new_bucket_id = CreateStorageBucketFixture::default()
+        let new_bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_objects_limit(new_bucket_objects_limit)
             .with_size_limit(new_bucket_size_limit)
@@ -520,7 +520,7 @@ fn update_storage_buckets_for_bags_fails_with_exceeding_the_voucher_objects_numb
 
         let new_buckets = BTreeSet::from_iter(vec![new_bucket_id]);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(new_buckets.clone())
@@ -556,7 +556,7 @@ fn update_storage_buckets_for_bags_fails_with_exceeding_the_voucher_objects_tota
 
         let new_bucket_objects_limit = 1;
         let new_bucket_size_limit = 5;
-        let new_bucket_id = CreateStorageBucketFixture::default()
+        let new_bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_objects_limit(new_bucket_objects_limit)
             .with_size_limit(new_bucket_size_limit)
@@ -565,7 +565,7 @@ fn update_storage_buckets_for_bags_fails_with_exceeding_the_voucher_objects_tota
 
         let new_buckets = BTreeSet::from_iter(vec![new_bucket_id]);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(new_buckets.clone())
@@ -583,7 +583,7 @@ fn update_storage_buckets_for_working_group_static_bags_succeeded() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
@@ -594,7 +594,7 @@ fn update_storage_buckets_for_working_group_static_bags_succeeded() {
         let static_bag_id = StaticBagId::WorkingGroup(WorkingGroup::Storage);
         let bag_id = BagId::<Test>::Static(static_bag_id.clone());
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(buckets.clone())
@@ -613,7 +613,7 @@ fn update_storage_buckets_for_dynamic_bags_succeeded() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
@@ -626,7 +626,7 @@ fn update_storage_buckets_for_dynamic_bags_succeeded() {
         let bag_id = BagId::<Test>::Dynamic(dynamic_bag_id.clone());
         create_dynamic_bag(&dynamic_bag_id);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_remove_bucket_ids(buckets.clone())
@@ -642,7 +642,7 @@ fn update_storage_buckets_for_bags_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -651,7 +651,7 @@ fn update_storage_buckets_for_bags_fails_with_non_leader_origin() {
 #[test]
 fn update_storage_buckets_for_bags_fails_with_empty_params() {
     build_test_externalities().execute_with(|| {
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketIdCollectionsAreEmpty.into()));
     });
@@ -667,14 +667,14 @@ fn update_storage_buckets_for_bags_fails_with_non_existing_storage_buckets() {
         let bag_id = BagId::<Test>::Static(StaticBagId::Council);
 
         // Invalid added bucket ID.
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(buckets.clone())
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
 
         // Invalid removed bucket ID.
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_remove_bucket_ids(buckets.clone())
@@ -690,7 +690,7 @@ fn update_storage_buckets_for_bags_fails_with_going_beyond_the_buckets_per_bag_l
         let buckets = BTreeSet::from_iter((0..=limit).into_iter());
         let bag_id = BagId::<Test>::Static(StaticBagId::Council);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(buckets.clone())
@@ -707,7 +707,7 @@ fn update_storage_buckets_succeeds_with_add_remove_within_limits() {
         let _bucket2 = create_default_storage_bucket_and_assign_to_bag(bag_id.clone());
         let _bucket3 = create_default_storage_bucket_and_assign_to_bag(bag_id.clone());
 
-        let bucket4 = CreateStorageBucketFixture::default()
+        let bucket4 = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
@@ -717,7 +717,7 @@ fn update_storage_buckets_succeeds_with_add_remove_within_limits() {
 
         let add_buckets = BTreeSet::from_iter(vec![bucket4]);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(add_buckets.clone())
@@ -725,7 +725,7 @@ fn update_storage_buckets_succeeds_with_add_remove_within_limits() {
 
         let remove_buckets = BTreeSet::from_iter(vec![bucket1]);
 
-        UpdateStorageBucketForBagsFixture::default()
+        UpdateStorageBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_add_bucket_ids(add_buckets)
@@ -824,7 +824,7 @@ fn upload_succeeded_with_data_size_fee() {
 
         let data_size_fee = 100;
 
-        UpdateDataObjectPerMegabyteFeeFixture::default()
+        UpdateDataObjectPerMegabyteFeeFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_fee(data_size_fee)
             .call_and_assert(Ok(()));
@@ -1124,7 +1124,7 @@ fn upload_fails_with_insufficient_balance_for_data_size_fee() {
 
         let data_size_fee = 1000;
 
-        UpdateDataObjectPerMegabyteFeeFixture::default()
+        UpdateDataObjectPerMegabyteFeeFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_fee(data_size_fee)
             .call_and_assert(Ok(()));
@@ -1155,7 +1155,7 @@ fn upload_fails_with_data_size_fee_changed() {
 
         let data_size_fee = 1000;
 
-        UpdateDataObjectPerMegabyteFeeFixture::default()
+        UpdateDataObjectPerMegabyteFeeFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_fee(data_size_fee)
             .call_and_assert(Ok(()));
@@ -1180,7 +1180,7 @@ fn upload_failed_with_blocked_uploading() {
         };
 
         let new_blocking_status = true;
-        UpdateUploadingBlockedStatusFixture::default()
+        UpdateUploadingBlockedStatusFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_status(new_blocking_status)
             .call_and_assert(Ok(()));
@@ -1201,7 +1201,7 @@ fn upload_failed_with_blacklisted_data_object() {
         let hash = object_creation_list[0].ipfs_content_id.clone();
         let add_hashes = BTreeSet::from_iter(vec![hash]);
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(add_hashes)
             .call_and_assert(Ok(()));
@@ -1228,13 +1228,13 @@ fn set_storage_operator_metadata_succeeded() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -1242,7 +1242,7 @@ fn set_storage_operator_metadata_succeeded() {
 
         let metadata = b"http://localhost:4000".to_vec();
 
-        SetStorageOperatorMetadataFixture::default()
+        SetStorageOperatorMetadataFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_worker_id(storage_provider_id)
             .with_storage_bucket_id(bucket_id)
@@ -1260,7 +1260,7 @@ fn set_storage_operator_metadata_succeeded() {
 #[test]
 fn set_storage_operator_metadata_fails_with_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        SetStorageOperatorMetadataFixture::default()
+        SetStorageOperatorMetadataFixture::new()
             .with_origin(RawOrigin::Root)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -1269,7 +1269,7 @@ fn set_storage_operator_metadata_fails_with_invalid_origin() {
 #[test]
 fn set_storage_operator_metadata_fails_with_invalid_storage_bucket() {
     build_test_externalities().execute_with(|| {
-        SetStorageOperatorMetadataFixture::default()
+        SetStorageOperatorMetadataFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
     });
@@ -1282,39 +1282,39 @@ fn set_storage_operator_metadata_fails_with_invalid_storage_association() {
         let invite_worker = Some(storage_provider_id);
 
         // Missing invitation
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        SetStorageOperatorMetadataFixture::default()
+        SetStorageOperatorMetadataFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
             .call_and_assert(Err(Error::<Test>::StorageProviderMustBeSet.into()));
 
         // Not accepted invitation
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        SetStorageOperatorMetadataFixture::default()
+        SetStorageOperatorMetadataFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
             .call_and_assert(Err(Error::<Test>::InvalidStorageProvider.into()));
 
         // Invitation accepted. Incorrect storage provider.
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
             .call_and_assert(Ok(()));
 
         let incorrect_storage_provider_id = 888;
-        SetStorageOperatorMetadataFixture::default()
+        SetStorageOperatorMetadataFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(incorrect_storage_provider_id)
@@ -1367,7 +1367,7 @@ fn accept_pending_data_objects_succeeded() {
         // Check `accepted` flag for the fist data object in the bag.
         assert_eq!(data_object.accepted, false);
 
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_worker_id(storage_provider_id)
             .with_storage_bucket_id(bucket_id)
@@ -1397,13 +1397,13 @@ fn accept_pending_data_objects_fails_with_unrelated_storage_bucket() {
         let static_bag_id = StaticBagId::Council;
         let bag_id = BagId::<Test>::Static(static_bag_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_transactor_account_id(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID)
             .with_storage_bucket_id(bucket_id)
@@ -1428,7 +1428,7 @@ fn accept_pending_data_objects_fails_with_unrelated_storage_bucket() {
 
         let data_object_ids = BTreeSet::from_iter(vec![data_object_id]);
 
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_worker_id(storage_provider_id)
             .with_storage_bucket_id(bucket_id)
@@ -1444,13 +1444,13 @@ fn accept_pending_data_objects_fails_with_non_existing_dynamic_bag() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_transactor_account_id(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID)
             .with_storage_bucket_id(bucket_id)
@@ -1467,7 +1467,7 @@ fn accept_pending_data_objects_fails_with_non_existing_dynamic_bag() {
 
         let data_object_ids = BTreeSet::from_iter(vec![data_object_id]);
 
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_worker_id(storage_provider_id)
             .with_storage_bucket_id(bucket_id)
@@ -1484,13 +1484,13 @@ fn accept_pending_data_objects_fails_with_invalid_transactor_account_id() {
         let invite_worker = Some(storage_provider_id);
         let transactor_account_id = 11111;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_transactor_account_id(transactor_account_id)
             .with_storage_bucket_id(bucket_id)
@@ -1507,7 +1507,7 @@ fn accept_pending_data_objects_fails_with_invalid_transactor_account_id() {
 
         let data_object_ids = BTreeSet::from_iter(vec![data_object_id]);
 
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_worker_id(storage_provider_id)
             .with_storage_bucket_id(bucket_id)
@@ -1527,7 +1527,7 @@ fn accept_pending_data_objects_succeeded_with_dynamic_bag() {
         let objects_limit = 1;
         let size_limit = 100;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .with_objects_limit(objects_limit)
@@ -1535,7 +1535,7 @@ fn accept_pending_data_objects_succeeded_with_dynamic_bag() {
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_transactor_account_id(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID)
             .with_storage_bucket_id(bucket_id)
@@ -1564,7 +1564,7 @@ fn accept_pending_data_objects_succeeded_with_dynamic_bag() {
 
         let data_object_ids = BTreeSet::from_iter(vec![data_object_id]);
 
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_worker_id(storage_provider_id)
             .with_bag_id(bag_id.clone())
@@ -1581,7 +1581,7 @@ fn accept_pending_data_objects_succeeded_with_dynamic_bag() {
 #[test]
 fn accept_pending_data_objects_fails_with_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Root)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -1602,7 +1602,7 @@ fn accept_pending_data_objects_fails_with_empty_params() {
             size_limit,
         );
 
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -1630,7 +1630,7 @@ fn accept_pending_data_objects_fails_with_non_existing_data_object() {
 
         let data_object_ids = BTreeSet::from_iter(vec![data_object_id]);
 
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_data_object_ids(data_object_ids)
@@ -1647,7 +1647,7 @@ fn accept_pending_data_objects_fails_with_invalid_storage_provider() {
 
         let bucket_id = create_default_storage_bucket_and_assign_to_bag(bag_id.clone());
 
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::StorageProviderMustBeSet.into()));
@@ -1657,7 +1657,7 @@ fn accept_pending_data_objects_fails_with_invalid_storage_provider() {
 #[test]
 fn accept_pending_data_objects_fails_with_non_existing_bucket_id() {
     build_test_externalities().execute_with(|| {
-        AcceptPendingDataObjectsFixture::default()
+        AcceptPendingDataObjectsFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
     });
@@ -1672,13 +1672,13 @@ fn cancel_storage_bucket_operator_invite_succeeded() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        CancelStorageBucketInvitationFixture::default()
+        CancelStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Ok(()));
@@ -1694,7 +1694,7 @@ fn cancel_storage_bucket_operator_invite_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_storage_provider_id = 1;
 
-        CancelStorageBucketInvitationFixture::default()
+        CancelStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(non_storage_provider_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -1703,7 +1703,7 @@ fn cancel_storage_bucket_operator_invite_fails_with_non_leader_origin() {
 #[test]
 fn cancel_storage_bucket_operator_invite_fails_with_non_existing_storage_bucket() {
     build_test_externalities().execute_with(|| {
-        CancelStorageBucketInvitationFixture::default()
+        CancelStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
     });
@@ -1712,13 +1712,13 @@ fn cancel_storage_bucket_operator_invite_fails_with_non_existing_storage_bucket(
 #[test]
 fn cancel_storage_bucket_operator_invite_fails_with_non_invited_storage_provider() {
     build_test_externalities().execute_with(|| {
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(None)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        CancelStorageBucketInvitationFixture::default()
+        CancelStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::NoStorageBucketInvitation.into()));
@@ -1730,19 +1730,19 @@ fn cancel_storage_bucket_operator_invite_fails_with_already_set_storage_provider
     build_test_externalities().execute_with(|| {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(Some(storage_provider_id))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
             .call_and_assert(Ok(()));
 
-        CancelStorageBucketInvitationFixture::default()
+        CancelStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::StorageProviderAlreadySet.into()));
@@ -1757,12 +1757,12 @@ fn invite_storage_bucket_operator_succeeded() {
 
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteStorageBucketOperatorFixture::default()
+        InviteStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_operator_worker_id(storage_provider_id)
@@ -1780,7 +1780,7 @@ fn invite_storage_bucket_operator_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        InviteStorageBucketOperatorFixture::default()
+        InviteStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -1789,7 +1789,7 @@ fn invite_storage_bucket_operator_fails_with_non_leader_origin() {
 #[test]
 fn invite_storage_bucket_operator_fails_with_non_existing_storage_bucket() {
     build_test_externalities().execute_with(|| {
-        InviteStorageBucketOperatorFixture::default()
+        InviteStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
     });
@@ -1800,13 +1800,13 @@ fn invite_storage_bucket_operator_fails_with_non_missing_invitation() {
     build_test_externalities().execute_with(|| {
         let invited_worker_id = DEFAULT_STORAGE_PROVIDER_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(Some(invited_worker_id))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteStorageBucketOperatorFixture::default()
+        InviteStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::InvitedStorageProvider.into()));
@@ -1818,12 +1818,12 @@ fn invite_storage_bucket_operator_fails_with_invalid_storage_provider_id() {
     build_test_externalities().execute_with(|| {
         let invalid_storage_provider_id = 155;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteStorageBucketOperatorFixture::default()
+        InviteStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_operator_worker_id(invalid_storage_provider_id)
@@ -1839,7 +1839,7 @@ fn update_uploading_blocked_status_succeeded() {
 
         let new_blocking_status = true;
 
-        UpdateUploadingBlockedStatusFixture::default()
+        UpdateUploadingBlockedStatusFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_status(new_blocking_status)
             .call_and_assert(Ok(()));
@@ -1855,7 +1855,7 @@ fn update_uploading_blocked_status_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateUploadingBlockedStatusFixture::default()
+        UpdateUploadingBlockedStatusFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -2217,7 +2217,7 @@ fn delete_data_objects_succeeded() {
             DataObjectDeletionPrize::get()
         );
 
-        DeleteDataObjectsFixture::default()
+        DeleteDataObjectsFixture::new()
             .with_bag_id(bag_id.clone())
             .with_data_object_ids(data_object_ids.clone())
             .with_deletion_prize_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
@@ -2259,7 +2259,7 @@ fn delete_data_objects_fails_with_non_existent_dynamic_bag() {
 
         let data_object_ids = BTreeSet::from_iter(vec![data_object_id]);
 
-        DeleteDataObjectsFixture::default()
+        DeleteDataObjectsFixture::new()
             .with_bag_id(bag_id.clone())
             .with_data_object_ids(data_object_ids.clone())
             .with_deletion_prize_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
@@ -2276,7 +2276,7 @@ fn delete_data_objects_fails_with_invalid_treasury_balance() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        CreateStorageBucketFixture::default()
+        CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
@@ -2307,7 +2307,7 @@ fn delete_data_objects_fails_with_invalid_treasury_balance() {
             <StorageTreasury<Test>>::usable_balance(),
         );
 
-        DeleteDataObjectsFixture::default()
+        DeleteDataObjectsFixture::new()
             .with_bag_id(council_bag_id.clone())
             .with_data_object_ids(data_object_ids.clone())
             .with_deletion_prize_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
@@ -2357,7 +2357,7 @@ fn delete_data_objects_succeeded_with_voucher_usage() {
         assert_eq!(bucket.voucher.objects_used, 1);
         assert_eq!(bucket.voucher.size_used, object_creation_list[0].size);
 
-        DeleteDataObjectsFixture::default()
+        DeleteDataObjectsFixture::new()
             .with_bag_id(bag_id.clone())
             .with_data_object_ids(data_object_ids.clone())
             .call_and_assert(Ok(()));
@@ -2380,7 +2380,7 @@ fn delete_data_objects_succeeded_with_voucher_usage() {
 #[test]
 fn delete_data_objects_fails_with_empty_params() {
     build_test_externalities().execute_with(|| {
-        DeleteDataObjectsFixture::default()
+        DeleteDataObjectsFixture::new()
             .call_and_assert(Err(Error::<Test>::DataObjectIdParamsAreEmpty.into()));
     });
 }
@@ -2393,7 +2393,7 @@ fn delete_data_objects_fails_with_non_existing_data_object() {
         let data_object_id = 0;
         let data_object_ids = BTreeSet::from_iter(vec![data_object_id]);
 
-        DeleteDataObjectsFixture::default()
+        DeleteDataObjectsFixture::new()
             .with_bag_id(council_bag_id.clone())
             .with_data_object_ids(data_object_ids.clone())
             .call_and_assert(Err(Error::<Test>::DataObjectDoesntExist.into()));
@@ -2406,13 +2406,13 @@ fn update_storage_bucket_status_succeeded() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
         let new_status = true;
-        UpdateStorageBucketStatusFixture::default()
+        UpdateStorageBucketStatusFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_new_status(new_status)
@@ -2427,7 +2427,7 @@ fn update_storage_bucket_status_succeeded() {
 #[test]
 fn update_storage_bucket_status_fails_with_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        UpdateStorageBucketStatusFixture::default()
+        UpdateStorageBucketStatusFixture::new()
             .with_origin(RawOrigin::Root)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -2436,7 +2436,7 @@ fn update_storage_bucket_status_fails_with_invalid_origin() {
 #[test]
 fn update_storage_bucket_status_fails_with_invalid_storage_bucket() {
     build_test_externalities().execute_with(|| {
-        UpdateStorageBucketStatusFixture::default()
+        UpdateStorageBucketStatusFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
     });
@@ -2452,7 +2452,7 @@ fn update_blacklist_succeeded() {
         let cid2 = vec![2];
 
         let add_hashes = BTreeSet::from_iter(vec![cid1.clone()]);
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(add_hashes.clone())
             .call_and_assert(Ok(()));
@@ -2463,7 +2463,7 @@ fn update_blacklist_succeeded() {
         let remove_hashes = BTreeSet::from_iter(vec![cid1.clone()]);
         let add_hashes = BTreeSet::from_iter(vec![cid2.clone()]);
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(add_hashes.clone())
             .with_remove_hashes(remove_hashes.clone())
@@ -2486,7 +2486,7 @@ fn update_blacklist_failed_with_exceeding_size_limit() {
 
         let add_hashes = BTreeSet::from_iter(vec![cid1.clone()]);
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(add_hashes.clone())
             .call_and_assert(Ok(()));
@@ -2494,7 +2494,7 @@ fn update_blacklist_failed_with_exceeding_size_limit() {
         let remove_hashes = BTreeSet::from_iter(vec![cid1.clone()]);
         let add_hashes = BTreeSet::from_iter(vec![cid2.clone(), cid3.clone()]);
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(add_hashes.clone())
             .with_remove_hashes(remove_hashes.clone())
@@ -2515,7 +2515,7 @@ fn update_blacklist_failed_with_exceeding_size_limit_with_non_existent_remove_ha
 
         let add_hashes = BTreeSet::from_iter(vec![cid1.clone()]);
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(add_hashes.clone())
             .call_and_assert(Ok(()));
@@ -2523,7 +2523,7 @@ fn update_blacklist_failed_with_exceeding_size_limit_with_non_existent_remove_ha
         let remove_hashes = BTreeSet::from_iter(vec![cid3.clone()]);
         let add_hashes = BTreeSet::from_iter(vec![cid2.clone()]);
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(add_hashes.clone())
             .with_remove_hashes(remove_hashes.clone())
@@ -2542,12 +2542,12 @@ fn update_blacklist_succeeds_with_existent_remove_hashes() {
 
         let add_hashes = BTreeSet::from_iter(vec![cid1.clone()]);
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(add_hashes.clone())
             .call_and_assert(Ok(()));
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(add_hashes.clone())
             .call_and_assert(Ok(()));
@@ -2562,7 +2562,7 @@ fn update_blacklist_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -2584,7 +2584,7 @@ fn create_storage_bucket_and_assign_to_bag(
     set_max_voucher_limits();
     set_default_update_storage_buckets_per_bag_limit();
 
-    let bucket_id = CreateStorageBucketFixture::default()
+    let bucket_id = CreateStorageBucketFixture::new()
         .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
         .with_invite_worker(storage_provider_id)
         .with_objects_limit(objects_limit)
@@ -2594,14 +2594,14 @@ fn create_storage_bucket_and_assign_to_bag(
 
     let buckets = BTreeSet::from_iter(vec![bucket_id]);
 
-    UpdateStorageBucketForBagsFixture::default()
+    UpdateStorageBucketForBagsFixture::new()
         .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
         .with_bag_id(bag_id.clone())
         .with_add_bucket_ids(buckets.clone())
         .call_and_assert(Ok(()));
 
     if let Some(storage_provider_id) = storage_provider_id {
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_transactor_account_id(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID)
             .with_storage_bucket_id(bucket_id)
@@ -2641,7 +2641,7 @@ fn delete_dynamic_bags_succeeded() {
             deletion_prize_value
         );
 
-        DeleteDynamicBagFixture::default()
+        DeleteDynamicBagFixture::new()
             .with_bag_id(dynamic_bag_id.clone())
             .with_deletion_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
             .call_and_assert(Ok(()));
@@ -2685,7 +2685,7 @@ fn delete_dynamic_bags_succeeded_with_assigned_distribution_buckets() {
             (family2, family_policy_number2),
         ]);
 
-        UpdateFamiliesInDynamicBagCreationPolicyFixture::default()
+        UpdateFamiliesInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_families(family_policy)
             .call_and_assert(Ok(()));
@@ -2717,7 +2717,7 @@ fn delete_dynamic_bags_succeeded_with_assigned_distribution_buckets() {
             assert_eq!(bucket.assigned_bags, 1);
         }
 
-        DeleteDynamicBagFixture::default()
+        DeleteDynamicBagFixture::new()
             .with_bag_id(dynamic_bag_id.clone())
             .with_deletion_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
             .call_and_assert(Ok(()));
@@ -2763,7 +2763,7 @@ fn delete_dynamic_bags_succeeded_with_assigned_storage_buckets() {
             assert_eq!(bucket.assigned_bags, 1);
         }
 
-        DeleteDynamicBagFixture::default()
+        DeleteDynamicBagFixture::new()
             .with_bag_id(dynamic_bag_id.clone())
             .with_deletion_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
             .call_and_assert(Ok(()));
@@ -2781,7 +2781,7 @@ fn delete_dynamic_bags_fails_with_non_existent_dynamic_bag() {
     build_test_externalities().execute_with(|| {
         let dynamic_bag_id = DynamicBagId::<Test>::Member(DEFAULT_MEMBER_ID);
 
-        DeleteDynamicBagFixture::default()
+        DeleteDynamicBagFixture::new()
             .with_bag_id(dynamic_bag_id.clone())
             .with_deletion_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
             .call_and_assert(Err(Error::<Test>::DynamicBagDoesntExist.into()));
@@ -2810,7 +2810,7 @@ fn delete_dynamic_bags_fails_with_insufficient_balance_for_deletion_prize() {
             <StorageTreasury<Test>>::usable_balance(),
         );
 
-        DeleteDynamicBagFixture::default()
+        DeleteDynamicBagFixture::new()
             .with_bag_id(dynamic_bag_id.clone())
             .with_deletion_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
             .call_and_assert(Err(Error::<Test>::InsufficientTreasuryBalance.into()));
@@ -2823,12 +2823,12 @@ fn delete_storage_bucket_succeeded() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        DeleteStorageBucketFixture::default()
+        DeleteStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Ok(()));
@@ -2842,7 +2842,7 @@ fn delete_storage_bucket_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        DeleteStorageBucketFixture::default()
+        DeleteStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -2851,7 +2851,7 @@ fn delete_storage_bucket_fails_with_non_leader_origin() {
 #[test]
 fn delete_storage_bucket_fails_with_non_existing_storage_bucket() {
     build_test_externalities().execute_with(|| {
-        DeleteStorageBucketFixture::default()
+        DeleteStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
     });
@@ -2880,7 +2880,7 @@ fn delete_storage_bucket_fails_with_non_empty_bucket() {
             .with_params(upload_params.clone())
             .call_and_assert(Ok(()));
 
-        DeleteStorageBucketFixture::default()
+        DeleteStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::CannotDeleteNonEmptyStorageBucket.into()));
@@ -2894,7 +2894,7 @@ fn delete_storage_bucket_fails_with_assigned_bag() {
 
         let bucket_id = create_default_storage_bucket_and_assign_to_bag(bag_id.clone());
 
-        DeleteStorageBucketFixture::default()
+        DeleteStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::StorageBucketIsBoundToBag.into()));
@@ -2910,19 +2910,19 @@ fn remove_storage_bucket_operator_succeeded() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
             .call_and_assert(Ok(()));
 
-        RemoveStorageBucketOperatorFixture::default()
+        RemoveStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Ok(()));
@@ -2936,7 +2936,7 @@ fn remove_storage_bucket_operator_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_storage_provider_id = 1;
 
-        RemoveStorageBucketOperatorFixture::default()
+        RemoveStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(non_storage_provider_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -2945,7 +2945,7 @@ fn remove_storage_bucket_operator_fails_with_non_leader_origin() {
 #[test]
 fn remove_storage_bucket_operator_fails_with_non_existing_storage_bucket() {
     build_test_externalities().execute_with(|| {
-        RemoveStorageBucketOperatorFixture::default()
+        RemoveStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
     });
@@ -2957,13 +2957,13 @@ fn remove_storage_bucket_operator_fails_with_non_accepted_storage_provider() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        RemoveStorageBucketOperatorFixture::default()
+        RemoveStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::StorageProviderMustBeSet.into()));
@@ -2973,13 +2973,13 @@ fn remove_storage_bucket_operator_fails_with_non_accepted_storage_provider() {
 #[test]
 fn remove_storage_bucket_operator_fails_with_missing_storage_provider() {
     build_test_externalities().execute_with(|| {
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(None)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        RemoveStorageBucketOperatorFixture::default()
+        RemoveStorageBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .call_and_assert(Err(Error::<Test>::StorageProviderMustBeSet.into()));
@@ -2994,7 +2994,7 @@ fn update_data_size_fee_succeeded() {
 
         let new_fee = 1000;
 
-        UpdateDataObjectPerMegabyteFeeFixture::default()
+        UpdateDataObjectPerMegabyteFeeFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_fee(new_fee)
             .call_and_assert(Ok(()));
@@ -3008,7 +3008,7 @@ fn update_data_size_fee_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateDataObjectPerMegabyteFeeFixture::default()
+        UpdateDataObjectPerMegabyteFeeFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -3024,7 +3024,7 @@ fn data_size_fee_calculation_works_properly() {
 
         let data_size_fee = 1000;
 
-        UpdateDataObjectPerMegabyteFeeFixture::default()
+        UpdateDataObjectPerMegabyteFeeFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_fee(data_size_fee)
             .call_and_assert(Ok(()));
@@ -3100,7 +3100,7 @@ fn update_storage_buckets_per_bag_limit_succeeded() {
 
         let new_limit = 4;
 
-        UpdateStorageBucketsPerBagLimitFixture::default()
+        UpdateStorageBucketsPerBagLimitFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_limit(new_limit)
             .call_and_assert(Ok(()));
@@ -3116,7 +3116,7 @@ fn update_storage_buckets_per_bag_limit_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateStorageBucketsPerBagLimitFixture::default()
+        UpdateStorageBucketsPerBagLimitFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -3127,14 +3127,14 @@ fn update_storage_buckets_per_bag_limit_fails_with_incorrect_value() {
     build_test_externalities().execute_with(|| {
         let new_limit = 0;
 
-        UpdateStorageBucketsPerBagLimitFixture::default()
+        UpdateStorageBucketsPerBagLimitFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_limit(new_limit)
             .call_and_assert(Err(Error::<Test>::StorageBucketsPerBagLimitTooLow.into()));
 
         let new_limit = 100;
 
-        UpdateStorageBucketsPerBagLimitFixture::default()
+        UpdateStorageBucketsPerBagLimitFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_limit(new_limit)
             .call_and_assert(Err(Error::<Test>::StorageBucketsPerBagLimitTooHigh.into()));
@@ -3142,7 +3142,7 @@ fn update_storage_buckets_per_bag_limit_fails_with_incorrect_value() {
 }
 
 fn set_update_storage_buckets_per_bag_limit(new_limit: u64) {
-    UpdateStorageBucketsPerBagLimitFixture::default()
+    UpdateStorageBucketsPerBagLimitFixture::new()
         .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
         .with_new_limit(new_limit)
         .call_and_assert(Ok(()))
@@ -3165,13 +3165,13 @@ fn set_storage_bucket_voucher_limits_succeeded() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -3180,7 +3180,7 @@ fn set_storage_bucket_voucher_limits_succeeded() {
         let new_objects_size_limit = 1;
         let new_objects_number_limit = 1;
 
-        SetStorageBucketVoucherLimitsFixture::default()
+        SetStorageBucketVoucherLimitsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_new_objects_number_limit(new_objects_number_limit)
@@ -3201,13 +3201,13 @@ fn set_storage_bucket_voucher_limits_fails_with_invalid_values() {
         let storage_provider_id = DEFAULT_STORAGE_PROVIDER_ID;
         let invite_worker = Some(storage_provider_id);
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -3216,13 +3216,13 @@ fn set_storage_bucket_voucher_limits_fails_with_invalid_values() {
         let invalid_objects_size_limit = 1000;
         let invalid_objects_number_limit = 1000;
 
-        SetStorageBucketVoucherLimitsFixture::default()
+        SetStorageBucketVoucherLimitsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_new_objects_size_limit(invalid_objects_size_limit)
             .call_and_assert(Err(Error::<Test>::VoucherMaxObjectSizeLimitExceeded.into()));
 
-        SetStorageBucketVoucherLimitsFixture::default()
+        SetStorageBucketVoucherLimitsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_new_objects_number_limit(invalid_objects_number_limit)
@@ -3235,7 +3235,7 @@ fn set_storage_bucket_voucher_limits_fails_with_invalid_values() {
 #[test]
 fn set_storage_bucket_voucher_limits_fails_with_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        SetStorageBucketVoucherLimitsFixture::default()
+        SetStorageBucketVoucherLimitsFixture::new()
             .with_origin(RawOrigin::Root)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -3244,7 +3244,7 @@ fn set_storage_bucket_voucher_limits_fails_with_invalid_origin() {
 #[test]
 fn set_storage_bucket_voucher_limits_fails_with_invalid_storage_bucket() {
     build_test_externalities().execute_with(|| {
-        SetStorageBucketVoucherLimitsFixture::default()
+        SetStorageBucketVoucherLimitsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::StorageBucketDoesntExist.into()));
     });
@@ -3255,7 +3255,7 @@ fn set_max_voucher_limits() {
 }
 
 fn set_max_voucher_limits_with_params(size_limit: u64, objects_limit: u64) {
-    UpdateStorageBucketsVoucherMaxLimitsFixture::default()
+    UpdateStorageBucketsVoucherMaxLimitsFixture::new()
         .with_new_objects_size_limit(size_limit)
         .with_new_objects_number_limit(objects_limit)
         .call_and_assert(Ok(()));
@@ -3270,7 +3270,7 @@ fn update_storage_buckets_voucher_max_limits_succeeded() {
         let new_size_limit = 14;
         let new_number_limit = 4;
 
-        UpdateStorageBucketsVoucherMaxLimitsFixture::default()
+        UpdateStorageBucketsVoucherMaxLimitsFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_objects_number_limit(new_number_limit)
             .with_new_objects_size_limit(new_size_limit)
@@ -3288,7 +3288,7 @@ fn update_storage_buckets_voucher_max_limits_fails_with_bad_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateStorageBucketsVoucherMaxLimitsFixture::default()
+        UpdateStorageBucketsVoucherMaxLimitsFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -3316,7 +3316,7 @@ fn create_dynamic_bag_succeeded() {
             (family2, family_policy_number2),
         ]);
 
-        UpdateFamiliesInDynamicBagCreationPolicyFixture::default()
+        UpdateFamiliesInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_families(family_policy)
             .call_and_assert(Ok(()));
@@ -3640,7 +3640,7 @@ fn update_number_of_storage_buckets_in_dynamic_bag_creation_policy_succeeded() {
         let dynamic_bag_type = DynamicBagType::Channel;
         let new_bucket_number = 40;
 
-        UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture::default()
+        UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_storage_buckets_number(new_bucket_number)
             .with_dynamic_bag_type(dynamic_bag_type)
@@ -3660,7 +3660,7 @@ fn update_number_of_storage_buckets_in_dynamic_bag_creation_policy_fails_with_ba
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture::default()
+        UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -3679,7 +3679,7 @@ fn dynamic_bag_creation_policy_defaults_and_updates_succeeded() {
             DefaultMemberDynamicBagNumberOfStorageBuckets::get()
         );
 
-        UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture::default()
+        UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_storage_buckets_number(new_bucket_number)
             .with_dynamic_bag_type(dynamic_bag_type)
@@ -3696,7 +3696,7 @@ fn dynamic_bag_creation_policy_defaults_and_updates_succeeded() {
             DefaultChannelDynamicBagNumberOfStorageBuckets::get()
         );
 
-        UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture::default()
+        UpdateNumberOfStorageBucketsInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_storage_buckets_number(new_bucket_number)
             .with_dynamic_bag_type(dynamic_bag_type)
@@ -3713,7 +3713,7 @@ fn create_distribution_bucket_family_succeeded() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
@@ -3729,7 +3729,7 @@ fn create_distribution_bucket_family_succeeded() {
 #[test]
 fn create_distribution_bucket_family_fails_with_non_signed_origin() {
     build_test_externalities().execute_with(|| {
-        CreateDistributionBucketFamilyFixture::default()
+        CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::None)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -3739,12 +3739,12 @@ fn create_distribution_bucket_family_fails_with_non_signed_origin() {
 fn create_distribution_bucket_family_fails_with_exceeding_family_number_limit() {
     build_test_externalities().execute_with(|| {
         for _ in 0..MaxDistributionBucketFamilyNumber::get() {
-            CreateDistributionBucketFamilyFixture::default()
+            CreateDistributionBucketFamilyFixture::new()
                 .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
                 .call_and_assert(Ok(()));
         }
 
-        CreateDistributionBucketFamilyFixture::default()
+        CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(
                 Error::<Test>::MaxDistributionBucketFamilyNumberLimitExceeded.into(),
@@ -3758,12 +3758,12 @@ fn delete_distribution_bucket_family_succeeded() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        DeleteDistributionBucketFamilyFixture::default()
+        DeleteDistributionBucketFamilyFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()));
@@ -3780,12 +3780,12 @@ fn delete_distribution_bucket_family_fails_with_assgined_bags() {
         let static_bag_id = StaticBagId::Council;
         let bag_id: BagId<Test> = static_bag_id.into();
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_id = CreateDistributionBucketFixture::default()
+        let bucket_id = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_accept_new_bags(true)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -3794,7 +3794,7 @@ fn delete_distribution_bucket_family_fails_with_assgined_bags() {
 
         let add_buckets_ids = BTreeSet::from_iter(vec![bucket_id]);
 
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_family_id(family_id)
@@ -3808,7 +3808,7 @@ fn delete_distribution_bucket_family_fails_with_assgined_bags() {
         let bag = Storage::bag(&bag_id);
         assert_eq!(bag.distributed_by, add_buckets);
 
-        DeleteDistributionBucketFamilyFixture::default()
+        DeleteDistributionBucketFamilyFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionBucketIsBoundToBag.into()));
@@ -3818,7 +3818,7 @@ fn delete_distribution_bucket_family_fails_with_assgined_bags() {
 #[test]
 fn delete_distribution_bucket_family_fails_with_bound_member_dynamic_bag_creation_policy() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
@@ -3827,13 +3827,13 @@ fn delete_distribution_bucket_family_fails_with_bound_member_dynamic_bag_creatio
         let families = BTreeMap::from_iter(vec![(family_id, new_bucket_number)]);
         let dynamic_bag_type = DynamicBagType::Member;
 
-        UpdateFamiliesInDynamicBagCreationPolicyFixture::default()
+        UpdateFamiliesInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_families(families.clone())
             .with_dynamic_bag_type(dynamic_bag_type)
             .call_and_assert(Ok(()));
 
-        DeleteDistributionBucketFamilyFixture::default()
+        DeleteDistributionBucketFamilyFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(
@@ -3845,7 +3845,7 @@ fn delete_distribution_bucket_family_fails_with_bound_member_dynamic_bag_creatio
 #[test]
 fn delete_distribution_bucket_family_fails_with_bound_channel_dynamic_bag_creation_policy() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
@@ -3854,13 +3854,13 @@ fn delete_distribution_bucket_family_fails_with_bound_channel_dynamic_bag_creati
         let families = BTreeMap::from_iter(vec![(family_id, new_bucket_number)]);
         let dynamic_bag_type = DynamicBagType::Channel;
 
-        UpdateFamiliesInDynamicBagCreationPolicyFixture::default()
+        UpdateFamiliesInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_families(families.clone())
             .with_dynamic_bag_type(dynamic_bag_type)
             .call_and_assert(Ok(()));
 
-        DeleteDistributionBucketFamilyFixture::default()
+        DeleteDistributionBucketFamilyFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(
@@ -3872,7 +3872,7 @@ fn delete_distribution_bucket_family_fails_with_bound_channel_dynamic_bag_creati
 #[test]
 fn delete_distribution_bucket_family_fails_with_non_signed_origin() {
     build_test_externalities().execute_with(|| {
-        DeleteDistributionBucketFamilyFixture::default()
+        DeleteDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::None)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -3881,7 +3881,7 @@ fn delete_distribution_bucket_family_fails_with_non_signed_origin() {
 #[test]
 fn delete_distribution_bucket_family_fails_with_non_existing_family() {
     build_test_externalities().execute_with(|| {
-        DeleteDistributionBucketFamilyFixture::default()
+        DeleteDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(
                 Error::<Test>::DistributionBucketFamilyDoesntExist.into()
@@ -3897,12 +3897,12 @@ fn create_distribution_bucket_succeeded() {
 
         let accept_new_bags = true;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_id = CreateDistributionBucketFixture::default()
+        let bucket_id = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_accept_new_bags(accept_new_bags)
@@ -3924,7 +3924,7 @@ fn create_distribution_bucket_succeeded() {
 #[test]
 fn create_distribution_bucket_fails_with_non_signed_origin() {
     build_test_externalities().execute_with(|| {
-        CreateDistributionBucketFixture::default()
+        CreateDistributionBucketFixture::new()
             .with_origin(RawOrigin::None)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -3933,7 +3933,7 @@ fn create_distribution_bucket_fails_with_non_signed_origin() {
 #[test]
 fn create_distribution_bucket_fails_with_non_existing_family() {
     build_test_externalities().execute_with(|| {
-        CreateDistributionBucketFixture::default()
+        CreateDistributionBucketFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(
                 Error::<Test>::DistributionBucketFamilyDoesntExist.into()
@@ -3947,19 +3947,19 @@ fn update_distribution_bucket_status_succeeded() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
         let new_status = true;
-        UpdateDistributionBucketStatusFixture::default()
+        UpdateDistributionBucketStatusFixture::new()
             .with_family_id(family_id)
             .with_distribution_bucket_index(bucket_index)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -3982,7 +3982,7 @@ fn update_distribution_bucket_status_succeeded() {
 #[test]
 fn update_distribution_bucket_status_fails_with_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        UpdateDistributionBucketStatusFixture::default()
+        UpdateDistributionBucketStatusFixture::new()
             .with_origin(RawOrigin::Root)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -3991,12 +3991,12 @@ fn update_distribution_bucket_status_fails_with_invalid_origin() {
 #[test]
 fn update_distribution_bucket_status_fails_with_invalid_distribution_bucket() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        UpdateDistributionBucketStatusFixture::default()
+        UpdateDistributionBucketStatusFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionBucketDoesntExist.into()));
@@ -4009,18 +4009,18 @@ fn delete_distribution_bucket_succeeded() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        DeleteDistributionBucketFixture::default()
+        DeleteDistributionBucketFixture::new()
             .with_distribution_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -4040,12 +4040,12 @@ fn delete_distribution_bucket_fails_with_assgined_bags() {
         let static_bag_id = StaticBagId::Council;
         let bag_id: BagId<Test> = static_bag_id.into();
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_accept_new_bags(true)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -4054,7 +4054,7 @@ fn delete_distribution_bucket_fails_with_assgined_bags() {
 
         let add_buckets_indices = BTreeSet::from_iter(vec![bucket_index]);
 
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_family_id(family_id)
@@ -4068,7 +4068,7 @@ fn delete_distribution_bucket_fails_with_assgined_bags() {
         let bag = Storage::bag(&bag_id);
         assert_eq!(bag.distributed_by, add_buckets);
 
-        DeleteDistributionBucketFixture::default()
+        DeleteDistributionBucketFixture::new()
             .with_distribution_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -4079,32 +4079,32 @@ fn delete_distribution_bucket_fails_with_assgined_bags() {
 #[test]
 fn delete_distribution_bucket_failed_with_existing_operators() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_operator_worker_id(DEFAULT_DISTRIBUTION_PROVIDER_ID)
             .call_and_assert(Ok(()));
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
             .with_worker_id(DEFAULT_DISTRIBUTION_PROVIDER_ID)
             .call_and_assert(Ok(()));
 
-        DeleteDistributionBucketFixture::default()
+        DeleteDistributionBucketFixture::new()
             .with_distribution_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -4117,7 +4117,7 @@ fn delete_distribution_bucket_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1111;
 
-        DeleteDistributionBucketFixture::default()
+        DeleteDistributionBucketFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -4126,12 +4126,12 @@ fn delete_distribution_bucket_fails_with_non_leader_origin() {
 #[test]
 fn delete_distribution_bucket_fails_with_non_existing_distribution_bucket() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        DeleteDistributionBucketFixture::default()
+        DeleteDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionBucketDoesntExist.into()));
@@ -4149,12 +4149,12 @@ fn update_distribution_buckets_for_bags_succeeded() {
         let static_bag_id = StaticBagId::Council;
         let bag_id: BagId<Test> = static_bag_id.into();
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_id = CreateDistributionBucketFixture::default()
+        let bucket_id = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_accept_new_bags(true)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -4163,7 +4163,7 @@ fn update_distribution_buckets_for_bags_succeeded() {
 
         let add_buckets_ids = BTreeSet::from_iter(vec![bucket_id]);
 
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_family_id(family_id)
@@ -4194,12 +4194,12 @@ fn update_distribution_buckets_for_bags_succeeded_with_additioonal_checks_on_add
         let static_bag_id = StaticBagId::Council;
         let bag_id: BagId<Test> = static_bag_id.into();
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_id = CreateDistributionBucketFixture::default()
+        let bucket_id = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_accept_new_bags(true)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -4208,7 +4208,7 @@ fn update_distribution_buckets_for_bags_succeeded_with_additioonal_checks_on_add
 
         let add_buckets_ids = BTreeSet::from_iter(vec![bucket_id]);
 
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_family_id(family_id)
@@ -4228,7 +4228,7 @@ fn update_distribution_buckets_for_bags_succeeded_with_additioonal_checks_on_add
 
         // ******
 
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_family_id(family_id)
@@ -4249,12 +4249,12 @@ fn update_distribution_buckets_for_bags_fails_with_non_existing_dynamic_bag() {
         let dynamic_bag_id = DynamicBagId::<Test>::Member(DEFAULT_MEMBER_ID);
         let bag_id: BagId<Test> = dynamic_bag_id.into();
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_id = CreateDistributionBucketFixture::default()
+        let bucket_id = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
@@ -4262,7 +4262,7 @@ fn update_distribution_buckets_for_bags_fails_with_non_existing_dynamic_bag() {
 
         let add_buckets = BTreeSet::from_iter(vec![bucket_id]);
 
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bag_id(bag_id.clone())
@@ -4279,12 +4279,12 @@ fn update_distribution_buckets_for_bags_fails_with_non_accepting_new_bags_bucket
         let static_bag_id = StaticBagId::Council;
         let bag_id: BagId<Test> = static_bag_id.into();
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_id = CreateDistributionBucketFixture::default()
+        let bucket_id = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_accept_new_bags(false)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -4293,7 +4293,7 @@ fn update_distribution_buckets_for_bags_fails_with_non_accepting_new_bags_bucket
 
         let add_buckets = BTreeSet::from_iter(vec![bucket_id]);
 
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bag_id(bag_id.clone())
@@ -4309,7 +4309,7 @@ fn update_distribution_buckets_for_bags_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -4318,7 +4318,7 @@ fn update_distribution_buckets_for_bags_fails_with_non_leader_origin() {
 #[test]
 fn update_distribution_buckets_for_bags_fails_with_empty_params() {
     build_test_externalities().execute_with(|| {
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(
                 Error::<Test>::DistributionBucketIdCollectionsAreEmpty.into()
@@ -4335,13 +4335,13 @@ fn update_distribution_buckets_for_bags_fails_with_non_existing_distribution_buc
         let buckets = BTreeSet::from_iter(vec![invalid_bucket_id]);
         let bag_id: BagId<Test> = StaticBagId::Council.into();
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
         // Invalid added bucket ID.
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_family_id(family_id)
@@ -4349,7 +4349,7 @@ fn update_distribution_buckets_for_bags_fails_with_non_existing_distribution_buc
             .call_and_assert(Err(Error::<Test>::DistributionBucketDoesntExist.into()));
 
         // Invalid removed bucket ID.
-        UpdateDistributionBucketForBagsFixture::default()
+        UpdateDistributionBucketForBagsFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bag_id(bag_id.clone())
             .with_family_id(family_id)
@@ -4370,7 +4370,7 @@ fn update_distribution_buckets_per_bag_limit_succeeded() {
 
         let new_limit = 4;
 
-        UpdateDistributionBucketsPerBagLimitFixture::default()
+        UpdateDistributionBucketsPerBagLimitFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_new_limit(new_limit)
             .call_and_assert(Ok(()));
@@ -4386,7 +4386,7 @@ fn update_distribution_buckets_per_bag_limit_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateDistributionBucketsPerBagLimitFixture::default()
+        UpdateDistributionBucketsPerBagLimitFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -4397,7 +4397,7 @@ fn update_distribution_buckets_per_bag_limit_fails_with_incorrect_value() {
     build_test_externalities().execute_with(|| {
         let new_limit = 0;
 
-        UpdateDistributionBucketsPerBagLimitFixture::default()
+        UpdateDistributionBucketsPerBagLimitFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_new_limit(new_limit)
             .call_and_assert(Err(
@@ -4406,7 +4406,7 @@ fn update_distribution_buckets_per_bag_limit_fails_with_incorrect_value() {
 
         let new_limit = 100;
 
-        UpdateDistributionBucketsPerBagLimitFixture::default()
+        UpdateDistributionBucketsPerBagLimitFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_new_limit(new_limit)
             .call_and_assert(Err(
@@ -4421,19 +4421,19 @@ fn update_distribution_bucket_mode_succeeded() {
         let starting_block = 1;
         run_to_block(starting_block);
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
         let distributing = false;
-        UpdateDistributionBucketModeFixture::default()
+        UpdateDistributionBucketModeFixture::new()
             .with_family_id(family_id)
             .with_distribution_bucket_index(bucket_index)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
@@ -4456,7 +4456,7 @@ fn update_distribution_bucket_mode_succeeded() {
 #[test]
 fn update_distribution_bucket_mode_fails_with_invalid_origin() {
     build_test_externalities().execute_with(|| {
-        UpdateDistributionBucketModeFixture::default()
+        UpdateDistributionBucketModeFixture::new()
             .with_origin(RawOrigin::Root)
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -4465,12 +4465,12 @@ fn update_distribution_bucket_mode_fails_with_invalid_origin() {
 #[test]
 fn update_distribution_bucket_mode_fails_with_invalid_distribution_bucket() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        UpdateDistributionBucketModeFixture::default()
+        UpdateDistributionBucketModeFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionBucketDoesntExist.into()));
@@ -4486,14 +4486,14 @@ fn update_families_in_dynamic_bag_creation_policy_succeeded() {
         let dynamic_bag_type = DynamicBagType::Channel;
         let new_bucket_number = 40;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
         let families = BTreeMap::from_iter(vec![(family_id, new_bucket_number)]);
 
-        UpdateFamiliesInDynamicBagCreationPolicyFixture::default()
+        UpdateFamiliesInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_families(families.clone())
             .with_dynamic_bag_type(dynamic_bag_type)
@@ -4511,7 +4511,7 @@ fn update_families_in_dynamic_bag_creation_policy_fails_with_bad_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        UpdateFamiliesInDynamicBagCreationPolicyFixture::default()
+        UpdateFamiliesInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -4526,7 +4526,7 @@ fn update_families_in_dynamic_bag_creation_policy_fails_with_invalid_family_id()
 
         let families = BTreeMap::from_iter(vec![(invalid_family_id, new_bucket_number)]);
 
-        UpdateFamiliesInDynamicBagCreationPolicyFixture::default()
+        UpdateFamiliesInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_families(families.clone())
             .with_dynamic_bag_type(dynamic_bag_type)
@@ -4539,7 +4539,7 @@ fn update_families_in_dynamic_bag_creation_policy_fails_with_invalid_family_id()
 fn create_distribution_bucket_family_with_buckets(
     bucket_number: u64,
 ) -> (u64, Vec<DistributionBucketId<Test>>) {
-    let family_id = CreateDistributionBucketFamilyFixture::default()
+    let family_id = CreateDistributionBucketFamilyFixture::new()
         .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
         .call_and_assert(Ok(()))
         .unwrap();
@@ -4547,7 +4547,7 @@ fn create_distribution_bucket_family_with_buckets(
     let bucket_ids = repeat(family_id)
         .take(bucket_number as usize)
         .map(|fam_id| {
-            let bucket_index = CreateDistributionBucketFixture::default()
+            let bucket_index = CreateDistributionBucketFixture::new()
                 .with_family_id(fam_id)
                 .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
                 .with_accept_new_bags(true)
@@ -4582,14 +4582,14 @@ fn distribution_bucket_family_pick_during_dynamic_bag_creation_succeeded() {
         let (family_id6, bucket_id6) = create_distribution_bucket_family_with_buckets(1);
 
         let deleted_bucket_id = bucket_id5[0].clone();
-        DeleteDistributionBucketFixture::default()
+        DeleteDistributionBucketFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(deleted_bucket_id.distribution_bucket_family_id)
             .with_distribution_bucket_index(deleted_bucket_id.distribution_bucket_index)
             .call_and_assert(Ok(()));
 
         let disabled_bucket_id = bucket_id6[0].clone();
-        UpdateDistributionBucketStatusFixture::default()
+        UpdateDistributionBucketStatusFixture::new()
             .with_new_status(false)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(disabled_bucket_id.distribution_bucket_family_id)
@@ -4605,7 +4605,7 @@ fn distribution_bucket_family_pick_during_dynamic_bag_creation_succeeded() {
             (family_id6, new_bucket_number),
         ]);
 
-        UpdateFamiliesInDynamicBagCreationPolicyFixture::default()
+        UpdateFamiliesInDynamicBagCreationPolicyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_families(families)
             .with_dynamic_bag_type(dynamic_bag_type)
@@ -4641,18 +4641,18 @@ fn invite_distribution_bucket_operator_succeeded() {
 
         let provider_id = DEFAULT_DISTRIBUTION_PROVIDER_ID;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
@@ -4671,7 +4671,7 @@ fn invite_distribution_bucket_operator_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_id = 1;
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -4680,12 +4680,12 @@ fn invite_distribution_bucket_operator_fails_with_non_leader_origin() {
 #[test]
 fn invite_distribution_bucket_operator_fails_with_non_existing_distribution_bucket() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionBucketDoesntExist.into()));
@@ -4697,25 +4697,25 @@ fn invite_distribution_bucket_operator_fails_with_non_missing_invitation() {
     build_test_externalities().execute_with(|| {
         let invited_worker_id = DEFAULT_DISTRIBUTION_PROVIDER_ID;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_operator_worker_id(invited_worker_id)
             .call_and_assert(Ok(()));
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
@@ -4732,25 +4732,25 @@ fn invite_distribution_bucket_operator_fails_with_exceeding_the_limit_of_pending
         let invited_worker_id = DEFAULT_DISTRIBUTION_PROVIDER_ID;
         let another_worker_id = ANOTHER_DISTRIBUTION_PROVIDER_ID;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_operator_worker_id(invited_worker_id)
             .call_and_assert(Ok(()));
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
@@ -4767,32 +4767,32 @@ fn invite_distribution_bucket_operator_fails_with_already_set_operator() {
     build_test_externalities().execute_with(|| {
         let invited_worker_id = DEFAULT_DISTRIBUTION_PROVIDER_ID;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_operator_worker_id(invited_worker_id)
             .call_and_assert(Ok(()));
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_worker_id(invited_worker_id)
             .call_and_assert(Ok(()));
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
@@ -4806,18 +4806,18 @@ fn invite_distribution_bucket_operator_fails_with_invalid_distribution_provider_
     build_test_externalities().execute_with(|| {
         let invalid_provider_id = 155;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
@@ -4836,25 +4836,25 @@ fn cancel_distribution_bucket_operator_invite_succeeded() {
 
         let provider_id = DEFAULT_DISTRIBUTION_PROVIDER_ID;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_operator_worker_id(provider_id)
             .call_and_assert(Ok(()));
 
-        CancelDistributionBucketInvitationFixture::default()
+        CancelDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
@@ -4873,7 +4873,7 @@ fn cancel_distribution_bucket_operator_invite_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let non_leader_account_id = 11111;
 
-        CancelDistributionBucketInvitationFixture::default()
+        CancelDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(non_leader_account_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -4882,12 +4882,12 @@ fn cancel_distribution_bucket_operator_invite_fails_with_non_leader_origin() {
 #[test]
 fn cancel_distribution_bucket_operator_invite_fails_with_non_existing_distribution_bucket() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        CancelDistributionBucketInvitationFixture::default()
+        CancelDistributionBucketInvitationFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionBucketDoesntExist.into()));
@@ -4897,18 +4897,18 @@ fn cancel_distribution_bucket_operator_invite_fails_with_non_existing_distributi
 #[test]
 fn cancel_distribution_bucket_operator_invite_fails_with_non_invited_distribution_provider() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        CancelDistributionBucketInvitationFixture::default()
+        CancelDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
@@ -4924,25 +4924,25 @@ fn accept_distribution_bucket_operator_invite_succeeded() {
 
         let provider_id = DEFAULT_DISTRIBUTION_PROVIDER_ID;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_operator_worker_id(provider_id)
             .call_and_assert(Ok(()));
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
@@ -4961,7 +4961,7 @@ fn accept_distribution_bucket_operator_invite_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let invalid_account_id = 11111;
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(invalid_account_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -4970,12 +4970,12 @@ fn accept_distribution_bucket_operator_invite_fails_with_non_leader_origin() {
 #[test]
 fn accept_distribution_bucket_operator_invite_fails_with_non_existing_distribution_bucket() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionBucketDoesntExist.into()));
@@ -4985,18 +4985,18 @@ fn accept_distribution_bucket_operator_invite_fails_with_non_existing_distributi
 #[test]
 fn accept_distribution_bucket_operator_invite_fails_with_non_invited_distribution_provider() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
@@ -5013,32 +5013,32 @@ fn set_distribution_operator_metadata_succeeded() {
         let provider_id = DEFAULT_DISTRIBUTION_PROVIDER_ID;
         let metadata = b"Metadata".to_vec();
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_operator_worker_id(provider_id)
             .call_and_assert(Ok(()));
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
             .with_worker_id(provider_id)
             .call_and_assert(Ok(()));
 
-        SetDistributionBucketMetadataFixture::default()
+        SetDistributionBucketMetadataFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
@@ -5059,7 +5059,7 @@ fn set_distribution_operator_metadata_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let invalid_account_id = 11111;
 
-        SetDistributionBucketMetadataFixture::default()
+        SetDistributionBucketMetadataFixture::new()
             .with_origin(RawOrigin::Signed(invalid_account_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -5068,12 +5068,12 @@ fn set_distribution_operator_metadata_fails_with_non_leader_origin() {
 #[test]
 fn set_distribution_operator_metadata_fails_with_non_existing_distribution_bucket() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        SetDistributionBucketMetadataFixture::default()
+        SetDistributionBucketMetadataFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .call_and_assert(Err(Error::<Test>::DistributionBucketDoesntExist.into()));
@@ -5083,18 +5083,18 @@ fn set_distribution_operator_metadata_fails_with_non_existing_distribution_bucke
 #[test]
 fn set_distribution_operator_metadata_fails_with_non_distribution_provider() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        SetDistributionBucketMetadataFixture::default()
+        SetDistributionBucketMetadataFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
@@ -5112,32 +5112,32 @@ fn remove_distribution_bucket_operator_succeeded() {
 
         let operator_id = DEFAULT_DISTRIBUTION_PROVIDER_ID;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_operator_worker_id(operator_id)
             .call_and_assert(Ok(()));
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
             .with_worker_id(operator_id)
             .call_and_assert(Ok(()));
 
-        RemoveDistributionBucketOperatorFixture::default()
+        RemoveDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
@@ -5154,7 +5154,7 @@ fn remove_distribution_bucket_operator_succeeded() {
 #[test]
 fn remove_distribution_bucket_operator_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
-        RemoveDistributionBucketOperatorFixture::default()
+        RemoveDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -5163,12 +5163,12 @@ fn remove_distribution_bucket_operator_fails_with_non_leader_origin() {
 #[test]
 fn remove_distribution_bucket_operator_fails_with_non_existing_distribution_bucket() {
     build_test_externalities().execute_with(|| {
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        RemoveDistributionBucketOperatorFixture::default()
+        RemoveDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(family_id)
             .call_and_assert(Err(Error::<Test>::DistributionBucketDoesntExist.into()));
@@ -5180,18 +5180,18 @@ fn remove_distribution_bucket_operator_fails_with_non_accepted_distribution_prov
     build_test_externalities().execute_with(|| {
         let operator_id = DEFAULT_DISTRIBUTION_PROVIDER_ID;
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let bucket_index = CreateDistributionBucketFixture::default()
+        let bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        RemoveDistributionBucketOperatorFixture::default()
+        RemoveDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
@@ -5200,14 +5200,14 @@ fn remove_distribution_bucket_operator_fails_with_non_accepted_distribution_prov
                 Error::<Test>::MustBeDistributionProviderOperatorForBucket.into(),
             ));
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(bucket_index)
             .with_family_id(family_id)
             .with_operator_worker_id(operator_id)
             .call_and_assert(Ok(()));
 
-        RemoveDistributionBucketOperatorFixture::default()
+        RemoveDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_bucket_index(bucket_index)
@@ -5226,12 +5226,12 @@ fn set_distribution_bucket_family_metadata_succeeded() {
 
         let metadata = b"Metadata".to_vec();
 
-        let family_id = CreateDistributionBucketFamilyFixture::default()
+        let family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        SetDistributionBucketFamilyMetadataFixture::default()
+        SetDistributionBucketFamilyMetadataFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_family_id(family_id)
             .with_metadata(metadata.clone())
@@ -5248,7 +5248,7 @@ fn set_distribution_bucket_family_metadata_fails_with_non_leader_origin() {
     build_test_externalities().execute_with(|| {
         let invalid_account_id = 11111;
 
-        SetDistributionBucketFamilyMetadataFixture::default()
+        SetDistributionBucketFamilyMetadataFixture::new()
             .with_origin(RawOrigin::Signed(invalid_account_id))
             .call_and_assert(Err(DispatchError::BadOrigin));
     });
@@ -5257,7 +5257,7 @@ fn set_distribution_bucket_family_metadata_fails_with_non_leader_origin() {
 #[test]
 fn set_distribution_bucket_family_metadata_fails_with_invalid_distribution_bucket_family() {
     build_test_externalities().execute_with(|| {
-        SetDistributionBucketFamilyMetadataFixture::default()
+        SetDistributionBucketFamilyMetadataFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Err(
                 Error::<Test>::DistributionBucketFamilyDoesntExist.into()
@@ -5554,7 +5554,7 @@ fn unsuccessful_dyn_bag_creation_with_upload_blocking() {
         create_storage_buckets(DEFAULT_STORAGE_BUCKETS_NUMBER);
         increase_account_balance(&DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
 
-        UpdateUploadingBlockedStatusFixture::default()
+        UpdateUploadingBlockedStatusFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_new_status(true)
             .call_and_assert(Ok(()));
@@ -5579,7 +5579,7 @@ fn unsuccessful_dyn_bag_creation_with_blacklisted_ipfs_id() {
             })
             .collect();
 
-        UpdateBlacklistFixture::default()
+        UpdateBlacklistFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_add_hashes(
                 objects
@@ -5627,7 +5627,7 @@ fn unsuccessful_dyn_bag_creation_with_no_bucket_accepting() {
         run_to_block(1);
 
         set_max_voucher_limits();
-        CreateStorageBucketFixture::default()
+        CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_accepting_new_bags(false)
             .create_several(DEFAULT_STORAGE_BUCKETS_NUMBER);
@@ -5649,13 +5649,13 @@ fn storage_operator_remark_successful() {
         let invite_worker = Some(storage_provider_id);
         let transactor_id = DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -5681,7 +5681,7 @@ fn storage_operator_remark_unsuccessful_with_invalid_bucket_id() {
         let invite_worker = Some(storage_provider_id);
         let transactor_id = DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
@@ -5689,7 +5689,7 @@ fn storage_operator_remark_unsuccessful_with_invalid_bucket_id() {
 
         let invalid_bucket_id = bucket_id.saturating_add(1);
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -5718,13 +5718,13 @@ fn storage_operator_remark_unsuccessful_with_invalid_origin() {
         let invite_worker = Some(storage_provider_id);
         let transactor_id = DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
             .unwrap();
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -5754,7 +5754,7 @@ fn storage_operator_remark_unsuccessful_with_invalid_worker_id() {
         let invite_worker = Some(storage_provider_id);
         let transactor_id = DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID;
 
-        let bucket_id = CreateStorageBucketFixture::default()
+        let bucket_id = CreateStorageBucketFixture::new()
             .with_origin(RawOrigin::Signed(STORAGE_WG_LEADER_ACCOUNT_ID))
             .with_invite_worker(invite_worker)
             .call_and_assert(Ok(()))
@@ -5762,7 +5762,7 @@ fn storage_operator_remark_unsuccessful_with_invalid_worker_id() {
 
         let invalid_worker_id = DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID.saturating_add(1);
 
-        AcceptStorageBucketInvitationFixture::default()
+        AcceptStorageBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_STORAGE_PROVIDER_ACCOUNT_ID))
             .with_storage_bucket_id(bucket_id)
             .with_worker_id(storage_provider_id)
@@ -5788,25 +5788,25 @@ fn distribution_operator_remark_successful() {
 
         let msg = b"test".to_vec();
 
-        let distribution_bucket_family_id = CreateDistributionBucketFamilyFixture::default()
+        let distribution_bucket_family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let distribution_bucket_index = CreateDistributionBucketFixture::default()
+        let distribution_bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(distribution_bucket_family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(distribution_bucket_index)
             .with_family_id(distribution_bucket_family_id)
             .with_operator_worker_id(DEFAULT_DISTRIBUTION_PROVIDER_ID)
             .call_and_assert(Ok(()));
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(distribution_bucket_family_id)
             .with_bucket_index(distribution_bucket_index)
@@ -5832,26 +5832,26 @@ fn distribution_operator_remark_unsuccessful_with_invalid_bucket_id() {
 
         let msg = b"test".to_vec();
 
-        let distribution_bucket_family_id = CreateDistributionBucketFamilyFixture::default()
+        let distribution_bucket_family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
         let invalid_distribution_bucket_family_id = distribution_bucket_family_id.saturating_add(1);
 
-        let distribution_bucket_index = CreateDistributionBucketFixture::default()
+        let distribution_bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(distribution_bucket_family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(distribution_bucket_index)
             .with_family_id(distribution_bucket_family_id)
             .with_operator_worker_id(DEFAULT_DISTRIBUTION_PROVIDER_ID)
             .call_and_assert(Ok(()));
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(distribution_bucket_family_id)
             .with_bucket_index(distribution_bucket_index)
@@ -5881,25 +5881,25 @@ fn distribution_operator_remark_unsuccessful_with_invalid_worker_id() {
         let invalid_distribution_worker_id = DEFAULT_DISTRIBUTION_PROVIDER_ID.saturating_add(1);
         let msg = b"test".to_vec();
 
-        let distribution_bucket_family_id = CreateDistributionBucketFamilyFixture::default()
+        let distribution_bucket_family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let distribution_bucket_index = CreateDistributionBucketFixture::default()
+        let distribution_bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(distribution_bucket_family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(distribution_bucket_index)
             .with_family_id(distribution_bucket_family_id)
             .with_operator_worker_id(DEFAULT_DISTRIBUTION_PROVIDER_ID)
             .call_and_assert(Ok(()));
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(distribution_bucket_family_id)
             .with_bucket_index(distribution_bucket_index)
@@ -5929,25 +5929,25 @@ fn distribution_operator_remark_unsuccessful_with_invalid_origin() {
         let invalid_distribution_worker_id = DEFAULT_DISTRIBUTION_PROVIDER_ID.saturating_add(1);
         let msg = b"test".to_vec();
 
-        let distribution_bucket_family_id = CreateDistributionBucketFamilyFixture::default()
+        let distribution_bucket_family_id = CreateDistributionBucketFamilyFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        let distribution_bucket_index = CreateDistributionBucketFixture::default()
+        let distribution_bucket_index = CreateDistributionBucketFixture::new()
             .with_family_id(distribution_bucket_family_id)
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .call_and_assert(Ok(()))
             .unwrap();
 
-        InviteDistributionBucketOperatorFixture::default()
+        InviteDistributionBucketOperatorFixture::new()
             .with_origin(RawOrigin::Signed(DISTRIBUTION_WG_LEADER_ACCOUNT_ID))
             .with_bucket_index(distribution_bucket_index)
             .with_family_id(distribution_bucket_family_id)
             .with_operator_worker_id(DEFAULT_DISTRIBUTION_PROVIDER_ID)
             .call_and_assert(Ok(()));
 
-        AcceptDistributionBucketInvitationFixture::default()
+        AcceptDistributionBucketInvitationFixture::new()
             .with_origin(RawOrigin::Signed(DEFAULT_DISTRIBUTION_PROVIDER_ACCOUNT_ID))
             .with_family_id(distribution_bucket_family_id)
             .with_bucket_index(distribution_bucket_index)

--- a/runtime-modules/support/derive-fixture/Cargo.toml
+++ b/runtime-modules/support/derive-fixture/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "derive-fixture"
+version = "0.1.0"
+authors = ['Joystream contributors']
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = "1"
+
+[features]
+default = ["std"]
+std = []

--- a/runtime-modules/support/derive-fixture/src/lib.rs
+++ b/runtime-modules/support/derive-fixture/src/lib.rs
@@ -7,7 +7,7 @@ use proc_macro2::TokenStream as TokenStream2;
 /// Generates setters methods for each field of the struct in the format `with_*`.
 /// Supports only structs with named fields. It supports generics.
 /// Usage:
-/// ```no_run
+/// ```ignore
 /// #[derive(Fixture, Default)]
 /// pub struct Foo{
 ///    pub val1: u32,

--- a/runtime-modules/support/derive-fixture/src/lib.rs
+++ b/runtime-modules/support/derive-fixture/src/lib.rs
@@ -1,4 +1,5 @@
 //! Contains procedural macros.
+//! Heavily influenced by [derive_new](https://github.com/nrc/derive-new)
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
@@ -6,7 +7,7 @@ use proc_macro2::TokenStream as TokenStream2;
 /// Generates setters methods for each field of the struct in the format `with_*`.
 /// Supports only structs with named fields. It supports generics.
 /// Usage:
-/// ```
+/// ```no_run
 /// #[derive(Fixture, Default)]
 /// pub struct Foo{
 ///    pub val1: u32,

--- a/runtime-modules/support/derive-fixture/src/lib.rs
+++ b/runtime-modules/support/derive-fixture/src/lib.rs
@@ -1,0 +1,77 @@
+//! Contains procedural macros.
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+
+/// Generates setters methods for each field of the struct in the format `with_*`.
+/// Supports only structs with named fields. It supports generics.
+/// Usage:
+/// ```
+/// #[derive(Fixture, Default)]
+/// pub struct Foo{
+///    pub val1: u32,
+///    pub val2: u32,
+/// }
+///
+/// fn some() {
+///     let foo = Foo::default()
+///         .with_val1(55)
+///         .with_val2(88);
+///
+///     ...
+/// }
+/// ```
+#[proc_macro_derive(Fixture)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    // Parse the input token stream for the struct.
+    let ast: syn::DeriveInput =
+        syn::parse(input).expect("Couldn't parse AST(derive Fixture macro)");
+
+    // Select struct type as the only supported type.
+    match ast.data {
+        syn::Data::Struct(ref s) => {
+            // Parse generics.
+            let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+            // Get s struct name.
+            let struct_name = &ast.ident;
+
+            // Create a new output token stream for the setters.
+            let mut token_stream = TokenStream2::new();
+
+            // Select named fields as the only supported field type.
+            match s.fields {
+                syn::Fields::Named(ref fields) => {
+                    for f in fields.named.clone() {
+                        // Get field identifier & type.
+                        let field_name = f.ident.expect("Works only with named fields");
+                        let field_type = f.ty;
+
+                        // Format setter name.
+                        let setter_name = quote::format_ident!("with_{}", field_name);
+
+                        // Generate output setter-function token stream.
+                        let imp = quote::quote!(
+                            impl #impl_generics #struct_name #ty_generics #where_clause {
+                                pub fn #setter_name(self, #field_name: #field_type) -> Self {
+                                    Self{
+                                            #field_name,
+                                            ..self
+                                        }
+                                }
+                            }
+                        );
+
+                        // Append the last token stream to the output token stream.
+                        token_stream.extend(imp);
+                    }
+                }
+                _ => panic!("Works only with named fields."),
+            }
+
+            // Return the total generated token stream.
+            token_stream.into()
+        }
+        _ => panic!("Works only with structs."),
+    }
+}


### PR DESCRIPTION
Our test fixtures contain a lot of similar functions to simplify tests:

```rust
struct FooFixture{
   origin: RawOrigin<u64>,
   account_id: u64,
   member_id: u64,
}

impl FooFixture{
   pub fn default() -> Self{
       origin: RawOrigin::Signed(DEFAULT_ACCOUNT_ID),
       account_id: Default::default(),
       member_id: Default::default(),
   }
   pub fn with_origin(self, origin: RawOrigin<u64>) -> Self{
      Self {
         origin,
         ..self  
    }

    pub fn with_account_id(self, account_id: u64) -> Self{
    ...
    }

    pub fn with_member_id(self, member_id: u64) -> Self{
    ...
    }
    
    pub fn call(self) {
    ...
    }
}
```

Usage will look like:
```rust
let fixture = FooFixture::default()
    .with_account_id(account_id)
    .with_member_id(member_id);
```

These extra lines of codes could be avoided using two [derive macros](https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros):
- the `default` method could be simplified using the [derive_new macro](https://github.com/nrc/derive-new)
- `with_*` methods could be autogenerated using the newly created **derive_fixture** macro. The PR contain a dedicated crate for this proc_macro.

New code will look like this:
```rust
#[derive(Fixture, new)]
struct FooFixture{
   #[new(value = "RawOrigin::Signed(DEFAULT_ACCOUNT_ID)")]
   origin: RawOrigin<u64>,

   #[new(default)]
   account_id: u64,

   #[new(default)]
   member_id: u64,
}

impl FooFixture{
    pub fn call(self) {
    ...
    }
}
```

Usage will look like similar to the original version:
```rust
let fixture = FooFixture::new()
    .with_account_id(account_id)
    .with_member_id(member_id);
```

#### Comments
- Rust demands that **derive_macro** code should be placed in a separate crate from the using code.
- The further ideas to improve testing and benchmarking experience would be introducing separate crates for tests and benchmarks with the common code.