### PR TITLE
Carthage playground

### DIFF
--- a/devops/git-hooks/pre-push
+++ b/devops/git-hooks/pre-push
@@ -4,19 +4,6 @@ set -e
 SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
 cd $SCRIPT_PATH
 
-source ../../scripts/features.sh
+../../scripts/cargo-checks.sh
 
-export WASM_BUILD_TOOLCHAIN=nightly-2022-05-11
-
-echo 'running clippy (rust linter)'
-# When custom build.rs triggers wasm-build-runner-impl to build we get error:
-# "Rust WASM toolchain not installed, please install it!"
-# So we skip building the WASM binary by setting BUILD_DUMMY_WASM_BINARY=1
-# Aggressive linting
-BUILD_DUMMY_WASM_BINARY=1 cargo "+$WASM_BUILD_TOOLCHAIN" clippy --release --all -- -D warnings
-
-echo 'running cargo unit tests'
-cargo "+$WASM_BUILD_TOOLCHAIN" test --release --all --features "${FEATURES}"
-
-echo 'running typescript lints'
 ../../scripts/lint-typescript.sh

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:packages": "./build-packages.sh",
     "setup": "./setup.sh",
     "start": "./start.sh",
-    "cargo-checks": "./devops/git-hooks/pre-commit && ./devops/git-hooks/pre-push",
+    "cargo-checks": "./scripts/cargo-checks.sh",
     "cargo-build": "./scripts/cargo-build.sh",
     "lint": "./scripts/lint-typescript.sh",
     "update-chain-metadata": "./scripts/fetch-chain-metadata.sh > chain-metadata.json",

--- a/scripts/cargo-checks.sh
+++ b/scripts/cargo-checks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+cd $SCRIPT_PATH
+
+echo 'running rust-fmt'
+cargo fmt --all -- --check
+
+source ./features.sh
+
+export WASM_BUILD_TOOLCHAIN=nightly-2022-05-11
+
+echo 'running clippy (rust linter)'
+# When custom build.rs triggers wasm-build-runner-impl to build we get error:
+# "Rust WASM toolchain not installed, please install it!"
+# So we skip building the WASM binary by setting BUILD_DUMMY_WASM_BINARY=1
+# Aggressive linting
+echo 'running cargo clippy'
+BUILD_DUMMY_WASM_BINARY=1 cargo "+$WASM_BUILD_TOOLCHAIN" clippy --release --all -- -D warnings
+
+echo 'running cargo unit tests'
+cargo "+$WASM_BUILD_TOOLCHAIN" test --release --all --features "${FEATURES}"

--- a/scripts/lint-typescript.sh
+++ b/scripts/lint-typescript.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+echo 'running typescript lints'
 yarn workspace query-node-root lint
 yarn workspace @joystream/distributor-cli lint
 yarn workspace network-tests lint

--- a/scripts/push-release-image.sh
+++ b/scripts/push-release-image.sh
@@ -1,8 +1,0 @@
-
-IMAGE=joystream/node:6740a4ae2bf40fe7c670fb49943cbbe290277601
-LATEST_TAG=joystream/node:latest
-docker manifest create $LATEST_TAG $IMAGE-amd64 $IMAGE-arm64 $IMAGE-arm
-docker manifest annotate $LATEST_TAG $IMAGE-amd64 --arch amd64
-docker manifest annotate $LATEST_TAG $IMAGE-arm64 --arch arm64
-docker manifest annotate $LATEST_TAG $IMAGE-arm --arch arm
-docker manifest push $LATEST_TAG

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
     export DEBIAN_FRONTEND=noninteractive
     # code build tools
     sudo apt-get update
-    sudo apt-get install -y coreutils clang llvm jq curl gcc xz-utils sudo pkg-config unzip libc6-dev make libssl-dev python
+    sudo apt-get install -y coreutils clang llvm jq curl gcc xz-utils sudo pkg-config unzip libc6-dev make libssl-dev python2
     # docker
     sudo apt-get install -y docker.io containerd runc
     # docker-compose


### PR DESCRIPTION
Some fixes for setup and linting scripts.
- On ubuntu 22.04 cannot install python package, you have to be more specific (python2 or python3)
- Factored out the cargo-checks into its own script because we also run ts linting in the git-hook, and in some CI workflows we don't bother installing yarn dependencies so it was [breaking joystream-node workflow](https://github.com/Joystream/joystream/runs/7345051271?check_suite_focus=true#step:6:3526)
- Deleted a script which I had checked-in at some point accidentally.