### PR TITLE
Creator tokens: Burning

### DIFF
--- a/runtime-modules/project-token/src/errors.rs
+++ b/runtime-modules/project-token/src/errors.rs
@@ -140,5 +140,12 @@ decl_error! {
         /// Attempt to modify supply when revenue split is active
         CannotModifySupplyWhenRevenueSplitsAreActive,
 
+        // ------ Burning ------------------------------------------------------
+
+        /// Provided amount to burn is == 0
+        BurnAmountIsZero,
+
+        /// Amount of tokens to burn exceeds total amount of tokens owned by the account
+        BurnAmountGreaterThanAccountTokensAmount,
     }
 }

--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -203,6 +203,74 @@ decl_module! {
             Ok(())
         }
 
+        /// Burn tokens from specified account
+        ///
+        /// Preconditions:
+        /// - `amount` is > 0
+        /// - origin signer is a controller account of `member_id` member
+        /// - token by `token_id` exists
+        /// - an account exists for `token_id` x `member_id`
+        /// - account's tokens amount is >= `amount`
+        /// - token supply can be modified (there is no active revenue split)
+        ///
+        /// Postconditions:
+        /// - starting with `unprocessed` beeing equal to `amount`, account's vesting schedules
+        ///   are iterated over and updated:
+        ///   - if a vesting scheduled has `vs.locked(current_block)` <= `unprocessed`:
+        ///     - `unprocessed` is set to `unprocessed - vs.locked(current_block)`
+        ///     - the vesting schedule is removed
+        ///   - if a vesting schedule has `vs.locked(current_block)` > `unprocessed`:
+        ///     - `unprocessed` is set to `0`
+        ///     - vesting schedule's `burned_amount` is updated to `vs.burned_amount + unprocessed`
+        /// - if the account has any `split_staking_status`, the `split_staking_status.amount`
+        ///   is reduced by `min(amount, split_staking_status.amount)`
+        /// - `account.amount` is reduced by `amount`
+        /// - token supply is reduced by `amount`
+        #[weight = 10_000_000] // TODO: adjust weight
+        pub fn burn(origin, token_id: T::TokenId, member_id: T::MemberId, amount: TokenBalanceOf<T>) -> DispatchResult {
+            // Ensure burn amount is non-zero
+            ensure!(
+                !amount.is_zero(),
+                Error::<T>::BurnAmountIsZero
+            );
+
+            // Ensure sender is member's controller account
+            T::MemberOriginValidator::ensure_member_controller_account_origin(
+                origin,
+                member_id
+            )?;
+
+            // Ensure token exists
+            let token_info = Self::ensure_token_exists(token_id)?;
+
+            // Ensure token account data exists by `token_id` x `member_id`
+            let account_info = Self::ensure_account_data_exists(token_id, &member_id)?;
+
+            // Ensure burn amount doesn't exceed account's tokens amount
+            ensure!(
+                account_info.amount >= amount,
+                Error::<T>::BurnAmountGreaterThanAccountTokensAmount
+            );
+
+            // Ensure token supply can be modified
+            token_info.ensure_can_modify_supply::<T>()?;
+
+            // == MUTATION SAFE ==
+            let now = Self::current_block();
+
+            // Burn tokens from the account
+            AccountInfoByTokenAndMember::<T>::mutate(token_id, member_id, |account| {
+                account.burn::<T>(amount, now);
+            });
+
+            // Decrease token supply by the burned amount
+            TokenInfoById::<T>::mutate(token_id, |token| {
+                token.decrease_supply_by(amount);
+            });
+
+            Ok(())
+        }
+
         /// Allow any user to remove an account
         ///
         /// Preconditions:
@@ -734,10 +802,7 @@ impl<T: Trait>
     /// no-op if outstanding credit is zero
     fn claim_patronage_credit(token_id: T::TokenId, member_id: T::MemberId) -> DispatchResult {
         let token_info = Self::ensure_token_exists(token_id)?;
-        ensure!(
-            matches!(token_info.revenue_split, RevenueSplitState::Inactive),
-            Error::<T>::CannotModifySupplyWhenRevenueSplitsAreActive,
-        );
+        token_info.ensure_can_modify_supply::<T>()?;
 
         Self::ensure_account_data_exists(token_id, &member_id).map(|_| ())?;
 

--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -215,13 +215,12 @@ decl_module! {
         ///
         /// Postconditions:
         /// - starting with `unprocessed` beeing equal to `amount`, account's vesting schedules
-        ///   are iterated over and updated:
-        ///   - if a vesting scheduled has `vs.locked(current_block)` <= `unprocessed`:
-        ///     - `unprocessed` is set to `unprocessed - vs.locked(current_block)`
-        ///     - the vesting schedule is removed
-        ///   - if a vesting schedule has `vs.locked(current_block)` > `unprocessed`:
-        ///     - `unprocessed` is set to `0`
-        ///     - vesting schedule's `burned_amount` is updated to `vs.burned_amount + unprocessed`
+        ///   are iterated over and:
+        ///   - updated with `burned_amount += uprocessed` if vesting schedule's unvested amount is
+        ///     greater than `uprocessed`
+        ///   - removed otherwise
+        ///   (after each iteration `unprocessed` is reduced by the amount of unvested tokens
+        ///   burned during that iteration)
         /// - if the account has any `split_staking_status`, the `split_staking_status.amount`
         ///   is reduced by `min(amount, split_staking_status.amount)`
         /// - `account.amount` is reduced by `amount`

--- a/runtime-modules/project-token/src/tests/canonical.rs
+++ b/runtime-modules/project-token/src/tests/canonical.rs
@@ -1404,7 +1404,7 @@ fn burn_ok_with_vesting_schedule_partially_burned_twice() {
 }
 
 #[test]
-fn burn_ok_with_partially_burned_vesting_schedule_working_as_expected() {
+fn burn_ok_with_partially_burned_vesting_schedule_amounts_working_as_expected() {
     let vesting_schedule = default_vesting_schedule();
     let vesting_schedule_end_block =
         vesting_schedule.linear_vesting_start_block + vesting_schedule.linear_vesting_duration;

--- a/runtime-modules/project-token/src/tests/fixtures.rs
+++ b/runtime-modules/project-token/src/tests/fixtures.rs
@@ -537,7 +537,8 @@ impl Fixture<PurchaseTokensOnSaleFixtureStateSnapshot> for PurchaseTokensOnSaleF
                         .as_ref()
                         .map_or(0, |vs| vs.post_cliff_total_amount)
                         .saturating_add(vesting_schedule.post_cliff_total_amount),
-                    linear_vesting_start_block: vesting_schedule.linear_vesting_start_block
+                    linear_vesting_start_block: vesting_schedule.linear_vesting_start_block,
+                    burned_amount: 0
                 }
             );
             // buyer's transferrable balance is unchanged

--- a/runtime-modules/project-token/src/tests/transfer.rs
+++ b/runtime-modules/project-token/src/tests/transfer.rs
@@ -2,7 +2,7 @@
 use frame_support::{assert_noop, assert_ok};
 
 use crate::tests::mock::*;
-use crate::tests::test_utils::TokenDataBuilder;
+use crate::tests::test_utils::{default_vesting_schedule, TokenDataBuilder};
 use crate::traits::PalletToken;
 use crate::types::{TransferPolicyOf, Transfers, Validated, VestingSource};
 use crate::Trait;
@@ -1094,7 +1094,10 @@ fn issuer_permissioned_token_transfer_fails_with_dst_vesting_schedules_limit_exc
 
     let config = GenesisConfigBuilder::new_empty()
         .with_token_and_owner(token_id, token_data, src_member_id, amount)
-        .with_account(dst, AccountData::new_with_max_vesting_schedules())
+        .with_account(
+            dst,
+            AccountData::default().with_max_vesting_schedules(default_vesting_schedule()),
+        )
         .build();
 
     build_test_externalities(config).execute_with(|| {


### PR DESCRIPTION
Addresses https://github.com/Joystream/joystream/issues/3640

Burning priority:
- Unvested and staked tokens are burned first
- Transferrable tokens are burned only if no unvested / staked tokens remain

This is achieved by introducing `burned_amount` property to `vesting_schedule`. `vesting_schedule.locks(b)` is equal to `max(0, unvested_amount (according to original schedule) - burned_amount)`. Multiple test cases have been added to ilustrate this and make sure everything works as expected.

When burning funds, all vesting schedules that either already were or just became stale (ended up with `locks(current_block) == 0`) are removed.

It is possible to immediately `dust_account` once all funds are burned, even if some of those funds were still locked in a vesting schedule before (unvested). If some tokens were staked, they need to be unstaked first however (even though the staked amount is now `0`), this is to prevent `burn` extrinsic from directly affecting the `staking_status` of an account (since this is a more risky ingerention than just changing the staked `amount` to `0`)