### PR TITLE
Storage pallet refunds based on old data object prizes

### DIFF
--- a/runtime-modules/storage/src/tests/fixtures.rs
+++ b/runtime-modules/storage/src/tests/fixtures.rs
@@ -1567,15 +1567,25 @@ impl CreateDynamicBagFixture {
     }
 
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
+        let balance_pre = Balances::usable_balance(self.params.deletion_prize_source_account_id);
+
         let actual_result = Storage::create_dynamic_bag(self.params.clone());
 
         assert_eq!(actual_result, expected_result);
 
         if actual_result.is_ok() {
+            let balance_post =
+                Balances::usable_balance(self.params.deletion_prize_source_account_id);
             let bag_id: BagId<Test> = self.params.bag_id.clone().into();
             assert!(<crate::Bags<Test>>::contains_key(&bag_id));
+
             let bag = <crate::Bags<Test>>::get(&bag_id);
             assert!(bag.stored_by.len() > 0);
+
+            assert_eq!(
+                balance_pre.saturating_sub(balance_post),
+                bag.deletion_prize.unwrap_or(0)
+            );
         }
     }
 }

--- a/runtime/src/weights/storage.rs
+++ b/runtime/src/weights/storage.rs
@@ -8,39 +8,39 @@ use frame_support::weights::{constants::RocksDbWeight as DbWeight, Weight};
 pub struct WeightInfo;
 impl storage::WeightInfo for WeightInfo {
     fn delete_storage_bucket() -> Weight {
-        (264_075_000 as Weight)
+        (274_132_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_uploading_blocked_status() -> Weight {
-        (235_451_000 as Weight)
+        (186_539_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_data_size_fee() -> Weight {
-        (202_095_000 as Weight)
+        (202_143_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_buckets_per_bag_limit() -> Weight {
-        (231_328_000 as Weight)
+        (220_381_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_buckets_voucher_max_limits() -> Weight {
-        (234_725_000 as Weight)
+        (223_934_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_number_of_storage_buckets_in_dynamic_bag_creation_policy() -> Weight {
-        (349_112_000 as Weight)
+        (289_476_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_blacklist(i: u32, j: u32) -> Weight {
-        (17_332_614_000 as Weight)
-            .saturating_add((83_179_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((37_985_000 as Weight).saturating_mul(j as Weight))
+        (24_544_022_000 as Weight)
+            .saturating_add((84_500_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((37_546_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -48,14 +48,14 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn create_storage_bucket() -> Weight {
-        (236_492_000 as Weight)
+        (338_423_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_storage_buckets_for_bag(i: u32, j: u32) -> Weight {
-        (404_085_000 as Weight)
-            .saturating_add((266_590_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((221_139_000 as Weight).saturating_mul(j as Weight))
+        (509_018_000 as Weight)
+            .saturating_add((278_439_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((211_679_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -64,76 +64,76 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
     }
     fn cancel_storage_bucket_operator_invite() -> Weight {
-        (295_703_000 as Weight)
+        (396_787_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn invite_storage_bucket_operator() -> Weight {
-        (524_963_000 as Weight)
+        (395_884_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn remove_storage_bucket_operator() -> Weight {
-        (314_556_000 as Weight)
+        (414_155_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_storage_bucket_status() -> Weight {
-        (326_587_000 as Weight)
+        (294_751_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_storage_bucket_voucher_limits() -> Weight {
-        (324_253_000 as Weight)
+        (308_162_000 as Weight)
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn accept_storage_bucket_invitation() -> Weight {
-        (297_798_000 as Weight)
+        (322_363_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_storage_operator_metadata(i: u32) -> Weight {
-        (275_715_000 as Weight)
-            .saturating_add((172_000 as Weight).saturating_mul(i as Weight))
+        (292_527_000 as Weight)
+            .saturating_add((191_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn accept_pending_data_objects(i: u32) -> Weight {
-        (255_615_000 as Weight)
-            .saturating_add((139_530_000 as Weight).saturating_mul(i as Weight))
+        (111_970_000 as Weight)
+            .saturating_add((143_330_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
     }
     fn create_distribution_bucket_family() -> Weight {
-        (218_919_000 as Weight)
+        (224_315_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(3 as Weight))
     }
     fn delete_distribution_bucket_family() -> Weight {
-        (343_995_000 as Weight)
+        (328_230_000 as Weight)
             .saturating_add(DbWeight::get().reads(7 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn create_distribution_bucket() -> Weight {
-        (267_467_000 as Weight)
+        (301_079_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(2 as Weight))
     }
     fn update_distribution_bucket_status() -> Weight {
-        (322_565_000 as Weight)
+        (328_476_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn delete_distribution_bucket() -> Weight {
-        (426_792_000 as Weight)
+        (271_446_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_distribution_buckets_for_bag(i: u32, j: u32) -> Weight {
         (0 as Weight)
-            .saturating_add((151_196_000 as Weight).saturating_mul(i as Weight))
-            .saturating_add((160_209_000 as Weight).saturating_mul(j as Weight))
+            .saturating_add((139_846_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((162_985_000 as Weight).saturating_mul(j as Weight))
             .saturating_add(DbWeight::get().reads(5 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(j as Weight)))
@@ -142,60 +142,60 @@ impl storage::WeightInfo for WeightInfo {
             .saturating_add(DbWeight::get().writes((1 as Weight).saturating_mul(j as Weight)))
     }
     fn update_distribution_buckets_per_bag_limit() -> Weight {
-        (181_614_000 as Weight)
+        (188_227_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_distribution_bucket_mode() -> Weight {
-        (328_580_000 as Weight)
+        (353_028_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn update_families_in_dynamic_bag_creation_policy(i: u32) -> Weight {
-        (251_916_000 as Weight)
-            .saturating_add((43_926_000 as Weight).saturating_mul(i as Weight))
+        (329_553_000 as Weight)
+            .saturating_add((35_409_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn invite_distribution_bucket_operator() -> Weight {
-        (466_366_000 as Weight)
+        (539_329_000 as Weight)
             .saturating_add(DbWeight::get().reads(4 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn cancel_distribution_bucket_operator_invite() -> Weight {
-        (350_614_000 as Weight)
+        (311_979_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn remove_distribution_bucket_operator() -> Weight {
-        (326_586_000 as Weight)
+        (316_736_000 as Weight)
             .saturating_add(DbWeight::get().reads(3 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_distribution_bucket_family_metadata(i: u32) -> Weight {
-        (224_534_000 as Weight)
-            .saturating_add((298_000 as Weight).saturating_mul(i as Weight))
+        (239_329_000 as Weight)
+            .saturating_add((203_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(3 as Weight))
     }
     fn accept_distribution_bucket_invitation() -> Weight {
-        (385_313_000 as Weight)
+        (341_649_000 as Weight)
             .saturating_add(DbWeight::get().reads(2 as Weight))
             .saturating_add(DbWeight::get().writes(1 as Weight))
     }
     fn set_distribution_operator_metadata(i: u32) -> Weight {
-        (443_529_000 as Weight)
-            .saturating_add((69_000 as Weight).saturating_mul(i as Weight))
+        (273_506_000 as Weight)
+            .saturating_add((176_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn storage_operator_remark(i: u32) -> Weight {
-        (271_675_000 as Weight)
-            .saturating_add((196_000 as Weight).saturating_mul(i as Weight))
+        (264_852_000 as Weight)
+            .saturating_add((240_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
     fn distribution_operator_remark(i: u32) -> Weight {
-        (293_456_000 as Weight)
-            .saturating_add((155_000 as Weight).saturating_mul(i as Weight))
+        (287_249_000 as Weight)
+            .saturating_add((153_000 as Weight).saturating_mul(i as Weight))
             .saturating_add(DbWeight::get().reads(2 as Weight))
     }
 }


### PR DESCRIPTION
- Closes #3698 

This solves the problem, the storage pallet has, 
We update a bag with a new object at T0 with a `DataObjectDeletionPrizeValue` (ex. 10)
At T1 we update `DataObjectDeletionPrizeValue` to 20
At T2 we delete the object created at T0
The deleting operation would withdraw 20 from the treasury, this behaviour can be used to steal funds.

This fix was a bit invasive, 
`ensure_sufficient_balance` has been changed to return all parts of the amounts to pay and receive 
```rust
        // check that user or treasury account have enough balance
        let (
            bag_deletion_prize_request,
            obj_deletion_prize_request,
            bag_deletion_prize_refund,
            obj_deletion_prize_refund,
            storage_fee,
        ) = Self::ensure_sufficient_balance(&bag_op, objects_to_update_voucher, &account_id)?;
```
This is used later to update `total_data_obj_deletion_prize_paid`, this variable has been added to the `Bag`
```rust
pub struct BagRecord<StorageBucketId: Ord, DistributionBucketId: Ord, Balance> {
    /// Associated storage buckets.
    pub stored_by: BTreeSet<StorageBucketId>,

    /// Associated distribution buckets.
    pub distributed_by: BTreeSet<DistributionBucketId>,

    /// Bag deletion prize (valid for dynamic bags).
    pub deletion_prize: Option<Balance>,

    /// Total object size for bag.
    pub objects_total_size: u64,

    /// Total object number for bag.
    pub objects_number: u64,

    /// Total amount of data object deletion prizes paid by members
    /// This amount decreases in case of refunds (delete operations)
    pub total_data_obj_deletion_prize_paid: Balance, <---------------------------------------
}
```
We use `total_data_obj_deletion_prize_paid` to delete the bag, instead of searching for all objects 
and sum all deletion_prizes, we just refund `total_data_obj_deletion_prize_paid` amount.
This variable is used also in the following functions, since we are decreasing objects from one bag and increasing the other.
 
```rust
fn move_data_objects(
        src_bag_id: BagId<T>,
        dest_bag_id: BagId<T>,
        objects: BTreeSet<T::DataObjectId>,
    ) -> DispatchResult;

fn change_storage_bucket_vouchers_for_bag(
        bag_id: &BagId<T>,
        bag: &Bag<T>,
        bag_change: &BagUpdate<T::Balance>,
        voucher_operation: OperationType,
    );
```


`compute_deletion_prizes` was splitted into two simpler functions 
```rust
    fn compute_obj_deletion_prize_request(num_obj_to_create: usize) -> BalanceOf<T> {
        let num_obj_to_create: BalanceOf<T> = num_obj_to_create.saturated_into();
        let obj_deletion_prize = Self::data_object_deletion_prize_value();

        num_obj_to_create.saturating_mul(obj_deletion_prize)
    }

    fn compute_obj_deletion_prize_refund(
        obj_to_delete: &BTreeMap<T::DataObjectId, BalanceOf<T>>,
    ) -> BalanceOf<T> {
        obj_to_delete
            .values()
            .cloned()
            .fold(Zero::zero(), |acc, val| acc.saturating_add(val))
    }
```
The deletion prizes were separated into different variables, to make it easier to calculate each situation.
Ex. When we transfer the funds, we calculate `bag_deletion_prize_request + obj_deletion_prize_request`
```rust
        let deletion_prize_request =
            bag_deletion_prize_request.saturating_add(obj_deletion_prize_request);
        if !deletion_prize_request.is_zero() {
            <StorageTreasury<T>>::deposit(&account_id, deletion_prize_request)?;
            //  slash: no-op if storage_fee = 0
            let _ = Balances::<T>::slash(&account_id, storage_fee);
        }
```

Later, we update `total_data_obj_deletion_prize_paid` by calculating
`total_data_obj_deletion_prize_paid + obj_deletion_prize_request - obj_deletion_prize_refund`
