### PR TITLE
linting improvements for unhandled promises + pre-push hook lint

### DIFF
--- a/cli/src/base/AccountsCommandBase.ts
+++ b/cli/src/base/AccountsCommandBase.ts
@@ -347,7 +347,7 @@ export default abstract class AccountsCommandBase extends ApiCommandBase {
     const { balances } = await this.getApi().getAccountSummary(address)
     const stakingStatus = await this.getApi().stakingAccountStatus(address)
 
-    if (lockId && !this.getApi().areAccountLocksCompatibleWith(address, lockId)) {
+    if (lockId && !(await this.getApi().areAccountLocksCompatibleWith(address, lockId))) {
       throw new CLIError(
         'This account is already used for other, incompatible staking purposes. Choose a different account...'
       )

--- a/devops/eslint-config/index.js
+++ b/devops/eslint-config/index.js
@@ -17,6 +17,7 @@ module.exports = {
     },
     ecmaVersion: 2019,
     sourceType: 'module',
+    project: './tsconfig.json',
   },
   extends: [
     'standard',
@@ -73,6 +74,13 @@ module.exports = {
         custom: { regex: '^([A-Z][a-z0-9]*_?)+', match: true }, // combined PascalCase and snake_case to allow ie. OpeningType_Worker
       }
     ],
+    '@typescript-eslint/no-floating-promises': [
+      'error',
+      {
+        ignoreVoid: true,
+      },
+    ],
+    '@typescript-eslint/no-misused-promises': 'error',
   },
   plugins: ['standard', '@typescript-eslint', 'react', 'react-hooks', 'prettier'],
 }

--- a/devops/git-hooks/pre-push
+++ b/devops/git-hooks/pre-push
@@ -16,3 +16,5 @@ BUILD_DUMMY_WASM_BINARY=1 cargo +nightly-2021-02-20 clippy --release --all -- -D
 
 echo 'running cargo unit tests'
 cargo +nightly-2021-02-20 test --release --all --features "${FEATURES}"
+
+../../scripts/lint-typescript.sh

--- a/distributor-node/src/app/index.ts
+++ b/distributor-node/src/app/index.ts
@@ -37,12 +37,21 @@ export class App {
 
   private setIntervals() {
     this.intervals = {
-      saveCacheState: setInterval(() => this.stateCache.save(), this.config.intervals.saveCacheState * 1000),
+      saveCacheState: setInterval(
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        () => this.stateCache.save(),
+        this.config.intervals.saveCacheState * 1000
+      ),
       checkStorageNodeResponseTimes: setInterval(
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         () => this.networking.checkActiveStorageNodeEndpoints(),
         this.config.intervals.checkStorageNodeResponseTimes * 1000
       ),
-      cacheCleanup: setInterval(() => this.content.cacheCleanup(), this.config.intervals.cacheCleanup * 1000),
+      cacheCleanup: setInterval(
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        () => this.content.cacheCleanup(),
+        this.config.intervals.cacheCleanup * 1000
+      ),
     }
   }
 

--- a/distributor-node/src/services/content/ContentService.ts
+++ b/distributor-node/src/services/content/ContentService.ts
@@ -258,6 +258,7 @@ export class ContentService {
         }
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       pipeline(dataStream, fileStream, async (err) => {
         dataStream.off('data', onData)
         const { bytesWritten } = fileStream

--- a/distributor-node/src/services/httpApi/HttpApiBase.ts
+++ b/distributor-node/src/services/httpApi/HttpApiBase.ts
@@ -42,6 +42,7 @@ export abstract class HttpApiBase {
 
   protected createRoutes(routes: HttpApiRoute[]): void {
     routes.forEach(([type, path, handler]) => {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       this.expressApp[type](path, this.routeWrapper(handler))
     })
   }

--- a/distributor-node/src/services/networking/NetworkingService.ts
+++ b/distributor-node/src/services/networking/NetworkingService.ts
@@ -174,7 +174,7 @@ export class NetworkingService {
       autostart: true,
     })
 
-    storageEndpoints.forEach(async (endpoint) => {
+    storageEndpoints.forEach((endpoint) => {
       availabilityQueue.push(async () => {
         await this.checkObjectAvailability(objectId, endpoint)
         return endpoint

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "./start.sh",
     "cargo-checks": "./devops/git-hooks/pre-commit && ./devops/git-hooks/pre-push",
     "cargo-build": "./scripts/cargo-build.sh",
+    "lint": "./scripts/lint-typescript.sh",
     "update-chain-metadata": "./scripts/fetch-chain-metadata.sh > chain-metadata.json",
     "verify-chain-metadata": "./scripts/verify-chain-metadata.sh"
   },

--- a/query-node/build.sh
+++ b/query-node/build.sh
@@ -14,7 +14,7 @@ yarn --cwd codegen install
 
 yarn clean
 yarn codegen:noinstall
-cp mappings/queryTemplates.ts generated/graphql-server/src/
+cp mappings/src/queryTemplates.ts generated/graphql-server/src/
 yarn typegen # if this fails try to run this command outside of yarn workspaces
 
 # We run yarn again to ensure graphql-server dependencies are installed

--- a/query-node/mappings/src/bounty.ts
+++ b/query-node/mappings/src/bounty.ts
@@ -503,7 +503,7 @@ export async function bounty_OracleJudgmentSubmitted({ event, store }: EventCont
   const entryJudgments = Array.from(bountyJudgment.entries())
 
   // Go to Withdrawal Period (and update entries statuses)
-  goToWithdrawalPeriod(store, bounty, entryJudgments)
+  await goToWithdrawalPeriod(store, bounty, entryJudgments)
 
   // Record the event
   const judgmentEvent = new OracleJudgmentSubmittedEvent({

--- a/query-node/mappings/src/content/commentAndReaction.ts
+++ b/query-node/mappings/src/content/commentAndReaction.ts
@@ -257,7 +257,7 @@ export async function processReactVideoMessage(
   const reactionsCountByReactionType = await getOrCreateVideoReactionsCountByReactionId(store, video, reactionResult)
 
   if (previousReactionByMember) {
-    changeOrRemovePreviousReaction(store, video, previousReactionByMember, reactionResult)
+    await changeOrRemovePreviousReaction(store, video, previousReactionByMember, reactionResult)
   } else {
     // new reaction
     const newReactionByMember = new VideoReaction({

--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -732,7 +732,7 @@ export async function contentNft_AuctionBidMade({ event, store }: EventContext &
     auction.auctionType.plannedEndAtBlock - auction.auctionType.extensionPeriod < event.blockNumber
   ) {
     auction.auctionType.plannedEndAtBlock = auction.auctionType.extensionPeriod
-    store.save<Auction>(auction)
+    await store.save<Auction>(auction)
   }
 
   // common event processing - second
@@ -1308,7 +1308,7 @@ export async function contentNft_NftSlingedBackToTheOriginalArtist({
 
   await getAllManagers(store).videoNfts.onMainEntityUpdate(nft)
 
-  store.save<OwnedNft>(nft)
+  await store.save<OwnedNft>(nft)
 
   // common event processing - second
 

--- a/query-node/mappings/src/queryTemplates.ts
+++ b/query-node/mappings/src/queryTemplates.ts
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 // this file will be copied to `/generated` folder; provides GraphQL query examples to GraphQL PLayground
 
 import {

--- a/query-node/mappings/tsconfig.json
+++ b/query-node/mappings/tsconfig.json
@@ -19,5 +19,6 @@
       "@polkadot/api/augment": ["../../types/augment/augment-api.ts"]
     }
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*"],
+  "exclude": ["./queryTemplates.ts"]
 }

--- a/scripts/lint-typescript.sh
+++ b/scripts/lint-typescript.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+yarn workspace query-node-root lint
+yarn workspace @joystream/distributor-cli lint
+yarn workspace network-tests lint
+yarn workspace @joystream/types checks
+yarn workspace @joystream/metadata-protobuf lint
+yarn workspace storage-node lint

--- a/storage-node/src/commands/server.ts
+++ b/storage-node/src/commands/server.ts
@@ -135,6 +135,7 @@ Supported values: warn, error, debug, info. Default:debug`,
     if (flags.sync) {
       logger.info(`Synchronization enabled.`)
       setTimeout(
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         async () =>
           runSyncWithInterval(
             api,

--- a/tests/network-tests/src/Job.ts
+++ b/tests/network-tests/src/Job.ts
@@ -33,7 +33,7 @@ export class Job {
     this._manager = manager
     this._flows = flows
     this._outcome = new InvertedPromise<JobOutcome>()
-    this._manager.on('run', this.run.bind(this))
+    this._manager.on('run', this.run.bind(this) as (jobProps: JobProps, resources: ResourceManager) => void)
     this.debug = extendDebug(`job:${this._label}`)
   }
 

--- a/tests/network-tests/src/Scenario.ts
+++ b/tests/network-tests/src/Scenario.ts
@@ -47,7 +47,14 @@ function writeOutput(api: Api, miniSecret: string) {
 
   fs.writeFileSync(OUTPUT_FILE_PATH, JSON.stringify(output, undefined, 2))
 }
+/*
+export function scenario(label: string, scene: (props: ScenarioProps) => Promise<void>): void {
+  scenario(label, scene)
+    .then
+}
 
+export async function scenarioInner(label: string, scene: (props: ScenarioProps) => Promise<void>): Promise<void> {
+*/
 export async function scenario(label: string, scene: (props: ScenarioProps) => Promise<void>): Promise<void> {
   // Load env variables - test framework specific
   config({ path: path.join(__dirname, '../.env') })

--- a/tests/network-tests/src/fixtures/content/nft/auctionCancelations.ts
+++ b/tests/network-tests/src/fixtures/content/nft/auctionCancelations.ts
@@ -63,7 +63,7 @@ export class AuctionCancelationsFixture extends BaseQueryNodeFixture {
       await this.api.cancelOpenAuctionBid(this.participant.account, this.participant.memberId.toNumber(), this.videoId)
 
       // ensure bid has been canceled
-      ensureMemberOpenAuctionBidsAreCancelled(this.query, this.videoId, this.participant)
+      await ensureMemberOpenAuctionBidsAreCancelled(this.query, this.videoId, this.participant)
 
       this.debug('Cancel auction')
       await this.api.cancelOpenAuction(this.author.account, this.author.memberId.toNumber(), this.videoId)
@@ -128,7 +128,7 @@ export class AuctionCancelationsFixture extends BaseQueryNodeFixture {
       await this.api.cancelOpenAuctionBid(this.participant.account, this.participant.memberId.toNumber(), this.videoId)
 
       // ensure bids has been canceled
-      ensureMemberOpenAuctionBidsAreCancelled(this.query, this.videoId, this.participant)
+      await ensureMemberOpenAuctionBidsAreCancelled(this.query, this.videoId, this.participant)
 
       this.debug('Cancel auction')
       await this.api.cancelOpenAuction(this.author.account, this.author.memberId.toNumber(), this.videoId)
@@ -177,7 +177,7 @@ export class AuctionCancelationsFixture extends BaseQueryNodeFixture {
       await this.api.cancelOpenAuctionBid(this.participant.account, this.participant.memberId.toNumber(), this.videoId)
 
       // ensure bid has been canceled
-      ensureMemberOpenAuctionBidsAreCancelled(this.query, this.videoId, this.participant)
+      await ensureMemberOpenAuctionBidsAreCancelled(this.query, this.videoId, this.participant)
 
       this.debug(`Check NFT ownership haven't change`)
       await assertNftOwner(this.query, this.videoId, this.author)

--- a/tests/network-tests/src/fixtures/content/nft/englishAuction.ts
+++ b/tests/network-tests/src/fixtures/content/nft/englishAuction.ts
@@ -79,7 +79,7 @@ export class NftEnglishAuctionFixture extends BaseQueryNodeFixture {
     )
 
     this.debug('Check Nft ownership in EnglishAuctionStarted event')
-    assertNftEventContentActor(
+    await assertNftEventContentActor(
       this.query,
       () => this.query.getEnglishAuctionStartedEvents([auctionStartedRuntimeEvent]),
       this.author.memberId.toString(),

--- a/tests/network-tests/src/fixtures/content/nft/updateBuyNowPrice.ts
+++ b/tests/network-tests/src/fixtures/content/nft/updateBuyNowPrice.ts
@@ -42,7 +42,7 @@ export class NftUpdateBuyNowPriceFixture extends BaseQueryNodeFixture {
     )
 
     this.debug('Check NFT buy now price change')
-    this.assertBuyNowPrice(this.query, this.videoId, newBuyNowPrice)
+    await this.assertBuyNowPrice(this.query, this.videoId, newBuyNowPrice)
   }
 
   private async assertBuyNowPrice(query: QueryNodeApi, videoId: number, newPrice: BN) {

--- a/tests/network-tests/src/scenarios/content-directory.ts
+++ b/tests/network-tests/src/scenarios/content-directory.ts
@@ -4,6 +4,7 @@ import nftAuctionAndOffers from '../flows/content/nftAuctionAndOffers'
 import commentsAndReactions from '../flows/content/commentsAndReactions'
 import { scenario } from '../Scenario'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Content directory', async ({ job }) => {
   const leadSetupJob = job('Set content working group leads', leadOpening(true, ['contentWorkingGroup']))
   const videoCountersJob = job('check active video counters', activeVideoCounters).requires(leadSetupJob)

--- a/tests/network-tests/src/scenarios/council.ts
+++ b/tests/network-tests/src/scenarios/council.ts
@@ -2,6 +2,7 @@ import electCouncil from '../flows/council/elect'
 import failToElectCouncil from '../flows/council/failToElect'
 import { scenario } from '../Scenario'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Council', async ({ job }) => {
   const councilJob = job('electing council', electCouncil)
   const secondCouncilJob = job('electing second council', electCouncil).requires(councilJob)

--- a/tests/network-tests/src/scenarios/forum.ts
+++ b/tests/network-tests/src/scenarios/forum.ts
@@ -7,6 +7,7 @@ import leadOpening from '../flows/working-groups/leadOpening'
 import threadTags from '../flows/forum/threadTags'
 import { scenario } from '../Scenario'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Forum', async ({ job }) => {
   const sudoHireLead = job('hiring working group leads', leadOpening())
   job('forum categories', categories).requires(sudoHireLead)

--- a/tests/network-tests/src/scenarios/forumPostDeletionsBug.ts
+++ b/tests/network-tests/src/scenarios/forumPostDeletionsBug.ts
@@ -2,6 +2,7 @@ import leadOpening from '../flows/working-groups/leadOpening'
 import multiplePostDeletionsBug from '../flows/forum/multiplePostDeletionsBug'
 import { scenario } from '../Scenario'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Forum post deletions bug', async ({ job }) => {
   const sudoHireLead = job('hiring working group leads', leadOpening())
   job('forum post deletions bug', multiplePostDeletionsBug).requires(sudoHireLead)

--- a/tests/network-tests/src/scenarios/full.ts
+++ b/tests/network-tests/src/scenarios/full.ts
@@ -35,6 +35,7 @@ import nftAuctionAndOffers from '../flows/content/nftAuctionAndOffers'
 import updatingVerificationStatus from '../flows/membership/updateVerificationStatus'
 import commentsAndReactions from '../flows/content/commentsAndReactions'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Full', async ({ job, env }) => {
   // Runtime upgrade should always be first job
   // (except councilJob, which is required for voting and should probably depend on the "source" runtime)

--- a/tests/network-tests/src/scenarios/initStorageAndDistribution.ts
+++ b/tests/network-tests/src/scenarios/initStorageAndDistribution.ts
@@ -4,6 +4,7 @@ import initDistribution, { singleBucketConfig as defaultDistributionConfig } fro
 import { scenario } from '../Scenario'
 import updateAccountsFlow from '../misc/updateAllWorkerRoleAccountsFlow'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Init storage and distribution', async ({ job }) => {
   const setupLead = job('setup leads', leaderSetup(true, ['storageWorkingGroup', 'distributionWorkingGroup']))
   const updateWorkerAccounts = job('Update worker accounts', updateAccountsFlow).after(setupLead)

--- a/tests/network-tests/src/scenarios/memberships.ts
+++ b/tests/network-tests/src/scenarios/memberships.ts
@@ -9,6 +9,7 @@ import { scenario } from '../Scenario'
 import updatingVerificationStatus from '../flows/membership/updateVerificationStatus'
 import leadOpening from '../flows/working-groups/leadOpening'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Memberships', async ({ job }) => {
   const membershipSystemJob = job('membership system', membershipSystem)
   const sudoHireLead = job('sudo lead opening', leadOpening(true, ['membershipWorkingGroup'])).after(

--- a/tests/network-tests/src/scenarios/olympia.ts
+++ b/tests/network-tests/src/scenarios/olympia.ts
@@ -6,6 +6,7 @@ import transferringInvites from '../flows/membership/transferringInvites'
 import managingStakingAccounts from '../flows/membership/managingStakingAccounts'
 import { scenario } from '../Scenario'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Olympia', async ({ job }) => {
   job('creating members', creatingMemberships)
   job('updating member profile', updatingMemberProfile)

--- a/tests/network-tests/src/scenarios/postRuntimeUpdate.ts
+++ b/tests/network-tests/src/scenarios/postRuntimeUpdate.ts
@@ -1,6 +1,7 @@
 import { scenario } from '../Scenario'
 import postRuntimeUpdateChecks from '../misc/postRuntimUpdateChecks'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Post Runtime Upgrade', async ({ job }) => {
   // Verify constants
   job('Run Checks', postRuntimeUpdateChecks)

--- a/tests/network-tests/src/scenarios/proposals.ts
+++ b/tests/network-tests/src/scenarios/proposals.ts
@@ -8,6 +8,7 @@ import expireProposal from '../flows/proposals/expireProposal'
 import proposalsDiscussion from '../flows/proposalsDiscussion'
 import { scenario } from '../Scenario'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Proposals', async ({ job, env }) => {
   const councilJob = job('electing council', electCouncil)
   const runtimeUpgradeProposalJob = env.RUNTIME_UPGRADE_TARGET_WASM_PATH

--- a/tests/network-tests/src/scenarios/proposalsDiscussion.ts
+++ b/tests/network-tests/src/scenarios/proposalsDiscussion.ts
@@ -2,6 +2,7 @@ import electCouncil from '../flows/council/elect'
 import proposalsDiscussion from '../flows/proposalsDiscussion'
 import { scenario } from '../Scenario'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Proposals discussion', async ({ job, env }) => {
   const councilJob = job('electing council', electCouncil)
   job('proposal discussion', [proposalsDiscussion]).requires(councilJob)

--- a/tests/network-tests/src/scenarios/setupNewChain.ts
+++ b/tests/network-tests/src/scenarios/setupNewChain.ts
@@ -6,6 +6,7 @@ import initStorage, { singleBucketConfig as defaultStorageConfig } from '../flow
 import initDistribution, { singleBucketConfig as defaultDistributionConfig } from '../flows/storage/initDistribution'
 import { scenario } from '../Scenario'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Setup new chain', async ({ job }) => {
   const leads = job('Set WorkingGroup Leads', leaderSetup())
   const updateAccounts = job('Update Worker Accounts', updateAccountsFlow).requires(leads)

--- a/tests/network-tests/src/scenarios/workingGroups.ts
+++ b/tests/network-tests/src/scenarios/workingGroups.ts
@@ -6,6 +6,7 @@ import workerActions from '../flows/working-groups/workerActions'
 import { scenario } from '../Scenario'
 import groupBudget from '../flows/working-groups/groupBudget'
 
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Working groups', async ({ job }) => {
   const sudoHireLead = job('sudo lead opening', leadOpening())
   job('openings and applications', openingsAndApplications).requires(sudoHireLead)

--- a/tests/network-tests/src/sender.ts
+++ b/tests/network-tests/src/sender.ts
@@ -51,7 +51,7 @@ export class Sender {
     const senderKeyPair: KeyringPair = this.keyring.getPair(addr)
 
     let finalized: { (result: ISubmittableResult): void }
-    const whenFinalized: Promise<ISubmittableResult> = new Promise(async (resolve, reject) => {
+    const whenFinalized: Promise<ISubmittableResult> = new Promise((resolve, reject) => {
       finalized = resolve
     })
 

--- a/tests/network-tests/src/utils.ts
+++ b/tests/network-tests/src/utils.ts
@@ -124,7 +124,9 @@ export class Utils {
         }
         debug('Condition not satisfied, waiting...')
       }
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       const interval = setInterval(check, intervalMs)
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       check()
     })
   }

--- a/types/.eslintignore
+++ b/types/.eslintignore
@@ -1,3 +1,4 @@
 **/*.d.ts
 augment/
 augment-types/
+augment-codec/

--- a/types/.eslintrc.js
+++ b/types/.eslintrc.js
@@ -5,4 +5,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['error'],
     '@typescript-eslint/naming-convention': 'off',
   },
+  parserOptions: {
+    project: './tsconfig-eslint.json',
+  },
 }

--- a/types/augment/all/types.ts
+++ b/types/augment/all/types.ts
@@ -209,62 +209,6 @@ export interface Category extends Struct {
 /** @name CategoryId */
 export interface CategoryId extends u64 {}
 
-/** @name Channel */
-export interface Channel extends Struct {
-  readonly owner: ChannelOwner;
-  readonly num_videos: u64;
-  readonly is_censored: bool;
-  readonly reward_account: Option<GenericAccountId>;
-  readonly collaborators: BTreeSet<MemberId>;
-  readonly moderators: BTreeSet<MemberId>;
-  readonly cumulative_payout_earned: u128;
-}
-
-/** @name ChannelCategory */
-export interface ChannelCategory extends Struct {}
-
-/** @name ChannelCategoryCreationParameters */
-export interface ChannelCategoryCreationParameters extends Struct {
-  readonly meta: Bytes;
-}
-
-/** @name ChannelCategoryId */
-export interface ChannelCategoryId extends u64 {}
-
-/** @name ChannelCategoryUpdateParameters */
-export interface ChannelCategoryUpdateParameters extends Struct {
-  readonly new_meta: Bytes;
-}
-
-/** @name ChannelCreationParameters */
-export interface ChannelCreationParameters extends Struct {
-  readonly assets: Option<StorageAssets>;
-  readonly meta: Option<Bytes>;
-  readonly reward_account: Option<GenericAccountId>;
-  readonly collaborators: BTreeSet<MemberId>;
-  readonly moderators: BTreeSet<MemberId>;
-}
-
-/** @name ChannelId */
-export interface ChannelId extends u64 {}
-
-/** @name ChannelOwner */
-export interface ChannelOwner extends Enum {
-  readonly isMember: boolean;
-  readonly asMember: MemberId;
-  readonly isCurators: boolean;
-  readonly asCurators: CuratorGroupId;
-}
-
-/** @name ChannelUpdateParameters */
-export interface ChannelUpdateParameters extends Struct {
-  readonly assets_to_upload: Option<StorageAssets>;
-  readonly new_meta: Option<Bytes>;
-  readonly reward_account: Option<Option<GenericAccountId>>;
-  readonly assets_to_remove: BTreeSet<DataObjectId>;
-  readonly collaborators: Option<BTreeSet<MemberId>>;
-}
-
 /** @name Cid */
 export interface Cid extends Bytes {}
 
@@ -554,6 +498,62 @@ export interface GeneralProposalParameters extends Struct {
   readonly description: Text;
   readonly staking_account_id: Option<AccountId>;
   readonly exact_execution_block: Option<u32>;
+}
+
+/** @name Channel */
+export interface Channel extends Struct {
+  readonly owner: ChannelOwner;
+  readonly num_videos: u64;
+  readonly is_censored: bool;
+  readonly reward_account: Option<GenericAccountId>;
+  readonly collaborators: BTreeSet<MemberId>;
+  readonly moderators: BTreeSet<MemberId>;
+  readonly cumulative_payout_earned: u128;
+}
+
+/** @name ChannelCategory */
+export interface ChannelCategory extends Struct {}
+
+/** @name ChannelCategoryCreationParameters */
+export interface ChannelCategoryCreationParameters extends Struct {
+  readonly meta: Bytes;
+}
+
+/** @name ChannelCategoryId */
+export interface ChannelCategoryId extends u64 {}
+
+/** @name ChannelCategoryUpdateParameters */
+export interface ChannelCategoryUpdateParameters extends Struct {
+  readonly new_meta: Bytes;
+}
+
+/** @name ChannelCreationParameters */
+export interface ChannelCreationParameters extends Struct {
+  readonly assets: Option<StorageAssets>;
+  readonly meta: Option<Bytes>;
+  readonly reward_account: Option<GenericAccountId>;
+  readonly collaborators: BTreeSet<MemberId>;
+  readonly moderators: BTreeSet<MemberId>;
+}
+
+/** @name ChannelId */
+export interface ChannelId extends u64 {}
+
+/** @name ChannelOwner */
+export interface ChannelOwner extends Enum {
+  readonly isMember: boolean;
+  readonly asMember: MemberId;
+  readonly isCurators: boolean;
+  readonly asCurators: CuratorGroupId;
+}
+
+/** @name ChannelUpdateParameters */
+export interface ChannelUpdateParameters extends Struct {
+  readonly assets_to_upload: Option<StorageAssets>;
+  readonly new_meta: Option<Bytes>;
+  readonly reward_account: Option<Option<GenericAccountId>>;
+  readonly assets_to_remove: BTreeSet<DataObjectId>;
+  readonly collaborators: Option<BTreeSet<MemberId>>;
 }
 
 /** @name InitTransactionalStatus */

--- a/types/tsconfig-eslint.json
+++ b/types/tsconfig-eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": []
+}


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/3461. 

Adds linting of all typescript files in monorepo to pre-push hook. The linting can also be invoked by running `yarn lint` in the root directory.

PR will likely be retargeted to the Carthage branch when QN is buildable.