### PR TITLE
runtime - removal of redundant test line in council module

### DIFF
--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -181,9 +181,6 @@ fn council_vote_for_winner_stakes_longer() {
         Mocks::release_vote_stake(voter_for_winner.origin.clone(), Err(()));
         Mocks::release_vote_stake(voter_for_looser.origin.clone(), Ok(()));
 
-        // try to release vote stake
-        Mocks::release_vote_stake(voter_for_winner.origin.clone(), Err(()));
-
         // run second election round
         Mocks::run_full_council_cycle(
             council_settings.cycle_duration,


### PR DESCRIPTION
I've noticed a redundant line in one of the council tests. This PR removes it.