### PR TITLE
Rhodes fix unset transactional status nullable field

### DIFF
--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -257,10 +257,16 @@ async function setNewNftTransactionalStatus(
     transactionalStatus = transactionalStatusOrTransactionalStatusAuction
   }
 
+  // FIXME: https://github.com/Joystream/hydra/issues/435
+
   // update transactionalStatus
-  nft.transactionalStatus = transactionalStatus
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  nft.transactionalStatus = transactionalStatus || null
   // update transactionStatusAuction
-  nft.transactionalStatusAuction = transactionalStatusAuction
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  nft.transactionalStatusAuction = transactionalStatusAuction || null
   // save NFT
   await store.save<OwnedNft>(nft)
 

--- a/query-node/schemas/contentNft.graphql
+++ b/query-node/schemas/contentNft.graphql
@@ -75,6 +75,11 @@ type OwnedNft
   "NFT's auction transactional status (if any)"
   transactionalStatusAuction: Auction
 
+  # It's a duplicate value used (probably) because of
+  # limitations in querying deeply nested variant relations
+  "NFT's auction transactional status (if any)"
+  transactionalStatusAuction: Auction
+
   "History of transacional status changes"
   transactionalStatusUpdates: [TransactionalStatusUpdate!]! @derivedFrom(field: "nft")
 
@@ -98,6 +103,11 @@ type TransactionalStatusUpdate @entity {
   "NFT's non-auction transactional status (if any)"
   transactionalStatus: TransactionalStatus
 
+  "NFT's auction transactional status (if any)"
+  transactionalStatusAuction: Auction
+
+  # It's a duplicate value used (probably) because of
+  # limitations in querying deeply nested variant relations
   "NFT's auction transactional status (if any)"
   transactionalStatusAuction: Auction
 

--- a/query-node/schemas/contentNft.graphql
+++ b/query-node/schemas/contentNft.graphql
@@ -75,11 +75,6 @@ type OwnedNft
   "NFT's auction transactional status (if any)"
   transactionalStatusAuction: Auction
 
-  # It's a duplicate value used (probably) because of
-  # limitations in querying deeply nested variant relations
-  "NFT's auction transactional status (if any)"
-  transactionalStatusAuction: Auction
-
   "History of transacional status changes"
   transactionalStatusUpdates: [TransactionalStatusUpdate!]! @derivedFrom(field: "nft")
 
@@ -103,11 +98,6 @@ type TransactionalStatusUpdate @entity {
   "NFT's non-auction transactional status (if any)"
   transactionalStatus: TransactionalStatus
 
-  "NFT's auction transactional status (if any)"
-  transactionalStatusAuction: Auction
-
-  # It's a duplicate value used (probably) because of
-  # limitations in querying deeply nested variant relations
   "NFT's auction transactional status (if any)"
   transactionalStatusAuction: Auction
 


### PR DESCRIPTION
related to #3560

Addresses the issue (https://github.com/Joystream/hydra/issues/435) of not being able to unset a nullable field after it has been set to some value.
