### PR TITLE
Creator token revenue split pausing

### DIFF
--- a/runtime-modules/project-token/src/errors.rs
+++ b/runtime-modules/project-token/src/errors.rs
@@ -137,5 +137,8 @@ decl_error! {
         /// Attempt to issue in a split with zero allocation amount
         CannotIssueSplitWithZeroAllocationAmount,
 
+        /// Attempt to modify supply when revenue split is active
+        CannotModifySupplyWhenRevenueSplitsAreActive,
+
     }
 }

--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -726,6 +726,8 @@ impl<T: Trait>
     /// Preconditions:
     /// - token by `token_id` must exists
     /// - `member_id` x `token_id` account must exist
+    /// - `to_account` must be valid for `token_id`
+    /// - `token.revenue_split` has Inactive status
     ///
     /// Postconditions:
     /// - outstanding patronage credit for `token_id` transferred to `member_id` account

--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -735,7 +735,12 @@ impl<T: Trait>
     /// no-op if outstanding credit is zero
     fn claim_patronage_credit(token_id: T::TokenId, member_id: T::MemberId) -> DispatchResult {
         let token_info = Self::ensure_token_exists(token_id)?;
-        Self::ensure_account_data_exists(token_id, &member_id).map(|_| ())?;
+        ensure!(
+            matches!(token_info.revenue_split, RevenueSplitState::Inactive),
+            Error::<T>::CannotModifySupplyWhenRevenueSplitsAreActive,
+        );
+
+        Self::ensure_account_data_exists(token_id, &to_account).map(|_| ())?;
 
         let now = Self::current_block();
         let unclaimed_patronage = token_info.unclaimed_patronage_at_block(now);

--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -726,7 +726,6 @@ impl<T: Trait>
     /// Preconditions:
     /// - token by `token_id` must exists
     /// - `member_id` x `token_id` account must exist
-    /// - `to_account` must be valid for `token_id`
     /// - `token.revenue_split` has Inactive status
     ///
     /// Postconditions:
@@ -740,7 +739,7 @@ impl<T: Trait>
             Error::<T>::CannotModifySupplyWhenRevenueSplitsAreActive,
         );
 
-        Self::ensure_account_data_exists(token_id, &to_account).map(|_| ())?;
+        Self::ensure_account_data_exists(token_id, &member_id).map(|_| ())?;
 
         let now = Self::current_block();
         let unclaimed_patronage = token_info.unclaimed_patronage_at_block(now);

--- a/runtime-modules/project-token/src/tests/patronage.rs
+++ b/runtime-modules/project-token/src/tests/patronage.rs
@@ -275,7 +275,7 @@ fn decreasing_patronage_rate_fails_invalid_token() {
 }
 
 #[test]
-fn claim_patronage_fails_with_ongoing_revenue_split() {
+fn claim_patronage_fails_with_active_revenue_split() {
     let token_id = token!(1);
     let (owner_id, owner_account) = member!(1);
     let (rate, blocks) = (rate!(10), block!(MIN_REVENUE_SPLIT_TIME_TO_START - 1));


### PR DESCRIPTION
Addresses #3737 

##### Changes
Extrinsics that can corrupt supply:
- `claim_patronage_credit`

It's now not possible to call one of the above extrinsics when revenue split state for a token is `Active`. 
Technically it won't cause a problem to modify supply value even when a revenue split is active but the `current_block` value is not in `[split_starting_block, split_starting_block + duration)`. But I think the above decision is simpler
