### PR TITLE
Rhodes. Runtime: Change NFT bid balance reservations to module account

### DIFF
--- a/runtime-modules/common/src/currency.rs
+++ b/runtime-modules/common/src/currency.rs
@@ -1,15 +1,4 @@
-use frame_support::traits::{Currency, LockableCurrency, ReservableCurrency};
 use sp_runtime::traits::Convert;
-
-pub trait GovernanceCurrency: frame_system::Trait + Sized {
-    type Currency: Currency<Self::AccountId>
-        + ReservableCurrency<Self::AccountId>
-        + LockableCurrency<Self::AccountId, Moment = Self::BlockNumber>;
-}
-
-pub type BalanceOf<T> = <<T as GovernanceCurrency>::Currency as Currency<
-    <T as frame_system::Trait>::AccountId,
->>::Balance;
 
 /// A structure that converts the currency type into a lossy u64
 /// And back from u128

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -1645,11 +1645,11 @@ decl_module! {
             // == MUTATION_SAFE ==
             //
 
-            // Make a new bid considering the old one (if any).
-            Self::make_bid_payment(&participant_account_id, bid_amount, old_bid_value)?;
-
             let (nft, event) = match open_auction.buy_now_price {
                 Some(buy_now_price) if bid_amount >= buy_now_price => {
+                    // Make a new bid considering the old one (if any) and the "buy-now-price".
+                    Self::make_bid_payment(&participant_account_id, buy_now_price, old_bid_value)?;
+
                     // complete auction @ buy_now_price
                     let updated_nft = Self::complete_auction(
                         nft,
@@ -1665,6 +1665,9 @@ decl_module! {
                     )
                 },
                 _ =>  {
+                    // Make a new bid considering the old one (if any).
+                    Self::make_bid_payment(&participant_account_id, bid_amount, old_bid_value)?;
+
                     OpenAuctionBidByVideoAndMember::<T>::insert(
                         video_id,
                         participant_id,
@@ -1731,11 +1734,11 @@ decl_module! {
             // == MUTATION_SAFE ==
             //
 
-            // Make a new bid considering the old one (if any).
-            Self::make_bid_payment(&participant_account_id, bid_amount, old_bid_value)?;
-
             let (updated_nft, event) = match eng_auction.buy_now_price {
                 Some(buy_now_price) if bid_amount >= buy_now_price => {
+                    // Make a new bid considering the old one (if any) and the "buy-now-price".
+                    Self::make_bid_payment(&participant_account_id, buy_now_price, old_bid_value)?;
+
                     // complete auction @ buy_now_price
                     let updated_nft = Self::complete_auction(
                         nft,
@@ -1752,6 +1755,10 @@ decl_module! {
                     )
                 },
                 _ => {
+
+                    // Make a new bid considering the old one (if any).
+                    Self::make_bid_payment(&participant_account_id, bid_amount, old_bid_value)?;
+
                     // update nft auction state
                     let updated_auction = eng_auction.with_bid(bid_amount, participant_id, current_block);
 

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -27,14 +27,14 @@ pub use storage::{
 };
 
 pub use common::{
-    currency::GovernanceCurrency, membership::MembershipInfoProvider, working_group::WorkingGroup,
-    MembershipTypes, StorageOwnership, Url,
+    membership::MembershipInfoProvider, working_group::WorkingGroup, MembershipTypes,
+    StorageOwnership, Url,
 };
 use frame_support::{
     decl_event, decl_module, decl_storage,
     dispatch::{DispatchError, DispatchResult},
     ensure,
-    traits::{Currency, ExistenceRequirement, Get, ReservableCurrency},
+    traits::{Currency, ExistenceRequirement, Get},
     Parameter,
 };
 
@@ -59,7 +59,6 @@ pub trait Trait:
     + membership::Trait
     + balances::Trait
     + storage::Trait
-    + GovernanceCurrency
 {
     /// The overarching event type.
     type Event: From<Event<Self>> + Into<<Self as frame_system::Trait>::Event>;
@@ -165,10 +164,10 @@ decl_storage! {
         pub MaxBidLockDuration get(fn max_bid_lock_duration) config(): T::BlockNumber;
 
         /// Min auction staring price
-        pub MinStartingPrice get(fn min_starting_price) config(): CurrencyOf<T>;
+        pub MinStartingPrice get(fn min_starting_price) config(): BalanceOf<T>;
 
         /// Max auction staring price
-        pub MaxStartingPrice get(fn max_starting_price) config(): CurrencyOf<T>;
+        pub MaxStartingPrice get(fn max_starting_price) config(): BalanceOf<T>;
 
         /// Min creator royalty percentage
         pub MinCreatorRoyalty get(fn min_creator_royalty) config(): Perbill;
@@ -177,10 +176,10 @@ decl_storage! {
         pub MaxCreatorRoyalty get(fn max_creator_royalty) config(): Perbill;
 
         /// Min auction bid step
-        pub MinBidStep get(fn min_bid_step) config(): CurrencyOf<T>;
+        pub MinBidStep get(fn min_bid_step) config(): BalanceOf<T>;
 
         /// Max auction bid step
-        pub MaxBidStep get(fn max_bid_step) config(): CurrencyOf<T>;
+        pub MaxBidStep get(fn max_bid_step) config(): BalanceOf<T>;
 
         /// Platform fee percentage
         pub PlatfromFeePercentage get(fn platform_fee_percentage) config(): Perbill;
@@ -1578,7 +1577,7 @@ decl_module! {
             origin,
             owner_id: ContentActor<T::CuratorGroupId, T::CuratorId, T::MemberId>,
             video_id: T::VideoId,
-            new_price: CurrencyOf<T>,
+            new_price: BalanceOf<T>,
         ) {
             // Ensure given video exists
             let video = Self::ensure_video_exists(&video_id)?;
@@ -1613,7 +1612,7 @@ decl_module! {
             origin,
             participant_id: T::MemberId,
             video_id: T::VideoId,
-            bid_amount: CurrencyOf<T>,
+            bid_amount: BalanceOf<T>,
         ) {
             // Authorize participant under given member id
             let participant_account_id = ensure_signed(origin)?;
@@ -1690,7 +1689,7 @@ decl_module! {
             origin,
             participant_id: T::MemberId,
             video_id: T::VideoId,
-            bid_amount: CurrencyOf<T>,
+            bid_amount: BalanceOf<T>,
         ) {
             // Authorize participant under given member id
             let participant_account_id = ensure_signed(origin)?;
@@ -1870,7 +1869,7 @@ decl_module! {
             owner_id: ContentActor<T::CuratorGroupId, T::CuratorId, T::MemberId>,
             video_id: T::VideoId,
             winner_id: T::MemberId,
-            commit: CurrencyOf<T>, // amount the auctioner is committed to
+            commit: BalanceOf<T>, // amount the auctioner is committed to
         ) {
             let winner_account_id = T::MemberAuthenticator::controller_account_id(winner_id)?;
             // Ensure video exists
@@ -1923,7 +1922,7 @@ decl_module! {
             video_id: T::VideoId,
             owner_id: ContentActor<T::CuratorGroupId, T::CuratorId, T::MemberId>,
             to: T::MemberId,
-            price: Option<CurrencyOf<T>>,
+            price: Option<BalanceOf<T>>,
         ) {
 
             // Ensure given video exists
@@ -2031,7 +2030,7 @@ decl_module! {
             origin,
             video_id: T::VideoId,
             owner_id: ContentActor<T::CuratorGroupId, T::CuratorId, T::MemberId>,
-            price: CurrencyOf<T>,
+            price: BalanceOf<T>,
         ) {
 
             // Ensure given video exists
@@ -2069,7 +2068,7 @@ decl_module! {
             origin,
             video_id: T::VideoId,
             participant_id: T::MemberId,
-            price_commit: CurrencyOf<T>, // in order to avoid front running
+            price_commit: BalanceOf<T>, // in order to avoid front running
         ) {
 
             // Authorize participant under given member id
@@ -2442,7 +2441,7 @@ decl_event!(
         OpenAuctionId = <T as Trait>::OpenAuctionId,
         NftIssuanceParameters = NftIssuanceParameters<T>,
         Balance = BalanceOf<T>,
-        CurrencyAmount = CurrencyOf<T>,
+        CurrencyAmount = BalanceOf<T>,
         ChannelCreationParameters = ChannelCreationParameters<T>,
         ChannelUpdateParameters = ChannelUpdateParameters<T>,
         VideoCreationParameters = VideoCreationParameters<T>,

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -1757,7 +1757,7 @@ decl_module! {
 
             let (updated_nft, event) = match eng_auction.buy_now_price {
                 Some(buy_now_price) if bid_amount >= buy_now_price => {
-                    // Make a new bid considering the old one (if any) and the "buy-now-price".
+                    // Make a new bid considering the "buy-now-price".
                     Self::make_bid_payment(
                         &participant_account_id,
                         buy_now_price,
@@ -1781,7 +1781,7 @@ decl_module! {
                 },
                 _ => {
 
-                    // Make a new bid considering the old one (if any).
+                    // Make a new bid.
                     Self::make_bid_payment(
                         &participant_account_id,
                         bid_amount,

--- a/runtime-modules/content/src/nft/mod.rs
+++ b/runtime-modules/content/src/nft/mod.rs
@@ -28,19 +28,19 @@ impl<T: Trait> Module<T> {
         if let Some(old_bid) = old_bid {
             if bid >= old_bid {
                 // Deposit the difference to the module account.
-                let combined_bid = bid.saturating_sub(old_bid);
-                ContentTreasury::<T>::deposit(&participant, combined_bid)
+                let bid_diff_amount = bid.saturating_sub(old_bid);
+                ContentTreasury::<T>::deposit(&participant, bid_diff_amount)
             } else {
                 // Withdraw the difference from the module account.
-                let combined_bid = old_bid.saturating_sub(bid);
-                ContentTreasury::<T>::withdraw(&participant, combined_bid)
+                let bid_diff_amount = old_bid.saturating_sub(bid);
+                ContentTreasury::<T>::withdraw(&participant, bid_diff_amount)
             }
         } else {
             ContentTreasury::<T>::deposit(&participant, bid)
         }
     }
 
-    /// Make bid transfer to the treasury account or get refunded if the old bid is greater than a new one.
+    /// Withdraw the bid from the treasury account.
     pub(crate) fn withdraw_bid_payment(
         participant: &T::AccountId,
         bid: BalanceOf<T>,

--- a/runtime-modules/content/src/nft/mod.rs
+++ b/runtime-modules/content/src/nft/mod.rs
@@ -1,5 +1,4 @@
 mod types;
-use frame_support::traits::ReservableCurrency;
 use sp_std::borrow::ToOwned;
 pub use types::*;
 
@@ -346,7 +345,8 @@ impl<T: Trait> Module<T> {
 
         // Slash amount from sender
         if is_auction {
-            let _ = Balances::<T>::slash_reserved(&sender_account_id, amount);
+            let module_account_id = ContentTreasury::<T>::module_account_id();
+            let _ = Balances::<T>::slash(&module_account_id, amount);
         } else {
             let _ = Balances::<T>::slash(&sender_account_id, amount);
         }

--- a/runtime-modules/content/src/nft/types.rs
+++ b/runtime-modules/content/src/nft/types.rs
@@ -463,31 +463,31 @@ pub struct OpenAuctionParamsRecord<BlockNumber, Balance, MemberId: Ord> {
 // Aliases
 pub type EnglishAuction<T> = EnglishAuctionRecord<
     <T as frame_system::Trait>::BlockNumber,
-    CurrencyOf<T>,
+    BalanceOf<T>,
     <T as common::MembershipTypes>::MemberId,
 >;
 
 pub type OpenAuction<T> = OpenAuctionRecord<
     <T as frame_system::Trait>::BlockNumber,
     <T as Trait>::OpenAuctionId,
-    CurrencyOf<T>,
+    BalanceOf<T>,
     <T as common::MembershipTypes>::MemberId,
 >;
 
 pub type EnglishAuctionParams<T> = EnglishAuctionParamsRecord<
     <T as frame_system::Trait>::BlockNumber,
-    CurrencyOf<T>,
+    BalanceOf<T>,
     <T as common::MembershipTypes>::MemberId,
 >;
 
 pub type OpenAuctionParams<T> = OpenAuctionParamsRecord<
     <T as frame_system::Trait>::BlockNumber,
-    CurrencyOf<T>,
+    BalanceOf<T>,
     <T as common::MembershipTypes>::MemberId,
 >;
 
 pub type OpenAuctionBid<T> = OpenAuctionBidRecord<
-    CurrencyOf<T>,
+    BalanceOf<T>,
     <T as frame_system::Trait>::BlockNumber,
     <T as Trait>::OpenAuctionId,
 >;
@@ -500,7 +500,7 @@ pub type Nft<T> = OwnedNft<
 
 pub type TransactionalStatus<T> = TransactionalStatusRecord<
     <T as common::MembershipTypes>::MemberId,
-    CurrencyOf<T>,
+    BalanceOf<T>,
     EnglishAuction<T>,
     OpenAuction<T>,
 >;
@@ -509,5 +509,5 @@ pub type InitTransactionalStatus<T> = InitTransactionalStatusRecord<
     EnglishAuctionParams<T>,
     OpenAuctionParams<T>,
     <T as common::MembershipTypes>::MemberId,
-    CurrencyOf<T>,
+    BalanceOf<T>,
 >;

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -15,7 +15,6 @@ use staking_handler::LockComparator;
 
 use crate::ContentActorAuthenticator;
 use crate::Trait;
-use common::currency::GovernanceCurrency;
 
 /// Module Aliases
 pub type System = frame_system::Module<Test>;
@@ -172,10 +171,6 @@ impl pallet_timestamp::Trait for Test {
     type OnTimestampSet = ();
     type MinimumPeriod = MinimumPeriod;
     type WeightInfo = ();
-}
-
-impl GovernanceCurrency for Test {
-    type Currency = balances::Module<Self>;
 }
 
 parameter_types! {

--- a/runtime-modules/content/src/tests/nft/cancel_open_auction_bid.rs
+++ b/runtime-modules/content/src/tests/nft/cancel_open_auction_bid.rs
@@ -75,12 +75,18 @@ fn cancel_open_auction_bid() {
         let bid_lock_duration = Content::min_bid_lock_duration();
         run_to_block(bid_lock_duration + 1);
 
+        let bid = Content::min_starting_price();
+        let module_account_id = ContentTreasury::<Test>::module_account_id();
+        assert_eq!(Balances::<Test>::usable_balance(&module_account_id), bid);
+
         // Cancel auction bid
         assert_ok!(Content::cancel_open_auction_bid(
             Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
             SECOND_MEMBER_ID,
             video_id,
         ));
+
+        assert_eq!(Balances::<Test>::usable_balance(&module_account_id), 0);
 
         // Runtime tested state after call
 

--- a/runtime-modules/content/src/tests/nft/claim_won_english_auction.rs
+++ b/runtime-modules/content/src/tests/nft/claim_won_english_auction.rs
@@ -149,10 +149,8 @@ fn settle_english_auction_cannot_be_completed() {
         ));
 
         // Make an attempt to claim won english auction if it did not expire yet
-        let settle_english_auction_result = Content::settle_english_auction(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id,
-        );
+        let settle_english_auction_result =
+            Content::settle_english_auction(Origin::signed(SECOND_MEMBER_ACCOUNT_ID), video_id);
 
         // Failure checked
         assert_err!(
@@ -171,10 +169,8 @@ fn settle_english_auction_video_does_not_exist() {
         let video_id = NextVideoId::<Test>::get();
 
         // Make an attempt to claim won english auction which corresponding video does not exist
-        let settle_english_auction_result = Content::settle_english_auction(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id,
-        );
+        let settle_english_auction_result =
+            Content::settle_english_auction(Origin::signed(SECOND_MEMBER_ACCOUNT_ID), video_id);
 
         // Failure checked
         assert_err!(
@@ -197,10 +193,8 @@ fn settle_english_auction_nft_is_not_issued() {
         create_default_member_owned_channel_with_video();
 
         // Make an attempt to claim won english auction for nft which is not issued yet
-        let settle_english_auction_result = Content::settle_english_auction(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id,
-        );
+        let settle_english_auction_result =
+            Content::settle_english_auction(Origin::signed(SECOND_MEMBER_ACCOUNT_ID), video_id);
 
         // Failure checked
         assert_err!(
@@ -231,10 +225,8 @@ fn settle_english_auction_not_in_auction_state() {
         ));
 
         // Make an attempt to claim won english auction for nft which is not in auction state
-        let settle_english_auction_result = Content::settle_english_auction(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id,
-        );
+        let settle_english_auction_result =
+            Content::settle_english_auction(Origin::signed(SECOND_MEMBER_ACCOUNT_ID), video_id);
 
         // Failure checked
         assert_err!(
@@ -296,10 +288,8 @@ fn settle_english_auction_is_not_english_auction_type() {
         ));
 
         // Make an attempt to claim won english auction for nft which is not in english auction state
-        let settle_english_auction_result = Content::settle_english_auction(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id,
-        );
+        let settle_english_auction_result =
+            Content::settle_english_auction(Origin::signed(SECOND_MEMBER_ACCOUNT_ID), video_id);
 
         // Failure checked
         assert_err!(
@@ -351,10 +341,8 @@ fn settle_english_auction_last_bid_does_not_exist() {
         run_to_block(Content::max_auction_duration() + 1);
 
         // Make an attempt to claim won english auction if last bid does not exist
-        let settle_english_auction_result = Content::settle_english_auction(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id,
-        );
+        let settle_english_auction_result =
+            Content::settle_english_auction(Origin::signed(SECOND_MEMBER_ACCOUNT_ID), video_id);
 
         // Failure checked
         assert_err!(
@@ -431,10 +419,8 @@ fn settle_english_auction_ok_with_nft_claimed_by_non_winner() {
         run_to_block(Content::max_auction_duration() + 1);
 
         // Make an attempt to claim won english auction if last bid does not exist
-        let settle_english_auction_result = Content::settle_english_auction(
-            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
-            video_id,
-        );
+        let settle_english_auction_result =
+            Content::settle_english_auction(Origin::signed(SECOND_MEMBER_ACCOUNT_ID), video_id);
 
         // Failure checked
         assert_ok!(settle_english_auction_result);

--- a/runtime-modules/content/src/tests/nft/claim_won_english_auction.rs
+++ b/runtime-modules/content/src/tests/nft/claim_won_english_auction.rs
@@ -52,6 +52,9 @@ fn settle_english_auction() {
 
         let _ = balances::Module::<Test>::deposit_creating(&SECOND_MEMBER_ACCOUNT_ID, bid);
 
+        let module_account_id = ContentTreasury::<Test>::module_account_id();
+        assert_eq!(Balances::<Test>::usable_balance(&module_account_id), 0);
+
         // Make nft auction bid
         assert_ok!(Content::make_english_auction_bid(
             Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
@@ -59,6 +62,9 @@ fn settle_english_auction() {
             video_id,
             bid,
         ));
+
+        // Module account contains a bid.
+        assert_eq!(Balances::<Test>::usable_balance(&module_account_id), bid);
 
         // Runtime tested state before call
 
@@ -73,6 +79,9 @@ fn settle_english_auction() {
             Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
             video_id,
         ));
+
+        // Module account is empty.
+        assert_eq!(Balances::<Test>::usable_balance(&module_account_id), 0);
 
         // Runtime tested state after call
 

--- a/runtime-modules/content/src/tests/nft/claim_won_english_auction.rs
+++ b/runtime-modules/content/src/tests/nft/claim_won_english_auction.rs
@@ -506,7 +506,7 @@ fn settle_english_auction_ok_with_balances_check() {
         // Run to the block where auction expires
         run_to_block(Content::max_auction_duration() + 1);
 
-        // Make an attempt to claim won english auction if last bid does not exist
+        // Settle the auciton.
         let settle_english_auction_result =
             Content::settle_english_auction(Origin::signed(SECOND_MEMBER_ACCOUNT_ID), video_id);
 

--- a/runtime-modules/content/src/tests/nft/make_bid.rs
+++ b/runtime-modules/content/src/tests/nft/make_bid.rs
@@ -139,6 +139,9 @@ fn make_bid() {
 
         let _ = balances::Module::<Test>::deposit_creating(&SECOND_MEMBER_ACCOUNT_ID, bid);
 
+        let module_account_id = ContentTreasury::<Test>::module_account_id();
+        assert_eq!(Balances::<Test>::usable_balance(&module_account_id), 0);
+
         // Make nft auction bid
         assert_ok!(Content::make_open_auction_bid(
             Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
@@ -146,6 +149,9 @@ fn make_bid() {
             video_id,
             bid,
         ));
+
+        // Module account contains a bid.
+        assert_eq!(Balances::<Test>::usable_balance(&module_account_id), bid);
 
         // Ensure nft status changed to given Auction
         let nft = Content::ensure_nft_exists(video_id).unwrap();
@@ -583,7 +589,7 @@ fn make_bid_succeeds_with_higher_offer_and_locking_period_not_expired() {
 }
 
 #[test]
-fn make_bid_fails_by_unreserving_prevous_funds() {
+fn make_bid_fails_by_insufficient_funds_for_the_next_bid() {
     with_default_mock_builder(|| {
         // Run to block one to see emitted events
         run_to_block(1);
@@ -594,12 +600,7 @@ fn make_bid_fails_by_unreserving_prevous_funds() {
 
         setup_open_auction_scenario_with_bid(init_bid);
 
-        let new_bid = init_bid.saturating_add(NEXT_BID_OFFSET);
-        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, NEXT_BID_OFFSET);
-        assert_eq!(
-            Balances::<Test>::total_balance(&SECOND_MEMBER_ACCOUNT_ID),
-            new_bid
-        );
+        let new_bid = init_bid + NEXT_BID_OFFSET;
 
         assert_err!(
             Content::make_open_auction_bid(
@@ -807,7 +808,7 @@ fn make_bid_ok_with_english_auction_completion_and_total_balance_slashed() {
         ));
 
         assert_eq!(
-            Balances::<Test>::free_balance(&SECOND_MEMBER_ACCOUNT_ID),
+            Balances::<Test>::usable_balance(&SECOND_MEMBER_ACCOUNT_ID),
             BIDDER_BALANCE - DEFAULT_BUY_NOW_PRICE,
         );
     })

--- a/runtime-modules/content/src/tests/nft/make_bid.rs
+++ b/runtime-modules/content/src/tests/nft/make_bid.rs
@@ -1149,7 +1149,7 @@ fn english_auction_increased_bid_works_correctly() {
 }
 
 #[test]
-fn open_auction_completion_with_increased_bid_works_correctly() {
+fn open_auction_increased_bid_works_correctly() {
     with_default_mock_builder(|| {
         // Run to block one to see emitted events
         run_to_block(1);

--- a/runtime-modules/content/src/tests/nft/make_bid.rs
+++ b/runtime-modules/content/src/tests/nft/make_bid.rs
@@ -1118,7 +1118,7 @@ fn english_auction_increased_bid_works_correctly() {
 
         let video_id = Content::next_video_id();
         setup_english_auction_scenario();
-        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, BIDDER_BALANCE);
+        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, 2 * Content::min_bid_step());
 
         let initial_balance = Balances::<Test>::usable_balance(&SECOND_MEMBER_ACCOUNT_ID);
 
@@ -1155,7 +1155,7 @@ fn open_auction_increased_bid_works_correctly() {
         run_to_block(1);
 
         let video_id = Content::next_video_id();
-        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, BIDDER_BALANCE);
+        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, 2 * Content::min_bid_step());
         setup_open_auction_scenario();
 
         let initial_balance = Balances::<Test>::usable_balance(&SECOND_MEMBER_ACCOUNT_ID);
@@ -1187,13 +1187,13 @@ fn open_auction_increased_bid_works_correctly() {
 }
 
 #[test]
-fn open_auction_completion_with_decreased_bid_works_correctly() {
+fn open_auction_decreased_bid_works_correctly() {
     with_default_mock_builder(|| {
         // Run to block one to see emitted events
         run_to_block(1);
 
         let video_id = Content::next_video_id();
-        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, BIDDER_BALANCE);
+        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, 2 * Content::min_bid_step());
         setup_open_auction_scenario();
 
         let initial_balance = Balances::<Test>::usable_balance(&SECOND_MEMBER_ACCOUNT_ID);

--- a/runtime-modules/content/src/types.rs
+++ b/runtime-modules/content/src/types.rs
@@ -501,7 +501,6 @@ impl<T: balances::Trait, ModId: Get<ModuleId>> ModuleAccount<T> for ModuleAccoun
 pub type ContentTreasury<T> = ModuleAccountHandler<T, <T as Trait>::ModuleId>;
 pub type Balances<T> = balances::Module<T>;
 pub type BalanceOf<T> = <Balances<T> as Currency<<T as frame_system::Trait>::AccountId>>::Balance;
-pub type CurrencyOf<T> = common::currency::BalanceOf<T>;
 pub type Storage<T> = storage::Module<T>;
 
 /// Type, used in diffrent numeric constraints representations

--- a/runtime-modules/storage/src/tests/mocks.rs
+++ b/runtime-modules/storage/src/tests/mocks.rs
@@ -129,10 +129,6 @@ impl pallet_timestamp::Trait for Test {
     type WeightInfo = ();
 }
 
-impl common::currency::GovernanceCurrency for Test {
-    type Currency = balances::Module<Self>;
-}
-
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
     pub const MaximumBlockWeight: u32 = 1024;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -471,10 +471,6 @@ impl pallet_finality_tracker::Trait for Runtime {
     type ReportLatency = ReportLatency;
 }
 
-impl common::currency::GovernanceCurrency for Runtime {
-    type Currency = pallet_balances::Module<Self>;
-}
-
 parameter_types! {
     pub const MaxNumberOfCuratorsPerGroup: MaxNumber = 50;
     pub const MaxModerators: u64 = 5;    // TODO: update


### PR DESCRIPTION
We [decided](https://github.com/Joystream/joystream/issues/3429) to change NFT bids in the content pallet from balance reservations to the module account.

#### Changes
- removed obsolete `GovernanceCurrency` type in favor of generic `BalanceOf` to enable the usage of `ContentTreasury` for bids
- removed `ReservableCurrency` methods in favor of the `ContentTreasury` methods
- changed extrinsics
    - make_open_auction_bid
    - make_english_auction_bid
    - cancel_open_auction_bid
 