### PR TITLE
Fix chainspec builder new command

### DIFF
--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -28,11 +28,10 @@ pub mod initial_members;
 use grandpa_primitives::AuthorityId as GrandpaId;
 use hex_literal::hex;
 use node_runtime::{
-    constants::currency::*, constants::JOY_ADDRESS_PREFIX, membership, wasm_binary_unwrap,
-    AuthorityDiscoveryConfig, BabeConfig, BalancesConfig, Block, ContentConfig, CouncilConfig,
-    ForumConfig, GrandpaConfig, ImOnlineConfig, MaxNominations, MembersConfig, ReferendumConfig,
-    SessionConfig, SessionKeys, StakerStatus, StakingConfig, SudoConfig, SystemConfig,
-    TransactionPaymentConfig,
+    constants::currency::*, membership, wasm_binary_unwrap, AuthorityDiscoveryConfig, BabeConfig,
+    BalancesConfig, Block, ContentConfig, CouncilConfig, ForumConfig, GrandpaConfig,
+    ImOnlineConfig, MaxNominations, MembersConfig, ReferendumConfig, SessionConfig, SessionKeys,
+    StakerStatus, StakingConfig, SudoConfig, SystemConfig, TransactionPaymentConfig,
 };
 use pallet_im_online::sr25519::AuthorityId as ImOnlineId;
 use sc_chain_spec::ChainSpecExtension;
@@ -48,6 +47,7 @@ use sp_runtime::{
     Perbill,
 };
 
+pub use node_runtime::constants::JOY_ADDRESS_PREFIX;
 pub use node_runtime::primitives::{AccountId, Balance, Signature};
 pub use node_runtime::GenesisConfig;
 

--- a/utils/chain-spec-builder/src/main.rs
+++ b/utils/chain-spec-builder/src/main.rs
@@ -25,14 +25,14 @@ use std::{
 
 use joystream_node::chain_spec::{
     self, content_config, forum_config, initial_balances, initial_members,
-    joy_chain_spec_properties, AccountId,
+    joy_chain_spec_properties, AccountId, JOY_ADDRESS_PREFIX,
 };
 
 use sc_chain_spec::ChainType;
 use sc_keystore::LocalKeystore;
 use sc_telemetry::TelemetryEndpoints;
 use sp_core::{
-    crypto::{ByteArray, Ss58Codec},
+    crypto::{ByteArray, Ss58AddressFormat, Ss58Codec},
     sr25519,
 };
 use sp_keystore::{SyncCryptoStore, SyncCryptoStorePtr};
@@ -73,7 +73,7 @@ enum ChainSpecBuilder {
         authority_seeds: Vec<String>,
         /// Active nominators (SS58 format), each backing a random subset of the aforementioned
         /// authorities.
-        #[clap(long, short, default_value = "0")]
+        #[clap(long, short)]
         nominator_accounts: Vec<String>,
         /// Endowed account address (SS58 format).
         #[clap(long, short)]
@@ -85,13 +85,13 @@ enum ChainSpecBuilder {
         #[clap(long, short, default_value = "./chain_spec.json")]
         chain_spec_path: PathBuf,
         /// The path to an initial members data
-        #[structopt(long, short)]
+        #[structopt(long)]
         initial_members_path: Option<PathBuf>,
         /// The path to an initial forum data
-        #[structopt(long, short)]
+        #[structopt(long)]
         initial_forum_path: Option<PathBuf>,
         /// The path to an initial balances file
-        #[structopt(long, short)]
+        #[structopt(long)]
         initial_balances_path: Option<PathBuf>,
         /// Deployment type: dev, local, staging, live
         #[structopt(long, short, default_value = "live")]
@@ -122,13 +122,13 @@ enum ChainSpecBuilder {
         #[clap(long, short)]
         keystore_path: Option<PathBuf>,
         /// The path to an initial members data
-        #[clap(long, short)]
+        #[clap(long)]
         initial_members_path: Option<PathBuf>,
         /// The path to an initial forum data
-        #[clap(long, short)]
+        #[clap(long)]
         initial_forum_path: Option<PathBuf>,
         /// The path to an initial balances file
-        #[clap(long, short)]
+        #[clap(long)]
         initial_balances_path: Option<PathBuf>,
         /// Deployment type: dev, local, staging, live
         #[clap(long, short, default_value = "live")]
@@ -264,7 +264,7 @@ fn generate_chain_spec(
 ) -> Result<String, String> {
     let parse_account = |address: String| {
         AccountId::from_string(&address)
-            .map_err(|err| format!("Failed to parse account address: {:?}", err))
+            .map_err(|err| format!("Failed to parse account address: {:?} {:?}", address, err))
     };
 
     let nominator_accounts = nominator_accounts
@@ -389,6 +389,8 @@ async fn main() -> Result<(), String> {
 		 ensure proper functioning of the included runtime compile (or run) the chain spec builder binary in \
 		 `--release` mode.\n",
 	);
+
+    sp_core::crypto::set_default_ss58_version(Ss58AddressFormat::custom(JOY_ADDRESS_PREFIX));
 
     let builder = ChainSpecBuilder::from_args();
     let chain_spec_path = builder.chain_spec_path().to_path_buf();


### PR DESCRIPTION
- Set default address prefix to joystream prefix
- Remove incorrect default value for nominators argument
- force long argument for `--initial-...` argument, to avoid ambiguous `-i` short form