### PR TITLE
Ephesus. Runtime. Add NFT-limits to the content pallet.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3834,6 +3834,8 @@ dependencies = [
 name = "pallet-content"
 version = "3.2.0"
 dependencies = [
+ "derive-fixture",
+ "derive-new",
  "frame-support",
  "frame-system",
  "pallet-balances",

--- a/runtime-modules/content/Cargo.toml
+++ b/runtime-modules/content/Cargo.toml
@@ -25,7 +25,8 @@ pallet-timestamp = { package = 'pallet-timestamp', default-features = false, git
 randomness-collective-flip = { package = 'pallet-randomness-collective-flip', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62'}
 staking-handler = { package = 'pallet-staking-handler', default-features = false, path = '../staking-handler'}
 working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group'}
-
+derive-fixture = { package = 'derive-fixture', default-features = false, path = '../support/derive-fixture'}
+derive-new = "0.5"
 
 [features]
 default = ['std']

--- a/runtime-modules/content/src/errors.rs
+++ b/runtime-modules/content/src/errors.rs
@@ -283,7 +283,10 @@ decl_error! {
         // Insufficient council budget to cover channel reward claim
         InsufficientCouncilBudget,
 
-        // Can't issue more NFTs: daily limit exceeded.
+        // Can't issue more NFTs: global daily limit exceeded.
         GlobalNftDailyLimitExceeded,
+
+        // Can't issue more NFTs: global weekly limit exceeded.
+        GlobalNftWeeklyLimitExceeded,
     }
 }

--- a/runtime-modules/content/src/errors.rs
+++ b/runtime-modules/content/src/errors.rs
@@ -288,5 +288,11 @@ decl_error! {
 
         // Can't issue more NFTs: global weekly limit exceeded.
         GlobalNftWeeklyLimitExceeded,
+
+        // Can't issue more NFTs: channel daily limit exceeded.
+        ChannelNftDailyLimitExceeded,
+
+        // Can't issue more NFTs: channel weekly limit exceeded.
+        ChannelNftWeeklyLimitExceeded,
     }
 }

--- a/runtime-modules/content/src/errors.rs
+++ b/runtime-modules/content/src/errors.rs
@@ -282,5 +282,8 @@ decl_error! {
 
         // Insufficient council budget to cover channel reward claim
         InsufficientCouncilBudget,
+
+        // Can't issue more NFTs: daily limit exceeded.
+        GlobalNftDailyLimitExceeded,
     }
 }

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -2413,6 +2413,23 @@ decl_module! {
             Self::deposit_event(RawEvent::NftOwnerRemarked(actor, video_id, msg));
         }
 
+        /// Updates global or channel NFT limit.
+        #[weight = 10_000_000] // TODO: adjust weight
+        pub fn update_nft_limit(
+            origin,
+            nft_limit_id: NftLimitId<T::ChannelId>,
+            limit: LimitPerPeriod<T::BlockNumber>,
+        ) {
+            ensure_nft_limits_auth_success::<T>(origin, nft_limit_id)?;
+
+            //
+            // == MUTATION SAFE ==
+            //
+
+            <NftLimitsById::<T>>::insert(nft_limit_id, limit);
+
+            Self::deposit_event(RawEvent::NftLimitUpdated(nft_limit_id, limit));
+        }
     }
 }
 
@@ -2839,6 +2856,7 @@ decl_event!(
         ModeratorSet = BTreeSet<<T as MembershipTypes>::MemberId>,
         AccountId = <T as frame_system::Trait>::AccountId,
         UpdateChannelPayoutsParameters = UpdateChannelPayoutsParameters<T>,
+        BlockNumber = <T as frame_system::Trait>::BlockNumber,
     {
         // Curators
         CuratorGroupCreated(CuratorGroupId),
@@ -2933,5 +2951,8 @@ decl_event!(
         ChannelCollaboratorRemarked(ContentActor, ChannelId, Vec<u8>),
         ChannelModeratorRemarked(ContentActor, ChannelId, Vec<u8>),
         NftOwnerRemarked(ContentActor, VideoId, Vec<u8>),
+
+        /// Nft limits
+        NftLimitUpdated(NftLimitId<ChannelId>, LimitPerPeriod<BlockNumber>),
     }
 );

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -54,12 +54,6 @@ use sp_runtime::{
 };
 use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
 
-//TODO:
-// - consts
-// - proposals
-// - config
-// -
-
 /// Module configuration trait for Content Directory Module
 pub trait Trait:
     frame_system::Trait
@@ -235,6 +229,19 @@ decl_storage! {
             NftLimitId<T::ChannelId> => NftCounter<T::BlockNumber>;
 
     }
+    add_extra_genesis {
+        build(|_| {
+            // We set initial global NFT limits
+            NftLimitsById::<T>::insert(
+                NftLimitId::GlobalDaily,
+                T::DefaultGlobalDailyNftLimit::get()
+            );
+            NftLimitsById::<T>::insert(
+                NftLimitId::GlobalWeekly,
+                T::DefaultGlobalWeeklyNftLimit::get()
+            );
+        });
+    }
 }
 
 decl_module! {
@@ -247,6 +254,22 @@ decl_module! {
 
         /// Exports const -  max number of curators per group
         const MaxNumberOfCuratorsPerGroup: MaxNumber = T::MaxNumberOfCuratorsPerGroup::get();
+
+        /// Exports const - default global daily NFT limit.
+        const DefaultGlobalDailyNftLimit: LimitPerPeriod<T::BlockNumber> =
+            T::DefaultGlobalDailyNftLimit::get();
+
+        /// Exports const - default global weekly NFT limit.
+        const DefaultGlobalWeeklyNftLimit: LimitPerPeriod<T::BlockNumber> =
+            T::DefaultGlobalDailyNftLimit::get();
+
+        /// Exports const - default channel daily NFT limit.
+        const DefaultChannelDailyNftLimit: LimitPerPeriod<T::BlockNumber> =
+            T::DefaultGlobalDailyNftLimit::get();
+
+        /// Exports const - default channel weekly NFT limit.
+        const DefaultChannelWeeklyNftLimit: LimitPerPeriod<T::BlockNumber> =
+            T::DefaultGlobalDailyNftLimit::get();
 
         // ======
         // Next set of extrinsics can only be invoked by lead.

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -53,6 +53,16 @@ use sp_runtime::{
     ModuleId,
 };
 use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
+
+//TODO:
+// - consts
+// - proposals
+// - config
+// - set extrinsics
+// - enum type for limits
+// - shared map and config for nft limit enums??
+// -
+
 /// Module configuration trait for Content Directory Module
 pub trait Trait:
     frame_system::Trait
@@ -212,6 +222,12 @@ decl_storage! {
 
         /// Global daily NFT counter.
         pub GlobalDailyNftCounter get(fn global_nft_daily_counter): NftCounter<T::BlockNumber>;
+
+        /// Global weekly NFT limit.
+        pub GlobalWeeklyNftLimit get(fn global_nft_weekly_limit): LimitPerPeriod<T::BlockNumber>;
+
+        /// Global weekly NFT counter.
+        pub GlobalWeeklyNftCounter get(fn global_nft_weekly_counter): NftCounter<T::BlockNumber>;
     }
 }
 
@@ -768,7 +784,7 @@ decl_module! {
             //
 
             if nft_status.is_some() {
-                Self::increment_nft_numbers(&channel_id);
+                Self::increment_nft_counters(&channel_id);
             }
 
             // add it to the onchain state
@@ -844,7 +860,7 @@ decl_module! {
             //
 
             if nft_status.is_some() {
-                Self::increment_nft_numbers(&channel_id);
+                Self::increment_nft_counters(&channel_id);
             }
 
             if let Some(upload_assets) = params.assets_to_upload.as_ref() {
@@ -1474,7 +1490,7 @@ decl_module! {
             // == MUTATION SAFE ==
             //
 
-            Self::increment_nft_numbers(&channel_id);
+            Self::increment_nft_counters(&channel_id);
 
             // Update the video
             VideoById::<T>::mutate(video_id, |v| v.set_nft_status(nft_status));
@@ -2726,20 +2742,31 @@ impl<T: Trait> Module<T> {
         Ok(())
     }
 
-    // Increment NFT numbers for a channel and global numbers.
-    fn increment_nft_numbers(_channel_id: &T::ChannelId) {
+    // Increment NFT numbers for a channel and global counters.
+    fn increment_nft_counters(_channel_id: &T::ChannelId) {
+        Self::increment_global_daily_nft_counter();
+        Self::increment_global_weekly_nft_counter();
+    }
+
+    // Increment global daily NFT counter.
+    fn increment_global_daily_nft_counter() {
         GlobalDailyNftCounter::<T>::mutate(|nft_counter| {
             let global_daily_limit = Self::global_nft_daily_limit();
             let current_block = frame_system::Module::<T>::block_number();
 
-            if nft_counter.is_current_period(current_block, global_daily_limit.block_number_period)
-            {
-                nft_counter.counter += 1;
-            } else {
-                nft_counter.counter = 1;
-            }
+            nft_counter
+                .update_for_current_period(current_block, global_daily_limit.block_number_period);
+        });
+    }
 
-            nft_counter.last_updated = current_block;
+    // Increment global weekly NFT counter.
+    fn increment_global_weekly_nft_counter() {
+        GlobalWeeklyNftCounter::<T>::mutate(|nft_counter| {
+            let global_weekly_limit = Self::global_nft_weekly_limit();
+            let current_block = frame_system::Module::<T>::block_number();
+
+            nft_counter
+                .update_for_current_period(current_block, global_weekly_limit.block_number_period);
         });
     }
 
@@ -2749,19 +2776,36 @@ impl<T: Trait> Module<T> {
         let global_daily_counter = Self::global_nft_daily_counter();
         let global_daily_limit = Self::global_nft_daily_limit();
 
-        ensure!(
-            !global_daily_limit.limit.is_zero(),
-            Error::<T>::GlobalNftDailyLimitExceeded
-        );
+        Self::check_generic_nft_limit(
+            &global_daily_limit,
+            &global_daily_counter,
+            Error::<T>::GlobalNftDailyLimitExceeded,
+        )?;
+
+        // Global weekly limit.
+        let global_weekly_counter = Self::global_nft_weekly_counter();
+        let global_weekly_limit = Self::global_nft_weekly_limit();
+
+        Self::check_generic_nft_limit(
+            &global_weekly_limit,
+            &global_weekly_counter,
+            Error::<T>::GlobalNftWeeklyLimitExceeded,
+        )?;
+
+        Ok(())
+    }
+
+    // Checks generic NFT-limit.
+    fn check_generic_nft_limit(
+        nft_limit: &LimitPerPeriod<T::BlockNumber>,
+        nft_counter: &NftCounter<T::BlockNumber>,
+        error: Error<T>,
+    ) -> DispatchResult {
+        ensure!(!nft_limit.limit.is_zero(), error);
 
         let current_block = frame_system::Module::<T>::block_number();
-        if global_daily_counter
-            .is_current_period(current_block, global_daily_limit.block_number_period)
-        {
-            ensure!(
-                global_daily_counter.counter < global_daily_limit.limit,
-                Error::<T>::GlobalNftDailyLimitExceeded
-            );
+        if nft_counter.is_current_period(current_block, nft_limit.block_number_period) {
+            ensure!(nft_counter.counter < nft_limit.limit, error);
         }
 
         Ok(())

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -792,6 +792,10 @@ decl_module! {
                     }
                 )?;
 
+            if nft_status.is_some() {
+                Self::check_nft_limits(&channel)?;
+            }
+
             // create the video struct
             let video: Video<T> = VideoRecord {
                 in_channel: channel_id,
@@ -808,10 +812,6 @@ decl_module! {
                     &sender
                 );
                 Storage::<T>::upload_data_objects(params)?;
-            }
-
-            if nft_status.is_some() {
-                Self::check_nft_limits(&channel)?;
             }
 
             //

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -494,13 +494,14 @@ decl_module! {
                 collaborators: params.collaborators.clone(),
                 moderators: params.moderators.clone(),
                 cumulative_reward_claimed: BalanceOf::<T>::zero(),
+                daily_nft_limit: T::DefaultChannelDailyNftLimit::get(),
+                weekly_nft_limit: T::DefaultChannelWeeklyNftLimit::get(),
+                daily_nft_counter: Default::default(),
+                weekly_nft_counter: Default::default(),
             };
 
             // add channel to onchain state
             ChannelById::<T>::insert(channel_id, channel.clone());
-
-            // Set default NFT daily and weekly limits.
-            Self::set_default_nft_limits(channel_id);
 
             Self::deposit_event(RawEvent::ChannelCreated(actor, channel_id, channel, params));
         }
@@ -658,9 +659,6 @@ decl_module! {
             // remove channel from on chain state
             ChannelById::<T>::remove(channel_id);
 
-            // Remove NFT limits for a channel.
-            Self::remove_nft_limits(channel_id);
-
             // deposit event
             Self::deposit_event(RawEvent::ChannelDeleted(actor, channel_id));
 
@@ -811,16 +809,12 @@ decl_module! {
             }
 
             if nft_status.is_some() {
-                Self::check_nft_limits(&channel_id)?;
+                Self::check_nft_limits(&channel)?;
             }
 
             //
             // == MUTATION SAFE ==
             //
-
-            if nft_status.is_some() {
-                Self::increment_nft_counters(&channel_id);
-            }
 
             // add it to the onchain state
             VideoById::<T>::insert(video_id, video);
@@ -832,6 +826,9 @@ decl_module! {
 
             ChannelById::<T>::mutate(channel_id, |channel| {
                 channel.num_videos = channel.num_videos.saturating_add(1);
+                if nft_status.is_some() {
+                    Self::increment_nft_counters(channel);
+                }
             });
 
             Self::deposit_event(RawEvent::VideoCreated(actor, channel_id, video_id, params));
@@ -887,16 +884,12 @@ decl_module! {
                 )?;
 
             if nft_status.is_some() {
-                Self::check_nft_limits(&channel_id)?;
+                Self::check_nft_limits(&channel)?;
             }
 
             //
             // == MUTATION SAFE ==
             //
-
-            if nft_status.is_some() {
-                Self::increment_nft_counters(&channel_id);
-            }
 
             if let Some(upload_assets) = params.assets_to_upload.as_ref() {
                 let params = Self::construct_upload_parameters(
@@ -916,7 +909,9 @@ decl_module! {
             }
 
             if nft_status.is_some() {
-                VideoById::<T>::mutate(&video_id, |video| video.nft_status = nft_status);
+                ChannelById::<T>::mutate(channel_id, |channel| {
+                    Self::increment_nft_counters(channel);
+                });
             }
 
             Self::deposit_event(RawEvent::VideoUpdated(actor, video_id, params));
@@ -1519,13 +1514,15 @@ decl_module! {
             // The content owner will be..
             let nft_status = Self::construct_owned_nft(&params, video_id)?;
 
-            Self::check_nft_limits(&channel_id)?;
+            Self::check_nft_limits(&channel)?;
 
             //
             // == MUTATION SAFE ==
             //
 
-            Self::increment_nft_counters(&channel_id);
+            ChannelById::<T>::mutate(channel_id, |channel| {
+                Self::increment_nft_counters(channel);
+            });
 
             // Update the video
             VideoById::<T>::mutate(video_id, |v| v.set_nft_status(nft_status));
@@ -2795,15 +2792,14 @@ impl<T: Trait> Module<T> {
     }
 
     // Increment NFT numbers for a channel and global counters.
-    fn increment_nft_counters(channel_id: &T::ChannelId) {
-        Self::increment_nft_counter(NftLimitId::GlobalDaily);
-        Self::increment_nft_counter(NftLimitId::GlobalWeekly);
-        Self::increment_nft_counter(NftLimitId::ChannelDaily(*channel_id));
-        Self::increment_nft_counter(NftLimitId::ChannelWeekly(*channel_id));
+    fn increment_nft_counters(channel: &mut Channel<T>) {
+        Self::increment_global_nft_counter(NftLimitId::GlobalDaily);
+        Self::increment_global_nft_counter(NftLimitId::GlobalWeekly);
+        channel.increment_channel_nft_counters(frame_system::Module::<T>::block_number());
     }
 
-    // Increment NFT counter.
-    fn increment_nft_counter(nft_limit_id: NftLimitId<T::ChannelId>) {
+    // Increment global NFT counter.
+    fn increment_global_nft_counter(nft_limit_id: NftLimitId<T::ChannelId>) {
         let nft_limit = Self::nft_limit_by_id(nft_limit_id);
         let current_block = frame_system::Module::<T>::block_number();
 
@@ -2813,59 +2809,50 @@ impl<T: Trait> Module<T> {
     }
 
     // Checks all NFT-limits
-    fn check_nft_limits(channel_id: &T::ChannelId) -> DispatchResult {
+    fn check_nft_limits(channel: &Channel<T>) -> DispatchResult {
         // Global daily limit.
+        let nft_limit_id = NftLimitId::GlobalDaily;
+        let nft_limit = Self::nft_limit_by_id(nft_limit_id);
+        let nft_counter = Self::nft_counter_by_id(nft_limit_id);
         Self::check_generic_nft_limit(
-            NftLimitId::GlobalDaily,
+            &nft_limit,
+            &nft_counter,
             Error::<T>::GlobalNftDailyLimitExceeded,
         )?;
 
         // Global weekly limit.
+        let nft_limit_id = NftLimitId::GlobalWeekly;
+        let nft_limit = Self::nft_limit_by_id(nft_limit_id);
+        let nft_counter = Self::nft_counter_by_id(nft_limit_id);
         Self::check_generic_nft_limit(
-            NftLimitId::GlobalWeekly,
+            &nft_limit,
+            &nft_counter,
             Error::<T>::GlobalNftWeeklyLimitExceeded,
         )?;
 
         // Channel daily limit.
         Self::check_generic_nft_limit(
-            NftLimitId::ChannelDaily(*channel_id),
+            &channel.daily_nft_limit,
+            &channel.daily_nft_counter,
             Error::<T>::ChannelNftDailyLimitExceeded,
         )?;
 
         // Channel weekly limit.
         Self::check_generic_nft_limit(
-            NftLimitId::ChannelWeekly(*channel_id),
+            &channel.weekly_nft_limit,
+            &channel.weekly_nft_counter,
             Error::<T>::ChannelNftWeeklyLimitExceeded,
         )?;
 
         Ok(())
     }
 
-    // Set default daily and weekly NFT limits for a channel.
-    fn set_default_nft_limits(channel_id: T::ChannelId) {
-        NftLimitsById::<T>::mutate(NftLimitId::ChannelDaily(channel_id), |nft_limit| {
-            *nft_limit = T::DefaultChannelDailyNftLimit::get();
-        });
-
-        NftLimitsById::<T>::mutate(NftLimitId::ChannelWeekly(channel_id), |nft_limit| {
-            *nft_limit = T::DefaultChannelWeeklyNftLimit::get();
-        });
-    }
-
-    // Remove daily and weekly NFT limits for a channel.
-    fn remove_nft_limits(channel_id: T::ChannelId) {
-        NftLimitsById::<T>::remove(NftLimitId::ChannelDaily(channel_id));
-        NftLimitsById::<T>::remove(NftLimitId::ChannelWeekly(channel_id));
-    }
-
     // Checks generic NFT-limit.
     fn check_generic_nft_limit(
-        nft_limit_id: NftLimitId<T::ChannelId>,
+        nft_limit: &LimitPerPeriod<T::BlockNumber>,
+        nft_counter: &NftCounter<T::BlockNumber>,
         error: Error<T>,
     ) -> DispatchResult {
-        let nft_limit = Self::nft_limit_by_id(nft_limit_id);
-        let nft_counter = Self::nft_counter_by_id(nft_limit_id);
-
         ensure!(!nft_limit.limit.is_zero(), error);
 
         let current_block = frame_system::Module::<T>::block_number();

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -217,17 +217,13 @@ decl_storage! {
         double_map hasher(blake2_128_concat) T::VideoId,
         hasher(blake2_128_concat) T::MemberId => OpenAuctionBid<T>;
 
-        /// Global daily NFT limit.
-        pub GlobalDailyNftLimit get(fn global_nft_daily_limit):
-            LimitPerPeriod<T::BlockNumber>;
-
-        /// Global weekly NFT limit.
-        pub GlobalWeeklyNftLimit get(fn global_nft_weekly_limit):
-            LimitPerPeriod<T::BlockNumber>;
+        /// Nft limits map.
+        pub NftLimitsById get(fn nft_limit_by_id): map hasher(blake2_128_concat)
+            NftLimitId<T::ChannelId> => LimitPerPeriod<T::BlockNumber>;
 
         /// Nft counters map.
         pub NftCountersById get(fn nft_counter_by_id): map hasher(blake2_128_concat)
-            NftCounterId<T::ChannelId> => NftCounter<T::BlockNumber>;
+            NftLimitId<T::ChannelId> => NftCounter<T::BlockNumber>;
 
     }
 }
@@ -2743,32 +2739,26 @@ impl<T: Trait> Module<T> {
         Ok(())
     }
 
-    fn get_nft_limit(nft_limit_id: NftLimitId<T::ChannelId>) -> LimitPerPeriod<T::BlockNumber> {
-        match nft_limit_id {
-            NftLimitId::GlobalDaily => Self::global_nft_daily_limit(),
-            NftLimitId::GlobalWeekly => Self::global_nft_weekly_limit(),
-            _ => unimplemented!(),
-        }
-    }
-
     // Increment NFT numbers for a channel and global counters.
-    fn increment_nft_counters(_channel_id: &T::ChannelId) {
-        Self::increment_nft_counter(NftCounterId::GlobalDaily);
-        Self::increment_nft_counter(NftCounterId::GlobalWeekly);
+    fn increment_nft_counters(channel_id: &T::ChannelId) {
+        Self::increment_nft_counter(NftLimitId::GlobalDaily);
+        Self::increment_nft_counter(NftLimitId::GlobalWeekly);
+        Self::increment_nft_counter(NftLimitId::ChannelDaily(*channel_id));
+        Self::increment_nft_counter(NftLimitId::ChannelWeekly(*channel_id));
     }
 
     // Increment NFT counter.
-    fn increment_nft_counter(nft_counter_id: NftCounterId<T::ChannelId>) {
-        let nft_limit = Self::get_nft_limit(nft_counter_id);
+    fn increment_nft_counter(nft_limit_id: NftLimitId<T::ChannelId>) {
+        let nft_limit = Self::nft_limit_by_id(nft_limit_id);
         let current_block = frame_system::Module::<T>::block_number();
 
-        NftCountersById::<T>::mutate(nft_counter_id, |nft_counter| {
+        NftCountersById::<T>::mutate(nft_limit_id, |nft_counter| {
             nft_counter.update_for_current_period(current_block, nft_limit.block_number_period);
         });
     }
 
     // Checks all NFT-limits
-    fn check_nft_limits(_channel_id: &T::ChannelId) -> DispatchResult {
+    fn check_nft_limits(channel_id: &T::ChannelId) -> DispatchResult {
         // Global daily limit.
         Self::check_generic_nft_limit(
             NftLimitId::GlobalDaily,
@@ -2781,6 +2771,18 @@ impl<T: Trait> Module<T> {
             Error::<T>::GlobalNftWeeklyLimitExceeded,
         )?;
 
+        // Channel daily limit.
+        Self::check_generic_nft_limit(
+            NftLimitId::ChannelDaily(*channel_id),
+            Error::<T>::ChannelNftDailyLimitExceeded,
+        )?;
+
+        // Channel weekly limit.
+        Self::check_generic_nft_limit(
+            NftLimitId::ChannelWeekly(*channel_id),
+            Error::<T>::ChannelNftWeeklyLimitExceeded,
+        )?;
+
         Ok(())
     }
 
@@ -2789,7 +2791,7 @@ impl<T: Trait> Module<T> {
         nft_limit_id: NftLimitId<T::ChannelId>,
         error: Error<T>,
     ) -> DispatchResult {
-        let nft_limit = Self::get_nft_limit(nft_limit_id);
+        let nft_limit = Self::nft_limit_by_id(nft_limit_id);
         let nft_counter = Self::nft_counter_by_id(nft_limit_id);
 
         ensure!(!nft_limit.limit.is_zero(), error);

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -220,15 +220,21 @@ decl_storage! {
         double_map hasher(blake2_128_concat) T::VideoId,
         hasher(blake2_128_concat) T::MemberId => OpenAuctionBid<T>;
 
-        /// Nft counters map.
-        pub NftCountersById get(fn nft_counter_by_id): map hasher(blake2_128_concat)
-            NftLimitId<T::ChannelId> => NftCounter<T::BlockNumber>;
+        /// Global daily NFT counter.
+        pub GlobalDailyNftCounter get(fn global_daily_nft_counter):
+            NftCounter<T::BlockNumber>;
+
+        /// Global weekly NFT counter.
+        pub GlobalWeeklyNftCounter get(fn global_weekly_nft_counter):
+            NftCounter<T::BlockNumber>;
 
         /// Global daily NFT limit.
-        pub GlobalDailyNftLimit get(fn global_daily_nft_limit): LimitPerPeriod<T::BlockNumber>;
+        pub GlobalDailyNftLimit get(fn global_daily_nft_limit):
+            LimitPerPeriod<T::BlockNumber>;
 
         /// Global weekly NFT limit.
-        pub GlobalWeeklyNftLimit get(fn global_weekly_nft_limit): LimitPerPeriod<T::BlockNumber>;
+        pub GlobalWeeklyNftLimit get(fn global_weekly_nft_limit):
+            LimitPerPeriod<T::BlockNumber>;
 
     }
     add_extra_genesis {
@@ -2789,43 +2795,38 @@ impl<T: Trait> Module<T> {
 
     // Increment NFT numbers for a channel and global counters.
     fn increment_nft_counters(channel: &mut Channel<T>) {
-        Self::increment_global_nft_counter(NftLimitId::GlobalDaily, Self::global_daily_nft_limit());
-        Self::increment_global_nft_counter(
-            NftLimitId::GlobalWeekly,
-            Self::global_weekly_nft_limit(),
-        );
+        Self::increment_global_nft_counters();
         channel.increment_channel_nft_counters(frame_system::Module::<T>::block_number());
     }
 
-    // Increment global NFT counter.
-    fn increment_global_nft_counter(
-        nft_limit_id: NftLimitId<T::ChannelId>,
-        nft_limit: LimitPerPeriod<T::BlockNumber>,
-    ) {
+    // Increment global NFT counters (daily and weekly).
+    fn increment_global_nft_counters() {
         let current_block = frame_system::Module::<T>::block_number();
 
-        NftCountersById::<T>::mutate(nft_limit_id, |nft_counter| {
-            nft_counter.update_for_current_period(current_block, nft_limit.block_number_period);
+        let daily_limit = Self::global_daily_nft_limit();
+        GlobalDailyNftCounter::<T>::mutate(|nft_counter| {
+            nft_counter.update_for_current_period(current_block, daily_limit.block_number_period);
+        });
+
+        let weekly_limit = Self::global_weekly_nft_limit();
+        GlobalWeeklyNftCounter::<T>::mutate(|nft_counter| {
+            nft_counter.update_for_current_period(current_block, weekly_limit.block_number_period);
         });
     }
 
     // Checks all NFT-limits
     fn check_nft_limits(channel: &Channel<T>) -> DispatchResult {
         // Global daily limit.
-        let nft_limit_id = NftLimitId::GlobalDaily;
-        let nft_counter = Self::nft_counter_by_id(nft_limit_id);
         Self::check_generic_nft_limit(
             &Self::global_daily_nft_limit(),
-            &nft_counter,
+            &Self::global_daily_nft_counter(),
             Error::<T>::GlobalNftDailyLimitExceeded,
         )?;
 
         // Global weekly limit.
-        let nft_limit_id = NftLimitId::GlobalWeekly;
-        let nft_counter = Self::nft_counter_by_id(nft_limit_id);
         Self::check_generic_nft_limit(
             &Self::global_weekly_nft_limit(),
-            &nft_counter,
+            &Self::global_weekly_nft_counter(),
             Error::<T>::GlobalNftWeeklyLimitExceeded,
         )?;
 

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -218,16 +218,17 @@ decl_storage! {
         hasher(blake2_128_concat) T::MemberId => OpenAuctionBid<T>;
 
         /// Global daily NFT limit.
-        pub GlobalDailyNftLimit get(fn global_nft_daily_limit): LimitPerPeriod<T::BlockNumber>;
-
-        /// Global daily NFT counter.
-        pub GlobalDailyNftCounter get(fn global_nft_daily_counter): NftCounter<T::BlockNumber>;
+        pub GlobalDailyNftLimit get(fn global_nft_daily_limit):
+            LimitPerPeriod<T::BlockNumber>;
 
         /// Global weekly NFT limit.
-        pub GlobalWeeklyNftLimit get(fn global_nft_weekly_limit): LimitPerPeriod<T::BlockNumber>;
+        pub GlobalWeeklyNftLimit get(fn global_nft_weekly_limit):
+            LimitPerPeriod<T::BlockNumber>;
 
-        /// Global weekly NFT counter.
-        pub GlobalWeeklyNftCounter get(fn global_nft_weekly_counter): NftCounter<T::BlockNumber>;
+        /// Nft counters map.
+        pub NftCountersById get(fn nft_counter_by_id): map hasher(blake2_128_concat)
+            NftCounterId<T::ChannelId> => NftCounter<T::BlockNumber>;
+
     }
 }
 
@@ -2742,53 +2743,41 @@ impl<T: Trait> Module<T> {
         Ok(())
     }
 
+    fn get_nft_limit(nft_limit_id: NftLimitId<T::ChannelId>) -> LimitPerPeriod<T::BlockNumber> {
+        match nft_limit_id {
+            NftLimitId::GlobalDaily => Self::global_nft_daily_limit(),
+            NftLimitId::GlobalWeekly => Self::global_nft_weekly_limit(),
+            _ => unimplemented!(),
+        }
+    }
+
     // Increment NFT numbers for a channel and global counters.
     fn increment_nft_counters(_channel_id: &T::ChannelId) {
-        Self::increment_global_daily_nft_counter();
-        Self::increment_global_weekly_nft_counter();
+        Self::increment_nft_counter(NftCounterId::GlobalDaily);
+        Self::increment_nft_counter(NftCounterId::GlobalWeekly);
     }
 
-    // Increment global daily NFT counter.
-    fn increment_global_daily_nft_counter() {
-        GlobalDailyNftCounter::<T>::mutate(|nft_counter| {
-            let global_daily_limit = Self::global_nft_daily_limit();
-            let current_block = frame_system::Module::<T>::block_number();
+    // Increment NFT counter.
+    fn increment_nft_counter(nft_counter_id: NftCounterId<T::ChannelId>) {
+        let nft_limit = Self::get_nft_limit(nft_counter_id);
+        let current_block = frame_system::Module::<T>::block_number();
 
-            nft_counter
-                .update_for_current_period(current_block, global_daily_limit.block_number_period);
-        });
-    }
-
-    // Increment global weekly NFT counter.
-    fn increment_global_weekly_nft_counter() {
-        GlobalWeeklyNftCounter::<T>::mutate(|nft_counter| {
-            let global_weekly_limit = Self::global_nft_weekly_limit();
-            let current_block = frame_system::Module::<T>::block_number();
-
-            nft_counter
-                .update_for_current_period(current_block, global_weekly_limit.block_number_period);
+        NftCountersById::<T>::mutate(nft_counter_id, |nft_counter| {
+            nft_counter.update_for_current_period(current_block, nft_limit.block_number_period);
         });
     }
 
     // Checks all NFT-limits
     fn check_nft_limits(_channel_id: &T::ChannelId) -> DispatchResult {
         // Global daily limit.
-        let global_daily_counter = Self::global_nft_daily_counter();
-        let global_daily_limit = Self::global_nft_daily_limit();
-
         Self::check_generic_nft_limit(
-            &global_daily_limit,
-            &global_daily_counter,
+            NftLimitId::GlobalDaily,
             Error::<T>::GlobalNftDailyLimitExceeded,
         )?;
 
         // Global weekly limit.
-        let global_weekly_counter = Self::global_nft_weekly_counter();
-        let global_weekly_limit = Self::global_nft_weekly_limit();
-
         Self::check_generic_nft_limit(
-            &global_weekly_limit,
-            &global_weekly_counter,
+            NftLimitId::GlobalWeekly,
             Error::<T>::GlobalNftWeeklyLimitExceeded,
         )?;
 
@@ -2797,10 +2786,12 @@ impl<T: Trait> Module<T> {
 
     // Checks generic NFT-limit.
     fn check_generic_nft_limit(
-        nft_limit: &LimitPerPeriod<T::BlockNumber>,
-        nft_counter: &NftCounter<T::BlockNumber>,
+        nft_limit_id: NftLimitId<T::ChannelId>,
         error: Error<T>,
     ) -> DispatchResult {
+        let nft_limit = Self::get_nft_limit(nft_limit_id);
+        let nft_counter = Self::nft_counter_by_id(nft_limit_id);
+
         ensure!(!nft_limit.limit.is_zero(), error);
 
         let current_block = frame_system::Module::<T>::block_number();

--- a/runtime-modules/content/src/permissions/mod.rs
+++ b/runtime-modules/content/src/permissions/mod.rs
@@ -490,3 +490,22 @@ pub fn ensure_authorized_to_update_max_reward<T: Trait>(sender: &T::AccountId) -
 pub fn ensure_authorized_to_update_min_cashout<T: Trait>(sender: &T::AccountId) -> DispatchResult {
     ensure_lead_auth_success::<T>(sender)
 }
+
+// Authenticate NFT-limits change
+pub fn ensure_nft_limits_auth_success<T: Trait>(
+    origin: T::Origin,
+    nft_limit_id: NftLimitId<T::ChannelId>,
+) -> DispatchResult {
+    match nft_limit_id {
+        NftLimitId::GlobalDaily | NftLimitId::GlobalWeekly => {
+            ensure_root(origin)?;
+        }
+        NftLimitId::ChannelDaily(..) | NftLimitId::ChannelWeekly(..) => {
+            let sender = ensure_signed(origin)?;
+
+            ensure_lead_auth_success::<T>(&sender)?;
+        }
+    };
+
+    Ok(())
+}

--- a/runtime-modules/content/src/tests/fixtures.rs
+++ b/runtime-modules/content/src/tests/fixtures.rs
@@ -126,6 +126,10 @@ impl CreateChannelFixture {
                         moderators: self.params.moderators.clone(),
                         num_videos: Zero::zero(),
                         cumulative_reward_claimed: Zero::zero(),
+                        daily_nft_limit: DefaultChannelDailyNftLimit::get(),
+                        weekly_nft_limit: DefaultChannelWeeklyNftLimit::get(),
+                        daily_nft_counter: Default::default(),
+                        weekly_nft_counter: Default::default(),
                     },
                     self.params.clone(),
                 ))
@@ -439,6 +443,10 @@ impl UpdateChannelFixture {
                             num_videos: channel_pre.num_videos,
                             moderators: channel_pre.moderators,
                             cumulative_reward_claimed: BalanceOf::<Test>::zero(),
+                            daily_nft_limit: channel_post.daily_nft_limit,
+                            weekly_nft_limit: channel_post.weekly_nft_limit,
+                            daily_nft_counter: channel_post.daily_nft_counter,
+                            weekly_nft_counter: channel_post.weekly_nft_counter,
                         },
                         self.params.clone(),
                     ))

--- a/runtime-modules/content/src/tests/fixtures.rs
+++ b/runtime-modules/content/src/tests/fixtures.rs
@@ -1721,7 +1721,7 @@ pub fn create_default_curator_owned_channel() {
 pub fn create_default_member_owned_channel_with_video() {
     create_default_member_owned_channel();
 
-    set_default_global_nft_limits();
+    set_default_nft_limits();
 
     CreateVideoFixture::default()
         .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)

--- a/runtime-modules/content/src/tests/fixtures.rs
+++ b/runtime-modules/content/src/tests/fixtures.rs
@@ -1961,14 +1961,14 @@ pub struct UpdateNftLimitFixture {
 
 impl UpdateNftLimitFixture {
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
-        let old_limit = Content::nft_limit_by_id(self.nft_limit_id);
+        let old_limit = nft_limit_by_id(self.nft_limit_id);
 
         let actual_result =
             Content::update_nft_limit(self.origin.clone().into(), self.nft_limit_id, self.limit);
 
         assert_eq!(actual_result, expected_result);
 
-        let new_limit = Content::nft_limit_by_id(self.nft_limit_id);
+        let new_limit = nft_limit_by_id(self.nft_limit_id);
         if actual_result.is_ok() {
             assert_eq!(self.limit, new_limit);
 

--- a/runtime-modules/content/src/tests/fixtures.rs
+++ b/runtime-modules/content/src/tests/fixtures.rs
@@ -1721,6 +1721,8 @@ pub fn create_default_curator_owned_channel() {
 pub fn create_default_member_owned_channel_with_video() {
     create_default_member_owned_channel();
 
+    set_default_global_nft_limits();
+
     CreateVideoFixture::default()
         .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
         .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -864,30 +864,28 @@ pub(crate) fn set_all_nft_limits(channel_id: u64, limit: LimitPerPeriod<u64>) {
 }
 
 pub(crate) fn set_global_daily_nft_limit(limit: LimitPerPeriod<u64>) {
-    <crate::NftLimitsById<Test>>::insert(NftLimitId::GlobalDaily, limit);
+    Content::set_nft_limit(NftLimitId::GlobalDaily, limit);
 }
 
 pub(crate) fn set_global_weekly_nft_limit(limit: LimitPerPeriod<u64>) {
-    <crate::NftLimitsById<Test>>::insert(NftLimitId::GlobalWeekly, limit);
+    Content::set_nft_limit(NftLimitId::GlobalWeekly, limit);
 }
 
 pub(crate) fn set_channel_daily_nft_limit(channel_id: u64, limit: LimitPerPeriod<u64>) {
-    crate::ChannelById::<Test>::mutate(channel_id, |channel| {
-        channel.daily_nft_limit = limit;
-    });
+    Content::set_nft_limit(NftLimitId::ChannelDaily(channel_id), limit);
 }
 
 pub(crate) fn set_channel_weekly_nft_limit(channel_id: u64, limit: LimitPerPeriod<u64>) {
-    crate::ChannelById::<Test>::mutate(channel_id, |channel| {
-        channel.weekly_nft_limit = limit;
-    });
+    Content::set_nft_limit(NftLimitId::ChannelWeekly(channel_id), limit);
 }
 
-pub(crate) fn set_nft_limit(limit_id: NftLimitId<u64>, limit: LimitPerPeriod<u64>) {
+pub(crate) fn nft_limit_by_id(limit_id: NftLimitId<ChannelId>) -> LimitPerPeriod<u64> {
     match limit_id {
-        NftLimitId::GlobalDaily => set_global_daily_nft_limit(limit),
-        NftLimitId::GlobalWeekly => set_global_weekly_nft_limit(limit),
-        NftLimitId::ChannelDaily(channel_id) => set_channel_daily_nft_limit(channel_id, limit),
-        NftLimitId::ChannelWeekly(channel_id) => set_channel_weekly_nft_limit(channel_id, limit),
+        NftLimitId::GlobalDaily => crate::GlobalDailyNftLimit::<Test>::get(),
+        NftLimitId::GlobalWeekly => crate::GlobalWeeklyNftLimit::<Test>::get(),
+        NftLimitId::ChannelDaily(channel_id) => Content::channel_by_id(channel_id).daily_nft_limit,
+        NftLimitId::ChannelWeekly(channel_id) => {
+            Content::channel_by_id(channel_id).weekly_nft_limit
+        }
     }
 }

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -819,13 +819,22 @@ impl common::council::CouncilBudgetManager<u64, u64> for CouncilBudgetManager {
 
 pub(crate) fn set_default_global_nft_limits() {
     let limit = LimitPerPeriod::<u64> {
-        limit: 1,
-        block_number_period: 100,
+        limit: 1000,
+        block_number_period: 1000,
     };
 
     set_global_nft_limits(limit);
 }
 
 pub(crate) fn set_global_nft_limits(limit: LimitPerPeriod<u64>) {
+    set_global_daily_nft_limit(limit);
+    set_global_weekly_nft_limit(limit);
+}
+
+pub(crate) fn set_global_daily_nft_limit(limit: LimitPerPeriod<u64>) {
     <crate::GlobalDailyNftLimit<Test>>::put(limit);
+}
+
+pub(crate) fn set_global_weekly_nft_limit(limit: LimitPerPeriod<u64>) {
+    <crate::GlobalWeeklyNftLimit<Test>>::put(limit);
 }

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -336,19 +336,19 @@ parameter_types! {
     pub const DefaultGlobalDailyNftLimit: LimitPerPeriod<u64> = LimitPerPeriod {
         block_number_period: 100,
         limit: 10000,
-    };  // TODO: update
+    };
     pub const DefaultGlobalWeeklyNftLimit: LimitPerPeriod<u64> = LimitPerPeriod {
         block_number_period: 1000,
         limit: 50000,
-    };  // TODO: update
+    };
     pub const DefaultChannelDailyNftLimit: LimitPerPeriod<u64> = LimitPerPeriod {
         block_number_period: 100,
         limit: 100,
-    };  // TODO: update
+    };
     pub const DefaultChannelWeeklyNftLimit: LimitPerPeriod<u64> = LimitPerPeriod {
         block_number_period: 1000,
         limit: 500,
-    };  // TODO: update
+    };
 }
 
 impl Trait for Test {

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -816,3 +816,16 @@ impl common::council::CouncilBudgetManager<u64, u64> for CouncilBudgetManager {
         Ok(())
     }
 }
+
+pub(crate) fn set_default_global_nft_limits() {
+    let limit = LimitPerPeriod::<u64> {
+        limit: 1,
+        block_number_period: 100,
+    };
+
+    set_global_nft_limits(limit);
+}
+
+pub(crate) fn set_global_nft_limits(limit: LimitPerPeriod<u64>) {
+    <crate::GlobalDailyNftLimit<Test>>::put(limit);
+}

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -333,6 +333,22 @@ parameter_types! {
     pub const PricePerByte: u32 = 2;
     pub const VideoCommentsModuleId: ModuleId = ModuleId(*b"m0:forum"); // module : forum
     pub const BloatBondCap: u32 = 1000;
+    pub const DefaultGlobalDailyNftLimit: LimitPerPeriod<u64> = LimitPerPeriod {
+        block_number_period: 100,
+        limit: 10000,
+    };  // TODO: update
+    pub const DefaultGlobalWeeklyNftLimit: LimitPerPeriod<u64> = LimitPerPeriod {
+        block_number_period: 1000,
+        limit: 50000,
+    };  // TODO: update
+    pub const DefaultChannelDailyNftLimit: LimitPerPeriod<u64> = LimitPerPeriod {
+        block_number_period: 100,
+        limit: 100,
+    };  // TODO: update
+    pub const DefaultChannelWeeklyNftLimit: LimitPerPeriod<u64> = LimitPerPeriod {
+        block_number_period: 1000,
+        limit: 500,
+    };  // TODO: update
 }
 
 impl Trait for Test {
@@ -386,6 +402,18 @@ impl Trait for Test {
 
     /// council budget manager
     type CouncilBudgetManager = CouncilBudgetManager;
+
+    /// Default global daily NFT limit.
+    type DefaultGlobalDailyNftLimit = DefaultGlobalDailyNftLimit;
+
+    /// Default global weekly NFT limit.
+    type DefaultGlobalWeeklyNftLimit = DefaultGlobalWeeklyNftLimit;
+
+    /// Default channel daily NFT limit.
+    type DefaultChannelDailyNftLimit = DefaultChannelDailyNftLimit;
+
+    /// Default channel weekly NFT limit.
+    type DefaultChannelWeeklyNftLimit = DefaultChannelWeeklyNftLimit;
 }
 
 // #[derive (Default)]

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -817,24 +817,40 @@ impl common::council::CouncilBudgetManager<u64, u64> for CouncilBudgetManager {
     }
 }
 
-pub(crate) fn set_default_global_nft_limits() {
+pub(crate) fn set_default_nft_limits() {
     let limit = LimitPerPeriod::<u64> {
         limit: 1000,
         block_number_period: 1000,
     };
 
-    set_global_nft_limits(limit);
+    let channel_id = 1;
+
+    set_all_nft_limits(channel_id, limit);
 }
 
-pub(crate) fn set_global_nft_limits(limit: LimitPerPeriod<u64>) {
+pub(crate) fn set_all_nft_limits(channel_id: u64, limit: LimitPerPeriod<u64>) {
     set_global_daily_nft_limit(limit);
     set_global_weekly_nft_limit(limit);
+    set_channel_daily_nft_limit(channel_id, limit);
+    set_channel_weekly_nft_limit(channel_id, limit);
 }
 
 pub(crate) fn set_global_daily_nft_limit(limit: LimitPerPeriod<u64>) {
-    <crate::GlobalDailyNftLimit<Test>>::put(limit);
+    set_nft_limit(NftLimitId::GlobalDaily, limit);
 }
 
 pub(crate) fn set_global_weekly_nft_limit(limit: LimitPerPeriod<u64>) {
-    <crate::GlobalWeeklyNftLimit<Test>>::put(limit);
+    set_nft_limit(NftLimitId::GlobalWeekly, limit);
+}
+
+pub(crate) fn set_channel_daily_nft_limit(channel_id: u64, limit: LimitPerPeriod<u64>) {
+    set_nft_limit(NftLimitId::ChannelDaily(channel_id), limit);
+}
+
+pub(crate) fn set_channel_weekly_nft_limit(channel_id: u64, limit: LimitPerPeriod<u64>) {
+    set_nft_limit(NftLimitId::ChannelWeekly(channel_id), limit);
+}
+
+pub(crate) fn set_nft_limit(limit_id: NftLimitId<u64>, limit: LimitPerPeriod<u64>) {
+    <crate::NftLimitsById<Test>>::insert(limit_id, limit);
 }

--- a/runtime-modules/content/src/tests/mock.rs
+++ b/runtime-modules/content/src/tests/mock.rs
@@ -864,21 +864,30 @@ pub(crate) fn set_all_nft_limits(channel_id: u64, limit: LimitPerPeriod<u64>) {
 }
 
 pub(crate) fn set_global_daily_nft_limit(limit: LimitPerPeriod<u64>) {
-    set_nft_limit(NftLimitId::GlobalDaily, limit);
+    <crate::NftLimitsById<Test>>::insert(NftLimitId::GlobalDaily, limit);
 }
 
 pub(crate) fn set_global_weekly_nft_limit(limit: LimitPerPeriod<u64>) {
-    set_nft_limit(NftLimitId::GlobalWeekly, limit);
+    <crate::NftLimitsById<Test>>::insert(NftLimitId::GlobalWeekly, limit);
 }
 
 pub(crate) fn set_channel_daily_nft_limit(channel_id: u64, limit: LimitPerPeriod<u64>) {
-    set_nft_limit(NftLimitId::ChannelDaily(channel_id), limit);
+    crate::ChannelById::<Test>::mutate(channel_id, |channel| {
+        channel.daily_nft_limit = limit;
+    });
 }
 
 pub(crate) fn set_channel_weekly_nft_limit(channel_id: u64, limit: LimitPerPeriod<u64>) {
-    set_nft_limit(NftLimitId::ChannelWeekly(channel_id), limit);
+    crate::ChannelById::<Test>::mutate(channel_id, |channel| {
+        channel.weekly_nft_limit = limit;
+    });
 }
 
 pub(crate) fn set_nft_limit(limit_id: NftLimitId<u64>, limit: LimitPerPeriod<u64>) {
-    <crate::NftLimitsById<Test>>::insert(limit_id, limit);
+    match limit_id {
+        NftLimitId::GlobalDaily => set_global_daily_nft_limit(limit),
+        NftLimitId::GlobalWeekly => set_global_weekly_nft_limit(limit),
+        NftLimitId::ChannelDaily(channel_id) => set_channel_daily_nft_limit(channel_id, limit),
+        NftLimitId::ChannelWeekly(channel_id) => set_channel_weekly_nft_limit(channel_id, limit),
+    }
 }

--- a/runtime-modules/content/src/tests/nft.rs
+++ b/runtime-modules/content/src/tests/nft.rs
@@ -13,3 +13,4 @@ mod sell_nft;
 mod sling_nft_back;
 mod start_nft_auction;
 mod update_buy_now;
+mod update_nft_limit;

--- a/runtime-modules/content/src/tests/nft/issue_nft.rs
+++ b/runtime-modules/content/src/tests/nft/issue_nft.rs
@@ -248,117 +248,115 @@ fn issue_nft_fails_with_invalid_open_auction_parameters() {
 #[test]
 fn issue_nft_failed_because_of_the_global_daily_limit() {
     with_default_mock_builder(|| {
-        // Run to block one to see emitted events
-        run_to_block(1);
-
-        let video_id = NextVideoId::<Test>::get();
-
-        create_initial_storage_buckets_helper();
-        increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
-        create_default_member_owned_channel_with_video();
-        set_global_nft_limits(Default::default());
-
-        // Issue nft
-        assert_eq!(
-            Content::issue_nft(
-                Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-                video_id,
-                NftIssuanceParameters::<Test>::default(),
-            ),
-            Err(Error::<Test>::GlobalNftDailyLimitExceeded.into()),
+        nft_test_helper_for_exceeded_limit(
+            NftLimitId::GlobalDaily,
+            Error::<Test>::GlobalNftDailyLimitExceeded,
         );
     })
 }
+
 #[test]
 fn issue_nft_failed_because_of_the_global_weekly_limit() {
     with_default_mock_builder(|| {
-        // Run to block one to see emitted events
-        run_to_block(1);
-
-        let video_id = NextVideoId::<Test>::get();
-
-        create_initial_storage_buckets_helper();
-        increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
-        create_default_member_owned_channel_with_video();
-        set_global_weekly_nft_limit(Default::default());
-
-        // Issue nft
-        assert_eq!(
-            Content::issue_nft(
-                Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-                video_id,
-                NftIssuanceParameters::<Test>::default(),
-            ),
-            Err(Error::<Test>::GlobalNftWeeklyLimitExceeded.into()),
+        nft_test_helper_for_exceeded_limit(
+            NftLimitId::GlobalWeekly,
+            Error::<Test>::GlobalNftWeeklyLimitExceeded,
         );
     })
+}
+
+#[test]
+fn issue_nft_failed_because_of_the_channel_weekly_limit() {
+    with_default_mock_builder(|| {
+        let channel_id = 1;
+        nft_test_helper_for_exceeded_limit(
+            NftLimitId::ChannelWeekly(channel_id),
+            Error::<Test>::ChannelNftWeeklyLimitExceeded,
+        );
+    })
+}
+
+#[test]
+fn issue_nft_failed_because_of_the_daily_weekly_limit() {
+    with_default_mock_builder(|| {
+        let channel_id = 1;
+        nft_test_helper_for_exceeded_limit(
+            NftLimitId::ChannelDaily(channel_id),
+            Error::<Test>::ChannelNftDailyLimitExceeded,
+        );
+    })
+}
+
+fn nft_test_helper_for_exceeded_limit(nft_limit_id: NftLimitId<u64>, expected_error: Error<Test>) {
+    // Run to block one to see emitted events
+    run_to_block(1);
+
+    let video_id = NextVideoId::<Test>::get();
+
+    create_initial_storage_buckets_helper();
+    increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
+    create_default_member_owned_channel_with_video();
+    set_nft_limit(nft_limit_id, Default::default());
+
+    // Issue nft
+    assert_eq!(
+        Content::issue_nft(
+            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
+            ContentActor::Member(DEFAULT_MEMBER_ID),
+            video_id,
+            NftIssuanceParameters::<Test>::default(),
+        ),
+        Err(expected_error.into()),
+    );
 }
 
 #[test]
 fn issue_nft_global_daily_limit_works_as_expected() {
     with_default_mock_builder(|| {
-        // Run to block one to see emitted events
-        run_to_block(1);
-
-        let video_id = NextVideoId::<Test>::get();
-
-        create_initial_storage_buckets_helper();
-        increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
-        create_default_member_owned_channel_with_video();
-
-        let global_period_in_blocks = 10;
-        set_global_daily_nft_limit(LimitPerPeriod::<u64> {
-            limit: 1,
-            block_number_period: global_period_in_blocks,
-        });
-
-        // Issue nft 1
-        assert_ok!(Content::issue_nft(
-            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            ContentActor::Member(DEFAULT_MEMBER_ID),
-            video_id,
-            NftIssuanceParameters::<Test>::default(),
-        ));
-
-        let video_id = NextVideoId::<Test>::get();
-
-        CreateVideoFixture::default()
-            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
-            .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
-            .with_assets(StorageAssets::<Test> {
-                expected_data_size_fee: Storage::<Test>::data_object_per_mega_byte_fee(),
-                object_creation_list: create_data_objects_helper(),
-            })
-            .call_and_assert(Ok(()));
-
-        // Issue nft 2
-        assert_eq!(
-            Content::issue_nft(
-                Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-                ContentActor::Member(DEFAULT_MEMBER_ID),
-                video_id,
-                NftIssuanceParameters::<Test>::default(),
-            ),
-            Err(Error::<Test>::GlobalNftDailyLimitExceeded.into()),
+        test_helper_for_nft_limit_works_as_expected(
+            NftLimitId::GlobalDaily,
+            Error::<Test>::GlobalNftDailyLimitExceeded,
         );
-
-        run_to_block(global_period_in_blocks);
-
-        // Issue nft 3
-        assert_ok!(Content::issue_nft(
-            Origin::signed(DEFAULT_MEMBER_ACCOUNT_ID),
-            ContentActor::Member(DEFAULT_MEMBER_ID),
-            video_id,
-            NftIssuanceParameters::<Test>::default(),
-        ));
     })
 }
 
 #[test]
 fn issue_nft_global_weekly_limit_works_as_expected() {
     with_default_mock_builder(|| {
+        test_helper_for_nft_limit_works_as_expected(
+            NftLimitId::GlobalWeekly,
+            Error::<Test>::GlobalNftWeeklyLimitExceeded,
+        );
+    })
+}
+
+#[test]
+fn issue_nft_channel_daily_limit_works_as_expected() {
+    with_default_mock_builder(|| {
+        let channel_id = 1;
+        test_helper_for_nft_limit_works_as_expected(
+            NftLimitId::ChannelDaily(channel_id),
+            Error::<Test>::ChannelNftDailyLimitExceeded,
+        );
+    })
+}
+
+#[test]
+fn issue_nft_channel_weekly_limit_works_as_expected() {
+    with_default_mock_builder(|| {
+        let channel_id = 1;
+        test_helper_for_nft_limit_works_as_expected(
+            NftLimitId::ChannelWeekly(channel_id),
+            Error::<Test>::ChannelNftWeeklyLimitExceeded,
+        );
+    })
+}
+
+fn test_helper_for_nft_limit_works_as_expected(
+    nft_limit_id: NftLimitId<u64>,
+    expected_error: Error<Test>,
+) {
+    with_default_mock_builder(|| {
         // Run to block one to see emitted events
         run_to_block(1);
 
@@ -369,10 +367,14 @@ fn issue_nft_global_weekly_limit_works_as_expected() {
         create_default_member_owned_channel_with_video();
 
         let global_period_in_blocks = 10;
-        set_global_weekly_nft_limit(LimitPerPeriod::<u64> {
-            limit: 1,
-            block_number_period: global_period_in_blocks,
-        });
+
+        set_nft_limit(
+            nft_limit_id,
+            LimitPerPeriod::<u64> {
+                limit: 1,
+                block_number_period: global_period_in_blocks,
+            },
+        );
 
         // Issue nft 1
         assert_ok!(Content::issue_nft(
@@ -401,7 +403,7 @@ fn issue_nft_global_weekly_limit_works_as_expected() {
                 video_id,
                 NftIssuanceParameters::<Test>::default(),
             ),
-            Err(Error::<Test>::GlobalNftWeeklyLimitExceeded.into()),
+            Err(expected_error.into()),
         );
 
         run_to_block(global_period_in_blocks);

--- a/runtime-modules/content/src/tests/nft/issue_nft.rs
+++ b/runtime-modules/content/src/tests/nft/issue_nft.rs
@@ -296,7 +296,7 @@ fn nft_test_helper_for_exceeded_limit(nft_limit_id: NftLimitId<u64>, expected_er
     create_initial_storage_buckets_helper();
     increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
     create_default_member_owned_channel_with_video();
-    set_nft_limit(nft_limit_id, Default::default());
+    Content::set_nft_limit(nft_limit_id, Default::default());
 
     // Issue nft
     assert_eq!(
@@ -368,7 +368,7 @@ fn test_helper_for_nft_limit_works_as_expected(
 
         let global_period_in_blocks = 10;
 
-        set_nft_limit(
+        Content::set_nft_limit(
             nft_limit_id,
             LimitPerPeriod::<u64> {
                 limit: 1,

--- a/runtime-modules/content/src/tests/nft/update_nft_limit.rs
+++ b/runtime-modules/content/src/tests/nft/update_nft_limit.rs
@@ -1,0 +1,91 @@
+#![cfg(test)]
+use crate::tests::fixtures::*;
+use crate::tests::mock::*;
+use crate::*;
+use frame_system::RawOrigin;
+
+#[test]
+fn update_nft_limits_works_as_expected_for_global_daily_limit() {
+    with_default_mock_builder(|| {
+        let lead = RawOrigin::Signed(LEAD_ACCOUNT_ID);
+        let root = RawOrigin::Root;
+        let member = RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID);
+        let nft_limit_id = NftLimitId::GlobalDaily;
+
+        update_nft_limit_test_helper(root.clone(), nft_limit_id, Ok(()));
+        update_nft_limit_test_helper(lead.clone(), nft_limit_id, Err(DispatchError::BadOrigin));
+        update_nft_limit_test_helper(member.clone(), nft_limit_id, Err(DispatchError::BadOrigin));
+    })
+}
+
+#[test]
+fn update_nft_limits_works_as_expected_for_global_weekly_limit() {
+    with_default_mock_builder(|| {
+        let lead = RawOrigin::Signed(LEAD_ACCOUNT_ID);
+        let root = RawOrigin::Root;
+        let member = RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID);
+        let nft_limit_id = NftLimitId::GlobalWeekly;
+
+        update_nft_limit_test_helper(root.clone(), nft_limit_id, Ok(()));
+        update_nft_limit_test_helper(lead.clone(), nft_limit_id, Err(DispatchError::BadOrigin));
+        update_nft_limit_test_helper(member.clone(), nft_limit_id, Err(DispatchError::BadOrigin));
+    })
+}
+
+#[test]
+fn update_nft_limits_works_as_expected_for_channel_daily_limit() {
+    with_default_mock_builder(|| {
+        let lead = RawOrigin::Signed(LEAD_ACCOUNT_ID);
+        let root = RawOrigin::Root;
+        let member = RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID);
+        let channel_id = 1;
+        let nft_limit_id = NftLimitId::ChannelDaily(channel_id);
+
+        update_nft_limit_test_helper(root.clone(), nft_limit_id, Err(DispatchError::BadOrigin));
+        update_nft_limit_test_helper(lead.clone(), nft_limit_id, Ok(()));
+        update_nft_limit_test_helper(
+            member.clone(),
+            nft_limit_id,
+            Err(Error::<Test>::LeadAuthFailed.into()),
+        );
+    })
+}
+
+#[test]
+fn update_nft_limits_works_as_expected_for_channel_weekly_limit() {
+    with_default_mock_builder(|| {
+        let lead = RawOrigin::Signed(LEAD_ACCOUNT_ID);
+        let root = RawOrigin::Root;
+        let member = RawOrigin::Signed(DEFAULT_MEMBER_ACCOUNT_ID);
+        let channel_id = 1;
+        let nft_limit_id = NftLimitId::ChannelWeekly(channel_id);
+
+        update_nft_limit_test_helper(root.clone(), nft_limit_id, Err(DispatchError::BadOrigin));
+        update_nft_limit_test_helper(lead.clone(), nft_limit_id, Ok(()));
+        update_nft_limit_test_helper(
+            member.clone(),
+            nft_limit_id,
+            Err(Error::<Test>::LeadAuthFailed.into()),
+        );
+    })
+}
+
+fn update_nft_limit_test_helper(
+    origin: RawOrigin<AccountId>,
+    nft_limit_id: NftLimitId<u64>,
+    expected_result: DispatchResult,
+) {
+    // Run to block one to see emitted events
+    run_to_block(1);
+
+    let new_limit = LimitPerPeriod {
+        block_number_period: 1111,
+        limit: 7777,
+    };
+
+    UpdateNftLimitFixture::new()
+        .with_origin(origin)
+        .with_nft_limit_id(nft_limit_id)
+        .with_limit(new_limit)
+        .call_and_assert(expected_result);
+}

--- a/runtime-modules/content/src/tests/nft/update_nft_limit.rs
+++ b/runtime-modules/content/src/tests/nft/update_nft_limit.rs
@@ -89,3 +89,60 @@ fn update_nft_limit_test_helper(
         .with_limit(new_limit)
         .call_and_assert(expected_result);
 }
+
+// channel creation tests
+#[test]
+fn default_channel_nft_limits_set_successfully() {
+    with_default_mock_builder(|| {
+        // Run to block one to see emitted events
+        run_to_block(1);
+
+        CreateChannelFixture::default()
+            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
+            .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
+            .call_and_assert(Ok(()));
+
+        let channel_id = 1;
+        assert_eq!(
+            Content::nft_limit_by_id(NftLimitId::ChannelDaily(channel_id)),
+            DefaultChannelDailyNftLimit::get()
+        );
+        assert_eq!(
+            Content::nft_limit_by_id(NftLimitId::ChannelWeekly(channel_id)),
+            DefaultChannelWeeklyNftLimit::get()
+        );
+    })
+}
+
+#[test]
+fn channel_nft_limits_removed_successfully() {
+    with_default_mock_builder(|| {
+        run_to_block(1);
+
+        create_initial_storage_buckets_helper();
+        increase_account_balance_helper(DEFAULT_CURATOR_ACCOUNT_ID, INITIAL_BALANCE);
+        create_default_curator_owned_channel();
+
+        let channel_id = 1;
+        // Values present.
+        assert!(crate::NftLimitsById::<Test>::contains_key(
+            &NftLimitId::ChannelDaily(channel_id)
+        ));
+        assert!(crate::NftLimitsById::<Test>::contains_key(
+            &NftLimitId::ChannelWeekly(channel_id)
+        ));
+
+        DeleteChannelFixture::default()
+            .with_sender(LEAD_ACCOUNT_ID)
+            .with_actor(ContentActor::Lead)
+            .call_and_assert(Ok(()));
+
+        // Values removed.
+        assert!(!crate::NftLimitsById::<Test>::contains_key(
+            &NftLimitId::ChannelDaily(channel_id)
+        ));
+        assert!(!crate::NftLimitsById::<Test>::contains_key(
+            &NftLimitId::ChannelWeekly(channel_id)
+        ));
+    })
+}

--- a/runtime-modules/content/src/tests/nft/update_nft_limit.rs
+++ b/runtime-modules/content/src/tests/nft/update_nft_limit.rs
@@ -103,46 +103,11 @@ fn default_channel_nft_limits_set_successfully() {
             .call_and_assert(Ok(()));
 
         let channel_id = 1;
+        let channel = Content::channel_by_id(channel_id);
+        assert_eq!(channel.daily_nft_limit, DefaultChannelDailyNftLimit::get());
         assert_eq!(
-            Content::nft_limit_by_id(NftLimitId::ChannelDaily(channel_id)),
-            DefaultChannelDailyNftLimit::get()
-        );
-        assert_eq!(
-            Content::nft_limit_by_id(NftLimitId::ChannelWeekly(channel_id)),
+            channel.weekly_nft_limit,
             DefaultChannelWeeklyNftLimit::get()
         );
-    })
-}
-
-#[test]
-fn channel_nft_limits_removed_successfully() {
-    with_default_mock_builder(|| {
-        run_to_block(1);
-
-        create_initial_storage_buckets_helper();
-        increase_account_balance_helper(DEFAULT_CURATOR_ACCOUNT_ID, INITIAL_BALANCE);
-        create_default_curator_owned_channel();
-
-        let channel_id = 1;
-        // Values present.
-        assert!(crate::NftLimitsById::<Test>::contains_key(
-            &NftLimitId::ChannelDaily(channel_id)
-        ));
-        assert!(crate::NftLimitsById::<Test>::contains_key(
-            &NftLimitId::ChannelWeekly(channel_id)
-        ));
-
-        DeleteChannelFixture::default()
-            .with_sender(LEAD_ACCOUNT_ID)
-            .with_actor(ContentActor::Lead)
-            .call_and_assert(Ok(()));
-
-        // Values removed.
-        assert!(!crate::NftLimitsById::<Test>::contains_key(
-            &NftLimitId::ChannelDaily(channel_id)
-        ));
-        assert!(!crate::NftLimitsById::<Test>::contains_key(
-            &NftLimitId::ChannelWeekly(channel_id)
-        ));
     })
 }

--- a/runtime-modules/content/src/tests/videos.rs
+++ b/runtime-modules/content/src/tests/videos.rs
@@ -1251,7 +1251,7 @@ fn nft_test_helper_for_exceeded_limit_on_creating_video(
     create_default_member_owned_channel();
     set_default_nft_limits();
 
-    set_nft_limit(nft_limit_id, Default::default());
+    Content::set_nft_limit(nft_limit_id, Default::default());
 
     // create video with nft issued
     CreateVideoFixture::default()
@@ -1317,7 +1317,7 @@ fn nft_test_helper_for_exceeded_limit_on_updating_video(
     create_default_member_owned_channel();
     set_default_nft_limits();
 
-    set_nft_limit(nft_limit_id, Default::default());
+    Content::set_nft_limit(nft_limit_id, Default::default());
 
     // create video with nft issued
     CreateVideoFixture::default()

--- a/runtime-modules/content/src/tests/videos.rs
+++ b/runtime-modules/content/src/tests/videos.rs
@@ -1199,3 +1199,137 @@ fn unsuccessful_video_deletion_with_nft_already_issued() {
             .call_and_assert(Err(Error::<Test>::NftAlreadyExists.into()))
     })
 }
+
+#[test]
+fn create_video_failed_with_exceeded_global_daily_nft_limits() {
+    with_default_mock_builder(|| {
+        nft_test_helper_for_exceeded_limit_on_creating_video(
+            NftLimitId::GlobalDaily,
+            Error::<Test>::GlobalNftDailyLimitExceeded,
+        );
+    })
+}
+
+#[test]
+fn create_video_failed_with_exceeded_global_weekly_nft_limits() {
+    with_default_mock_builder(|| {
+        nft_test_helper_for_exceeded_limit_on_creating_video(
+            NftLimitId::GlobalWeekly,
+            Error::<Test>::GlobalNftWeeklyLimitExceeded,
+        );
+    })
+}
+#[test]
+fn create_video_failed_with_exceeded_channel_daily_nft_limits() {
+    with_default_mock_builder(|| {
+        let channel_id = 1;
+        nft_test_helper_for_exceeded_limit_on_creating_video(
+            NftLimitId::ChannelDaily(channel_id),
+            Error::<Test>::ChannelNftDailyLimitExceeded,
+        );
+    })
+}
+#[test]
+fn create_video_failed_with_exceeded_channel_weekly_nft_limits() {
+    with_default_mock_builder(|| {
+        let channel_id = 1;
+        nft_test_helper_for_exceeded_limit_on_creating_video(
+            NftLimitId::ChannelWeekly(channel_id),
+            Error::<Test>::ChannelNftWeeklyLimitExceeded,
+        );
+    })
+}
+
+fn nft_test_helper_for_exceeded_limit_on_creating_video(
+    nft_limit_id: NftLimitId<u64>,
+    expected_error: Error<Test>,
+) {
+    run_to_block(1);
+
+    create_initial_storage_buckets_helper();
+    increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
+    create_default_member_owned_channel();
+    set_default_nft_limits();
+
+    set_nft_limit(nft_limit_id, Default::default());
+
+    // create video with nft issued
+    CreateVideoFixture::default()
+        .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
+        .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
+        .with_nft_issuance(NftIssuanceParameters::<Test> {
+            royalty: None,
+            nft_metadata: b"test_nft_metadata".to_vec(),
+            non_channel_owner: Some(SECOND_MEMBER_ID),
+            init_transactional_status: Default::default(),
+        })
+        .call_and_assert(Err(expected_error.into()));
+}
+
+#[test]
+fn update_video_failed_with_exceeded_global_daily_nft_limits() {
+    with_default_mock_builder(|| {
+        nft_test_helper_for_exceeded_limit_on_updating_video(
+            NftLimitId::GlobalDaily,
+            Error::<Test>::GlobalNftDailyLimitExceeded,
+        );
+    })
+}
+
+fn update_video_failed_with_exceeded_global_weekly_nft_limits() {
+    with_default_mock_builder(|| {
+        nft_test_helper_for_exceeded_limit_on_updating_video(
+            NftLimitId::GlobalWeekly,
+            Error::<Test>::GlobalNftWeeklyLimitExceeded,
+        );
+    })
+}
+#[test]
+fn update_video_failed_with_exceeded_channel_daily_nft_limits() {
+    with_default_mock_builder(|| {
+        let channel_id = 1;
+        nft_test_helper_for_exceeded_limit_on_updating_video(
+            NftLimitId::ChannelDaily(channel_id),
+            Error::<Test>::ChannelNftDailyLimitExceeded,
+        );
+    })
+}
+#[test]
+fn update_video_failed_with_exceeded_channel_weekly_nft_limits() {
+    with_default_mock_builder(|| {
+        let channel_id = 1;
+        nft_test_helper_for_exceeded_limit_on_updating_video(
+            NftLimitId::ChannelWeekly(channel_id),
+            Error::<Test>::ChannelNftWeeklyLimitExceeded,
+        );
+    })
+}
+
+fn nft_test_helper_for_exceeded_limit_on_updating_video(
+    nft_limit_id: NftLimitId<u64>,
+    expected_error: Error<Test>,
+) {
+    run_to_block(1);
+
+    create_initial_storage_buckets_helper();
+    increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
+    create_default_member_owned_channel();
+    set_default_nft_limits();
+
+    set_nft_limit(nft_limit_id, Default::default());
+
+    // create video with nft issued
+    CreateVideoFixture::default()
+        .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
+        .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
+        .call_and_assert(Ok(()));
+
+    UpdateVideoFixture::default()
+        .with_nft_issuance(NftIssuanceParameters::<Test> {
+            royalty: None,
+            nft_metadata: b"test_nft_metadata".to_vec(),
+            non_channel_owner: Some(SECOND_MEMBER_ID),
+            init_transactional_status: Default::default(),
+        })
+        .call_and_assert(Err(expected_error.into()));
+}

--- a/runtime-modules/content/src/tests/videos.rs
+++ b/runtime-modules/content/src/tests/videos.rs
@@ -1175,7 +1175,7 @@ fn unsuccessful_video_deletion_with_nft_already_issued() {
         create_initial_storage_buckets_helper();
         increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
         create_default_member_owned_channel();
-        set_default_global_nft_limits();
+        set_default_nft_limits();
 
         // create video with nft issued
         CreateVideoFixture::default()

--- a/runtime-modules/content/src/tests/videos.rs
+++ b/runtime-modules/content/src/tests/videos.rs
@@ -1175,6 +1175,7 @@ fn unsuccessful_video_deletion_with_nft_already_issued() {
         create_initial_storage_buckets_helper();
         increase_account_balance_helper(DEFAULT_MEMBER_ACCOUNT_ID, INITIAL_BALANCE);
         create_default_member_owned_channel();
+        set_default_global_nft_limits();
 
         // create video with nft issued
         CreateVideoFixture::default()

--- a/runtime-modules/content/src/tests/videos.rs
+++ b/runtime-modules/content/src/tests/videos.rs
@@ -1276,6 +1276,7 @@ fn update_video_failed_with_exceeded_global_daily_nft_limits() {
     })
 }
 
+#[test]
 fn update_video_failed_with_exceeded_global_weekly_nft_limits() {
     with_default_mock_builder(|| {
         nft_test_helper_for_exceeded_limit_on_updating_video(

--- a/runtime-modules/content/src/types.rs
+++ b/runtime-modules/content/src/types.rs
@@ -1,5 +1,31 @@
 use crate::*;
 
+/// Defines NFT counter ID type for global and channel NFT limits.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Copy)]
+pub enum NftCounterId<ChannelId> {
+    /// Global daily NFT counter ID.
+    GlobalDaily,
+
+    /// Global weekly NFT counter ID.
+    GlobalWeekly,
+
+    /// Channel daily NFT counter ID.
+    ChannelDaily(ChannelId),
+
+    /// Channel weekly NFT counter ID.
+    ChannelWeekly(ChannelId),
+}
+
+// Alias: similar meaning.
+pub type NftLimitId<ChannelId> = NftCounterId<ChannelId>;
+
+// Default trait implemented for the NftCounterId. Required by Substrate.
+impl<ChannelId> Default for NftCounterId<ChannelId> {
+    fn default() -> Self {
+        Self::GlobalDaily
+    }
+}
 /// Defines limit for object for a defined period.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, Copy)]

--- a/runtime-modules/content/src/types.rs
+++ b/runtime-modules/content/src/types.rs
@@ -1,5 +1,45 @@
 use crate::*;
 
+/// Defines limit for object for a defined period.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default)]
+pub struct LimitPerPeriod<BlockNumber> {
+    /// Limit for objects.
+    pub limit: u64,
+
+    /// Period in blocks for active limit.
+    pub block_number_period: BlockNumber,
+}
+
+/// Defines limit for object for a defined period.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default)]
+pub struct NftCounter<BlockNumber: BaseArithmetic + Copy> {
+    /// Counter for objects.
+    pub counter: u64,
+
+    /// Last updated block number for this counter.
+    pub last_updated: BlockNumber,
+}
+
+impl<BlockNumber: BaseArithmetic + Copy> NftCounter<BlockNumber> {
+    // Defines whether the counter is valid for the current block.
+    pub(crate) fn is_current_period(
+        &self,
+        current_block: BlockNumber,
+        period_length: BlockNumber,
+    ) -> bool {
+        if period_length.is_zero() {
+            return false;
+        }
+
+        let last_updated_period_number = self.last_updated / period_length;
+        let current_period_number = current_block / period_length;
+
+        last_updated_period_number == current_period_number
+    }
+}
+
 /// Specifies how a new asset will be provided on creating and updating
 /// Channels, Videos, Series and Person
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/runtime-modules/content/src/types.rs
+++ b/runtime-modules/content/src/types.rs
@@ -2,7 +2,7 @@ use crate::*;
 
 /// Defines limit for object for a defined period.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Default, Copy)]
 pub struct LimitPerPeriod<BlockNumber> {
     /// Limit for objects.
     pub limit: u64,
@@ -37,6 +37,21 @@ impl<BlockNumber: BaseArithmetic + Copy> NftCounter<BlockNumber> {
         let current_period_number = current_block / period_length;
 
         last_updated_period_number == current_period_number
+    }
+
+    // Defines whether the counter is valid for the current block.
+    pub(crate) fn update_for_current_period(
+        &mut self,
+        current_block: BlockNumber,
+        period_length: BlockNumber,
+    ) {
+        if self.is_current_period(current_block, period_length) {
+            self.counter += 1;
+        } else {
+            self.counter = 1;
+        }
+
+        self.last_updated = current_block;
     }
 }
 

--- a/runtime-modules/content/src/types.rs
+++ b/runtime-modules/content/src/types.rs
@@ -1,9 +1,9 @@
 use crate::*;
 
-/// Defines NFT counter ID type for global and channel NFT limits.
+/// Defines NFT limit ID type for global and channel NFT limits and counters.
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, Copy)]
-pub enum NftCounterId<ChannelId> {
+pub enum NftLimitId<ChannelId> {
     /// Global daily NFT counter ID.
     GlobalDaily,
 
@@ -17,11 +17,8 @@ pub enum NftCounterId<ChannelId> {
     ChannelWeekly(ChannelId),
 }
 
-// Alias: similar meaning.
-pub type NftLimitId<ChannelId> = NftCounterId<ChannelId>;
-
-// Default trait implemented for the NftCounterId. Required by Substrate.
-impl<ChannelId> Default for NftCounterId<ChannelId> {
+// Default trait implemented for the NftLimitId. Required by Substrate.
+impl<ChannelId> Default for NftLimitId<ChannelId> {
     fn default() -> Self {
         Self::GlobalDaily
     }

--- a/runtime-modules/content/src/types.rs
+++ b/runtime-modules/content/src/types.rs
@@ -198,7 +198,7 @@ impl<MemberId: Ord, CuratorGroupId, AccountId, Balance, BlockNumber: BaseArithme
             .update_for_current_period(current_block, self.daily_nft_limit.block_number_period);
 
         self.weekly_nft_counter
-            .update_for_current_period(current_block, self.daily_nft_limit.block_number_period);
+            .update_for_current_period(current_block, self.weekly_nft_limit.block_number_period);
     }
 }
 

--- a/runtime-modules/proposals/codex/src/benchmarking.rs
+++ b/runtime-modules/proposals/codex/src/benchmarking.rs
@@ -4,6 +4,7 @@ use crate::Module as Codex;
 use balances::Module as Balances;
 use common::working_group::WorkingGroup;
 use common::BalanceKind;
+use content::LimitPerPeriod;
 use frame_benchmarking::{account, benchmarks, Zero};
 use frame_support::sp_runtime::traits::Bounded;
 use frame_support::traits::Currency;
@@ -854,6 +855,34 @@ benchmarks! {
             proposal_details
         );
     }
+
+    create_proposal_update_nft_limit {
+        let t in ...;
+        let d in ...;
+
+        let (account_id, member_id, general_proposal_paramters) =
+            create_proposal_parameters::<T>(t, d);
+
+        let proposal_details = ProposalDetails::UpdateNftLimit(
+            GlobalNftLimitType::DailyLimit,
+            LimitPerPeriod::<T::BlockNumber> {
+                limit: 100,
+                block_number_period: 1000u32.into(),
+            },
+        );
+    }: create_proposal(
+        RawOrigin::Signed(account_id.clone()),
+        general_proposal_paramters.clone(),
+        proposal_details.clone()
+    )
+    verify {
+        create_proposal_verify::<T>(
+            account_id,
+            member_id,
+            general_proposal_paramters,
+            proposal_details
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1038,6 +1067,13 @@ mod tests {
     fn test_update_channel_payouts() {
         initial_test_ext().execute_with(|| {
             assert_ok!(test_benchmark_create_proposal_update_channel_payouts::<Test>());
+        });
+    }
+
+    #[test]
+    fn test_update_nft_limit_proposal() {
+        initial_test_ext().execute_with(|| {
+            assert_ok!(test_benchmark_create_proposal_update_nft_limit::<Test>());
         });
     }
 }

--- a/runtime-modules/proposals/codex/src/tests/mock.rs
+++ b/runtime-modules/proposals/codex/src/tests/mock.rs
@@ -640,6 +640,7 @@ impl crate::Trait for Test {
     type UnlockBlogPostProposalParameters = DefaultProposalParameters;
     type VetoProposalProposalParameters = DefaultProposalParameters;
     type UpdateChannelPayoutsProposalParameters = DefaultProposalParameters;
+    type UpdateNftLimitProposalParameters = DefaultProposalParameters;
 }
 
 parameter_types! {
@@ -910,6 +911,9 @@ impl crate::WeightInfo for () {
         0
     }
     fn create_proposal_update_channel_payouts(_: u32, _: u32, _: u32) -> Weight {
+        0
+    }
+    fn create_proposal_update_nft_limit(_: u32, _: u32) -> Weight {
         0
     }
 }

--- a/runtime-modules/proposals/codex/src/tests/mod.rs
+++ b/runtime-modules/proposals/codex/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod mock;
 
+use content::LimitPerPeriod;
 use frame_support::dispatch::{DispatchError, DispatchResult};
 use frame_support::storage::StorageMap;
 use frame_support::traits::Currency;
@@ -2043,5 +2044,78 @@ fn create_update_channel_payouts_proposal_fails_when_min_cashout_exceeds_max_cas
             ),
             Err(Error::<Test>::InvalidChannelPayoutsProposalMinCashoutExceedsMaxCashout.into())
         );
+    });
+}
+
+#[test]
+fn create_update_nft_limit_proposal_common_checks_succeed() {
+    initial_test_ext().execute_with(|| {
+        let general_proposal_parameters_no_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: None,
+            exact_execution_block: None,
+        };
+
+        let general_proposal_parameters = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(1),
+            exact_execution_block: None,
+        };
+
+        let general_proposal_parameters_incorrect_staking = GeneralProposalParameters::<Test> {
+            member_id: 1,
+            title: b"title".to_vec(),
+            description: b"body".to_vec(),
+            staking_account_id: Some(STAKING_ACCOUNT_ID_NOT_BOUND_TO_MEMBER),
+            exact_execution_block: None,
+        };
+
+        let proposal_details = ProposalDetails::UpdateNftLimit(
+            GlobalNftLimitType::DailyLimit,
+            LimitPerPeriod {
+                limit: 100,
+                block_number_period: 1000,
+            },
+        );
+
+        let proposal_fixture = ProposalTestFixture {
+            general_proposal_parameters: general_proposal_parameters.clone(),
+            proposal_details: proposal_details.clone(),
+            insufficient_rights_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::None.into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    proposal_details.clone(),
+                )
+            },
+            invalid_stake_account_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_incorrect_staking.clone(),
+                    proposal_details.clone(),
+                )
+            },
+            empty_stake_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters_no_staking.clone(),
+                    proposal_details.clone(),
+                )
+            },
+            successful_call: || {
+                ProposalCodex::create_proposal(
+                    RawOrigin::Signed(1).into(),
+                    general_proposal_parameters.clone(),
+                    proposal_details.clone(),
+                )
+            },
+            proposal_parameters: <Test as crate::Trait>::SetInvitationCountProposalParameters::get(
+            ),
+        };
+        proposal_fixture.check_all();
     });
 }

--- a/runtime-modules/proposals/codex/src/types.rs
+++ b/runtime-modules/proposals/codex/src/types.rs
@@ -9,6 +9,8 @@ use common::working_group::WorkingGroup;
 use common::BalanceKind;
 use common::FundingRequestParameters;
 
+use content::LimitPerPeriod;
+use content::NftLimitId;
 use working_group::StakePolicy;
 
 /// Encodes proposal using its details information.
@@ -124,6 +126,9 @@ pub enum ProposalDetails<
 
     /// `Update Channel Payouts` proposal
     UpdateChannelPayouts(UpdateChannelPayoutsParameters),
+
+    /// `Update global NFT limit` proposal
+    UpdateNftLimit(GlobalNftLimitType, LimitPerPeriod<BlockNumber>),
 }
 
 impl<
@@ -215,4 +220,23 @@ pub struct CreateOpeningParameters<BlockNumber, Balance> {
 
     /// Identifier for working group.
     pub group: WorkingGroup,
+}
+/// Parameters for the 'Set NFT limit' proposal.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Copy)]
+pub enum GlobalNftLimitType {
+    /// Global daily NFT limit.
+    DailyLimit,
+
+    /// Global weekly NFT limit.
+    WeeklyLimit,
+}
+
+impl<ChannelId> From<GlobalNftLimitType> for NftLimitId<ChannelId> {
+    fn from(item: GlobalNftLimitType) -> Self {
+        match item {
+            GlobalNftLimitType::DailyLimit => NftLimitId::GlobalDaily,
+            GlobalNftLimitType::WeeklyLimit => NftLimitId::GlobalWeekly,
+        }
+    }
 }

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -45,6 +45,7 @@ pub const EPOCH_DURATION_IN_SLOTS: u64 = {
 pub const MINUTES: BlockNumber = 60 / (SECS_PER_BLOCK as BlockNumber);
 pub const HOURS: BlockNumber = MINUTES * 60;
 pub const DAYS: BlockNumber = HOURS * 24;
+pub const WEEKS: BlockNumber = DAYS * 7;
 
 // 1 in 4 blocks (on average, not counting collisions) will be primary babe blocks.
 pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);

--- a/runtime/src/integration/proposals/proposal_encoder.rs
+++ b/runtime/src/integration/proposals/proposal_encoder.rs
@@ -152,6 +152,9 @@ impl ProposalEncoder<Runtime> for ExtrinsicProposalEncoder {
             ProposalDetails::UpdateChannelPayouts(params) => {
                 Call::Content(content::Call::update_channel_payouts(params))
             }
+            ProposalDetails::UpdateNftLimit(limit_type, limit) => {
+                Call::Content(content::Call::update_nft_limit(limit_type.into(), limit))
+            }
         };
 
         call.encode()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -91,6 +91,7 @@ pub use referendum;
 pub use working_group;
 
 pub use content;
+pub use content::LimitPerPeriod;
 pub use content::MaxNumber;
 
 /// This runtime version.
@@ -483,6 +484,22 @@ parameter_types! {
     pub const PricePerByte: u32 = 2; // TODO: update
     pub const ContentModuleId: ModuleId = ModuleId(*b"mContent"); // module content
     pub const BloatBondCap: u32 = 1000;  // TODO: update
+    pub const DefaultGlobalDailyNftLimit: LimitPerPeriod<BlockNumber> = LimitPerPeriod {
+        block_number_period: DAYS,
+        limit: 10000,
+    };  // TODO: update
+    pub const DefaultGlobalWeeklyNftLimit: LimitPerPeriod<BlockNumber> = LimitPerPeriod {
+        block_number_period: WEEKS,
+        limit: 50000,
+    };  // TODO: update
+    pub const DefaultChannelDailyNftLimit: LimitPerPeriod<BlockNumber> = LimitPerPeriod {
+        block_number_period: DAYS,
+        limit: 100,
+    };  // TODO: update
+    pub const DefaultChannelWeeklyNftLimit: LimitPerPeriod<BlockNumber> = LimitPerPeriod {
+        block_number_period: WEEKS,
+        limit: 500,
+    };  // TODO: update
 }
 
 impl content::Trait for Runtime {
@@ -503,6 +520,10 @@ impl content::Trait for Runtime {
     type ModuleId = ContentModuleId;
     type MemberAuthenticator = Members;
     type CouncilBudgetManager = Council;
+    type DefaultGlobalDailyNftLimit = DefaultGlobalDailyNftLimit;
+    type DefaultGlobalWeeklyNftLimit = DefaultGlobalWeeklyNftLimit;
+    type DefaultChannelDailyNftLimit = DefaultChannelDailyNftLimit;
+    type DefaultChannelWeeklyNftLimit = DefaultChannelWeeklyNftLimit;
 }
 
 // The referendum instance alias.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1124,6 +1124,7 @@ impl proposals_codex::Trait for Runtime {
     type UnlockBlogPostProposalParameters = UnlockBlogPostProposalParameters;
     type VetoProposalProposalParameters = VetoProposalProposalParameters;
     type UpdateChannelPayoutsProposalParameters = UpdateChannelPayoutsProposalParameters;
+    type UpdateNftLimitProposalParameters = UpdateNftLimitProposalParameters;
     type WeightInfo = weights::proposals_codex::WeightInfo;
 }
 

--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -372,3 +372,17 @@ pub(crate) fn update_channel_payouts_proposal() -> ProposalParameters<BlockNumbe
         constitutionality: 1,
     }
 }
+
+// Proposal parameters for the 'Update NFT limit' proposal
+pub(crate) fn update_nft_limit_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 72000,
+        grace_period: 0,
+        approval_quorum_percentage: 60,
+        approval_threshold_percentage: 80,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(100_000),
+        constitutionality: 1,
+    }
+}

--- a/runtime/src/proposals_configuration/mod.rs
+++ b/runtime/src/proposals_configuration/mod.rs
@@ -100,4 +100,7 @@ parameter_types! {
 
     pub UpdateChannelPayoutsProposalParameters: ProposalParameters<BlockNumber, Balance> =
         update_channel_payouts_proposal();
+
+    pub UpdateNftLimitProposalParameters: ProposalParameters<BlockNumber, Balance> =
+        update_nft_limit_proposal();
 }

--- a/runtime/src/proposals_configuration/staging.rs
+++ b/runtime/src/proposals_configuration/staging.rs
@@ -372,3 +372,17 @@ pub(crate) fn update_channel_payouts_proposal() -> ProposalParameters<BlockNumbe
         constitutionality: 1,
     }
 }
+
+// Proposal parameters for the 'Update NFT limit' proposal
+pub(crate) fn update_nft_limit_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 200,
+        grace_period: 0,
+        approval_quorum_percentage: 60,
+        approval_threshold_percentage: 80,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(100_000),
+        constitutionality: 1,
+    }
+}

--- a/runtime/src/proposals_configuration/testing.rs
+++ b/runtime/src/proposals_configuration/testing.rs
@@ -373,3 +373,17 @@ pub(crate) fn update_channel_payouts_proposal() -> ProposalParameters<BlockNumbe
         constitutionality: 1,
     }
 }
+
+// Proposal parameters for the 'Update NFT limit' proposal
+pub(crate) fn update_nft_limit_proposal() -> ProposalParameters<BlockNumber, Balance> {
+    ProposalParameters {
+        voting_period: 30,
+        grace_period: 0,
+        approval_quorum_percentage: 60,
+        approval_threshold_percentage: 80,
+        slashing_quorum_percentage: 60,
+        slashing_threshold_percentage: 80,
+        required_stake: Some(100_000),
+        constitutionality: 1,
+    }
+}

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -9,7 +9,8 @@ use crate::tests::{
 };
 use crate::{BlogInstance, MembershipWorkingGroupInstance, ProposalCancellationFee, Runtime};
 use codec::Encode;
-use proposals_codex::{GeneralProposalParameters, ProposalDetails};
+use content::{LimitPerPeriod, NftLimitId};
+use proposals_codex::{GeneralProposalParameters, GlobalNftLimitType, ProposalDetails};
 use proposals_engine::{
     ApprovedProposalDecision, Proposal, ProposalCreationParameters, ProposalParameters,
     ProposalStatus, VoteKind, VotersParameters, VotingResults,
@@ -37,6 +38,7 @@ pub type Council = council::Module<Runtime>;
 pub type Membership = membership::Module<Runtime>;
 pub type MembershipWorkingGroup = working_group::Module<Runtime, MembershipWorkingGroupInstance>;
 pub type Blog = blog::Module<Runtime, BlogInstance>;
+pub type Content = content::Module<Runtime>;
 
 struct VoteGenerator {
     proposal_id: u32,
@@ -1202,5 +1204,44 @@ fn proposal_reactivation_succeeds() {
             CouncilManager::<Runtime>::total_voters_count(),
             council_size
         );
+    });
+}
+
+#[test]
+fn update_nft_limit_proposal_succeeds() {
+    initial_test_ext().execute_with(|| {
+        let member_id = create_new_members(1)[0];
+        let account_id = account_from_member_id(member_id);
+
+        let limit_type = GlobalNftLimitType::DailyLimit;
+        let new_limit = LimitPerPeriod {
+            limit: 9999,
+            block_number_period: 9999,
+        };
+
+        let codex_extrinsic_test_fixture = CodexProposalTestFixture::default_for_call(|| {
+            let general_proposal_parameters = GeneralProposalParameters::<Runtime> {
+                member_id: member_id,
+                title: b"title".to_vec(),
+                description: b"body".to_vec(),
+                staking_account_id: Some(account_id.clone()),
+                exact_execution_block: None,
+            };
+
+            ProposalCodex::create_proposal(
+                RawOrigin::Signed(account_id.clone()).into(),
+                general_proposal_parameters,
+                ProposalDetails::UpdateNftLimit(limit_type, new_limit),
+            )
+        })
+        .with_member_id(member_id as u64);
+
+        codex_extrinsic_test_fixture.call_extrinsic_and_assert();
+
+        let params = <Runtime as proposals_codex::Trait>::UpdateNftLimitProposalParameters::get();
+        run_to_block(System::block_number() + params.grace_period + 1);
+
+        let nft_limit_id: NftLimitId<crate::ChannelId> = limit_type.into();
+        assert_eq!(Content::nft_limit_by_id(nft_limit_id), new_limit);
     });
 }

--- a/runtime/src/tests/proposals_integration/mod.rs
+++ b/runtime/src/tests/proposals_integration/mod.rs
@@ -1242,6 +1242,6 @@ fn update_nft_limit_proposal_succeeds() {
         run_to_block(System::block_number() + params.grace_period + 1);
 
         let nft_limit_id: NftLimitId<crate::ChannelId> = limit_type.into();
-        assert_eq!(Content::nft_limit_by_id(nft_limit_id), new_limit);
+        assert_eq!(content::GlobalDailyNftLimit::<Runtime>::get(), new_limit);
     });
 }

--- a/runtime/src/weights/proposals_codex.rs
+++ b/runtime/src/weights/proposals_codex.rs
@@ -199,4 +199,11 @@ impl proposals_codex::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(9 as Weight))
     }
+    fn create_proposal_update_nft_limit(t: u32, d: u32) -> Weight {
+        (652_251_000 as Weight)
+            .saturating_add((180_000 as Weight).saturating_mul(t as Weight))
+            .saturating_add((224_000 as Weight).saturating_mul(d as Weight))
+            .saturating_add(DbWeight::get().reads(7 as Weight))
+            .saturating_add(DbWeight::get().writes(9 as Weight))
+    }
 }


### PR DESCRIPTION
This PR adds NFT-limits to the content pallet.

[Original Issue](https://github.com/Joystream/joystream/issues/2651)

#### Limit types
1. daily or weekly
1. global or channel

Unlike the original issue this PR allows setting channel NFT limits to leaders only. This will change after the [moderation action permissioning system](https://github.com/Joystream/joystream/issues/3610) is integrated.

## Comments
* There are four combinations of these limits like `global daily` limit. 
* Limits are imposed on the NFT-issuing extrinsics (like 'update_video'). 
* Global limits update requires `root` privileges and could be set using a new proposal.
* Channel limits update requires `curator` privileges and could be set using a dedicated extrinsic.

## Changes
*  content-pallet: `issue_nft`, `create_video` and `update_video` extrinsics are affected
* new default constants (exported) for NFT limits (DefaultGlobalDailyNftLimit, DefaultGlobalWeeklyNftLimit, DefaultChannelDailyNftLimit, DefaultChannelWeeklyNftLimit)
* default channel limits are set on the channel creation
* channel limits are removed on the channel deletion
* global limits are set on the genesis
* new limits could be set using the new extrinsic in the pallet-content: `update_nft_limit`
* new global limits could be using the new proposal: `update_nft_limit`
* tests for runtime, proposals-codex-pallet, and pallet-content crates
* benchmarking for proposals-codex-pallet



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202078489349362/1202133891752150) by [Unito](https://www.unito.io)
