### PR TITLE
Storage pallet: remove checks for InsufficientTreasuryBalance

### DIFF
--- a/runtime/src/weights/storage.rs
+++ b/runtime/src/weights/storage.rs
@@ -8,39 +8,39 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl storage::WeightInfo for WeightInfo {
     fn delete_storage_bucket() -> Weight {
-        (293_000_000 as Weight)
+        (317_413_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_uploading_blocked_status() -> Weight {
-        (216_000_000 as Weight)
+        (189_782_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_data_size_fee() -> Weight {
-        (260_000_000 as Weight)
+        (196_115_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_buckets_per_bag_limit() -> Weight {
-        (226_000_000 as Weight)
+        (182_889_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_buckets_voucher_max_limits() -> Weight {
-        (226_000_000 as Weight)
+        (190_419_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_number_of_storage_buckets_in_dynamic_bag_creation_policy() -> Weight {
-        (260_000_000 as Weight)
+        (232_678_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_blacklist(i: u32, j: u32) -> Weight {
-        (34_250_806_000 as Weight)
-            .saturating_add((101_714_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((48_925_000 as Weight).saturating_mul(j as Weight))
+        (13_645_053_000 as Weight)
+            .saturating_add((83_597_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((37_380_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -48,14 +48,14 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn create_storage_bucket() -> Weight {
-        (606_000_000 as Weight)
+        (240_467_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_storage_buckets_for_bag(i: u32, j: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((393_338_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((324_358_000 as Weight).saturating_mul(j as Weight))
+        (270_490_000 as Weight)
+            .saturating_add((269_565_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((212_258_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -64,76 +64,76 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
     }
     fn cancel_storage_bucket_operator_invite() -> Weight {
-        (386_000_000 as Weight)
+        (297_014_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn invite_storage_bucket_operator() -> Weight {
-        (599_000_000 as Weight)
+        (422_034_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn remove_storage_bucket_operator() -> Weight {
-        (489_000_000 as Weight)
+        (346_469_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_bucket_status() -> Weight {
-        (376_000_000 as Weight)
+        (292_900_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_storage_bucket_voucher_limits() -> Weight {
-        (744_000_000 as Weight)
+        (305_285_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn accept_storage_bucket_invitation() -> Weight {
-        (454_000_000 as Weight)
+        (296_288_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_storage_operator_metadata(i: u32) -> Weight {
-        (325_027_000 as Weight)
-            .saturating_add((211_000 as Weight).saturating_mul(i as Weight))
+        (278_785_000 as Weight)
+            .saturating_add((165_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn accept_pending_data_objects(i: u32) -> Weight {
-        (852_583_000 as Weight)
-            .saturating_add((166_274_000 as Weight).saturating_mul(i as Weight))
+        (291_655_000 as Weight)
+            .saturating_add((140_696_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn create_distribution_bucket_family() -> Weight {
-        (304_000_000 as Weight)
+        (222_147_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn delete_distribution_bucket_family() -> Weight {
-        (404_000_000 as Weight)
+        (426_333_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn create_distribution_bucket() -> Weight {
-        (329_000_000 as Weight)
+        (356_622_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_distribution_bucket_status() -> Weight {
-        (382_000_000 as Weight)
+        (281_274_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn delete_distribution_bucket() -> Weight {
-        (315_000_000 as Weight)
+        (318_750_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_distribution_buckets_for_bag(i: u32, j: u32) -> Weight {
-        (9_111_681_000 as Weight)
-            .saturating_add((182_993_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((141_955_000 as Weight).saturating_mul(j as Weight))
+        (0 as Weight)
+            .saturating_add((138_846_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((162_318_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -142,60 +142,60 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
     }
     fn update_distribution_buckets_per_bag_limit() -> Weight {
-        (255_000_000 as Weight)
+        (194_614_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_distribution_bucket_mode() -> Weight {
-        (574_000_000 as Weight)
+        (279_984_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_families_in_dynamic_bag_creation_policy(i: u32) -> Weight {
-        (358_386_000 as Weight)
-            .saturating_add((46_414_000 as Weight).saturating_mul(i as Weight))
+        (239_918_000 as Weight)
+            .saturating_add((44_315_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn invite_distribution_bucket_operator() -> Weight {
-        (521_000_000 as Weight)
+        (416_879_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn cancel_distribution_bucket_operator_invite() -> Weight {
-        (565_000_000 as Weight)
+        (291_868_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn remove_distribution_bucket_operator() -> Weight {
-        (846_000_000 as Weight)
+        (295_730_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_distribution_bucket_family_metadata(i: u32) -> Weight {
-        (346_367_000 as Weight)
-            .saturating_add((180_000 as Weight).saturating_mul(i as Weight))
+        (228_419_000 as Weight)
+            .saturating_add((175_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
     }
     fn accept_distribution_bucket_invitation() -> Weight {
-        (1_464_000_000 as Weight)
+        (300_696_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_distribution_operator_metadata(i: u32) -> Weight {
-        (390_779_000 as Weight)
-            .saturating_add((149_000 as Weight).saturating_mul(i as Weight))
+        (248_844_000 as Weight)
+            .saturating_add((210_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn storage_operator_remark(i: u32) -> Weight {
-        (502_563_000 as Weight)
-            .saturating_add((151_000 as Weight).saturating_mul(i as Weight))
+        (301_223_000 as Weight)
+            .saturating_add((147_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn distribution_operator_remark(i: u32) -> Weight {
-        (374_922_000 as Weight)
-            .saturating_add((363_000 as Weight).saturating_mul(i as Weight))
+        (273_244_000 as Weight)
+            .saturating_add((136_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
 }


### PR DESCRIPTION

- Closes #3694

`NetDeletionPrizeTypes` removed, instead a tupple of three balances (`DeletionPrizeAndStorageFee`) is returned from :

```rust
       let (deletion_prize_request, deletion_prize_refund, storage_fee) =
            Self::ensure_sufficient_balance(
                &bag_op,
                new_voucher_update,
                deletion_prize,
                &account_id,
            )?;
```
Since clippy complained that a three-element tuple is a too complex object, we had two options:
creating a type or place an attribute allowing clippy for complex objects warnings.
I think a type is more idiomatic
```rust
type DeletionPrizeAndStorageFee<T> = (BalanceOf<T>, BalanceOf<T>, BalanceOf<T>);
```
Treasury check was removed
```rust
ensure!(<StorageTreasury<T>>::usable_balance() >= b,
            Error::<T>::InsufficientTreasuryBalance)
```
deletion_prize_request, deletion_prize_refund

net_prize is replaced by two variables,  `deletion_prize_request` and `deletion_prize_refund`
Where `deletion_prize_request` is the amount a member has to pay to the treasury if he wants to store a bag or an object, 
(used while creating and updating).
`deletion_prize_refund` is the amount owed by the treasury to the member