### PR TITLE
QN Update election round on successful council election

### DIFF
--- a/query-node/mappings/src/council.ts
+++ b/query-node/mappings/src/council.ts
@@ -497,8 +497,8 @@ export async function council_NewCouncilElected({ event, store }: EventContext &
     electedAtBlock: event.blockNumber,
     electedAtTime: new Date(event.blockTimestamp),
     electedAtNetwork: CURRENT_NETWORK,
-    councilElections: oldElectedCouncil?.nextCouncilElections || [], // always empty ?
-    nextCouncilElections: [], // always empty ?
+    councilElections: [],
+    nextCouncilElections: [],
     isResigned: false,
   })
 

--- a/query-node/mappings/src/council.ts
+++ b/query-node/mappings/src/council.ts
@@ -341,8 +341,9 @@ export async function council_AnnouncingPeriodStarted({ event, store }: EventCon
 
   // specific event processing
 
+  // Get last cycleId
+  const { cycleId } = await getCurrentElectionRound(store)
   // restart elections
-  const { cycleId } = await concludeElectionRound(store, event)
   await startNextElectionRound(store, event, cycleId + 1)
 }
 


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/3573 and https://github.com/Joystream/joystream/issues/3727

For testing I ran a specific scenario with testing runtime profile:

```ts
import electCouncil from '../flows/council/elect'
import { scenario } from '../Scenario'

scenario('Council', async ({ job }) => {
  const firstCouncilJob = job('electing council', electCouncil)
  const secondCouncilJob = job('electing second council', electCouncil).requires(firstCouncilJob)
}
```

At the end of the scenario (immediately) ran query:

```graphql
query {
  electionRounds (orderBy: [createdAt_DESC] limit: 3) {
    cycleId
    isFinished
    electedCouncil { id isResigned }
    nextElectedCouncil{ id }
  }
  electedCouncils (orderBy: [createdAt_DESC] limit: 3) {
    id
    councilElections { cycleId }
  }
}
```

and got expected results:
```json
{
  "data": {
    "electionRounds": [
      {
        "cycleId": 13,
        "isFinished": true, // <--
        "electedCouncil": {
          "id": "00000001", // prior elected council, that was active during this election cycle 13
          "isResigned": true
        },
        "nextElectedCouncil": {
          "id": "00000002" // the second council that was elected in this cycle 13
        }
      },
      {
        "cycleId": 12,
        "isFinished": true,
        "electedCouncil": {
          "id": "00000000",
          "isResigned": true
        },
        "nextElectedCouncil": {
          "id": "00000001" // council elected in cycle 12
        }
      },
      {
        "cycleId": 11,
        "isFinished": true,
        "electedCouncil": {
          "id": "00000000",
          "isResigned": true
        },
        "nextElectedCouncil": null
      }
    ],
    "electedCouncils": [
      {
        "id": "00000002",
        "councilElections": [
          {
            "cycleId": 13
          }
        ]
      },
      {
        "id": "00000001",
        "councilElections": [
          {
            "cycleId": 12
          }
        ]
      },
      {
        "id": "00000000",
        "councilElections": []
      }
    ]
  }
}
```