### PR TITLE
fix OwnedNft.isOwnedByChannel field

### DIFF
--- a/query-node/mappings/src/content/nft.ts
+++ b/query-node/mappings/src/content/nft.ts
@@ -173,6 +173,7 @@ async function resetNftTransactionalStatusFromVideo(
   if (newOwner) {
     nft.ownerMember = newOwner
     nft.ownerCuratorGroup = undefined
+    nft.isOwnedByChannel = false
   }
 
   // reset transactional status
@@ -421,8 +422,8 @@ export async function createNft(
     : undefined
   const decodedMetadata = nftIssuanceParameters.nftMetadata.toString()
 
-  // Is NFT owned by channel or some member
-  const isOwnedByChannel = !ownerMember
+  // Newly minted NFT is always owned by a channel unless nonChannelOwner was set
+  const isOwnedByChannel = !nftIssuanceParameters.nonChannelOwner.isSome
 
   // channel ownerCuratorGroup (if any)
   const ownerCuratorGroup = isOwnedByChannel ? video.channel.ownerCuratorGroup : undefined


### PR DESCRIPTION
Previously `OwnedNft.isOwnedByChannel` would always be false since we're always setting `ownerMember`. This PR changes this field so that it actually notifies whether NFT is owned by a channel