### PR TITLE
CLI fixes: selecting distribution buckets & subtitile assets indices

### DIFF
--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -508,7 +508,12 @@ export default class Api {
       const bucketsCountPolicy = [...distributionBucketFamiliesPolicy]
         .find(([familyId]) => familyId.toString() === id)?.[1]
         .toNumber()
-      if (bucketsCountPolicy && bucketsCountPolicy > buckets.length) {
+
+      if (!bucketsCountPolicy) {
+        continue
+      }
+
+      if (bucketsCountPolicy > buckets.length) {
         throw new CLIError(
           `Distribution buckets policy constraint unsatisfied. Not enough buckets exist in Bucket Family ${id}`
         )

--- a/cli/src/commands/content/createVideo.ts
+++ b/cli/src/commands/content/createVideo.ts
@@ -77,18 +77,20 @@ export default class CreateVideoCommand extends UploadCommandBase {
     meta.thumbnailPhoto = videoAssetIndices.thumbnailPhotoPath
 
     // Subtitle assets
-    const resolvedSubtitleAssets = await Promise.all(
-      (subtitles || []).map(async (subtitleInputParameters, i) => {
-        const { subtitleAssetPath } = subtitleInputParameters
-        const [[resolvedAsset], assetIndices] = await this.resolveAndValidateAssets({ subtitleAssetPath }, input)
-        // Set assets indices in the metadata
-        if (meta.subtitles) {
-          meta.subtitles[i].newAsset =
-            assetIndices.subtitleAssetPath || 0 + Object.entries(videoAssetIndices).length + i
-        }
-        return resolvedAsset
-      })
-    )
+    let subtitleAssetIndex = Object.values(videoAssetIndices).filter((v) => v !== undefined).length
+    const resolvedSubtitleAssets = (
+      await Promise.all(
+        (subtitles || []).map(async (subtitleInputParameters, i) => {
+          const { subtitleAssetPath } = subtitleInputParameters
+          const [[resolvedAsset]] = await this.resolveAndValidateAssets({ subtitleAssetPath }, input)
+          // Set assets indices in the metadata
+          if (meta.subtitles && resolvedAsset) {
+            meta.subtitles[i].newAsset = subtitleAssetIndex++
+          }
+          return resolvedAsset
+        })
+      )
+    ).filter((r) => r)
 
     // Try to get video file metadata
     if (videoAssetIndices.videoPath !== undefined) {

--- a/cli/src/commands/content/updateVideo.ts
+++ b/cli/src/commands/content/updateVideo.ts
@@ -95,18 +95,20 @@ export default class UpdateVideoCommand extends UploadCommandBase {
     meta.thumbnailPhoto = videoAssetIndices.thumbnailPhotoPath
 
     // Subtitle assets
-    const resolvedSubtitleAssets = await Promise.all(
-      (subtitles || []).map(async (subtitleInputParameters, i) => {
-        const { subtitleAssetPath } = subtitleInputParameters
-        const [[resolvedAsset], assetIndices] = await this.resolveAndValidateAssets({ subtitleAssetPath }, input)
-        // Set assets indices in the metadata
-        if (meta.subtitles) {
-          meta.subtitles[i].newAsset =
-            assetIndices.subtitleAssetPath || 0 + Object.entries(videoAssetIndices).length + i
-        }
-        return resolvedAsset
-      })
-    )
+    let subtitleAssetIndex = Object.values(videoAssetIndices).filter((v) => v !== undefined).length
+    const resolvedSubtitleAssets = (
+      await Promise.all(
+        (subtitles || []).map(async (subtitleInputParameters, i) => {
+          const { subtitleAssetPath } = subtitleInputParameters
+          const [[resolvedAsset]] = await this.resolveAndValidateAssets({ subtitleAssetPath }, input)
+          // Set assets indices in the metadata
+          if (meta.subtitles && resolvedAsset) {
+            meta.subtitles[i].newAsset = subtitleAssetIndex++
+          }
+          return resolvedAsset
+        })
+      )
+    ).filter((r) => r)
 
     // Prepare and send the extrinsic
     const serializedMeta = metadataToBytes(VideoMetadata, meta)


### PR DESCRIPTION
Fixes for Carthage CLI:


* Fixed handling for distribution buckets selection when some families are not included in the policy
* Fixed indices of subtitle assets in case other assets (like video thumbnail, video media or previous subtitles' assets) are not provided



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202132419573087/1202914194106559) by [Unito](https://www.unito.io)
