### PR TITLE
Drop raspberry pi build for release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -45,43 +45,44 @@ jobs:
           path: joystream-node-macos.tar.gz
           retention-days: 1
 
-  build-rpi-binary:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+  # build-rpi-binary:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
 
-      - id: compute_shasum
-        name: Compute runtime code shasum
-        run: |
-          export RUNTIME_CODE_SHASUM=`scripts/runtime-code-shasum.sh`
-          echo "::set-output name=shasum::${RUNTIME_CODE_SHASUM}"
+  #     - id: compute_shasum
+  #       name: Compute runtime code shasum
+  #       run: |
+  #         export RUNTIME_CODE_SHASUM=`scripts/runtime-code-shasum.sh`
+  #         echo "::set-output name=shasum::${RUNTIME_CODE_SHASUM}"
 
-      - name: Run Setup
-        run: |
-          ./setup.sh
+  #     - name: Run Setup
+  #       run: |
+  #         ./setup.sh
 
-      - name: Build binaries
-        run: |
-          export WORKSPACE_ROOT=`cargo metadata --offline --no-deps --format-version 1 | jq .workspace_root -r`
-          sudo chmod a+w $WORKSPACE_ROOT
-          sudo chmod -R a+w $HOME/.cargo/registry
-          ./scripts/raspberry-cross-build.sh
+  #     - name: Build binaries
+  #       run: |
+  #         export WORKSPACE_ROOT=`cargo metadata --offline --no-deps --format-version 1 | jq .workspace_root -r`
+  #         sudo chmod a+w $WORKSPACE_ROOT
+  #         sudo chmod -R a+w $HOME/.cargo/registry
+  #         ./scripts/raspberry-cross-build.sh
 
-      - name: Tar the binary
-        run: |
-          tar czvf joystream-node-rpi.tar.gz -C ./target/arm-unknown-linux-gnueabihf/release joystream-node
+  #     - name: Tar the binary
+  #       run: |
+  #         tar czvf joystream-node-rpi.tar.gz -C ./target/arm-unknown-linux-gnueabihf/release joystream-node
 
-      - name: Temporarily save node binary
-        uses: actions/upload-artifact@v2
-        with:
-          name: joystream-node-rpi-${{ steps.compute_shasum.outputs.shasum }}
-          path: joystream-node-rpi.tar.gz
-          retention-days: 1
+  #     - name: Temporarily save node binary
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: joystream-node-rpi-${{ steps.compute_shasum.outputs.shasum }}
+  #         path: joystream-node-rpi.tar.gz
+  #         retention-days: 1
 
   create-release:
     runs-on: ubuntu-latest
-    needs: [build-mac-binary, build-rpi-binary]
+    # needs: [build-mac-binary, build-rpi-binary]
+    needs: build-mac-binary
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -113,8 +114,8 @@ jobs:
           docker cp $(docker create --rm $IMAGE-arm64):/joystream/node ./joystream-node
           tar -czvf joystream-node-$VERSION_AND_COMMIT-arm64-linux-gnu.tar.gz joystream-node
 
-          docker cp $(docker create --rm $IMAGE-arm):/joystream/node ./joystream-node
-          tar -czvf joystream-node-$VERSION_AND_COMMIT-armv7-linux-gnu.tar.gz joystream-node
+          # docker cp $(docker create --rm $IMAGE-arm):/joystream/node ./joystream-node
+          # tar -czvf joystream-node-$VERSION_AND_COMMIT-armv7-linux-gnu.tar.gz joystream-node
 
       - name: Retrieve saved MacOS binary
         uses: actions/download-artifact@v2
@@ -129,7 +130,7 @@ jobs:
       - name: Rename MacOS and RPi tar
         run: |
           mv joystream-node-macos.tar.gz joystream-node-${{ steps.extract_binaries.outputs.version_and_commit }}-x86_64-macos.tar.gz
-          mv joystream-node-rpi.tar.gz joystream-node-${{ steps.extract_binaries.outputs.version_and_commit }}-rpi.tar.gz
+          # mv joystream-node-rpi.tar.gz joystream-node-${{ steps.extract_binaries.outputs.version_and_commit }}-rpi.tar.gz
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -122,10 +122,10 @@ jobs:
         with:
           name: joystream-node-macos-${{ steps.compute_shasum.outputs.shasum }}
 
-      - name: Retrieve saved RPi binary
-        uses: actions/download-artifact@v2
-        with:
-          name: joystream-node-rpi-${{ steps.compute_shasum.outputs.shasum }}
+      # - name: Retrieve saved RPi binary
+      #   uses: actions/download-artifact@v2
+      #   with:
+      #     name: joystream-node-rpi-${{ steps.compute_shasum.outputs.shasum }}
 
       - name: Rename MacOS and RPi tar
         run: |


### PR DESCRIPTION
To create binaries in github workflow https://github.com/Joystream/joystream/releases/tag/v11.0.0-alpha-1 
I had to drop building for raspberry pi.