### PR TITLE
use production runtime in runtime upgrade test

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -57,9 +57,8 @@ jobs:
         run: |
           if ! [ -f joystream-node-docker-image.tar.gz ]; then
             docker build .\
-              --file joystream-node.Dockerfile\
-              --tag joystream/node\
-              --build-arg CARGO_FEATURES="testing_runtime"
+              --file joystream-node.Dockerfile \
+              --tag joystream/node
             docker save --output joystream-node-docker-image.tar joystream/node
             gzip joystream-node-docker-image.tar
             cp joystream-node-docker-image.tar.gz ~/docker-images/


### PR DESCRIPTION
Make sure future runtime upgrade scenario integration tests are run against production runtime.

Discovered looking at test run: https://github.com/Joystream/joystream/runs/6608958193?check_suite_focus=true#step:8:171