### PR TITLE
fix initial balances and initial members args

### DIFF
--- a/devops/aws/roles/common/tasks/chain-spec-node-keys.yml
+++ b/devops/aws/roles/common/tasks/chain-spec-node-keys.yml
@@ -26,8 +26,8 @@
     --chain-spec-path {{ chain_spec_path }}
     --endowed 1 --keystore-path {{ remote_data_path }}
     {% if deployment_type is defined and deployment_type|length > 0 %}--deployment {{ deployment_type }}{% endif %}
-    {% if initial_members_file is defined and initial_members_file|length > 0 %}--initial-balances-path {{ remote_code_path }}/initial-balances.json{% endif %}
-    {% if initial_balances_file is defined and initial_balances_file|length > 0 %}
+    {% if initial_balances_file is defined and initial_balances_file|length > 0 %}--initial-balances-path {{ remote_code_path }}/initial-balances.json{% endif %}
+    {% if initial_members_file is defined and initial_members_file|length > 0 %}
     --initial-members-path {{ remote_code_path }}/query-node/mappings/src/bootstrap-data/data/members.json
     {% endif %}
   register: chain_spec_output


### PR DESCRIPTION
I came across this bug in passing the wrong path to initial members and balances when deploying a new network.