### PR TITLE
bump protobuf-metadata package to v2.4.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
     "@apollo/client": "^3.3.13",
     "@ffprobe-installer/ffprobe": "^1.4.1",
-    "@joystream/metadata-protobuf": "^2.2.0",
+    "@joystream/metadata-protobuf": "^2.4.0",
     "@joystream/types": "^0.20.2",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.14.0",

--- a/distributor-node/package.json
+++ b/distributor-node/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@apollo/client": "^3.2.5",
     "@elastic/ecs-winston-format": "^1.1.0",
-    "@joystream/metadata-protobuf": "^2.2.0",
+    "@joystream/metadata-protobuf": "^2.4.0",
     "@joystream/types": "^0.20.2",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/metadata-protobuf/package.json
+++ b/metadata-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/metadata-protobuf",
-  "version": "2.2.0",
+  "version": "2.4.0",
   "description": "Joystream Metadata Protobuf Library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -19,7 +19,7 @@
     "@polkadot/types": "8.9.1",
     "@joystream/hydra-common": "^4.0.0-alpha.6",
     "@joystream/hydra-db-utils": "^4.0.0-alpha.6",
-    "@joystream/metadata-protobuf": "^2.2.0",
+    "@joystream/metadata-protobuf": "^2.4.0",
     "@joystream/types": "^0.20.2",
     "@joystream/warthog": "^2.41.9",
     "@apollo/client": "^3.2.5"

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.21",
     "@elastic/ecs-winston-format": "^1.3.1",
-    "@joystream/metadata-protobuf": "^2.2.0",
+    "@joystream/metadata-protobuf": "^2.4.0",
     "@joystream/types": "^0.20.2",
     "@oclif/command": "^1",
     "@oclif/config": "^1",


### PR DESCRIPTION
Bumped version and published to npm https://www.npmjs.com/package/@joystream/metadata-protobuf/v/2.4.0