### PR TITLE
Rhodes fix bids cancellation bug

### DIFF
--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -382,6 +382,9 @@ async function createBid(
     const newTopBid = findTopBid(bidsList)
     if (newTopBid) {
       newTopBid.auctionTopBid = auction
+      if (cancelledBidsIds.includes(newTopBid.id)) {
+        newTopBid.isCanceled = true
+      }
       await store.save<Bid>(newTopBid)
     }
   }

--- a/tests/network-tests/src/QueryNodeApi.ts
+++ b/tests/network-tests/src/QueryNodeApi.ts
@@ -332,6 +332,10 @@ import {
   GetEnglishAuctionSettledEventsByEventIdsQuery,
   GetEnglishAuctionSettledEventsByEventIdsQueryVariables,
   GetEnglishAuctionSettledEventsByEventIds,
+  BidFieldsFragment,
+  GetBidsByMemberIdQuery,
+  GetBidsByMemberIdQueryVariables,
+  GetBidsByMemberId,
 } from './graphql/generated/queries'
 import { Maybe } from './graphql/generated/schema'
 import { OperationDefinitionNode } from 'graphql'
@@ -1138,6 +1142,14 @@ export class QueryNodeApi {
       GetOwnedNftByVideoId,
       { videoId },
       'ownedNfts'
+    )
+  }
+
+  public async bidsByMemberId(videoId: string, memberId: string): Promise<BidFieldsFragment[]> {
+    return this.multipleEntitiesQuery<GetBidsByMemberIdQuery, GetBidsByMemberIdQueryVariables>(
+      GetBidsByMemberId,
+      { videoId, memberId },
+      'bids'
     )
   }
 

--- a/tests/network-tests/src/fixtures/content/nft/auctionCancelations.ts
+++ b/tests/network-tests/src/fixtures/content/nft/auctionCancelations.ts
@@ -4,7 +4,7 @@ import { QueryNodeApi } from '../../../QueryNodeApi'
 import { IMember } from '../createMembers'
 import { PlaceBidsInAuctionFixture } from './placeBidsInAuction'
 import { Utils } from '../../../utils'
-import { assertNftOwner } from './utils'
+import { assertNftOwner, ensureMemberOpenAuctionBidsAreCancelled } from './utils'
 import BN from 'bn.js'
 
 export class AuctionCancelationsFixture extends BaseQueryNodeFixture {
@@ -26,44 +26,161 @@ export class AuctionCancelationsFixture extends BaseQueryNodeFixture {
     this.debug('Issue video NFT')
     await this.api.issueNft(this.author.keyringPair.address, this.author.memberId.toNumber(), this.videoId)
 
-    this.debug('Start NFT auction')
-    const {
-      auctionParams,
-      startingPrice,
-      minimalBidStep,
-      bidLockDuration,
-    } = await this.api.createOpenAuctionParameters()
-    await this.api.startOpenAuction(
-      this.author.keyringPair.address,
-      this.author.memberId.toNumber(),
-      this.videoId,
-      auctionParams
-    )
+    // SCENARIO 1: Cancel bid during auction
+    {
+      this.debug('Start NFT auction')
+      const {
+        auctionParams,
+        startingPrice,
+        minimalBidStep,
+        bidLockDuration,
+      } = await this.api.createOpenAuctionParameters()
+      await this.api.startOpenAuction(
+        this.author.keyringPair.address,
+        this.author.memberId.toNumber(),
+        this.videoId,
+        auctionParams
+      )
 
-    this.debug('Place bid')
-    const placeBidsFixture = new PlaceBidsInAuctionFixture(
-      this.api,
-      this.query,
-      [this.participant],
-      startingPrice,
-      minimalBidStep,
-      this.videoId,
-      'Open'
-    )
-    await new FixtureRunner(placeBidsFixture).run()
+      this.debug('Place bid')
+      const placeBidsFixture = new PlaceBidsInAuctionFixture(
+        this.api,
+        this.query,
+        [this.participant],
+        startingPrice,
+        minimalBidStep,
+        this.videoId,
+        'Open'
+      )
+      await new FixtureRunner(placeBidsFixture).run()
 
-    this.debug('Wait for bid to be cancelable')
+      this.debug('Wait for bid to be cancelable')
 
-    const waitBlocks = bidLockDuration.toNumber() + 1
-    await Utils.wait(this.api.getBlockDuration().muln(waitBlocks).toNumber())
+      const waitBlocks = bidLockDuration.toNumber() + 1
+      await Utils.wait(this.api.getBlockDuration().muln(waitBlocks).toNumber())
 
-    this.debug('Cancel bid')
-    await this.api.cancelOpenAuctionBid(this.participant.account, this.participant.memberId.toNumber(), this.videoId)
+      this.debug('Cancel bid')
+      await this.api.cancelOpenAuctionBid(this.participant.account, this.participant.memberId.toNumber(), this.videoId)
 
-    this.debug('Cancel auction')
-    await this.api.cancelOpenAuction(this.author.account, this.author.memberId.toNumber(), this.videoId)
+      // ensure bid has been canceled
+      ensureMemberOpenAuctionBidsAreCancelled(this.query, this.videoId, this.participant)
 
-    this.debug(`Check NFT ownership haven't change`)
-    await assertNftOwner(this.query, this.videoId, this.author)
+      this.debug('Cancel auction')
+      await this.api.cancelOpenAuction(this.author.account, this.author.memberId.toNumber(), this.videoId)
+
+      this.debug(`Check NFT ownership haven't change`)
+      await assertNftOwner(this.query, this.videoId, this.author)
+    }
+
+    // SCENARIO 2: Cancel bid by re-bidding auction
+    {
+      const {
+        auctionParams,
+        startingPrice,
+        minimalBidStep,
+        bidLockDuration,
+      } = await this.api.createOpenAuctionParameters()
+
+      this.debug('Start NFT auction')
+      await this.api.startOpenAuction(
+        this.author.keyringPair.address,
+        this.author.memberId.toNumber(),
+        this.videoId,
+        auctionParams
+      )
+
+      this.debug('Place first bid in auction')
+      const placeFirstBidFixture = new PlaceBidsInAuctionFixture(
+        this.api,
+        this.query,
+        [this.participant],
+        startingPrice.addn(1),
+        minimalBidStep,
+        this.videoId,
+        'Open'
+      )
+      await new FixtureRunner(placeFirstBidFixture).run()
+
+      this.debug('Wait for bid to be cancelable')
+
+      const waitBlocksForFirstBid = bidLockDuration.toNumber() + 1
+      await Utils.wait(this.api.getBlockDuration().muln(waitBlocksForFirstBid).toNumber())
+
+      this.debug('Place second bid auction')
+      // This should cancel the first bid by member
+      const placeBidsInFirstAuctionFixture = new PlaceBidsInAuctionFixture(
+        this.api,
+        this.query,
+        [this.participant],
+        startingPrice,
+        minimalBidStep,
+        this.videoId,
+        'Open'
+      )
+      await new FixtureRunner(placeBidsInFirstAuctionFixture).run()
+
+      this.debug('Wait for bid to be cancelable')
+
+      const waitBlocksForSecondBid = bidLockDuration.toNumber() + 1
+      await Utils.wait(this.api.getBlockDuration().muln(waitBlocksForSecondBid).toNumber())
+
+      this.debug('Cancel bid')
+      await this.api.cancelOpenAuctionBid(this.participant.account, this.participant.memberId.toNumber(), this.videoId)
+
+      // ensure bids has been canceled
+      ensureMemberOpenAuctionBidsAreCancelled(this.query, this.videoId, this.participant)
+
+      this.debug('Cancel auction')
+      await this.api.cancelOpenAuction(this.author.account, this.author.memberId.toNumber(), this.videoId)
+
+      this.debug(`Check NFT ownership haven't change`)
+      await assertNftOwner(this.query, this.videoId, this.author)
+    }
+
+    // SCENARIO 3: Cancel bid after auction
+    {
+      this.debug('Start NFT auction')
+      const {
+        auctionParams,
+        startingPrice,
+        minimalBidStep,
+        bidLockDuration,
+      } = await this.api.createOpenAuctionParameters()
+      await this.api.startOpenAuction(
+        this.author.keyringPair.address,
+        this.author.memberId.toNumber(),
+        this.videoId,
+        auctionParams
+      )
+
+      this.debug('Place bid')
+      const placeBidsFixture = new PlaceBidsInAuctionFixture(
+        this.api,
+        this.query,
+        [this.participant],
+        startingPrice,
+        minimalBidStep,
+        this.videoId,
+        'Open'
+      )
+      await new FixtureRunner(placeBidsFixture).run()
+
+      this.debug('Wait for bid to be cancelable')
+
+      const waitBlocks = bidLockDuration.toNumber() + 1
+      await Utils.wait(this.api.getBlockDuration().muln(waitBlocks).toNumber())
+
+      this.debug('Cancel auction')
+      await this.api.cancelOpenAuction(this.author.account, this.author.memberId.toNumber(), this.videoId)
+
+      this.debug('Cancel bid')
+      await this.api.cancelOpenAuctionBid(this.participant.account, this.participant.memberId.toNumber(), this.videoId)
+
+      // ensure bid has been canceled
+      ensureMemberOpenAuctionBidsAreCancelled(this.query, this.videoId, this.participant)
+
+      this.debug(`Check NFT ownership haven't change`)
+      await assertNftOwner(this.query, this.videoId, this.author)
+    }
   }
 }

--- a/tests/network-tests/src/fixtures/content/nft/utils.ts
+++ b/tests/network-tests/src/fixtures/content/nft/utils.ts
@@ -27,6 +27,23 @@ export async function assertAuctionAndBids(query: QueryNodeApi, videoId: number,
   )
 }
 
+export async function ensureMemberOpenAuctionBidsAreCancelled(
+  query: QueryNodeApi,
+  videoId: number,
+  member: IMember
+): Promise<void> {
+  await query.tryQueryWithTimeout(
+    () => query.bidsByMemberId(videoId.toString(), member.memberId.toString()),
+    (bids) => {
+      bids.forEach((bid) => {
+        if (bid.auction.auctionType.__typename === 'AuctionTypeOpen') {
+          assert.equal(bid.isCanceled, true, `Some bid by member ${member} on nft ${videoId} are uncancelled`)
+        }
+      })
+    }
+  )
+}
+
 export async function assertNftOwner(
   query: QueryNodeApi,
   videoId: number,

--- a/tests/network-tests/src/graphql/generated/queries.ts
+++ b/tests/network-tests/src/graphql/generated/queries.ts
@@ -66,6 +66,20 @@ export type ChannelCategoryFieldsFragment = { id: string; activeVideosCounter: n
 
 export type VideoCategoryFieldsFragment = { id: string; activeVideosCounter: number }
 
+export type BidFieldsFragment = {
+  id: string
+  isCanceled: boolean
+  amount: any
+  createdInBlock: number
+  bidder: { id: string; handle: string }
+  auction: {
+    auctionType:
+      | { __typename: 'AuctionTypeEnglish'; extensionPeriod: number }
+      | { __typename: 'AuctionTypeOpen'; bidLockDuration: number }
+  }
+  nft: { id: string }
+}
+
 export type OwnedNftFieldsFragment = {
   id: string
   metadata: string
@@ -93,7 +107,7 @@ export type OwnedNftFieldsFragment = {
           minimalBidStep: number
         }
       | { __typename: 'AuctionTypeOpen'; bidLockDuration: number }
-    bids: Array<{ id: string; amount: any; createdInBlock: number; bidder: { id: string; handle: string } }>
+    bids: Array<BidFieldsFragment>
     topBid?: Types.Maybe<{ id: string; amount: any; bidder: { id: string } }>
   }>
   creatorChannel: { id: string }
@@ -131,6 +145,13 @@ export type GetOwnedNftByVideoIdQueryVariables = Types.Exact<{
 }>
 
 export type GetOwnedNftByVideoIdQuery = { ownedNfts: Array<OwnedNftFieldsFragment> }
+
+export type GetBidsByMemberIdQueryVariables = Types.Exact<{
+  videoId: Types.Scalars['ID']
+  memberId: Types.Scalars['ID']
+}>
+
+export type GetBidsByMemberIdQuery = { bids: Array<BidFieldsFragment> }
 
 export type GetChannelNftCollectorsQueryVariables = Types.Exact<{ [key: string]: never }>
 
@@ -2180,6 +2201,32 @@ export const VideoCategoryFields = gql`
     activeVideosCounter
   }
 `
+export const BidFields = gql`
+  fragment BidFields on Bid {
+    id
+    bidder {
+      id
+      handle
+    }
+    auction {
+      auctionType {
+        __typename
+        ... on AuctionTypeOpen {
+          bidLockDuration
+        }
+        ... on AuctionTypeEnglish {
+          extensionPeriod
+        }
+      }
+    }
+    nft {
+      id
+    }
+    isCanceled
+    amount
+    createdInBlock
+  }
+`
 export const OwnedNftFields = gql`
   fragment OwnedNftFields on OwnedNft {
     id
@@ -2217,13 +2264,7 @@ export const OwnedNftFields = gql`
         }
       }
       bids {
-        id
-        bidder {
-          id
-          handle
-        }
-        amount
-        createdInBlock
+        ...BidFields
       }
       topBid {
         id
@@ -2240,6 +2281,7 @@ export const OwnedNftFields = gql`
     lastSalePrice
     lastSaleDate
   }
+  ${BidFields}
 `
 export const ChannelNftCollectorFields = gql`
   fragment ChannelNftCollectorFields on ChannelNftCollectors {
@@ -4106,6 +4148,14 @@ export const GetOwnedNftByVideoId = gql`
     }
   }
   ${OwnedNftFields}
+`
+export const GetBidsByMemberId = gql`
+  query getBidsByMemberId($videoId: ID!, $memberId: ID!) {
+    bids(where: { nft: { id_eq: $videoId }, bidder: { id_eq: $memberId } }) {
+      ...BidFields
+    }
+  }
+  ${BidFields}
 `
 export const GetChannelNftCollectors = gql`
   query getChannelNftCollectors {

--- a/tests/network-tests/src/graphql/generated/schema.ts
+++ b/tests/network-tests/src/graphql/generated/schema.ts
@@ -859,6 +859,8 @@ export type AuctionBidMadeEvent = Event &
     ownerCuratorGroupId?: Maybe<Scalars['String']>
     previousTopBid?: Maybe<Bid>
     previousTopBidId?: Maybe<Scalars['String']>
+    previousTopBidder?: Maybe<Membership>
+    previousTopBidderId?: Maybe<Scalars['String']>
   }
 
 export type AuctionBidMadeEventConnection = {
@@ -878,6 +880,7 @@ export type AuctionBidMadeEventCreateInput = {
   ownerMember?: Maybe<Scalars['ID']>
   ownerCuratorGroup?: Maybe<Scalars['ID']>
   previousTopBid?: Maybe<Scalars['ID']>
+  previousTopBidder?: Maybe<Scalars['ID']>
 }
 
 export type AuctionBidMadeEventEdge = {
@@ -912,6 +915,8 @@ export enum AuctionBidMadeEventOrderByInput {
   OwnerCuratorGroupDesc = 'ownerCuratorGroup_DESC',
   PreviousTopBidAsc = 'previousTopBid_ASC',
   PreviousTopBidDesc = 'previousTopBid_DESC',
+  PreviousTopBidderAsc = 'previousTopBidder_ASC',
+  PreviousTopBidderDesc = 'previousTopBidder_DESC',
 }
 
 export type AuctionBidMadeEventUpdateInput = {
@@ -925,6 +930,7 @@ export type AuctionBidMadeEventUpdateInput = {
   ownerMember?: Maybe<Scalars['ID']>
   ownerCuratorGroup?: Maybe<Scalars['ID']>
   previousTopBid?: Maybe<Scalars['ID']>
+  previousTopBidder?: Maybe<Scalars['ID']>
 }
 
 export type AuctionBidMadeEventWhereInput = {
@@ -982,6 +988,7 @@ export type AuctionBidMadeEventWhereInput = {
   ownerMember?: Maybe<MembershipWhereInput>
   ownerCuratorGroup?: Maybe<CuratorGroupWhereInput>
   previousTopBid?: Maybe<BidWhereInput>
+  previousTopBidder?: Maybe<MembershipWhereInput>
   AND?: Maybe<Array<AuctionBidMadeEventWhereInput>>
   OR?: Maybe<Array<AuctionBidMadeEventWhereInput>>
 }
@@ -1398,6 +1405,7 @@ export type Bid = BaseGraphQlObject & {
   indexInBlock: Scalars['Int']
   auctionbidmadeeventpreviousTopBid?: Maybe<Array<AuctionBidMadeEvent>>
   bidmadecompletingauctioneventpreviousTopBid?: Maybe<Array<BidMadeCompletingAuctionEvent>>
+  openauctionbidacceptedeventwinningBid?: Maybe<Array<OpenAuctionBidAcceptedEvent>>
 }
 
 export type BidConnection = {
@@ -1453,6 +1461,8 @@ export type BidMadeCompletingAuctionEvent = Event &
     price: Scalars['BigInt']
     previousTopBid?: Maybe<Bid>
     previousTopBidId?: Maybe<Scalars['String']>
+    previousTopBidder?: Maybe<Membership>
+    previousTopBidderId?: Maybe<Scalars['String']>
   }
 
 export type BidMadeCompletingAuctionEventConnection = {
@@ -1472,6 +1482,7 @@ export type BidMadeCompletingAuctionEventCreateInput = {
   ownerCuratorGroup?: Maybe<Scalars['ID']>
   price: Scalars['String']
   previousTopBid?: Maybe<Scalars['ID']>
+  previousTopBidder?: Maybe<Scalars['ID']>
 }
 
 export type BidMadeCompletingAuctionEventEdge = {
@@ -1506,6 +1517,8 @@ export enum BidMadeCompletingAuctionEventOrderByInput {
   PriceDesc = 'price_DESC',
   PreviousTopBidAsc = 'previousTopBid_ASC',
   PreviousTopBidDesc = 'previousTopBid_DESC',
+  PreviousTopBidderAsc = 'previousTopBidder_ASC',
+  PreviousTopBidderDesc = 'previousTopBidder_DESC',
 }
 
 export type BidMadeCompletingAuctionEventUpdateInput = {
@@ -1519,6 +1532,7 @@ export type BidMadeCompletingAuctionEventUpdateInput = {
   ownerCuratorGroup?: Maybe<Scalars['ID']>
   price?: Maybe<Scalars['String']>
   previousTopBid?: Maybe<Scalars['ID']>
+  previousTopBidder?: Maybe<Scalars['ID']>
 }
 
 export type BidMadeCompletingAuctionEventWhereInput = {
@@ -1576,6 +1590,7 @@ export type BidMadeCompletingAuctionEventWhereInput = {
   ownerMember?: Maybe<MembershipWhereInput>
   ownerCuratorGroup?: Maybe<CuratorGroupWhereInput>
   previousTopBid?: Maybe<BidWhereInput>
+  previousTopBidder?: Maybe<MembershipWhereInput>
   AND?: Maybe<Array<BidMadeCompletingAuctionEventWhereInput>>
   OR?: Maybe<Array<BidMadeCompletingAuctionEventWhereInput>>
 }
@@ -1672,6 +1687,9 @@ export type BidWhereInput = {
   bidmadecompletingauctioneventpreviousTopBid_none?: Maybe<BidMadeCompletingAuctionEventWhereInput>
   bidmadecompletingauctioneventpreviousTopBid_some?: Maybe<BidMadeCompletingAuctionEventWhereInput>
   bidmadecompletingauctioneventpreviousTopBid_every?: Maybe<BidMadeCompletingAuctionEventWhereInput>
+  openauctionbidacceptedeventwinningBid_none?: Maybe<OpenAuctionBidAcceptedEventWhereInput>
+  openauctionbidacceptedeventwinningBid_some?: Maybe<OpenAuctionBidAcceptedEventWhereInput>
+  openauctionbidacceptedeventwinningBid_every?: Maybe<OpenAuctionBidAcceptedEventWhereInput>
   AND?: Maybe<Array<BidWhereInput>>
   OR?: Maybe<Array<BidWhereInput>>
 }
@@ -11491,10 +11509,12 @@ export type Membership = BaseGraphQlObject & {
   auctionbidcanceledeventownerMember?: Maybe<Array<AuctionBidCanceledEvent>>
   auctionbidmadeeventmember?: Maybe<Array<AuctionBidMadeEvent>>
   auctionbidmadeeventownerMember?: Maybe<Array<AuctionBidMadeEvent>>
+  auctionbidmadeeventpreviousTopBidder?: Maybe<Array<AuctionBidMadeEvent>>
   auctioncanceledeventownerMember?: Maybe<Array<AuctionCanceledEvent>>
   bidbidder?: Maybe<Array<Bid>>
   bidmadecompletingauctioneventmember?: Maybe<Array<BidMadeCompletingAuctionEvent>>
   bidmadecompletingauctioneventownerMember?: Maybe<Array<BidMadeCompletingAuctionEvent>>
+  bidmadecompletingauctioneventpreviousTopBidder?: Maybe<Array<BidMadeCompletingAuctionEvent>>
   bountycreator?: Maybe<Array<Bounty>>
   bountyoracle?: Maybe<Array<Bounty>>
   bountycontributioncontributor?: Maybe<Array<BountyContribution>>
@@ -11526,6 +11546,7 @@ export type Membership = BaseGraphQlObject & {
   offerstartedeventmember?: Maybe<Array<OfferStartedEvent>>
   offerstartedeventownerMember?: Maybe<Array<OfferStartedEvent>>
   openauctionbidacceptedeventownerMember?: Maybe<Array<OpenAuctionBidAcceptedEvent>>
+  openauctionbidacceptedeventwinningBidder?: Maybe<Array<OpenAuctionBidAcceptedEvent>>
   openauctionstartedeventownerMember?: Maybe<Array<OpenAuctionStartedEvent>>
   postdeletedeventactor?: Maybe<Array<PostDeletedEvent>>
   postreactedeventreactingMember?: Maybe<Array<PostReactedEvent>>
@@ -12168,6 +12189,9 @@ export type MembershipWhereInput = {
   auctionbidmadeeventownerMember_none?: Maybe<AuctionBidMadeEventWhereInput>
   auctionbidmadeeventownerMember_some?: Maybe<AuctionBidMadeEventWhereInput>
   auctionbidmadeeventownerMember_every?: Maybe<AuctionBidMadeEventWhereInput>
+  auctionbidmadeeventpreviousTopBidder_none?: Maybe<AuctionBidMadeEventWhereInput>
+  auctionbidmadeeventpreviousTopBidder_some?: Maybe<AuctionBidMadeEventWhereInput>
+  auctionbidmadeeventpreviousTopBidder_every?: Maybe<AuctionBidMadeEventWhereInput>
   auctioncanceledeventownerMember_none?: Maybe<AuctionCanceledEventWhereInput>
   auctioncanceledeventownerMember_some?: Maybe<AuctionCanceledEventWhereInput>
   auctioncanceledeventownerMember_every?: Maybe<AuctionCanceledEventWhereInput>
@@ -12180,6 +12204,9 @@ export type MembershipWhereInput = {
   bidmadecompletingauctioneventownerMember_none?: Maybe<BidMadeCompletingAuctionEventWhereInput>
   bidmadecompletingauctioneventownerMember_some?: Maybe<BidMadeCompletingAuctionEventWhereInput>
   bidmadecompletingauctioneventownerMember_every?: Maybe<BidMadeCompletingAuctionEventWhereInput>
+  bidmadecompletingauctioneventpreviousTopBidder_none?: Maybe<BidMadeCompletingAuctionEventWhereInput>
+  bidmadecompletingauctioneventpreviousTopBidder_some?: Maybe<BidMadeCompletingAuctionEventWhereInput>
+  bidmadecompletingauctioneventpreviousTopBidder_every?: Maybe<BidMadeCompletingAuctionEventWhereInput>
   bountycreator_none?: Maybe<BountyWhereInput>
   bountycreator_some?: Maybe<BountyWhereInput>
   bountycreator_every?: Maybe<BountyWhereInput>
@@ -12273,6 +12300,9 @@ export type MembershipWhereInput = {
   openauctionbidacceptedeventownerMember_none?: Maybe<OpenAuctionBidAcceptedEventWhereInput>
   openauctionbidacceptedeventownerMember_some?: Maybe<OpenAuctionBidAcceptedEventWhereInput>
   openauctionbidacceptedeventownerMember_every?: Maybe<OpenAuctionBidAcceptedEventWhereInput>
+  openauctionbidacceptedeventwinningBidder_none?: Maybe<OpenAuctionBidAcceptedEventWhereInput>
+  openauctionbidacceptedeventwinningBidder_some?: Maybe<OpenAuctionBidAcceptedEventWhereInput>
+  openauctionbidacceptedeventwinningBidder_every?: Maybe<OpenAuctionBidAcceptedEventWhereInput>
   openauctionstartedeventownerMember_none?: Maybe<OpenAuctionStartedEventWhereInput>
   openauctionstartedeventownerMember_some?: Maybe<OpenAuctionStartedEventWhereInput>
   openauctionstartedeventownerMember_every?: Maybe<OpenAuctionStartedEventWhereInput>
@@ -14322,6 +14352,10 @@ export type OpenAuctionBidAcceptedEvent = Event &
     ownerMemberId?: Maybe<Scalars['String']>
     ownerCuratorGroup?: Maybe<CuratorGroup>
     ownerCuratorGroupId?: Maybe<Scalars['String']>
+    winningBid?: Maybe<Bid>
+    winningBidId?: Maybe<Scalars['String']>
+    winningBidder?: Maybe<Membership>
+    winningBidderId?: Maybe<Scalars['String']>
   }
 
 export type OpenAuctionBidAcceptedEventConnection = {
@@ -14339,6 +14373,8 @@ export type OpenAuctionBidAcceptedEventCreateInput = {
   video: Scalars['ID']
   ownerMember?: Maybe<Scalars['ID']>
   ownerCuratorGroup?: Maybe<Scalars['ID']>
+  winningBid?: Maybe<Scalars['ID']>
+  winningBidder?: Maybe<Scalars['ID']>
 }
 
 export type OpenAuctionBidAcceptedEventEdge = {
@@ -14367,6 +14403,10 @@ export enum OpenAuctionBidAcceptedEventOrderByInput {
   OwnerMemberDesc = 'ownerMember_DESC',
   OwnerCuratorGroupAsc = 'ownerCuratorGroup_ASC',
   OwnerCuratorGroupDesc = 'ownerCuratorGroup_DESC',
+  WinningBidAsc = 'winningBid_ASC',
+  WinningBidDesc = 'winningBid_DESC',
+  WinningBidderAsc = 'winningBidder_ASC',
+  WinningBidderDesc = 'winningBidder_DESC',
 }
 
 export type OpenAuctionBidAcceptedEventUpdateInput = {
@@ -14378,6 +14418,8 @@ export type OpenAuctionBidAcceptedEventUpdateInput = {
   video?: Maybe<Scalars['ID']>
   ownerMember?: Maybe<Scalars['ID']>
   ownerCuratorGroup?: Maybe<Scalars['ID']>
+  winningBid?: Maybe<Scalars['ID']>
+  winningBidder?: Maybe<Scalars['ID']>
 }
 
 export type OpenAuctionBidAcceptedEventWhereInput = {
@@ -14428,6 +14470,8 @@ export type OpenAuctionBidAcceptedEventWhereInput = {
   video?: Maybe<VideoWhereInput>
   ownerMember?: Maybe<MembershipWhereInput>
   ownerCuratorGroup?: Maybe<CuratorGroupWhereInput>
+  winningBid?: Maybe<BidWhereInput>
+  winningBidder?: Maybe<MembershipWhereInput>
   AND?: Maybe<Array<OpenAuctionBidAcceptedEventWhereInput>>
   OR?: Maybe<Array<OpenAuctionBidAcceptedEventWhereInput>>
 }

--- a/tests/network-tests/src/graphql/queries/content.graphql
+++ b/tests/network-tests/src/graphql/queries/content.graphql
@@ -73,6 +73,32 @@ fragment VideoCategoryFields on VideoCategory {
   activeVideosCounter
 }
 
+fragment BidFields on Bid {
+  id
+  bidder {
+    id
+    handle
+  }
+  auction {
+    auctionType {
+      __typename
+      ... on AuctionTypeOpen {
+        bidLockDuration
+      }
+
+      ... on AuctionTypeEnglish {
+        extensionPeriod
+      }
+    }
+  }
+  nft {
+    id
+  }
+  isCanceled
+  amount
+  createdInBlock
+}
+
 fragment OwnedNftFields on OwnedNft {
   id
   video {
@@ -109,13 +135,7 @@ fragment OwnedNftFields on OwnedNft {
       }
     }
     bids {
-      id
-      bidder {
-        id
-        handle
-      }
-      amount
-      createdInBlock
+      ...BidFields
     }
     topBid {
       id
@@ -169,6 +189,12 @@ query getVideoCategoryById($id: ID!) {
 query getOwnedNftByVideoId($videoId: ID!) {
   ownedNfts(where: { video: { id_eq: $videoId } }) {
     ...OwnedNftFields
+  }
+}
+
+query getBidsByMemberId($videoId: ID!, $memberId: ID!) {
+  bids(where: { nft: { id_eq: $videoId }, bidder: { id_eq: $memberId } }) {
+    ...BidFields
   }
 }
 


### PR DESCRIPTION
Fixes `Bid.isCanceled` field inconsistency between runtime and QN in case of Open Auction Bid

Related PRs: #3620 #3627