### PR TITLE
Distributor node: Fix mime-type detection

### DIFF
--- a/distributor-node/docs/api/public/index.md
+++ b/distributor-node/docs/api/public/index.md
@@ -78,6 +78,7 @@ Returns json object describing current node status.
 ```json
 {
   "id": "string",
+  "version": "string",
   "objectsInCache": 0,
   "storageLimit": 0,
   "storageUsed": 0,
@@ -326,6 +327,7 @@ This operation does not require authentication
 ```json
 {
   "id": "string",
+  "version": "string",
   "objectsInCache": 0,
   "storageLimit": 0,
   "storageUsed": 0,
@@ -340,6 +342,7 @@ This operation does not require authentication
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |id|string|true|none|none|
+|version|string|true|none|none|
 |objectsInCache|integer|true|none|none|
 |storageLimit|integer|true|none|none|
 |storageUsed|integer|true|none|none|

--- a/distributor-node/docs/commands/dev.md
+++ b/distributor-node/docs/commands/dev.md
@@ -25,4 +25,4 @@ OPTIONS
   -y, --yes                        Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/dev/batchUpload.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/dev/batchUpload.ts)_
+_See code: [src/commands/dev/batchUpload.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/dev/batchUpload.ts)_

--- a/distributor-node/docs/commands/leader.md
+++ b/distributor-node/docs/commands/leader.md
@@ -39,7 +39,7 @@ DESCRIPTION
   Requires distribution working group leader permissions.
 ```
 
-_See code: [src/commands/leader/cancel-invitation.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/cancel-invitation.ts)_
+_See code: [src/commands/leader/cancel-invitation.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/cancel-invitation.ts)_
 
 ## `joystream-distributor leader:create-bucket`
 
@@ -60,7 +60,7 @@ OPTIONS
   -y, --yes                     Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/leader/create-bucket.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/create-bucket.ts)_
+_See code: [src/commands/leader/create-bucket.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/create-bucket.ts)_
 
 ## `joystream-distributor leader:create-bucket-family`
 
@@ -77,7 +77,7 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/leader/create-bucket-family.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/create-bucket-family.ts)_
+_See code: [src/commands/leader/create-bucket-family.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/create-bucket-family.ts)_
 
 ## `joystream-distributor leader:delete-bucket`
 
@@ -96,7 +96,7 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/leader/delete-bucket.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/delete-bucket.ts)_
+_See code: [src/commands/leader/delete-bucket.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/delete-bucket.ts)_
 
 ## `joystream-distributor leader:delete-bucket-family`
 
@@ -115,7 +115,7 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/leader/delete-bucket-family.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/delete-bucket-family.ts)_
+_See code: [src/commands/leader/delete-bucket-family.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/delete-bucket-family.ts)_
 
 ## `joystream-distributor leader:invite-bucket-operator`
 
@@ -140,7 +140,7 @@ DESCRIPTION
      Requires distribution working group leader permissions.
 ```
 
-_See code: [src/commands/leader/invite-bucket-operator.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/invite-bucket-operator.ts)_
+_See code: [src/commands/leader/invite-bucket-operator.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/invite-bucket-operator.ts)_
 
 ## `joystream-distributor leader:remove-bucket-operator`
 
@@ -165,7 +165,7 @@ DESCRIPTION
   Requires distribution working group leader permissions.
 ```
 
-_See code: [src/commands/leader/remove-bucket-operator.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/remove-bucket-operator.ts)_
+_See code: [src/commands/leader/remove-bucket-operator.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/remove-bucket-operator.ts)_
 
 ## `joystream-distributor leader:set-bucket-family-metadata`
 
@@ -189,7 +189,7 @@ DESCRIPTION
   Requires distribution working group leader permissions.
 ```
 
-_See code: [src/commands/leader/set-bucket-family-metadata.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/set-bucket-family-metadata.ts)_
+_See code: [src/commands/leader/set-bucket-family-metadata.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/set-bucket-family-metadata.ts)_
 
 ## `joystream-distributor leader:set-buckets-per-bag-limit`
 
@@ -208,7 +208,7 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/leader/set-buckets-per-bag-limit.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/set-buckets-per-bag-limit.ts)_
+_See code: [src/commands/leader/set-buckets-per-bag-limit.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/set-buckets-per-bag-limit.ts)_
 
 ## `joystream-distributor leader:update-bag`
 
@@ -251,7 +251,7 @@ EXAMPLE
   $ joystream-distributor leader:update-bag -b 1 -f 1 -a 1 2 3 -r 4 5
 ```
 
-_See code: [src/commands/leader/update-bag.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/update-bag.ts)_
+_See code: [src/commands/leader/update-bag.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/update-bag.ts)_
 
 ## `joystream-distributor leader:update-bucket-mode`
 
@@ -272,7 +272,7 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/leader/update-bucket-mode.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/update-bucket-mode.ts)_
+_See code: [src/commands/leader/update-bucket-mode.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/update-bucket-mode.ts)_
 
 ## `joystream-distributor leader:update-bucket-status`
 
@@ -292,7 +292,7 @@ OPTIONS
   -y, --yes                     Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/leader/update-bucket-status.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/update-bucket-status.ts)_
+_See code: [src/commands/leader/update-bucket-status.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/update-bucket-status.ts)_
 
 ## `joystream-distributor leader:update-dynamic-bag-policy`
 
@@ -319,4 +319,4 @@ EXAMPLE
   $ joystream-distributor leader:update-dynamic-bag-policy -t Member -p 1:5 2:10 3:5
 ```
 
-_See code: [src/commands/leader/update-dynamic-bag-policy.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/leader/update-dynamic-bag-policy.ts)_
+_See code: [src/commands/leader/update-dynamic-bag-policy.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/leader/update-dynamic-bag-policy.ts)_

--- a/distributor-node/docs/commands/node.md
+++ b/distributor-node/docs/commands/node.md
@@ -37,7 +37,7 @@ EXAMPLES
   $ joystream-distributor node:set-buckets --all
 ```
 
-_See code: [src/commands/node/set-buckets.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/node/set-buckets.ts)_
+_See code: [src/commands/node/set-buckets.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/node/set-buckets.ts)_
 
 ## `joystream-distributor node:set-worker`
 
@@ -60,7 +60,7 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/node/set-worker.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/node/set-worker.ts)_
+_See code: [src/commands/node/set-worker.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/node/set-worker.ts)_
 
 ## `joystream-distributor node:shutdown`
 
@@ -81,7 +81,7 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/node/shutdown.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/node/shutdown.ts)_
+_See code: [src/commands/node/shutdown.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/node/shutdown.ts)_
 
 ## `joystream-distributor node:start-public-api`
 
@@ -102,7 +102,7 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/node/start-public-api.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/node/start-public-api.ts)_
+_See code: [src/commands/node/start-public-api.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/node/start-public-api.ts)_
 
 ## `joystream-distributor node:stop-public-api`
 
@@ -123,4 +123,4 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/node/stop-public-api.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/node/stop-public-api.ts)_
+_See code: [src/commands/node/stop-public-api.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/node/stop-public-api.ts)_

--- a/distributor-node/docs/commands/operator.md
+++ b/distributor-node/docs/commands/operator.md
@@ -28,7 +28,7 @@ DESCRIPTION
   Requires the invited distribution group worker role key.
 ```
 
-_See code: [src/commands/operator/accept-invitation.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/operator/accept-invitation.ts)_
+_See code: [src/commands/operator/accept-invitation.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/operator/accept-invitation.ts)_
 
 ## `joystream-distributor operator:set-metadata`
 
@@ -56,4 +56,4 @@ DESCRIPTION
   Requires active distribution bucket operator worker role key.
 ```
 
-_See code: [src/commands/operator/set-metadata.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/operator/set-metadata.ts)_
+_See code: [src/commands/operator/set-metadata.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/operator/set-metadata.ts)_

--- a/distributor-node/docs/commands/start.md
+++ b/distributor-node/docs/commands/start.md
@@ -20,4 +20,4 @@ OPTIONS
   -y, --yes                    Answer "yes" to any prompt, skipping any manual confirmations
 ```
 
-_See code: [src/commands/start.ts](https://github.com/Joystream/joystream/blob/v0.1.0/src/commands/start.ts)_
+_See code: [src/commands/start.ts](https://github.com/Joystream/joystream/blob/v0.1.1/src/commands/start.ts)_

--- a/distributor-node/package.json
+++ b/distributor-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/distributor-cli",
   "description": "Joystream distributor node CLI",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Joystream contributors",
   "bin": {
     "joystream-distributor": "./bin/run"

--- a/distributor-node/package.json
+++ b/distributor-node/package.json
@@ -36,7 +36,6 @@
     "node-cleanup": "^2.1.2",
     "proper-lockfile": "^4.1.2",
     "queue": "^6.0.2",
-    "read-chunk": "^3.2.0",
     "send": "^0.17.1",
     "tslib": "^1",
     "winston": "^3.3.3",

--- a/distributor-node/src/api-spec/public.yml
+++ b/distributor-node/src/api-spec/public.yml
@@ -160,6 +160,7 @@ components:
       type: object
       required:
         - id
+        - version
         - objectsInCache
         - storageLimit
         - storageUsed
@@ -167,6 +168,8 @@ components:
         - downloadsInProgress
       properties:
         id:
+          type: string
+        version:
           type: string
         objectsInCache:
           type: integer

--- a/distributor-node/src/services/content/ContentService.ts
+++ b/distributor-node/src/services/content/ContentService.ts
@@ -9,7 +9,7 @@ import { Readable, pipeline } from 'stream'
 import { NetworkingService } from '../networking'
 import { ContentHash } from '../crypto/ContentHash'
 import { PendingDownloadStatusType } from '../networking/PendingDownload'
-import { promisify } from 'util';
+import { promisify } from 'util'
 
 export const DEFAULT_CONTENT_TYPE = 'application/octet-stream'
 export const MIME_TYPE_DETECTION_CHUNK_SIZE = 4100
@@ -168,15 +168,15 @@ export class ContentService {
     return new FileContinousReadStream(this.path(objectId), options)
   }
 
-  public async readFileChunk(path: string, bytes: number) {
-    const open = promisify(fs.open);
-    const read = promisify(fs.read);
-    const close = promisify(fs.close);
-    const buff = Buffer.alloc(bytes);
-    const fd = await open(path, 'r');
-    await read(fd, buff, 0, bytes, null);
-    await close(fd);
-    return buff;
+  public async readFileChunk(path: string, bytes: number): Promise<Buffer> {
+    const open = promisify(fs.open)
+    const read = promisify(fs.read)
+    const close = promisify(fs.close)
+    const buff = Buffer.alloc(bytes)
+    const fd = await open(path, 'r')
+    await read(fd, buff, 0, bytes, null)
+    await close(fd)
+    return buff
   }
 
   public async detectMimeType(objectId: string): Promise<string> {

--- a/distributor-node/src/services/content/ContentService.ts
+++ b/distributor-node/src/services/content/ContentService.ts
@@ -9,7 +9,7 @@ import { Readable, pipeline } from 'stream'
 import { NetworkingService } from '../networking'
 import { ContentHash } from '../crypto/ContentHash'
 import { PendingDownloadStatusType } from '../networking/PendingDownload'
-import { promisify } from 'util'
+import { FSP } from './FSPromise'
 
 export const DEFAULT_CONTENT_TYPE = 'application/octet-stream'
 export const MIME_TYPE_DETECTION_CHUNK_SIZE = 4100
@@ -169,13 +169,10 @@ export class ContentService {
   }
 
   public async readFileChunk(path: string, bytes: number): Promise<Buffer> {
-    const open = promisify(fs.open)
-    const read = promisify(fs.read)
-    const close = promisify(fs.close)
     const buff = Buffer.alloc(bytes)
-    const fd = await open(path, 'r')
-    await read(fd, buff, 0, bytes, null)
-    await close(fd)
+    const fd = await FSP.open(path, 'r')
+    await FSP.read(fd, buff, 0, bytes, null)
+    await FSP.close(fd)
     return buff
   }
 

--- a/distributor-node/src/services/content/ContentService.ts
+++ b/distributor-node/src/services/content/ContentService.ts
@@ -8,8 +8,8 @@ import FileType from 'file-type'
 import { Readable, pipeline } from 'stream'
 import { NetworkingService } from '../networking'
 import { ContentHash } from '../crypto/ContentHash'
-import readChunk from 'read-chunk'
 import { PendingDownloadStatusType } from '../networking/PendingDownload'
+import { promisify } from 'util';
 
 export const DEFAULT_CONTENT_TYPE = 'application/octet-stream'
 export const MIME_TYPE_DETECTION_CHUNK_SIZE = 4100
@@ -168,10 +168,21 @@ export class ContentService {
     return new FileContinousReadStream(this.path(objectId), options)
   }
 
+  public async readFileChunk(path: string, bytes: number) {
+    const open = promisify(fs.open);
+    const read = promisify(fs.read);
+    const close = promisify(fs.close);
+    const buff = Buffer.alloc(bytes);
+    const fd = await open(path, 'r');
+    await read(fd, buff, 0, bytes, null);
+    await close(fd);
+    return buff;
+  }
+
   public async detectMimeType(objectId: string): Promise<string> {
     const objectPath = this.path(objectId)
     try {
-      const buffer = await readChunk(objectPath, 0, MIME_TYPE_DETECTION_CHUNK_SIZE)
+      const buffer = await this.readFileChunk(objectPath, MIME_TYPE_DETECTION_CHUNK_SIZE)
       const result = await FileType.fromBuffer(buffer)
       return result?.mime || DEFAULT_CONTENT_TYPE
     } catch (err) {

--- a/distributor-node/src/services/content/FSPromise.ts
+++ b/distributor-node/src/services/content/FSPromise.ts
@@ -1,0 +1,8 @@
+import { promisify } from 'util'
+import fs from 'fs'
+
+export class FSP {
+  public static open = promisify(fs.open)
+  public static read = promisify(fs.read)
+  public static close = promisify(fs.close)
+}

--- a/distributor-node/src/services/httpApi/controllers/public.ts
+++ b/distributor-node/src/services/httpApi/controllers/public.ts
@@ -287,6 +287,7 @@ export class PublicApiController {
   public async status(req: express.Request, res: express.Response<StatusResponse>): Promise<void> {
     const data: StatusResponse = {
       id: this.config.id,
+      version: this.config.version,
       objectsInCache: this.stateCache.getCachedObjectsCount(),
       storageLimit: this.config.limits.storage,
       storageUsed: this.content.usedSpace,

--- a/distributor-node/src/services/parsers/ConfigParserService.ts
+++ b/distributor-node/src/services/parsers/ConfigParserService.ts
@@ -126,6 +126,11 @@ export class ConfigParserService {
       })
   }
 
+  public getNodeVersion(): string {
+    const packageJSON = JSON.parse(fs.readFileSync(path.join(__dirname, '../../../package.json')).toString())
+    return String(packageJSON.version)
+  }
+
   public parse(): Config {
     const { configPath } = this
     let inputConfig: Record<string, unknown> = {}
@@ -166,6 +171,7 @@ export class ConfigParserService {
 
     const parsedConfig: Config = {
       ...configJson,
+      version: this.getNodeVersion(),
       directories,
       keys,
       limits: {

--- a/distributor-node/src/types/config.ts
+++ b/distributor-node/src/types/config.ts
@@ -2,6 +2,7 @@ import { DistributorNodeConfiguration as ConfigJson } from './generated/ConfigJs
 import { DeepReadonly } from './common'
 
 export type Config = Omit<ConfigJson, 'limits'> & {
+  version: string
   limits: Omit<ConfigJson['limits'], 'storage' | 'maxCachedItemSize'> & {
     storage: number
     maxCachedItemSize?: number

--- a/distributor-node/src/types/generated/PublicApi.ts
+++ b/distributor-node/src/types/generated/PublicApi.ts
@@ -28,6 +28,7 @@ export interface components {
     }
     'StatusResponse': {
       'id': string
+      'version': string
       'objectsInCache': number
       'storageLimit': number
       'storageUsed': number


### PR DESCRIPTION
Removed dependency on `read-chunk` module due to an issue of unknown exact cause:
```
{
   "@timestamp":"2022-05-09T10:03:09.043Z",
   "log.level":"error",
   "message":"Error while trying to detect object mimeType: fsP.open is not a function",
   "ecs":{
      "version":"1.6.0"
   },
   "error":{
      "type":"TypeError",
      "message":"fsP.open is not a function",
      "stack_trace":"TypeError: fsP.open is not a function\n    at module.exports (/joystream/node_modules/with-open-file/index.js:13:6)\n    at readChunk (/joystream/node_modules/read-chunk/index.js:11:9)\n    at ContentService.detectMimeType (/joystream/distributor-node/src/services/content/ContentService.ts:174:37)\n    at /joystream/distributor-node/src/services/content/ContentService.ts:284:37\n    at internal/util.js:435:14\n    at finish (internal/streams/pipeline.js:162:7)\n    at internal/util.js:435:14\n    at WriteStream.<anonymous> (internal/streams/pipeline.js:65:7)\n    at WriteStream.<anonymous> (internal/util.js:435:14)\n    at WriteStream.onclose (internal/streams/end-of-stream.js:123:14)"
   },
   "label":"ContentService",
   "objectId":"3",
   "objectPath":"/data/3"
}
```
Implemented custom `readFileChunk` method in the `ContentService` instead.

Since the detected `mime-type` is beeing cached in distributor-node's `/{directories.cacheState}`, in order to reload mime types, the node operator needs to execute a command like:
```
cat /path/to/cache.json | jq '.mimeTypeByObjectId |= []' > tmp.json && mv tmp.json /path/to/cache.json
```
And restart the node