### PR TITLE
create_dynamic_bag: Remove data object fee checks when data objects are empty

### DIFF
--- a/runtime-modules/storage/src/lib.rs
+++ b/runtime-modules/storage/src/lib.rs
@@ -3215,18 +3215,20 @@ impl<T: Config> DataObjectStorage<T> for Module<T> {
     fn create_dynamic_bag(
         params: DynBagCreationParameters<T>,
     ) -> Result<(Bag<T>, BTreeSet<T::DataObjectId>), DispatchError> {
-        // ensure data object state bloat bond
-        ensure!(
-            params.expected_data_object_state_bloat_bond
-                == Self::data_object_state_bloat_bond_value(),
-            Error::<T>::DataObjectStateBloatBondChanged,
-        );
+        if !params.object_creation_list.is_empty() {
+            // ensure data object state bloat bond
+            ensure!(
+                params.expected_data_object_state_bloat_bond
+                    == Self::data_object_state_bloat_bond_value(),
+                Error::<T>::DataObjectStateBloatBondChanged,
+            );
 
-        // ensure specified data fee == storage data fee
-        ensure!(
-            params.expected_data_size_fee == DataObjectPerMegabyteFee::<T>::get(),
-            Error::<T>::DataSizeFeeChanged,
-        );
+            // ensure specified data fee == storage data fee
+            ensure!(
+                params.expected_data_size_fee == DataObjectPerMegabyteFee::<T>::get(),
+                Error::<T>::DataSizeFeeChanged,
+            );
+        }
 
         Self::validate_storage_buckets_for_dynamic_bag_type(
             params.bag_id.clone().into(),

--- a/runtime-modules/storage/src/tests/mod.rs
+++ b/runtime-modules/storage/src/tests/mod.rs
@@ -3679,6 +3679,10 @@ fn create_dynamic_bag_fails_with_invalid_data_object_state_bloat_bond() {
         let invalid_data_object_state_bloat_bond_value = 55;
         CreateDynamicBagFixture::default()
             .with_bag_id(dynamic_bag_id)
+            .with_objects(vec![DataObjectCreationParameters {
+                size: 1,
+                ipfs_content_id: vec![1],
+            }])
             .with_expected_data_object_state_bloat_bond(invalid_data_object_state_bloat_bond_value)
             .with_state_bloat_bond_account_id(DEFAULT_MEMBER_ACCOUNT_ID)
             .call_and_assert(Err(Error::<Test>::DataObjectStateBloatBondChanged.into()));


### PR DESCRIPTION
Addresses https://github.com/Joystream/joystream/issues/4103