### PR TITLE
fix: remove duplicate bidder IDs in `bidders` field in NFT events

### DIFF
--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -44,6 +44,7 @@ import BN from 'bn.js'
 import { PERBILL_ONE_PERCENT } from '../temporaryConstants'
 import { getAllManagers } from '../derivedPropertiesManager/applications'
 import { convertContentActorToChannelOrNftOwner, convertContentActor } from './utils'
+import _ from 'lodash'
 
 async function getExistingEntity<Type extends Video | Membership>(
   store: DatabaseManager,
@@ -282,8 +283,8 @@ async function finishAuction(
     ? findOpenAuctionWinningBid(auction.bids || [], openAuctionWinner.bidAmount, openAuctionWinner.winnerId, videoId)
     : (auction.topBid as Bid)
 
-  // load all bidders of auction
-  const bidders = (auction.bids || []).map((bid) => bid.bidder)
+  // load all unique bidders of auction
+  const bidders = (_.uniqBy(auction.bids, (b) => b.bidder.id) || []).map((bid) => bid.bidder)
 
   // update NFT's transactional status
   const { nft } = await resetNftTransactionalStatusFromVideo(

--- a/tests/network-tests/src/fixtures/content/nft/englishAuction.ts
+++ b/tests/network-tests/src/fixtures/content/nft/englishAuction.ts
@@ -30,7 +30,8 @@ export class NftEnglishAuctionFixture extends BaseQueryNodeFixture {
   public async execute(): Promise<void> {
     this.debug('Issue video NFT')
 
-    const auctionParticipants = [...this.participants, this.participants[0]]
+    // participants[0] places multiple bids
+    const auctionParticipants = [this.participants[0], ...this.participants]
     const winner = auctionParticipants[auctionParticipants.length - 1]
 
     // creator royalty

--- a/tests/network-tests/src/fixtures/content/nft/englishAuction.ts
+++ b/tests/network-tests/src/fixtures/content/nft/englishAuction.ts
@@ -30,7 +30,8 @@ export class NftEnglishAuctionFixture extends BaseQueryNodeFixture {
   public async execute(): Promise<void> {
     this.debug('Issue video NFT')
 
-    const winner = this.participants[this.participants.length - 1]
+    const auctionParticipants = [...this.participants, this.participants[0]]
+    const winner = auctionParticipants[auctionParticipants.length - 1]
 
     // creator royalty
     const creatorRoyalty = 5
@@ -88,7 +89,7 @@ export class NftEnglishAuctionFixture extends BaseQueryNodeFixture {
     const placeBidsFixture = new PlaceBidsInAuctionFixture(
       this.api,
       this.query,
-      this.participants,
+      auctionParticipants,
       startingPrice,
       minimalBidStep,
       this.videoId,


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/3672

Addresses the bug introduced in https://github.com/Joystream/joystream/pull/3655

In the attached PR we added auction `bidders` to NFT settled Events, and hence **Many-to-Many** relationship was created b/w `EnglishAuctionSettledEvent`/`OpenAuctionBidAcceptedEvent` and `Membership` tables.

And respective junction tables i.e. `english_auction_settled_event_membership` & `membership_open_auction_bid_accepted_event` were also created

<img width="748" alt="image" src="https://user-images.githubusercontent.com/37098720/165296341-75e8f881-32bb-4a9f-9eae-912ca14b57c2.png">

As you see, the junction table's _primary key_ is the combination of both eventId and memberId.

Previously, in mappings we were extracting `bidder` from each `bid`, and then setting the `EnglishAuctionSettledEvent.bidders` to the all the bidders of auction

Now since a member can put multiple bids on an auction during its auction period, there would have been duplicate **bidder/s** in the `bidders` field, which eventually violated the primary key constraint in the junction table