### PR TITLE
github actions dependencies version update

### DIFF
--- a/.github/workflows/create-ami.yml
+++ b/.github/workflows/create-ami.yml
@@ -28,7 +28,7 @@ jobs:
         id: ami_name
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: compute_shasum
         name: Compute runtime code shasum
@@ -39,7 +39,7 @@ jobs:
           tar czvf joystream-node-macos.tar.gz -C ./target/release joystream-node
 
       - name: Temporarily save node binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: joystream-node-macos-${{ steps.compute_shasum.outputs.shasum }}
           path: joystream-node-macos.tar.gz
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: compute_shasum
         name: Compute runtime code shasum
@@ -73,7 +73,7 @@ jobs:
           tar czvf joystream-node-rpi.tar.gz -C ./target/arm-unknown-linux-gnueabihf/release joystream-node
 
       - name: Temporarily save node binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: joystream-node-rpi-${{ steps.compute_shasum.outputs.shasum }}
           path: joystream-node-rpi.tar.gz
@@ -84,7 +84,7 @@ jobs:
     needs: [build-mac-binary, build-rpi-binary]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - id: compute_shasum
         name: Compute runtime code shasum
@@ -117,12 +117,12 @@ jobs:
           tar -czvf joystream-node-$VERSION_AND_COMMIT-armv7-linux-gnu.tar.gz joystream-node
 
       - name: Retrieve saved MacOS binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: joystream-node-macos-${{ steps.compute_shasum.outputs.shasum }}
 
       - name: Retrieve saved RPi binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: joystream-node-rpi-${{ steps.compute_shasum.outputs.shasum }}
 

--- a/.github/workflows/deploy-node-network.yml
+++ b/.github/workflows/deploy-node-network.yml
@@ -20,7 +20,7 @@ jobs:
       STACK_NAME: ga-deploy-node-network-${{ github.run_number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set env variables
         id: myoutputs # set the outputs
@@ -173,13 +173,13 @@ jobs:
           7z a -p${{ steps.myoutputs.outputs.encryptionKey }} chain-data.7z mydata/*
 
       - name: Save the output as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: data-chainspec-auth
           path: devops/aws/chain-data.7z
 
       - name: Save the endpoints file as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: endpoints
           path: devops/aws/endpoints.json

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -42,7 +42,7 @@ jobs:
       STACK_NAME: ${{ github.event.inputs.stackNamePrefix }}-${{ github.event.inputs.branchName }}-${{ github.run_number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Ansible dependencies
         run: pipx inject ansible-core boto3 botocore
@@ -92,7 +92,7 @@ jobs:
                           ssh_pub_key='${{ github.event.inputs.sshPubKey }}'"
 
       - name: Save the endpoints file as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: endpoints
           path: devops/aws/endpoints.json

--- a/.github/workflows/joystream-apps-docker.yml
+++ b/.github/workflows/joystream-apps-docker.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Extract branch name
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           file: apps.Dockerfile
           push: true

--- a/.github/workflows/joystream-cli.yml
+++ b/.github/workflows/joystream-cli.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: checks
@@ -33,9 +33,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: checks

--- a/.github/workflows/joystream-node-docker-dev.yml
+++ b/.github/workflows/joystream-node-docker-dev.yml
@@ -26,9 +26,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
 
@@ -39,7 +39,7 @@ jobs:
           echo "::set-output name=shasum::${RUNTIME_CODE_SHASUM}"
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -52,7 +52,7 @@ jobs:
           echo "::set-output name=image_exists::${IMAGE_EXISTS}"
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: joystream-node.Dockerfile

--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -16,9 +16,9 @@ jobs:
       image_exists: ${{ steps.compute_main_image_exists.outputs.image_exists }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
 
@@ -29,7 +29,7 @@ jobs:
           echo "::set-output name=shasum::${RUNTIME_CODE_SHASUM}"
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -49,7 +49,7 @@ jobs:
           echo "::set-output name=image_exists::${IMAGE_EXISTS}"
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: joystream-node.Dockerfile
@@ -80,9 +80,9 @@ jobs:
         id: extract_branch
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
 
@@ -96,7 +96,7 @@ jobs:
           echo "::set-output name=shasum::${RUNTIME_CODE_SHASUM}"
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -165,7 +165,7 @@ jobs:
       TAG_SHASUM: ${{ needs.push-amd64.outputs.tag_shasum }}
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/joystream-node.yml
+++ b/.github/workflows/joystream-node.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
-      - uses: technote-space/get-diff-action@v6
+      - uses: technote-space/get-diff-action@v3
         with:
           PREFIX_FILTER: |
             node
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
-      - uses: technote-space/get-diff-action@v6
+      - uses: technote-space/get-diff-action@v3
         with:
           PREFIX_FILTER: |
             node

--- a/.github/workflows/joystream-node.yml
+++ b/.github/workflows/joystream-node.yml
@@ -7,11 +7,11 @@ jobs:
     name: Benchmarking
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
-      - uses: technote-space/get-diff-action@v3
+      - uses: technote-space/get-diff-action@v6
         with:
           PREFIX_FILTER: |
             node
@@ -51,11 +51,11 @@ jobs:
     name: Runtime Profiles
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
-      - uses: technote-space/get-diff-action@v3
+      - uses: technote-space/get-diff-action@v6
         with:
           PREFIX_FILTER: |
             node

--- a/.github/workflows/joystream-types.yml
+++ b/.github/workflows/joystream-types.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: checks
@@ -33,9 +33,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: checks

--- a/.github/workflows/metadata-protobuf.yml
+++ b/.github/workflows/metadata-protobuf.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: test protobuf

--- a/.github/workflows/network-tests.yml
+++ b/.github/workflows/network-tests.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: checks
@@ -29,9 +29,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: checks

--- a/.github/workflows/query-node.yml
+++ b/.github/workflows/query-node.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: checks
@@ -29,9 +29,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: checks

--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -22,8 +22,8 @@ jobs:
     outputs:
       use_artifact: ${{ steps.compute_shasum.outputs.shasum }}-joystream-node-docker-image.tar.gz
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
 
@@ -39,7 +39,7 @@ jobs:
         run: mkdir ~/docker-images
 
       - name: Cache docker images
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: joystream-node-docker
         with:
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Save joystream/node image to Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.compute_shasum.outputs.shasum }}-joystream-node-docker-image.tar.gz
           path: joystream-node-docker-image.tar.gz
@@ -88,12 +88,12 @@ jobs:
     needs: build_images
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
       - name: Get artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ needs.build_images.outputs.use_artifact }}
       - name: Install artifacts
@@ -118,12 +118,12 @@ jobs:
     needs: build_images
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
       - name: Get artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ needs.build_images.outputs.use_artifact }}
       - name: Install artifacts

--- a/.github/workflows/runtime-upgrade.yml
+++ b/.github/workflows/runtime-upgrade.yml
@@ -12,8 +12,8 @@ jobs:
     outputs:
       use_artifact: ${{ steps.compute_shasum.outputs.shasum }}-joystream-node-docker-image.tar.gz
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
 
@@ -27,7 +27,7 @@ jobs:
         run: mkdir ~/docker-images
 
       - name: Cache docker images
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: joystream-node-docker
         with:
@@ -65,7 +65,7 @@ jobs:
           fi
 
       - name: Save joystream/node image to Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.compute_shasum.outputs.shasum }}-joystream-node-docker-image.tar.gz
           path: joystream-node-docker-image.tar.gz
@@ -76,12 +76,12 @@ jobs:
     needs: build_images
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '14.x'
       - name: Get artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ needs.build_images.outputs.use_artifact }}
       - name: Install artifacts

--- a/.github/workflows/storage-node.yml
+++ b/.github/workflows/storage-node.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: checks
@@ -29,9 +29,9 @@ jobs:
       matrix:
         node-version: [14.x]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: checks


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/4063.

Upgrades Github actions dependencies to improve security, among other things, as described in a Hydra issue https://github.com/Joystream/hydra/issues/468.

Updates all dependencies except `technote-space/get-diff-action` that is currently in version `3`. When I tried the newest version `6`, Joystream node build failed on benchmarking https://github.com/Joystream/joystream/runs/7419359671 and there were some warnings in `technote-space/get-diff-action` log. Upgrading this package will likely need more tuning. Skipping for now.