### PR TITLE
QN: CuratorRemoved and channel.collaborators fixes

### DIFF
--- a/query-node/mappings/src/content/channel.ts
+++ b/query-node/mappings/src/content/channel.ts
@@ -64,7 +64,7 @@ export async function content_ChannelCreated(ctx: EventContext & StoreContext): 
     ...(await convertChannelOwnerToMemberOrCuratorGroup(store, owner)),
 
     collaborators: Array.from(channelCreationParameters.collaborators).map(
-      (id) => new Membership({ id: id.toString() })
+      (id) => new Membership({ id: id[0].toString() })
     ),
     rewardAccount: rewardAccount.toString(),
   })
@@ -135,7 +135,7 @@ export async function content_ChannelUpdated(ctx: EventContext & StoreContext): 
 
   const newCollaborators = channelUpdateParameters.collaborators.unwrapOr(undefined)
   if (newCollaborators) {
-    channel.collaborators = Array.from(newCollaborators).map((id) => new Membership({ id: id.toString() }))
+    channel.collaborators = Array.from(newCollaborators).map((id) => new Membership({ id: id[0].toString() }))
   }
 
   // transfer video active counter value to new category

--- a/query-node/mappings/src/content/curatorGroup.ts
+++ b/query-node/mappings/src/content/curatorGroup.ts
@@ -103,7 +103,7 @@ export async function content_CuratorAdded({ store, event }: EventContext & Stor
 
 export async function content_CuratorRemoved({ store, event }: EventContext & StoreContext): Promise<void> {
   // read event data
-  const [curatorGroupId, curatorId] = new Content.CuratorAddedEvent(event).params
+  const [curatorGroupId, curatorId] = new Content.CuratorRemovedEvent(event).params
 
   // load curator group
   const curatorGroup = await store.get(CuratorGroup, {
@@ -116,14 +116,7 @@ export async function content_CuratorRemoved({ store, event }: EventContext & St
     return inconsistentState('Non-existing curator group removal requested', curatorGroupId)
   }
 
-  // load curator
-  const curator = await getCurator(store, curatorId.toString())
-
-  if (!curator) {
-    return inconsistentState('Non-existing curator removal from curator group requested', curatorGroupId)
-  }
-
-  const curatorIndex = curatorGroup.curators.findIndex((item) => item.id.toString() === curator.toString())
+  const curatorIndex = curatorGroup.curators.findIndex((item) => item.id.toString() === curatorId.toString())
 
   // ensure curator group exists
   if (curatorIndex < 0) {


### PR DESCRIPTION
- fixes https://github.com/Joystream/joystream/issues/4136
- fixes issues with invalid parsing of `channel.collaborators`, causing a QN to crash on channel creation/update w/ collaborators