### PR TITLE
Rhodes nft events fields tweaks

### DIFF
--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -355,7 +355,7 @@ async function finishAuction(
   // save auction
   await store.save<Auction>(auction)
 
-  return { video, winner, boughtPrice, nft }
+  return { video, winner, boughtPrice, nft, winningBid }
 }
 
 async function createBid(
@@ -978,7 +978,7 @@ export async function contentNft_OpenAuctionBidAccepted({ event, store }: EventC
   // specific event processing
 
   // finish auction
-  const { video, boughtPrice, nft } = await finishAuction(store, videoId.toNumber(), event.blockNumber, {
+  const { video, boughtPrice, nft, winningBid } = await finishAuction(store, videoId.toNumber(), event.blockNumber, {
     bidAmount,
     winnerId: winnerId.toNumber(),
   })
@@ -1002,6 +1002,8 @@ export async function contentNft_OpenAuctionBidAccepted({ event, store }: EventC
     video,
     // prepare Nft owner (handles fields `ownerMember` and `ownerCuratorGroup`)
     ...(await convertContentActorToChannelOrNftOwner(store, contentActor)),
+    winningBid,
+    winningBidder: new Membership({ id: winnerId.toString() }),
   })
 
   await store.save<OpenAuctionBidAcceptedEvent>(announcingPeriodStartedEvent)

--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -741,7 +741,11 @@ export async function contentNft_NftIssued({ event, store }: EventContext & Stor
 export async function contentNft_AuctionBidMade({ event, store }: EventContext & StoreContext): Promise<void> {
   // common event processing
 
-  const [memberId, videoId, bidAmount] = new Content.AuctionBidMadeEvent(event).params
+  const [memberId, videoId, bidAmount, previousTopBidderId] = new Content.AuctionBidMadeEvent(event).params
+
+  const previousTopBidder = previousTopBidderId.isSome
+    ? new Membership({ id: previousTopBidderId.unwrap().toString() })
+    : undefined
 
   // specific event processing
 
@@ -773,7 +777,8 @@ export async function contentNft_AuctionBidMade({ event, store }: EventContext &
     bidAmount,
     ownerMember: nft.ownerMember,
     ownerCuratorGroup: nft.ownerCuratorGroup,
-    previousTopBid,
+    previousTopBid: previousTopBidder ? previousTopBid : undefined,
+    previousTopBidder,
   })
 
   await store.save<AuctionBidMadeEvent>(announcingPeriodStartedEvent)
@@ -923,7 +928,11 @@ export async function contentNft_BidMadeCompletingAuction({
 }: EventContext & StoreContext): Promise<void> {
   // common event processing
 
-  const [memberId, videoId] = new Content.BidMadeCompletingAuctionEvent(event).params
+  const [memberId, videoId, previousTopBidderId] = new Content.BidMadeCompletingAuctionEvent(event).params
+
+  const previousTopBidder = previousTopBidderId.isSome
+    ? new Membership({ id: previousTopBidderId.unwrap().toString() })
+    : undefined
 
   // specific event processing
 
@@ -954,7 +963,8 @@ export async function contentNft_BidMadeCompletingAuction({
     ownerMember: nft.ownerMember,
     ownerCuratorGroup: nft.ownerCuratorGroup,
     price,
-    previousTopBid,
+    previousTopBid: previousTopBidder ? previousTopBid : undefined,
+    previousTopBidder,
   })
 
   await store.save<BidMadeCompletingAuctionEvent>(announcingPeriodStartedEvent)

--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -942,7 +942,10 @@ export async function contentNft_BidMadeCompletingAuction({
   // specific event processing
 
   // create record for winning bid
-  const { previousTopBid } = await createBid(event, store, memberId.toNumber(), videoId.toNumber())
+  const {
+    previousTopBid,
+    nft: { ownerMember, ownerCuratorGroup },
+  } = await createBid(event, store, memberId.toNumber(), videoId.toNumber())
 
   // finish auction and transfer ownership
   const { winner: member, video, boughtPrice: price, nft } = await finishAuction(
@@ -965,8 +968,8 @@ export async function contentNft_BidMadeCompletingAuction({
 
     member,
     video,
-    ownerMember: nft.ownerMember,
-    ownerCuratorGroup: nft.ownerCuratorGroup,
+    ownerMember,
+    ownerCuratorGroup,
     price,
     previousTopBid: previousTopBidder ? previousTopBid : undefined,
     previousTopBidder,

--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -86,13 +86,15 @@ async function getCurrentAuctionFromVideo(
   errorMessageForVideo: string,
   errorMessageForNft: string,
   errorMessageForAuction: string,
-  relations: string[] = []
+  nftRelations: string[] = [],
+  auctionRelations: string[] = []
 ): Promise<{ video: Video; auction: Auction; nft: OwnedNft }> {
   // load video
   const video = await getRequiredExistingEntity(store, Video, videoId.toString(), errorMessageForVideo, [
     'nft',
+    ...nftRelations.map((item) => `nft.${item}`),
     'nft.auctions',
-    ...relations.map((item) => `nft.auctions.${item}`),
+    ...auctionRelations.map((item) => `nft.auctions.${item}`),
   ])
 
   const nft = video.nft
@@ -320,6 +322,7 @@ async function finishAuction(
     `Non-existing video's auction was completed`,
     `Non-existing NFT's auction was completed`,
     'Non-existing auction was completed',
+    ['ownerMember', 'ownerCuratorGroup'],
     ['topBid', 'topBid.bidder', 'bids', 'bids.bidder']
   )
 
@@ -386,6 +389,7 @@ async function createBid(
     'Non-existing video got bid',
     'Non-existing NFT got bid',
     'Non-existing auction got bid canceled',
+    ['ownerMember', 'ownerCuratorGroup'],
     ['topBid', 'bids', 'bids.bidder']
   )
 
@@ -798,6 +802,7 @@ export async function contentNft_AuctionBidCanceled({ event, store }: EventConte
     'Non-existing video got bid canceled',
     'Non-existing NFT got bid canceled',
     'Non-existing auction got bid canceled',
+    ['ownerMember', 'ownerCuratorGroup'],
     ['topBid', 'bids', 'bids.bidder']
   )
 

--- a/query-node/schemas/contentNftEvents.graphql
+++ b/query-node/schemas/contentNftEvents.graphql
@@ -324,6 +324,12 @@ type OpenAuctionBidAcceptedEvent implements Event @entity {
 
   "Curator group owning the Nft (if any) that accepted the open auction bid."
   ownerCuratorGroup: CuratorGroup
+
+  "Accepted/winning bid"
+  winningBid: Bid
+
+  "Winning bidder"
+  winningBidder: Membership
 }
 
 type OfferStartedEvent implements Event @entity {

--- a/query-node/schemas/contentNftEvents.graphql
+++ b/query-node/schemas/contentNftEvents.graphql
@@ -147,6 +147,9 @@ type AuctionBidMadeEvent implements Event @entity {
 
   "Bid that is being displaced by current bid in English auction"
   previousTopBid: Bid
+
+  "Previous top bidder"
+  previousTopBidder: Membership
 }
 
 type AuctionBidCanceledEvent implements Event @entity {
@@ -285,6 +288,9 @@ type BidMadeCompletingAuctionEvent implements Event @entity {
 
   "Bid that is being displaced by current bid in English auction"
   previousTopBid: Bid
+
+  "Previous top bidder"
+  previousTopBidder: Membership
 }
 
 type OpenAuctionBidAcceptedEvent implements Event @entity {


### PR DESCRIPTION
This PR contains fixes for multiple NFT event issues, I have added the commit for each.

- a897c2171bd18c8147f3a88318a2ce1c932ba1b9 implements #3603
- 2c93cac0117d43de20fd9bd903abbbcfa091b799 adds `winningBid field in OpenAuctionBidAcceptedEvent`
- 72925dd193be38ce3962df6d549cf8513c45c57d fixes #3604
- 5084366ecc764ef14702a87206b82e3d8483b373 sets `BidMadeCompletingAuctionEvent.ownerMember to member that is owning NFT when bid is placed (not to the member that places the Bid)`