### PR TITLE
Fix Vote Stake Unlocking

### DIFF
--- a/runtime-modules/council/src/lib.rs
+++ b/runtime-modules/council/src/lib.rs
@@ -1184,7 +1184,7 @@ impl<T: Trait> ReferendumConnection<T> for Module<T> {
     fn can_unlock_vote_stake(vote: &CastVoteOf<T>) -> Result<(), Error<T>> {
         let current_voting_cycle_id = AnnouncementPeriodNr::get();
 
-        // If the vote is for an election prior to the last concluded..
+        // If the vote was cast before the latest Announcing stage...
         if vote.cycle_id != current_voting_cycle_id {
             // ..it is always recoverable.
             return Ok(());

--- a/runtime-modules/council/src/tests.rs
+++ b/runtime-modules/council/src/tests.rs
@@ -171,7 +171,12 @@ fn council_vote_for_winner_stakes_longer() {
         let council_settings = CouncilSettings::<Runtime>::extract_settings();
 
         // run first election round
-        let params = Mocks::run_full_council_cycle(0, &[], 0);
+        let params = Mocks::run_council_cycle_with_interrupt(
+            0,
+            &[],
+            0,
+            Some(CouncilCycleInterrupt::AfterElectionComplete),
+        );
         let second_round_user_offset = 100; // some number higher than the number of voters
 
         let voter_for_winner = params.voters[0].clone();


### PR DESCRIPTION
Fix for https://github.com/Joystream/joystream/issues/3559

- Fix implementation of `council::can_unlock_vote_stake()` to match the rules described in the handbook
- Adjust run_full_council_cycle to support interrupt to allow testing vote unlocks during council idle stage