### PR TITLE
Check price of data object bloat bonds

### DIFF
--- a/runtime-modules/storage/src/tests/mocks.rs
+++ b/runtime-modules/storage/src/tests/mocks.rs
@@ -92,7 +92,7 @@ pub const VOUCHER_OBJECTS_LIMIT: u64 = 20;
 pub const DEFAULT_STORAGE_BUCKET_SIZE_LIMIT: u64 = 100;
 pub const DEFAULT_STORAGE_BUCKET_OBJECTS_LIMIT: u64 = 10;
 pub const DEFAULT_STORAGE_BUCKETS_NUMBER: u64 = 3;
-
+pub const ONE_MB: u64 = 1_048_576;
 impl crate::Trait for Test {
     type Event = TestEvent;
     type DataObjectId = u64;


### PR DESCRIPTION
`funds_needed_for_upload(params: UploadParameters<T>)` created in pallet storage
I think It's more advantageous to use `UploadParameters` as a parameter than to separate the fields into params.

This function calculates the storage fee and the net prize an actor has to pay if he wants to update X amount of data objects.
It only works on updates, so the net deletion prize is always positive (`NetDeletionPrize::<T>::Pos(b)`).

`net_prize = number of objects to update * DataObjectDeletionPrizeValue.`
`storage_fee = DataObjectPerMegabyteFee * round_up_to_nearest_integer(size of total objects in bytes / 1_048_576)`

`funds_needed_for_upload = net_prize + storage_fee`

- Closes #3607