### PR TITLE
Storage pallet charging total storage fee each time

### DIFF
--- a/runtime-modules/storage/src/tests/fixtures.rs
+++ b/runtime-modules/storage/src/tests/fixtures.rs
@@ -536,6 +536,22 @@ impl UploadFixture {
     }
 }
 
+pub fn create_data_object_candidates_with_size(
+    starting_index: u8,
+    number: u8,
+    size: u64,
+) -> Vec<DataObjectCreationParameters> {
+    let range = starting_index..(starting_index + number);
+
+    range
+        .into_iter()
+        .map(|idx| DataObjectCreationParameters {
+            size: size,
+            ipfs_content_id: create_cid(idx.into()),
+        })
+        .collect()
+}
+
 pub fn create_data_object_candidates(
     starting_index: u8,
     number: u8,

--- a/runtime-modules/storage/src/tests/mocks.rs
+++ b/runtime-modules/storage/src/tests/mocks.rs
@@ -67,7 +67,7 @@ parameter_types! {
     pub const DefaultChannelDynamicBagNumberOfStorageBuckets: u64 = 4;
     pub const DistributionBucketsPerBagValueConstraint: crate::DistributionBucketsPerBagValueConstraint =
         crate::DistributionBucketsPerBagValueConstraint {min: 2, max_min_diff: 7};
-    pub const MaxDataObjectSize: u64 = 400;
+    pub const MaxDataObjectSize: u64 = 5 * ONE_MB;
 }
 
 pub const STORAGE_WG_LEADER_ACCOUNT_ID: u64 = 100001;

--- a/runtime/src/weights/storage.rs
+++ b/runtime/src/weights/storage.rs
@@ -8,39 +8,39 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl storage::WeightInfo for WeightInfo {
     fn delete_storage_bucket() -> Weight {
-        (317_413_000 as Weight)
+        (264_075_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_uploading_blocked_status() -> Weight {
-        (189_782_000 as Weight)
+        (235_451_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_data_size_fee() -> Weight {
-        (196_115_000 as Weight)
+        (202_095_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_buckets_per_bag_limit() -> Weight {
-        (182_889_000 as Weight)
+        (231_328_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_buckets_voucher_max_limits() -> Weight {
-        (190_419_000 as Weight)
+        (234_725_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_number_of_storage_buckets_in_dynamic_bag_creation_policy() -> Weight {
-        (232_678_000 as Weight)
+        (349_112_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_blacklist(i: u32, j: u32) -> Weight {
-        (13_645_053_000 as Weight)
-            .saturating_add((83_597_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((37_380_000 as Weight).saturating_mul(j as Weight))
+        (17_332_614_000 as Weight)
+            .saturating_add((83_179_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((37_985_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -48,14 +48,14 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn create_storage_bucket() -> Weight {
-        (240_467_000 as Weight)
+        (236_492_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_storage_buckets_for_bag(i: u32, j: u32) -> Weight {
-        (270_490_000 as Weight)
-            .saturating_add((269_565_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((212_258_000 as Weight).saturating_mul(j as Weight))
+        (404_085_000 as Weight)
+            .saturating_add((266_590_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((221_139_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -64,76 +64,76 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
     }
     fn cancel_storage_bucket_operator_invite() -> Weight {
-        (297_014_000 as Weight)
+        (295_703_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn invite_storage_bucket_operator() -> Weight {
-        (422_034_000 as Weight)
+        (524_963_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn remove_storage_bucket_operator() -> Weight {
-        (346_469_000 as Weight)
+        (314_556_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_bucket_status() -> Weight {
-        (292_900_000 as Weight)
+        (326_587_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_storage_bucket_voucher_limits() -> Weight {
-        (305_285_000 as Weight)
+        (324_253_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn accept_storage_bucket_invitation() -> Weight {
-        (296_288_000 as Weight)
+        (297_798_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_storage_operator_metadata(i: u32) -> Weight {
-        (278_785_000 as Weight)
-            .saturating_add((165_000 as Weight).saturating_mul(i as Weight))
+        (275_715_000 as Weight)
+            .saturating_add((172_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn accept_pending_data_objects(i: u32) -> Weight {
-        (291_655_000 as Weight)
-            .saturating_add((140_696_000 as Weight).saturating_mul(i as Weight))
+        (255_615_000 as Weight)
+            .saturating_add((139_530_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn create_distribution_bucket_family() -> Weight {
-        (222_147_000 as Weight)
+        (218_919_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn delete_distribution_bucket_family() -> Weight {
-        (426_333_000 as Weight)
+        (343_995_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn create_distribution_bucket() -> Weight {
-        (356_622_000 as Weight)
+        (267_467_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_distribution_bucket_status() -> Weight {
-        (281_274_000 as Weight)
+        (322_565_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn delete_distribution_bucket() -> Weight {
-        (318_750_000 as Weight)
+        (426_792_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_distribution_buckets_for_bag(i: u32, j: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((138_846_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((162_318_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((151_196_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((160_209_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -142,60 +142,60 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
     }
     fn update_distribution_buckets_per_bag_limit() -> Weight {
-        (194_614_000 as Weight)
+        (181_614_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_distribution_bucket_mode() -> Weight {
-        (279_984_000 as Weight)
+        (328_580_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_families_in_dynamic_bag_creation_policy(i: u32) -> Weight {
-        (239_918_000 as Weight)
-            .saturating_add((44_315_000 as Weight).saturating_mul(i as Weight))
+        (251_916_000 as Weight)
+            .saturating_add((43_926_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn invite_distribution_bucket_operator() -> Weight {
-        (416_879_000 as Weight)
+        (466_366_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn cancel_distribution_bucket_operator_invite() -> Weight {
-        (291_868_000 as Weight)
+        (350_614_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn remove_distribution_bucket_operator() -> Weight {
-        (295_730_000 as Weight)
+        (326_586_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_distribution_bucket_family_metadata(i: u32) -> Weight {
-        (228_419_000 as Weight)
-            .saturating_add((175_000 as Weight).saturating_mul(i as Weight))
+        (224_534_000 as Weight)
+            .saturating_add((298_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
     }
     fn accept_distribution_bucket_invitation() -> Weight {
-        (300_696_000 as Weight)
+        (385_313_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_distribution_operator_metadata(i: u32) -> Weight {
-        (248_844_000 as Weight)
-            .saturating_add((210_000 as Weight).saturating_mul(i as Weight))
+        (443_529_000 as Weight)
+            .saturating_add((69_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn storage_operator_remark(i: u32) -> Weight {
-        (301_223_000 as Weight)
-            .saturating_add((147_000 as Weight).saturating_mul(i as Weight))
+        (271_675_000 as Weight)
+            .saturating_add((196_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn distribution_operator_remark(i: u32) -> Weight {
-        (273_244_000 as Weight)
-            .saturating_add((136_000 as Weight).saturating_mul(i as Weight))
+        (293_456_000 as Weight)
+            .saturating_add((155_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
 }

--- a/runtime/src/weights/storage.rs
+++ b/runtime/src/weights/storage.rs
@@ -8,39 +8,39 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl storage::WeightInfo for WeightInfo {
     fn delete_storage_bucket() -> Weight {
-        (293_000_000 as Weight)
+        (317_413_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_uploading_blocked_status() -> Weight {
-        (216_000_000 as Weight)
+        (189_782_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_data_size_fee() -> Weight {
-        (260_000_000 as Weight)
+        (196_115_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_buckets_per_bag_limit() -> Weight {
-        (226_000_000 as Weight)
+        (182_889_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_buckets_voucher_max_limits() -> Weight {
-        (226_000_000 as Weight)
+        (190_419_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_number_of_storage_buckets_in_dynamic_bag_creation_policy() -> Weight {
-        (260_000_000 as Weight)
+        (232_678_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_blacklist(i: u32, j: u32) -> Weight {
-        (34_250_806_000 as Weight)
-            .saturating_add((101_714_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((48_925_000 as Weight).saturating_mul(j as Weight))
+        (13_645_053_000 as Weight)
+            .saturating_add((83_597_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((37_380_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -48,14 +48,14 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn create_storage_bucket() -> Weight {
-        (606_000_000 as Weight)
+        (240_467_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_storage_buckets_for_bag(i: u32, j: u32) -> Weight {
-        (0 as Weight)
-            .saturating_add((393_338_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((324_358_000 as Weight).saturating_mul(j as Weight))
+        (270_490_000 as Weight)
+            .saturating_add((269_565_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((212_258_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -64,76 +64,76 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
     }
     fn cancel_storage_bucket_operator_invite() -> Weight {
-        (386_000_000 as Weight)
+        (297_014_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn invite_storage_bucket_operator() -> Weight {
-        (599_000_000 as Weight)
+        (422_034_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn remove_storage_bucket_operator() -> Weight {
-        (489_000_000 as Weight)
+        (346_469_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_bucket_status() -> Weight {
-        (376_000_000 as Weight)
+        (292_900_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_storage_bucket_voucher_limits() -> Weight {
-        (744_000_000 as Weight)
+        (305_285_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn accept_storage_bucket_invitation() -> Weight {
-        (454_000_000 as Weight)
+        (296_288_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_storage_operator_metadata(i: u32) -> Weight {
-        (325_027_000 as Weight)
-            .saturating_add((211_000 as Weight).saturating_mul(i as Weight))
+        (278_785_000 as Weight)
+            .saturating_add((165_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn accept_pending_data_objects(i: u32) -> Weight {
-        (852_583_000 as Weight)
-            .saturating_add((166_274_000 as Weight).saturating_mul(i as Weight))
+        (291_655_000 as Weight)
+            .saturating_add((140_696_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn create_distribution_bucket_family() -> Weight {
-        (304_000_000 as Weight)
+        (222_147_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn delete_distribution_bucket_family() -> Weight {
-        (404_000_000 as Weight)
+        (426_333_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn create_distribution_bucket() -> Weight {
-        (329_000_000 as Weight)
+        (356_622_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_distribution_bucket_status() -> Weight {
-        (382_000_000 as Weight)
+        (281_274_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn delete_distribution_bucket() -> Weight {
-        (315_000_000 as Weight)
+        (318_750_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_distribution_buckets_for_bag(i: u32, j: u32) -> Weight {
-        (9_111_681_000 as Weight)
-            .saturating_add((182_993_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((141_955_000 as Weight).saturating_mul(j as Weight))
+        (0 as Weight)
+            .saturating_add((138_846_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((162_318_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -142,60 +142,60 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
     }
     fn update_distribution_buckets_per_bag_limit() -> Weight {
-        (255_000_000 as Weight)
+        (194_614_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_distribution_bucket_mode() -> Weight {
-        (574_000_000 as Weight)
+        (279_984_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_families_in_dynamic_bag_creation_policy(i: u32) -> Weight {
-        (358_386_000 as Weight)
-            .saturating_add((46_414_000 as Weight).saturating_mul(i as Weight))
+        (239_918_000 as Weight)
+            .saturating_add((44_315_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn invite_distribution_bucket_operator() -> Weight {
-        (521_000_000 as Weight)
+        (416_879_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn cancel_distribution_bucket_operator_invite() -> Weight {
-        (565_000_000 as Weight)
+        (291_868_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn remove_distribution_bucket_operator() -> Weight {
-        (846_000_000 as Weight)
+        (295_730_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_distribution_bucket_family_metadata(i: u32) -> Weight {
-        (346_367_000 as Weight)
-            .saturating_add((180_000 as Weight).saturating_mul(i as Weight))
+        (228_419_000 as Weight)
+            .saturating_add((175_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
     }
     fn accept_distribution_bucket_invitation() -> Weight {
-        (1_464_000_000 as Weight)
+        (300_696_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_distribution_operator_metadata(i: u32) -> Weight {
-        (390_779_000 as Weight)
-            .saturating_add((149_000 as Weight).saturating_mul(i as Weight))
+        (248_844_000 as Weight)
+            .saturating_add((210_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn storage_operator_remark(i: u32) -> Weight {
-        (502_563_000 as Weight)
-            .saturating_add((151_000 as Weight).saturating_mul(i as Weight))
+        (301_223_000 as Weight)
+            .saturating_add((147_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn distribution_operator_remark(i: u32) -> Weight {
-        (374_922_000 as Weight)
-            .saturating_add((363_000 as Weight).saturating_mul(i as Weight))
+        (273_244_000 as Weight)
+            .saturating_add((136_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
 }


### PR DESCRIPTION
This PR is to be merged after this [#3717](https://github.com/Joystream/joystream/pull/3717)

- Closes #3697 

Main changes are:

These tests have been added, basically, test a sequence of uploads and see 
if the fee in the second upload is accumulated with the first upload.
`upload_succeeded_dynamic_bag_with_data_size_and_deletion_fee`
`upload_succeeded_static_bag_with_data_size_and_deletion_fee`

These tests have been deleted since the tests previous added replace them
`upload_succeeded_with_non_empty_bag`
`delete_dynamic_bags_fails_with_insufficient_balance_for_deletion_prize`

This helper function has been added to fixtures
`create_data_object_candidates_with_size`

Max size has been changed to 5Mb, this way we can test better the storage fee logic
`pub const MaxDataObjectSize: u64 = 5 * ONE_MB;`

`new_voucher_update` has been renamed to `all_objects_with_update_voucher`, since this new name expresses better that Voucher has all objects including the objects to add.

```rust
        let objects_to_update_voucher = VoucherUpdate::default()
            .add_objects_list(object_creation_list.as_slice())
            .sub_objects_list(objects_removal_list.as_slice());

        let all_objects_with_update_voucher = VoucherUpdate {
            objects_total_size,
            objects_number,
        }
        .add_objects_list(object_creation_list.as_slice())
        .sub_objects_list(objects_removal_list.as_slice());
```

`objects_to_update_voucher` has only the objects to update, this way we can calculate the correct storage fee by summing only the new objects.
```rust
        let objects_to_update_voucher = VoucherUpdate::default()
            .add_objects_list(object_creation_list.as_slice())
            .sub_objects_list(objects_removal_list.as_slice());
```
```rust
        Self::ensure_sufficient_balance(
              &bag_op,
              objects_to_update_voucher, <------------------
              deletion_prize,
              &account_id,
         )?;
```
