### PR TITLE
devops - TS lint script improvements + linting CI

### DIFF
--- a/.github/workflows/joystream-cli.yml
+++ b/.github/workflows/joystream-cli.yml
@@ -19,7 +19,6 @@ jobs:
           yarn install --frozen-lockfile
           yarn workspace @joystream/types build
           yarn workspace @joystream/metadata-protobuf build
-          yarn workspace @joystream/cli checks --quiet
       - name: yarn pack test
         run: |
           yarn workspace @joystream/cli pack --filename cli-pack-test.tgz
@@ -43,7 +42,6 @@ jobs:
           yarn install --frozen-lockfile --network-timeout 120000
           yarn workspace @joystream/types build
           yarn workspace @joystream/metadata-protobuf build
-          yarn workspace @joystream/cli checks --quiet
       - name: yarn pack test
         run: |
           yarn workspace @joystream/cli pack --filename cli-pack-test.tgz

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -17,6 +17,8 @@ jobs:
     - name: lint
       run: |
         yarn install --frozen-lockfile
+        yarn workspace @joystream/types build
+        yarn workspace @joystream/metadata-protobuf build
         yarn lint
 
   lint_osx:
@@ -34,4 +36,6 @@ jobs:
     - name: lint
       run: |
         yarn install --frozen-lockfile
+        yarn workspace @joystream/types build
+        yarn workspace @joystream/metadata-protobuf build
         yarn lint

--- a/.github/workflows/lint-typescript.yml
+++ b/.github/workflows/lint-typescript.yml
@@ -1,8 +1,8 @@
-name: joystream-types
+name: lint-typescript
 on: [pull_request, push]
 
 jobs:
-  types_checks_ubuntu:
+  lint_ubuntu:
     name: Ubuntu Checks
     runs-on: ubuntu-latest
     strategy:
@@ -14,18 +14,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: checks
+    - name: lint
       run: |
         yarn install --frozen-lockfile
-        yarn workspace @joystream/types build
-    - name: npm pack test
-      run: |
-        cd types
-        npm pack | tail -1 | xargs tar xzf
-        cd package && npm install
-        node ./index.js
+        yarn lint
 
-  types_checks_osx:
+  lint_osx:
     name: MacOS Checks
     runs-on: macos-latest
     strategy:
@@ -37,13 +31,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: checks
+    - name: lint
       run: |
-        yarn install --frozen-lockfile --network-timeout 120000
-        yarn workspace @joystream/types build
-    - name: npm pack test
-      run: |
-        cd types
-        npm pack | tail -1 | xargs tar xzf
-        cd package && npm install
-        node ./index.js
+        yarn install --frozen-lockfile
+        yarn lint

--- a/.github/workflows/metadata-protobuf.yml
+++ b/.github/workflows/metadata-protobuf.yml
@@ -18,5 +18,4 @@ jobs:
       run: |
         yarn install --frozen-lockfile
         yarn workspace @joystream/metadata-protobuf build
-        yarn workspace @joystream/metadata-protobuf checks --quiet
         yarn workspace @joystream/metadata-protobuf test

--- a/.github/workflows/network-tests.yml
+++ b/.github/workflows/network-tests.yml
@@ -20,7 +20,6 @@ jobs:
         yarn workspace @joystream/types build
         yarn workspace @joystream/metadata-protobuf build
         yarn workspace @joystream/cli build
-        yarn workspace network-tests checks --quiet
 
   network_build_osx:
     name: MacOS Checks
@@ -40,4 +39,3 @@ jobs:
         yarn workspace @joystream/types build
         yarn workspace @joystream/metadata-protobuf build
         yarn workspace @joystream/cli build
-        yarn workspace network-tests checks --quiet

--- a/.github/workflows/query-node.yml
+++ b/.github/workflows/query-node.yml
@@ -20,7 +20,6 @@ jobs:
         yarn workspace @joystream/types build
         yarn workspace @joystream/metadata-protobuf build
         yarn workspace query-node-root build
-        yarn workspace query-node-mappings checks --quiet
 
   query_node_build_osx:
     name: MacOS Checks
@@ -40,4 +39,3 @@ jobs:
         yarn workspace @joystream/types build
         yarn workspace @joystream/metadata-protobuf build
         yarn workspace query-node-root build
-        yarn workspace query-node-mappings checks --quiet

--- a/.github/workflows/storage-node.yml
+++ b/.github/workflows/storage-node.yml
@@ -19,7 +19,6 @@ jobs:
         yarn install --frozen-lockfile
         yarn workspace @joystream/types build
         yarn workspace @joystream/metadata-protobuf build
-        yarn workspace storage-node lint --quiet
         yarn workspace storage-node build
 
   storage_node_build_osx:
@@ -39,5 +38,4 @@ jobs:
         yarn install --frozen-lockfile --network-timeout 120000
         yarn workspace @joystream/types build
         yarn workspace @joystream/metadata-protobuf build
-        yarn workspace storage-node lint --quiet
         yarn workspace storage-node build

--- a/query-node/package.json
+++ b/query-node/package.json
@@ -8,6 +8,7 @@
     "kill": "./kill.sh",
     "rebuild": "yarn db:drop && yarn clean:query-node && yarn codegen:query-node && yarn db:prepare && yarn db:migrate",
     "lint": "yarn workspace query-node-mappings lint",
+    "checks": "yarn workspace query-node-mappings checks",
     "clean": "rm -rf ./generated",
     "clean:query-node": "rm -rf ./generated/graphql-server",
     "processor:start": "DEBUG=${DEBUG} hydra-processor run -e generated/graphql-server/.env",

--- a/scripts/lint-typescript.sh
+++ b/scripts/lint-typescript.sh
@@ -1,11 +1,60 @@
 #!/usr/bin/env bash
 set -e
 
-echo 'running typescript lints'
-yarn workspace query-node-root lint
-yarn workspace @joystream/distributor-cli checks
-yarn workspace @joystream/cli checks
-yarn workspace network-tests checks
-yarn workspace @joystream/types checks
-yarn workspace @joystream/metadata-protobuf checks
-yarn workspace storage-node checks
+# use
+# lint-typescript.sh # check-only format and lint
+# lint-typescript.sh --fix # ensure proper format and lint
+
+# enumerate all yarn workspaces that contains lintable TS code
+WORKSPACES=(
+  query-node-root
+  @joystream/distributor-cli
+  @joystream/cli
+  network-tests
+  @joystream/types
+  @joystream/metadata-protobuf
+  storage-node
+)
+
+# checks that whole code is properly formatted and linted
+function check_lint() {
+  echo 'Running TypeScript lints'
+
+  # print yarn workspace name that contains lint or format errors
+  function lint_error() {
+    echo "Linting error encountered in the package $1"
+    echo "Try running \`$0 --fix\` or fix issues manually"
+  }
+
+  for workspace in "${WORKSPACES[@]}"
+  do
+    # plan printing extra info on lint or format error
+    trap "lint_error $workspace" ERR
+
+    # check that workspace is formatted and linted
+    echo "Checking workspace '${workspace}'"
+    yarn workspace $workspace checks
+  done
+}
+
+# ensures proper format and lint in workspaces
+function fix_lint() {
+  echo 'Fixing TypeScript lints'
+
+  for workspace in "${WORKSPACES[@]}"
+  do
+    echo "Fixing workspace '${workspace}'"
+
+    # fix formating in workspace
+    yarn workspace $workspace format
+
+    # fix linting in worskpace
+    yarn workspace $workspace lint --fix
+  done
+}
+
+if [[ $1 == '--fix' ]]; then
+  fix_lint
+else
+  check_lint
+fi


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/4024.

Introduces a script that automatically fixes format and lint problems.
```
lint-typescript.sh --fix
```

Also, TS format and lint checks have been separated from all CI jobs into a new job that focuses solely on format and lint. That way builds and tests are not interrupted due to these kinds of problems which saves time in case of multiple tests or code quality errors.