### PR TITLE
Master fix member channel nft proceeds effectively credited

### DIFF
--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -1275,7 +1275,7 @@ decl_module! {
         ) -> DispatchResult {
             let channel = Self::ensure_channel_exists(&item.channel_id)?;
 
-            let reward_account = Self::ensure_reward_account(&channel)?;
+            let reward_account = Self::ensure_channel_has_beneficiary_account(&channel)?;
 
             ensure_actor_authorized_to_claim_payment::<T>(origin, &actor, &channel.owner)?;
 
@@ -1662,7 +1662,7 @@ decl_module! {
                     let royalty_payment = Self::build_royalty_payment(&video, nft.creator_royalty);
                     let updated_nft = Self::complete_auction(
                         nft,
-                        video.in_channel,
+                        &video,
                         royalty_payment,
                         participant_id,
                         buy_now_price,
@@ -1770,7 +1770,7 @@ decl_module! {
                     let royalty_payment = Self::build_royalty_payment(&video, nft.creator_royalty);
                     let updated_nft = Self::complete_auction(
                         nft,
-                        video.in_channel,
+                        &video,
                         royalty_payment,
                         participant_id,
                         buy_now_price,
@@ -1882,7 +1882,7 @@ decl_module! {
             let royalty_payment = Self::build_royalty_payment(&video, nft.creator_royalty);
             let updated_nft = Self::complete_auction(
                 nft,
-                video.in_channel,
+                &video,
                 royalty_payment,
                 top_bidder_id,
                 top_bid.amount
@@ -1935,7 +1935,7 @@ decl_module! {
             let royalty_payment = Self::build_royalty_payment(&video, nft.creator_royalty);
             let updated_nft = Self::complete_auction(
                 nft,
-                video.in_channel,
+                &video,
                 royalty_payment,
                 winner_id,
                 bid.amount,
@@ -2046,7 +2046,7 @@ decl_module! {
             Self::ensure_new_pending_offer_available_to_proceed(&nft, &receiver_account_id)?;
 
             // account_id where the nft offer price is deposited
-            let nft_owner_account = Self::ensure_nft_owner_account_id(video.in_channel, &nft).ok();
+            let nft_owner_account = Self::ensure_nft_owner_has_beneficiary_account(&video, &nft).ok();
             //
             // == MUTATION SAFE ==
             //
@@ -2122,7 +2122,7 @@ decl_module! {
             Self::ensure_can_buy_now(&nft, &participant_account_id, price_commit)?;
 
             // seller account
-            let old_nft_owner_account_id = Self::ensure_nft_owner_account_id(video.in_channel, &nft).ok();
+            let old_nft_owner_account_id = Self::ensure_nft_owner_has_beneficiary_account(&video, &nft).ok();
 
             //
             // == MUTATION SAFE ==
@@ -2428,7 +2428,7 @@ impl<T: Trait> Module<T> {
         Ok(())
     }
 
-    pub(crate) fn ensure_reward_account(
+    pub(crate) fn ensure_channel_has_beneficiary_account(
         channel: &Channel<T>,
     ) -> Result<T::AccountId, DispatchError> {
         if let Some(reward_account) = &channel.reward_account {

--- a/runtime-modules/content/src/lib.rs
+++ b/runtime-modules/content/src/lib.rs
@@ -2046,7 +2046,7 @@ decl_module! {
             Self::ensure_new_pending_offer_available_to_proceed(&nft, &receiver_account_id)?;
 
             // account_id where the nft offer price is deposited
-            let nft_owner_account = Self::ensure_owner_account_id(video.in_channel, &nft).ok();
+            let nft_owner_account = Self::ensure_nft_owner_account_id(video.in_channel, &nft).ok();
             //
             // == MUTATION SAFE ==
             //
@@ -2122,7 +2122,7 @@ decl_module! {
             Self::ensure_can_buy_now(&nft, &participant_account_id, price_commit)?;
 
             // seller account
-            let old_nft_owner_account_id = Self::ensure_owner_account_id(video.in_channel, &nft).ok();
+            let old_nft_owner_account_id = Self::ensure_nft_owner_account_id(video.in_channel, &nft).ok();
 
             //
             // == MUTATION SAFE ==

--- a/runtime-modules/content/src/nft/mod.rs
+++ b/runtime-modules/content/src/nft/mod.rs
@@ -416,7 +416,7 @@ impl<T: Trait> Module<T> {
     ) -> Result<EnglishAuction<T>, DispatchError> {
         if let TransactionalStatus::<T>::EnglishAuction(auction) = &nft.transactional_status {
             Ok(auction.to_owned())
-         } else {
+        } else {
             Err(Error::<T>::IsNotEnglishAuctionType.into())
         }
     }

--- a/runtime-modules/content/src/nft/mod.rs
+++ b/runtime-modules/content/src/nft/mod.rs
@@ -382,11 +382,13 @@ impl<T: Trait> Module<T> {
             .with_member_owner(winner_id)
     }
 
-    /// Channel reward account is
-    /// - Some -> use that as reward account
-    /// - None -> then if channel owner is:
-    ///   - Member -> use member controller account
-    ///   - CuratorGroup -> burn
+    /// NFT owned by:
+    /// - Member: member controller account is used
+    /// - Channel: then if reward account is:
+    ///    - `Some(acc)` -> use `acc` as reward account
+    ///    - `None` -> then if channel owner is:
+    ///      - `Member` -> use member controller account
+    ///      - `CuratorGroup` -> Error
     pub(crate) fn ensure_owner_account_id(
         channel_id: T::ChannelId,
         nft: &Nft<T>,

--- a/runtime-modules/content/src/nft/mod.rs
+++ b/runtime-modules/content/src/nft/mod.rs
@@ -470,20 +470,9 @@ impl<T: Trait> Module<T> {
         // payment is none if there is no royalty
         if let Some(royalty) = creator_royalty {
             let channel = Self::channel_by_id(&video.in_channel);
-            // use reward account if specified
-            if let Some(creator_reward_account) = channel.reward_account {
-                Some((royalty, creator_reward_account))
-            } else {
-                // otherwise resort to controller account for member owned channels
-                if let ChannelOwner::Member(member_id) = channel.owner {
-                    T::MemberAuthenticator::controller_account_id(member_id)
-                        .ok()
-                        .map(|reward_account| (royalty, reward_account))
-                } else {
-                    // no royalty paid for curator owned channel with unspecified reward account
-                    None
-                }
-            }
+            Self::ensure_reward_account(&channel)
+                .ok()
+                .map(|reward_acc| (royalty, reward_acc))
         } else {
             None
         }

--- a/runtime-modules/content/src/nft/mod.rs
+++ b/runtime-modules/content/src/nft/mod.rs
@@ -363,12 +363,12 @@ impl<T: Trait> Module<T> {
 
     pub(crate) fn complete_auction(
         nft: Nft<T>,
-        in_channel: T::ChannelId,
+        video: &Video<T>,
         royalty_payment: Option<(Royalty, T::AccountId)>,
         winner_id: T::MemberId,
         amount: BalanceOf<T>,
     ) -> Nft<T> {
-        let account_deposit_into = Self::ensure_nft_owner_account_id(in_channel, &nft).ok();
+        let account_deposit_into = Self::ensure_nft_owner_has_beneficiary_account(video, &nft).ok();
         let account_withdraw_from = ContentTreasury::<T>::module_account_id();
 
         Self::complete_payment(
@@ -389,15 +389,17 @@ impl<T: Trait> Module<T> {
     ///    - `None` -> then if channel owner is:
     ///      - `Member` -> use member controller account
     ///      - `CuratorGroup` -> Error
-    pub(crate) fn ensure_nft_owner_account_id(
-        channel_id: T::ChannelId,
+    /// In order to statically guarantee that `video.in_channel` exists, by leveraging the
+    /// Runtime invariant: `video` exists => `video.in_channel` exists
+    pub(crate) fn ensure_nft_owner_has_beneficiary_account(
+        video: &Video<T>,
         nft: &Nft<T>,
     ) -> Result<T::AccountId, DispatchError> {
         match nft.owner {
             NftOwner::Member(member_id) => T::MemberAuthenticator::controller_account_id(member_id),
             NftOwner::ChannelOwner => {
-                let channel = Self::ensure_channel_exists(&channel_id)?;
-                Self::ensure_reward_account(&channel)
+                let channel = Self::ensure_channel_exists(&video.in_channel)?;
+                Self::ensure_channel_has_beneficiary_account(&channel)
             }
         }
     }
@@ -470,7 +472,7 @@ impl<T: Trait> Module<T> {
         // payment is none if there is no royalty
         if let Some(royalty) = creator_royalty {
             let channel = Self::channel_by_id(&video.in_channel);
-            Self::ensure_reward_account(&channel)
+            Self::ensure_channel_has_beneficiary_account(&channel)
                 .ok()
                 .map(|reward_acc| (royalty, reward_acc))
         } else {

--- a/runtime-modules/content/src/nft/mod.rs
+++ b/runtime-modules/content/src/nft/mod.rs
@@ -398,7 +398,7 @@ impl<T: Trait> Module<T> {
         match nft.owner {
             NftOwner::Member(member_id) => T::MemberAuthenticator::controller_account_id(member_id),
             NftOwner::ChannelOwner => {
-                let channel = Self::ensure_channel_exists(&video.in_channel)?;
+                let channel = Self::channel_by_id(&video.in_channel);
                 Self::ensure_channel_has_beneficiary_account(&channel)
             }
         }
@@ -416,7 +416,7 @@ impl<T: Trait> Module<T> {
     ) -> Result<EnglishAuction<T>, DispatchError> {
         if let TransactionalStatus::<T>::EnglishAuction(auction) = &nft.transactional_status {
             Ok(auction.to_owned())
-        } else {
+         } else {
             Err(Error::<T>::IsNotEnglishAuctionType.into())
         }
     }

--- a/runtime-modules/content/src/tests/fixtures.rs
+++ b/runtime-modules/content/src/tests/fixtures.rs
@@ -1374,7 +1374,8 @@ impl ClaimChannelRewardFixture {
     pub fn call_and_assert(&self, expected_result: DispatchResult) {
         let origin = Origin::signed(self.sender.clone());
         let channel = Content::channel_by_id(self.item.channel_id);
-        let reward_account = Content::ensure_reward_account(&channel).unwrap_or_default();
+        let reward_account =
+            Content::ensure_channel_has_beneficiary_account(&channel).unwrap_or_default();
         let balance_pre = Balances::<Test>::usable_balance(&reward_account);
         let payout_earned_pre =
             Content::channel_by_id(self.item.channel_id).cumulative_payout_earned;

--- a/runtime-modules/content/src/tests/nft/accept_incoming_offer.rs
+++ b/runtime-modules/content/src/tests/nft/accept_incoming_offer.rs
@@ -181,7 +181,7 @@ fn accept_incoming_offer_no_incoming_offers() {
 }
 
 #[test]
-fn accept_incoming_offer_ok_with_reward_account_is_not_set_succeeds_with_member_owner_channel() {
+fn accept_incoming_offer_ok_with_reward_account_not_set_succeeds_with_member_owner_channel() {
     let video_id = 1u64;
     with_default_mock_builder(|| {
         // Run to block one to see emitted events

--- a/runtime-modules/content/src/tests/nft/buy_nft.rs
+++ b/runtime-modules/content/src/tests/nft/buy_nft.rs
@@ -578,6 +578,37 @@ pub fn proceeds_are_burned_if_nft_owned_by_curator_channel_with_no_reward_accoun
 }
 
 #[test]
+pub fn proceeds_are_correctly_credited_if_nft_owned_by_member_channel_with_no_reward_account_and_royalty_specified(
+) {
+    with_default_mock_builder(|| {
+        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, 100u64);
+        // channel with no reward account
+        CreateChannelFixture::default()
+            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
+            .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
+            .call();
+        CreateVideoFixture::default()
+            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
+            .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
+            .with_nft_in_sale(100u64)
+            .with_nft_royalty(1)
+            .call();
+
+        assert_ok!(Content::buy_nft(
+            Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
+            1u64,
+            SECOND_MEMBER_ID,
+            100u64,
+        ));
+
+        assert_eq!(
+            Balances::<Test>::usable_balance(DEFAULT_MEMBER_ACCOUNT_ID),
+            100u64 - (Content::platform_fee_percentage() * 100u64)
+        );
+    })
+}
+
+#[test]
 pub fn nft_channel_member_owner_is_correctly_credited_after_sale() {
     with_default_mock_builder(|| {
         increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, 100u64);

--- a/runtime-modules/content/src/tests/nft/buy_nft.rs
+++ b/runtime-modules/content/src/tests/nft/buy_nft.rs
@@ -463,28 +463,35 @@ fn buy_now_ok_with_nft_owner_member_credited_with_payment() {
 }
 
 #[test]
-fn buy_now_ok_with_nft_owner_member_owned_channel_credited_with_payment() {
+fn buy_now_ok_with_nft_owner_member_owned_channel_and_no_reward_account_credited_with_payment() {
     with_default_mock_builder(|| {
         // Run to block one to see emitted events
-        let starting_block = 1;
-        let video_id = Content::next_video_id();
-        run_to_block(starting_block);
-        setup_nft_on_sale_scenario();
-        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, DEFAULT_NFT_PRICE);
-        let platform_fee = Content::platform_fee_percentage().mul_floor(DEFAULT_NFT_PRICE);
-        let balance_pre = Balances::<Test>::usable_balance(DEFAULT_MEMBER_ACCOUNT_ID);
+        run_to_block(1u64);
 
+        let video_id = 1u64;
+        CreateChannelFixture::default()
+            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
+            .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
+            .call_and_assert(Ok(()));
+
+        CreateVideoFixture::default()
+            .with_sender(DEFAULT_MEMBER_ACCOUNT_ID)
+            .with_actor(ContentActor::Member(DEFAULT_MEMBER_ID))
+            .with_channel_id(1u64)
+            .with_nft_in_sale(100u64)
+            .call_and_assert(Ok(()));
+
+        increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, 100u64);
         assert_ok!(Content::buy_nft(
             Origin::signed(SECOND_MEMBER_ACCOUNT_ID),
             video_id,
             SECOND_MEMBER_ID,
-            DEFAULT_NFT_PRICE,
+            100u64,
         ));
 
         assert_eq!(
             Balances::<Test>::usable_balance(DEFAULT_MEMBER_ACCOUNT_ID),
-            // balance_pre - platform fee (since channel owner it retains royalty)
-            balance_pre + DEFAULT_NFT_PRICE - platform_fee,
+            100u64 - (Content::platform_fee_percentage() * 100u64),
         )
     })
 }
@@ -508,7 +515,6 @@ fn buy_now_ok_with_nft_owner_curator_group_owned_channel_and_non_set_account_and
         CreateVideoFixture::default()
             .with_sender(DEFAULT_CURATOR_ACCOUNT_ID)
             .with_actor(ContentActor::Curator(group_id, DEFAULT_CURATOR_ID))
-            .with_channel_id(NextChannelId::<Test>::get() - 1)
             .call_and_assert(Ok(()));
 
         assert_ok!(Content::issue_nft(
@@ -609,7 +615,7 @@ pub fn proceeds_are_correctly_credited_if_nft_owned_by_member_channel_with_no_re
 }
 
 #[test]
-pub fn nft_channel_member_owner_is_correctly_credited_after_sale() {
+pub fn nft_channel_member_owner_with_reward_account_set_is_correctly_credited_after_sale() {
     with_default_mock_builder(|| {
         increase_account_balance_helper(SECOND_MEMBER_ACCOUNT_ID, 100u64);
         CreateChannelFixture::default()


### PR DESCRIPTION
fixes #3762

No code has been lost, it is just that changes in https://github.com/Joystream/joystream/issues/3650 have never been implemented. Royalty payment was working correctly however

##### Changes
1. there is a test to check the above violation (NFT owned by channel, channel owned by member, and reward account not set) for each of the possible nft revenue event:
- Auction, both english and open use the same` complete_auction` internal logic hence they can be treated as equal in this respect
- Buy Now 
- Accept NFT Offer
2. `ensure_owner_account_id` has been renamed to `ensure_nft_owner_account_id` and internally uses `ensure_reward_account`, effectively implementing the business logic desired: https://github.com/Joystream/joystream/issues/3650
3. same thing as `build_royalty_payment` which worked correctly already, I just refactored it by reusing the `ensure_reward_account` method 
