### PR TITLE
Fix referendum winners calculation

### DIFF
--- a/runtime-modules/referendum/src/lib.rs
+++ b/runtime-modules/referendum/src/lib.rs
@@ -734,9 +734,10 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
     ) {
         // prepare new values
         let vote_power = T::calculate_vote_power(&account_id, &cast_vote.stake);
+        let total_vote_power = T::get_option_power(option_id) + vote_power;
         let option_result = OptionResult {
             option_id: *option_id,
-            vote_power,
+            vote_power: total_vote_power,
         };
         // try to insert option to winner list or update it's value when already present
         let new_winners = Self::try_winner_insert(
@@ -803,13 +804,7 @@ impl<T: Trait<I>, I: Instance> Mutations<T, I> {
 
             // update record in list when it is already present
             if let Some(index) = current_winners_index_of_vote_recipient {
-                let old_option_total = T::get_option_power(&option_result.option_id);
-                let new_option_total = old_option_total + option_result.vote_power;
-
-                new_winners[index] = OptionResult {
-                    option_id: option_result.option_id,
-                    vote_power: new_option_total,
-                };
+                new_winners[index] = option_result;
 
                 return (new_winners, Some(index));
             }

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -720,6 +720,18 @@ impl InstanceMocks<Runtime, DefaultInstance> {
         >,
         expected_referendum_result: BTreeMap<u64, <Runtime as Trait>::VotePower>,
     ) {
+        Self::check_revealing_finished_winners(expected_winners);
+        Self::check_revealing_finished_referendum_results(expected_referendum_result);
+    }
+
+    pub fn check_revealing_finished_winners(
+        expected_winners: Vec<
+            OptionResult<
+                <Runtime as common::membership::MembershipTypes>::MemberId,
+                <Runtime as Trait>::VotePower,
+            >,
+        >,
+    ) {
         assert_eq!(
             Stage::<Runtime, DefaultInstance>::get(),
             ReferendumStage::Inactive,
@@ -732,6 +744,15 @@ impl InstanceMocks<Runtime, DefaultInstance> {
                 .unwrap()
                 .event,
             TestEvent::event_mod_DefaultInstance(RawEvent::ReferendumFinished(expected_winners,))
+        );
+    }
+
+    pub fn check_revealing_finished_referendum_results(
+        expected_referendum_result: BTreeMap<u64, <Runtime as Trait>::VotePower>,
+    ) {
+        assert_eq!(
+            Stage::<Runtime, DefaultInstance>::get(),
+            ReferendumStage::Inactive,
         );
 
         INTERMEDIATE_RESULTS.with(|value| assert_eq!(*value.borrow(), expected_referendum_result,));

--- a/runtime-modules/referendum/src/mock.rs
+++ b/runtime-modules/referendum/src/mock.rs
@@ -38,6 +38,8 @@ pub const USER_REGULAR: u64 = 2;
 pub const USER_REGULAR_POWER_VOTES: u64 = 3;
 pub const USER_REGULAR_2: u64 = 4;
 pub const USER_REGULAR_3: u64 = 5;
+pub const USER_REGULAR_4: u64 = 6;
+pub const USER_REGULAR_5: u64 = 7;
 
 pub const POWER_VOTE_STRENGTH: u64 = 10;
 
@@ -450,6 +452,8 @@ pub fn build_test_externalities(
         topup_account(USER_REGULAR, amount);
         topup_account(USER_REGULAR_2, amount);
         topup_account(USER_REGULAR_3, amount);
+        topup_account(USER_REGULAR_4, amount);
+        topup_account(USER_REGULAR_5, amount);
         topup_account(USER_REGULAR_POWER_VOTES, amount);
 
         InstanceMockUtils::<Runtime, DefaultInstance>::increase_block_number(1)

--- a/runtime-modules/referendum/src/tests.rs
+++ b/runtime-modules/referendum/src/tests.rs
@@ -897,7 +897,7 @@ fn correct_candidates_make_it_into_winners_list() {
             salt2,
             option_to_vote_for2,
             Ok(()),
-        ); // at this time, the size of current_winners is 2, equal to winning_target_count, so revelaling smaller votes don't help the user3 to crowd out user2
+        );
 
         Mocks::reveal_vote(
             origin_voter3.clone(),

--- a/runtime-modules/referendum/src/tests.rs
+++ b/runtime-modules/referendum/src/tests.rs
@@ -795,9 +795,8 @@ fn winners_multiple_winners() {
     });
 }
 
-/// Test that illustrates that once the number of current_winners reaches winning_target_count, it becomes problematic for rivals to crowd out the top candidates
 #[test]
-fn full_list_of_intermediate_winners_problem() {
+fn correct_candidates_make_it_into_winners_list() {
     let config = default_genesis_config();
 
     build_test_externalities(config).execute_with(|| {
@@ -844,7 +843,7 @@ fn full_list_of_intermediate_winners_problem() {
             origin_voter1.clone(),
             account_id1,
             commitment1,
-            stake + 100,
+            (stake * 3) + 1,
             cycle_id.clone(),
             Ok(()),
         );
@@ -852,7 +851,7 @@ fn full_list_of_intermediate_winners_problem() {
             origin_voter2.clone(),
             account_id2,
             commitment2,
-            stake + 50,
+            stake * 2,
             cycle_id.clone(),
             Ok(()),
         );
@@ -860,7 +859,7 @@ fn full_list_of_intermediate_winners_problem() {
             origin_voter3.clone(),
             account_id3,
             commitment3,
-            stake + 30,
+            stake,
             cycle_id.clone(),
             Ok(()),
         );
@@ -868,7 +867,7 @@ fn full_list_of_intermediate_winners_problem() {
             origin_voter4.clone(),
             account_id4,
             commitment4,
-            stake + 30,
+            stake,
             cycle_id.clone(),
             Ok(()),
         );
@@ -876,7 +875,7 @@ fn full_list_of_intermediate_winners_problem() {
             origin_voter5.clone(),
             account_id5,
             commitment5,
-            stake + 30,
+            stake,
             cycle_id.clone(),
             Ok(()),
         );
@@ -923,18 +922,166 @@ fn full_list_of_intermediate_winners_problem() {
         );
         MockUtils::increase_block_number(reveal_stage_duration);
 
-        Mocks::check_revealing_finished(
+        // Check vote tallying was correct
+        Mocks::check_revealing_finished_referendum_results(
+            // total vote power stored by the client module, ordered by option id
+            MockUtils::transform_results(vec![(3 * stake) + 1, 2 * stake, 3 * stake]),
+        );
+
+        // Check selected winners is correct
+        Mocks::check_revealing_finished_winners(
+            // referendum winners ordered by highest to lowest total vote power
             vec![
                 OptionResult {
                     option_id: option_to_vote_for1,
-                    vote_power: stake + 100,
+                    vote_power: (3 * stake) + 1,
                 },
                 OptionResult {
                     option_id: option_to_vote_for3,
-                    vote_power: stake + 90,
+                    vote_power: 3 * stake,
                 },
             ],
-            MockUtils::transform_results(vec![100 + stake, 90 + stake, 0]),
+        );
+    });
+}
+
+#[test]
+fn correct_orderding_of_winners() {
+    let config = default_genesis_config();
+
+    build_test_externalities(config).execute_with(|| {
+        let voting_stage_duration = <Runtime as Trait>::VoteStageDuration::get();
+        let reveal_stage_duration = <Runtime as Trait>::RevealStageDuration::get();
+        let account_superuser = USER_ADMIN;
+        let account_id1 = USER_REGULAR;
+        let account_id2 = USER_REGULAR_2;
+        let account_id3 = USER_REGULAR_3;
+        let account_id4 = USER_REGULAR_4;
+
+        let origin = OriginType::Signed(account_superuser);
+        let origin_voter1 = OriginType::Signed(account_id1);
+        let origin_voter2 = OriginType::Signed(account_id2);
+        let origin_voter3 = OriginType::Signed(account_id3);
+        let origin_voter4 = OriginType::Signed(account_id4);
+
+        let cycle_id = 1;
+        let winning_target_count = 4;
+
+        let option_to_vote_for1 = 0;
+        let option_to_vote_for2 = 1;
+        let option_to_vote_for3 = 2;
+        let option_to_vote_for4 = 3;
+        let stake = <Runtime as Trait>::MinimumStake::get();
+        let (commitment1, salt1) =
+            MockUtils::calculate_commitment(&account_id1, &option_to_vote_for1, &cycle_id);
+        let (commitment2, salt2) =
+            MockUtils::calculate_commitment(&account_id2, &option_to_vote_for2, &cycle_id);
+        let (commitment3, salt3) =
+            MockUtils::calculate_commitment(&account_id3, &option_to_vote_for3, &cycle_id);
+        let (commitment4, salt4) =
+            MockUtils::calculate_commitment(&account_id4, &option_to_vote_for4, &cycle_id);
+
+        Mocks::start_referendum_extrinsic(
+            origin.clone(),
+            winning_target_count.clone(),
+            cycle_id,
+            Ok(()),
+        );
+        Mocks::vote(
+            origin_voter1.clone(),
+            account_id1,
+            commitment1,
+            stake,
+            cycle_id.clone(),
+            Ok(()),
+        );
+        Mocks::vote(
+            origin_voter2.clone(),
+            account_id2,
+            commitment2,
+            stake * 2,
+            cycle_id.clone(),
+            Ok(()),
+        );
+        Mocks::vote(
+            origin_voter3.clone(),
+            account_id3,
+            commitment3,
+            stake * 3,
+            cycle_id.clone(),
+            Ok(()),
+        );
+        Mocks::vote(
+            origin_voter4.clone(),
+            account_id4,
+            commitment4,
+            stake * 4,
+            cycle_id.clone(),
+            Ok(()),
+        );
+        // voting period starts at block 1
+        MockUtils::move_to_block(voting_stage_duration + 1);
+
+        Mocks::check_voting_finished(winning_target_count, cycle_id);
+
+        Mocks::reveal_vote(
+            origin_voter1.clone(),
+            account_id1,
+            salt1,
+            option_to_vote_for1,
+            Ok(()),
+        );
+        Mocks::reveal_vote(
+            origin_voter2.clone(),
+            account_id2,
+            salt2,
+            option_to_vote_for2,
+            Ok(()),
+        );
+        Mocks::reveal_vote(
+            origin_voter3.clone(),
+            account_id3,
+            salt3,
+            option_to_vote_for3,
+            Ok(()),
+        );
+        Mocks::reveal_vote(
+            origin_voter4.clone(),
+            account_id4,
+            salt4,
+            option_to_vote_for4,
+            Ok(()),
+        );
+
+        MockUtils::increase_block_number(reveal_stage_duration);
+
+        // Check vote tallying was correct
+        Mocks::check_revealing_finished_referendum_results(
+            // total vote power stored by the client module, ordered by option id
+            MockUtils::transform_results(vec![stake, 2 * stake, 3 * stake, 4 * stake]),
+        );
+
+        // Check selected winners is correct and proper order
+        Mocks::check_revealing_finished_winners(
+            // referendum winners ordered by highest to lowest total vote power
+            vec![
+                OptionResult {
+                    option_id: option_to_vote_for4,
+                    vote_power: 4 * stake,
+                },
+                OptionResult {
+                    option_id: option_to_vote_for3,
+                    vote_power: 3 * stake,
+                },
+                OptionResult {
+                    option_id: option_to_vote_for2,
+                    vote_power: 2 * stake,
+                },
+                OptionResult {
+                    option_id: option_to_vote_for1,
+                    vote_power: stake,
+                },
+            ],
         );
     });
 }


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/3530
- [x] Add test case - ported from https://github.com/Joystream/joystream/pull/3536
- [x] Add test case to check sorting of winners
- [x] Implement Fix

Test Failure before fix: https://github.com/Joystream/joystream/runs/6608269577?check_suite_focus=true#step:9:3088
