### PR TITLE
Carthage Disable runtime upgrade test workflow

### DIFF
--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -69,10 +69,11 @@ jobs:
         with:
           name: ${{ steps.compute_shasum.outputs.shasum }}-joystream-node-docker-image.tar.gz
           path: joystream-node-docker-image.tar.gz
-
+  
   runtime_upgrade:
-    # if: ${{ false }}
-    name: Runtime Upgrade From Rhodes Spec 6
+    # Re-Enable when we want to test carthage runtime updates
+    if: ${{ false }}
+    name: Runtime Upgrade From Carthage Spec 0
     needs: build_images
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Carthage is a new chain, testing upgrade from Rhodes runtime is not required.
Disabling.