### PR TITLE
fix: set ownerMember in EnglishAuctionSettledEvent to previous owner

### DIFF
--- a/tests/network-tests/src/fixtures/content/nft/englishAuction.ts
+++ b/tests/network-tests/src/fixtures/content/nft/englishAuction.ts
@@ -131,7 +131,7 @@ export class NftEnglishAuctionFixture extends BaseQueryNodeFixture {
     await assertNftEventContentActor(
       this.query,
       () => this.query.getEnglishAuctionSettledEvents([englishAuctionSettledRuntimeEvent]),
-      winner.memberId.toString(),
+      this.author.memberId.toString(),
       'Member'
     )
 


### PR DESCRIPTION
set `ownerMember` in `EnglishAuctionSettledEvent` to previous owner(not the auction winner)