### PR TITLE
Remove cyclic dependency between `membership` and `working_group` pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3947,7 +3947,6 @@ dependencies = [
  "pallet-common",
  "pallet-staking-handler",
  "pallet-timestamp",
- "pallet-working-group",
  "parity-scale-codec",
  "serde",
  "sp-arithmetic",

--- a/runtime-modules/membership/Cargo.toml
+++ b/runtime-modules/membership/Cargo.toml
@@ -23,7 +23,6 @@ frame-benchmarking = { package = 'frame-benchmarking', default-features = false,
 [dev-dependencies]
 sp-io = { package = 'sp-io', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62'}
 sp-core = { package = 'sp-core', default-features = false, git = 'https://github.com/paritytech/substrate.git', rev = '2cd20966cc09b059817c3ebe12fc130cdd850d62'}
-working-group = { package = 'pallet-working-group', default-features = false, path = '../working-group'}
 
 [features]
 default = ['std']

--- a/runtime-modules/membership/src/tests/mock.rs
+++ b/runtime-modules/membership/src/tests/mock.rs
@@ -17,8 +17,6 @@ use sp_runtime::{
     DispatchError, DispatchResult, Perbill,
 };
 
-pub(crate) type MembershipWorkingGroupInstance = working_group::Instance4;
-
 impl_outer_origin! {
     pub enum Origin for Test {}
 }
@@ -32,7 +30,6 @@ impl_outer_event! {
         membership_mod<T>,
         frame_system<T>,
         balances<T>,
-        working_group Instance4 <T>,
     }
 }
 
@@ -115,19 +112,6 @@ parameter_types! {
     pub const LeaderOpeningStake: u32 = 20;
 }
 
-impl working_group::Trait<MembershipWorkingGroupInstance> for Test {
-    type Event = TestEvent;
-    type MaxWorkerNumberLimit = MaxWorkerNumberLimit;
-    type StakingHandler = staking_handler::StakingManager<Self, LockId>;
-    type StakingAccountValidator = Membership;
-    type MemberOriginValidator = ();
-    type MinUnstakingPeriodLimit = ();
-    type RewardPeriod = ();
-    type WeightInfo = Weights;
-    type MinimumApplicationStake = MinimumApplicationStake;
-    type LeaderOpeningStake = LeaderOpeningStake;
-}
-
 impl LockComparator<u64> for Test {
     fn are_locks_conflicting(new_lock: &LockIdentifier, existing_locks: &[LockIdentifier]) -> bool {
         if *new_lock == InvitedMemberLockId::get() {
@@ -137,163 +121,6 @@ impl LockComparator<u64> for Test {
         }
     }
 }
-
-// Weights info stub
-pub struct Weights;
-impl working_group::WeightInfo for Weights {
-    fn on_initialize_leaving(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn on_initialize_rewarding_with_missing_reward(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn on_initialize_rewarding_with_missing_reward_cant_pay(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn on_initialize_rewarding_without_missing_reward(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn apply_on_opening(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn fill_opening_lead() -> u64 {
-        unimplemented!()
-    }
-
-    fn fill_opening_worker(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn update_role_account() -> u64 {
-        unimplemented!()
-    }
-
-    fn cancel_opening() -> u64 {
-        unimplemented!()
-    }
-
-    fn withdraw_application() -> u64 {
-        unimplemented!()
-    }
-
-    fn slash_stake(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn terminate_role_worker(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn terminate_role_lead(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn increase_stake() -> u64 {
-        unimplemented!()
-    }
-
-    fn decrease_stake() -> u64 {
-        unimplemented!()
-    }
-
-    fn spend_from_budget() -> u64 {
-        unimplemented!()
-    }
-
-    fn update_reward_amount() -> u64 {
-        unimplemented!()
-    }
-
-    fn set_status_text(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn update_reward_account() -> u64 {
-        unimplemented!()
-    }
-
-    fn set_budget() -> u64 {
-        unimplemented!()
-    }
-
-    fn add_opening(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn leave_role(_: u32) -> u64 {
-        unimplemented!()
-    }
-
-    fn lead_remark() -> Weight {
-        unimplemented!()
-    }
-
-    fn worker_remark() -> Weight {
-        unimplemented!()
-    }
-}
-
-// impl WeightInfo for () {
-//     fn buy_membership_without_referrer(_: u32, _: u32) -> Weight {
-//         0
-//     }
-//     fn buy_membership_with_referrer(_: u32, _: u32) -> Weight {
-//         0
-//     }
-//     fn update_profile(_: u32) -> Weight {
-//         0
-//     }
-//     fn update_accounts_none() -> Weight {
-//         0
-//     }
-//     fn update_accounts_root() -> Weight {
-//         0
-//     }
-//     fn update_accounts_controller() -> Weight {
-//         0
-//     }
-//     fn update_accounts_both() -> Weight {
-//         0
-//     }
-//     fn set_referral_cut() -> Weight {
-//         0
-//     }
-//     fn transfer_invites() -> Weight {
-//         0
-//     }
-//     fn invite_member(_: u32, _: u32) -> Weight {
-//         0
-//     }
-//     fn set_membership_price() -> Weight {
-//         0
-//     }
-//     fn update_profile_verification() -> Weight {
-//         0
-//     }
-//     fn set_leader_invitation_quota() -> Weight {
-//         0
-//     }
-//     fn set_initial_invitation_balance() -> Weight {
-//         0
-//     }
-//     fn set_initial_invitation_count() -> Weight {
-//         0
-//     }
-//     fn add_staking_account_candidate() -> Weight {
-//         0
-//     }
-//     fn confirm_staking_account() -> Weight {
-//         0
-//     }
-//     fn remove_staking_account() -> Weight {
-//         0
-//     }
-// }
 
 impl common::membership::MemberOriginValidator<Origin, u64, u64> for () {
     fn ensure_member_controller_account_origin(
@@ -354,7 +181,7 @@ impl common::working_group::WorkingGroupAuthenticator<Test> for () {
             if *worker_id == 1 || *worker_id == 0 {
                 Ok(())
             } else {
-                Err(working_group::Error::<Test, MembershipWorkingGroupInstance>::WorkerDoesNotExist.into())
+                Err(DispatchError::Other("worker does not exist"))
             }
         } else {
             Err(DispatchError::BadOrigin)

--- a/runtime-modules/membership/src/tests/mod.rs
+++ b/runtime-modules/membership/src/tests/mod.rs
@@ -264,11 +264,7 @@ fn update_verification_status_fails_with_invalid_worker_id() {
         UpdateMembershipVerificationFixture::default()
             .with_member_id(next_member_id)
             .with_worker_id(invalid_worker_id)
-            .call_and_assert(Err(working_group::Error::<
-                Test,
-                MembershipWorkingGroupInstance,
-            >::WorkerDoesNotExist
-                .into()));
+            .call_and_assert(Err(DispatchError::Other("worker does not exist")));
     });
 }
 


### PR DESCRIPTION
Fixes `rust-analyzer` errors:
```
[ERROR project_model::workspace] cyclic deps: pallet_working_group(CrateId(366)) -> pallet_membership(CrateId(345)), alternative path: pallet_membership(CrateId(345)) -> pallet_working_group(CrateId(366))
[ERROR project_model::workspace] cyclic deps: pallet_working_group(CrateId(366)) -> pallet_membership(CrateId(345)), alternative path: pallet_membership(CrateId(345)) -> pallet_working_group(CrateId(366))
```