### PR TITLE
query node - fix for active video counters not handeling video deletion properly

### DIFF
--- a/query-node/mappings/src/content/utils.ts
+++ b/query-node/mappings/src/content/utils.ts
@@ -62,10 +62,8 @@ const ASSET_TYPES = {
   ],
 } as const
 
-// all relations that need to be loaded for updating active video counters when deleting content
-export const videoRelationsForCountersBare = ['channel', 'channel.category', 'category']
 // all relations that need to be loaded for full evalution of video active status to work
-export const videoRelationsForCounters = [...videoRelationsForCountersBare, 'thumbnailPhoto', 'media']
+export const videoRelationsForCounters = ['channel', 'channel.category', 'category', 'thumbnailPhoto', 'media']
 
 async function processChannelAssets(
   { event, store }: EventContext & StoreContext,
@@ -492,7 +490,7 @@ export async function unsetAssetRelations(store: DatabaseManager, dataObject: St
         id: dataObject.id,
       },
     })),
-    relations: [...videoAssets, ...videoRelationsForCountersBare],
+    relations: [...videoRelationsForCounters],
   })
 
   if (channel) {

--- a/query-node/mappings/src/content/video.ts
+++ b/query-node/mappings/src/content/video.ts
@@ -5,7 +5,7 @@ import { EventContext, StoreContext } from '@joystream/hydra-common'
 import { In } from 'typeorm'
 import { Content } from '../../generated/types'
 import { deserializeMetadata, inconsistentState, logger } from '../common'
-import { processVideoMetadata, videoRelationsForCountersBare, videoRelationsForCounters } from './utils'
+import { processVideoMetadata, videoRelationsForCounters } from './utils'
 import { Channel, Video, VideoCategory } from 'query-node/dist/model'
 import { VideoMetadata, VideoCategoryMetadata } from '@joystream/metadata-protobuf'
 import { integrateMeta } from '@joystream/metadata-protobuf/utils'
@@ -183,7 +183,7 @@ export async function content_VideoDeleted({ store, event }: EventContext & Stor
   // load video
   const video = await store.get(Video, {
     where: { id: videoId.toString() },
-    relations: [...videoRelationsForCountersBare],
+    relations: [...videoRelationsForCounters],
   })
 
   // ensure video exists

--- a/query-node/mappings/src/derivedPropertiesManager/applications/activeVideoCounters.ts
+++ b/query-node/mappings/src/derivedPropertiesManager/applications/activeVideoCounters.ts
@@ -2,7 +2,7 @@ import { DerivedPropertiesManager } from '../classes'
 import { IExecutor, IListener, IChangePair } from '../interfaces'
 import { DatabaseManager } from '@joystream/hydra-common'
 import { Channel, ChannelCategory, Video, VideoCategory, StorageDataObject } from 'query-node/dist/model'
-import { videoRelationsForCountersBare } from '../../content/utils'
+import { videoRelationsForCounters } from '../../content/utils'
 
 export type IVideoDerivedEntites = 'channel' | 'channel.category' | 'category'
 export type IAvcChange = 1 | -1 | [1 | -1, IVideoDerivedEntites[]]
@@ -93,7 +93,7 @@ function hasVideoChanged(
 */
 class VideoUpdateListener implements IListener<Video, IAvcChange> {
   getRelationDependencies(): string[] {
-    return ['thumbnailPhoto', 'media']
+    return []
   }
 
   hasValueChanged(oldValue: Video | undefined, newValue: Video): IChangePair<IAvcChange> | undefined
@@ -284,7 +284,7 @@ class ChannelCategoryActiveVideoCounterExecutor implements IExecutor<Channel, IA
 }
 
 export function createVideoManager(store: DatabaseManager): DerivedPropertiesManager<Video, IAvcChange> {
-  const manager = new DerivedPropertiesManager<Video, IAvcChange>(store, Video, videoRelationsForCountersBare)
+  const manager = new DerivedPropertiesManager<Video, IAvcChange>(store, Video, videoRelationsForCounters)
 
   // listen to video change
   const listener = new VideoUpdateListener()

--- a/tests/network-tests/src/cli/joystream.ts
+++ b/tests/network-tests/src/cli/joystream.ts
@@ -200,6 +200,14 @@ export class JoystreamCLI extends CLI {
     }
   }
 
+  async deleteVideo(videoId: number): Promise<void> {
+    const { stdout, stderr, exitCode } = await this.run('content:deleteVideo', ['-v', videoId.toString(), '-f'])
+
+    if (exitCode) {
+      throw new Error(`Unexpected CLI failure on deleting video: "${stderr}"`)
+    }
+  }
+
   /**
     Updates a channel.
   */

--- a/tests/network-tests/src/fixtures/content/activeVideoCounters.ts
+++ b/tests/network-tests/src/fixtures/content/activeVideoCounters.ts
@@ -95,6 +95,14 @@ export class ActiveVideoCountersFixture extends BaseQueryNodeFixture {
     // end
     */
 
+    const oneDeletedItemCount = 1
+    this.debug('Delete video')
+    await this.cli.deleteVideo(this.videosData[0].videoId)
+
+    // check that deletion works
+    this.debug('Checking channels active video counter decreased')
+    await this.assertCounterMatch('channel', this.channelIds[0], videoCount - oneDeletedItemCount)
+
     this.debug('Done')
   }
 


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/3572.