### PR TITLE
fix open auction withdraw bid logic

### DIFF
--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -712,7 +712,7 @@ export async function contentNft_AuctionBidCanceled({ event, store }: EventConte
   )
 
   // retrieve relevant bid
-  const bid = (auction.bids || []).find((bid) => bid.bidder.id.toString() === memberId.toString())
+  const bid = (auction.bids || []).find((bid) => !bid.isCanceled && bid.bidder.id.toString() === memberId.toString())
 
   // ensure bid exists
   if (!bid) {


### PR DESCRIPTION
The problem case where we encountered this:
1. Place a bid on an open auction
2. Place a 2nd bid (replace previous one)
3. Now there are 2 bids (first cancelled, second not cancelled), all good
4. Withdraw a bid
5. The second bid is not cancelled (it should be)