### PR TITLE
Fix initial nominators setup at genesis

### DIFF
--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -193,7 +193,7 @@ pub fn testnet_genesis(
         .chain(initial_nominators.iter().map(|x| {
             use rand::{seq::SliceRandom, Rng};
             let limit = (MaxNominations::get() as usize).min(initial_authorities.len());
-            let count = rng.gen::<usize>() % limit;
+            let count = (rng.gen::<usize>() % limit).max(1); // at least one nomination
             let nominations = initial_authorities
                 .as_slice()
                 .choose_multiple(&mut rng, count)
@@ -274,7 +274,10 @@ pub fn testnet_genesis(
 fn development_config_genesis() -> GenesisConfig {
     testnet_genesis(
         vec![authority_keys_from_seed("Alice")],
-        vec![],
+        vec![
+            get_account_id_from_seed::<sr25519::Public>("Bob"),
+            get_account_id_from_seed::<sr25519::Public>("Charlie"),
+        ],
         get_account_id_from_seed::<sr25519::Public>("Alice"),
         development_endowed_accounts(),
         initial_members::none(),

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -193,7 +193,7 @@ pub fn testnet_genesis(
         .chain(initial_nominators.iter().map(|x| {
             use rand::{seq::SliceRandom, Rng};
             let limit = (MaxNominations::get() as usize).min(initial_authorities.len());
-            let count = (rng.gen::<usize>() % limit).max(1); // at least one nomination
+            let count = (rng.gen::<usize>() % limit).saturating_add(1); // at least one nomination
             let nominations = initial_authorities
                 .as_slice()
                 .choose_multiple(&mut rng, count)


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/3948#issuecomment-1170858038

Added two initial nominators to dev chain.

Test with

```bash
cargo test --release -p joystream-node
```

you should see the development chain spec construction test pass

```bash
test chain_spec::tests::test_create_development_chain_spec ... ok
```

Started dev chain and I can see two nominators:

![Screen Shot 2022-06-30 at 10 59 59 AM](https://user-images.githubusercontent.com/1621012/176618054-5b5b1788-d98b-4bf0-8231-90b63fe0b4af.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202132419573087/1202537343383647) by [Unito](https://www.unito.io)
