### PR TITLE
Fix: Hardcoded constants in api-scripts

### DIFF
--- a/utils/api-scripts/src/initialize-lead.ts
+++ b/utils/api-scripts/src/initialize-lead.ts
@@ -1,9 +1,7 @@
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { ExtrinsicsHelper, getAlicePair, getKeyFromSuri } from './helpers/extrinsics'
-import { u64 } from '@polkadot/types'
-import BN from 'bn.js'
 import { createType } from '@joystream/types'
-import { ApplicationId, OpeningId } from '@joystream/types/primitives'
+import { ApplicationId, MemberId, OpeningId } from '@joystream/types/primitives'
 
 const workingGroupModules = [
   'storageWorkingGroup',
@@ -19,8 +17,6 @@ const workingGroupModules = [
 
 type WorkingGroupModuleName = typeof workingGroupModules[number]
 
-const MIN_APPLICATION_STAKE = new BN(2000)
-
 async function main() {
   // Init api
   const WS_URI = process.env.WS_URI || 'ws://127.0.0.1:9944'
@@ -30,7 +26,9 @@ async function main() {
 
   const Group = process.env.GROUP || 'contentWorkingGroup'
   const LeadKeyPair = process.env.LEAD_URI ? getKeyFromSuri(process.env.LEAD_URI) : getAlicePair()
-  const StakeKeyPair = LeadKeyPair.derive(`//stake${Date.now()}`)
+  const StakeKeyPair = process.env.STAKING_URI
+    ? getKeyFromSuri(process.env.STAKING_URI)
+    : LeadKeyPair.derive(`//stake${Date.now()}`)
 
   if (!workingGroupModules.includes(Group as WorkingGroupModuleName)) {
     throw new Error(`Invalid working group: ${Group}`)
@@ -42,7 +40,7 @@ async function main() {
   // Create membership if not already created
   const memberEntries = await api.query.members.membershipById.entries()
   const matchingEntry = memberEntries.find(
-    ([storageKey, member]) => member.unwrap().controllerAccount.toString() === LeadKeyPair.address
+    ([, member]) => member.unwrap().controllerAccount.toString() === LeadKeyPair.address
   )
   let memberId = matchingEntry?.[0].args[0]
 
@@ -64,10 +62,16 @@ async function main() {
       ],
       'Failed to setup member account'
     )
-    memberId = memberRes.findRecord('members', 'MembershipBought')!.event.data[0] as u64
+    memberId = memberRes.findRecord('members', 'MembershipBought')?.event.data[0] as MemberId | undefined
+
+    if (!memberId) {
+      throw new Error('MembershipBought event not found')
+    }
   }
 
   // Create a new lead opening
+  const minApplicationStake = api.consts[groupModule].minimumApplicationStake
+  const minUnstakingPeriod = api.consts[groupModule].minUnstakingPeriodLimit
   if ((await api.query[groupModule].currentLead()).isSome) {
     console.log(`${groupModule} lead already exists, aborting...`)
   } else {
@@ -79,19 +83,23 @@ async function main() {
         '',
         'Leader',
         {
-          stakeAmount: MIN_APPLICATION_STAKE,
-          leavingUnstakingPeriod: 99999,
+          stakeAmount: minApplicationStake,
+          leavingUnstakingPeriod: minUnstakingPeriod,
         },
         null
       ),
       `Failed to create ${groupModule} lead opening!`
     )
-    const openingId = openingRes.findRecord(groupModule, 'OpeningAdded')!.event.data[0] as OpeningId
+    const openingId = openingRes.findRecord(groupModule, 'OpeningAdded')?.event.data[0] as OpeningId | undefined
+
+    if (!openingId) {
+      throw new Error('OpeningAdded event not found!')
+    }
 
     // Set up stake account
     const addCandidateTx = api.tx.members.addStakingAccountCandidate(memberId)
     const addCandidateFee = (await addCandidateTx.paymentInfo(StakeKeyPair.address)).partialFee
-    const stakingAccountBalance = MIN_APPLICATION_STAKE.add(addCandidateFee)
+    const stakingAccountBalance = minApplicationStake.add(addCandidateFee)
     console.log('Setting up staking account...')
     await txHelper.sendAndCheck(
       LeadKeyPair,
@@ -117,7 +125,7 @@ async function main() {
           roleAccountId: LeadKeyPair.address,
           openingId: openingId,
           stakeParameters: {
-            stake: MIN_APPLICATION_STAKE,
+            stake: minApplicationStake,
             staking_account_id: StakeKeyPair.address,
           },
         }),
@@ -125,7 +133,13 @@ async function main() {
       'Failed to apply on lead opening!'
     )
 
-    const applicationId = applicationRes.findRecord(groupModule, 'AppliedOnOpening')!.event.data[1] as ApplicationId
+    const applicationId = applicationRes.findRecord(groupModule, 'AppliedOnOpening')?.event.data[1] as
+      | ApplicationId
+      | undefined
+
+    if (!applicationId) {
+      throw new Error('AppliedOnOpening event not found!')
+    }
 
     // Fill opening
     console.log('Filling the opening...')

--- a/utils/api-scripts/src/initialize-worker.ts
+++ b/utils/api-scripts/src/initialize-worker.ts
@@ -1,7 +1,6 @@
 import { createType } from '@joystream/types'
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { ExtrinsicsHelper, getAlicePair, getKeyFromSuri } from './helpers/extrinsics'
-import BN from 'bn.js'
 import { ApplicationId, OpeningId } from '@joystream/types/primitives'
 
 const workingGroupModules = [
@@ -18,10 +17,6 @@ const workingGroupModules = [
 
 type WorkingGroupModuleName = typeof workingGroupModules[number]
 
-const MIN_APPLICATION_STAKE = new BN(2000)
-const STAKING_ACCOUNT_CANDIDATE_STAKE = new BN(200)
-const OPENING_STAKE = new BN(2000)
-
 async function main() {
   // Init api
   const WS_URI = process.env.WS_URI || 'ws://127.0.0.1:9944'
@@ -36,7 +31,9 @@ async function main() {
     ? getKeyFromSuri(process.env.WORKER_MEMBER_URI)
     : getAlicePair()
   const WorkerRoleKeyPair = process.env.WORKER_ROLE_URI ? getKeyFromSuri(process.env.WORKER_ROLE_URI) : getAlicePair()
-  const StakeKeyPair = WorkerRoleKeyPair.derive(`//stake${Date.now()}`)
+  const StakeKeyPair = process.env.STAKING_URI
+    ? getKeyFromSuri(process.env.STAKING_URI)
+    : WorkerRoleKeyPair.derive(`//stake${Date.now()}`)
   const InitialWorkerBalanceTopUp = parseInt(process.env.INITIAL_WORKER_BALANCE_TOP_UP || '0') // In order to dev-initialize the storage worker
 
   // Check if group exists
@@ -79,14 +76,17 @@ async function main() {
   }
 
   // Send opening stake to lead's stake account
-  console.log(`Topping up lead's staking account with OPENING_STAKE...`)
+  const openingStake = api.consts[groupModule].leaderOpeningStake
+  console.log(`Topping up lead's staking account with opening stake...`)
   await txHelper.sendAndCheck(
     LeadRoleKeyPair,
-    [api.tx.balances.transferKeepAlive(leadWorker.stakingAccountId, OPENING_STAKE)],
+    [api.tx.balances.transferKeepAlive(leadWorker.stakingAccountId, openingStake)],
     'Lead stake top-up failed'
   )
 
   // Create a new opening
+  const minApplicationStake = api.consts[groupModule].minimumApplicationStake
+  const minUnstakingPeriod = api.consts[groupModule].minUnstakingPeriodLimit
   console.log(`Creating ${groupModule} worker opening...`)
   const [openingRes] = await txHelper.sendAndCheck(
     LeadRoleKeyPair,
@@ -95,20 +95,24 @@ async function main() {
         '',
         'Regular',
         {
-          stakeAmount: MIN_APPLICATION_STAKE,
-          leavingUnstakingPeriod: 99999,
+          stakeAmount: minApplicationStake,
+          leavingUnstakingPeriod: minUnstakingPeriod,
         },
         null
       ),
     ],
     `Failed to create ${groupModule} worker opening!`
   )
-  const openingId = openingRes.findRecord(groupModule, 'OpeningAdded')!.event.data[0] as OpeningId
+  const openingId = openingRes.findRecord(groupModule, 'OpeningAdded')?.event.data[0] as OpeningId | undefined
+
+  if (!openingId) {
+    throw new Error('OpeningAdded event not found!')
+  }
 
   // Setting up stake account
   const addCandidateTx = api.tx.members.addStakingAccountCandidate(memberId)
   const addCandidateFee = (await addCandidateTx.paymentInfo(StakeKeyPair.address)).partialFee
-  const stakingAccountBalance = MIN_APPLICATION_STAKE.add(STAKING_ACCOUNT_CANDIDATE_STAKE).add(addCandidateFee)
+  const stakingAccountBalance = minApplicationStake.add(addCandidateFee)
   console.log('Setting up staking account...')
   await txHelper.sendAndCheck(
     WorkerMemberKeyPair,
@@ -134,7 +138,7 @@ async function main() {
         roleAccountId: WorkerRoleKeyPair.address,
         openingId,
         stakeParameters: {
-          stake: MIN_APPLICATION_STAKE,
+          stake: minApplicationStake,
           stakingAccountId: StakeKeyPair.address,
         },
       }),
@@ -142,7 +146,13 @@ async function main() {
     'Failed to apply on worker opening!'
   )
 
-  const applicationId = applicationRes.findRecord(groupModule, 'AppliedOnOpening')!.event.data[1] as ApplicationId
+  const applicationId = applicationRes.findRecord(groupModule, 'AppliedOnOpening')?.event.data[1] as
+    | ApplicationId
+    | undefined
+
+  if (!applicationId) {
+    throw new Error('AppliedOnOpening event not found!')
+  }
 
   // Filling the opening
   console.log('Filling the opening...')


### PR DESCRIPTION
Fix api-scripts that broke because of hardcoded constants like `MIN_APPLICATION_STAKE` which recently changed in the runtime.