### PR TITLE
Colossus: Verify workerId to transactorKey compatibility

### DIFF
--- a/storage-node/README.md
+++ b/storage-node/README.md
@@ -96,7 +96,7 @@ The actual data distribution (serving to end-users) is done via Argus - the dist
 ### Comments
 
 - Colossus relies on the [Query Node (Hydra)](https://www.joystream.org/hydra/) to get the blockchain data in a structured form.
-- Using Colossus as a functioning Storage Provider requires providing [account URI or key file and password](https://wiki.polkadot.network/docs/learn-accounts) as well as active `WorkerId` from the Storage Working group.
+- Using Colossus as a functioning Storage Provider requires providing [account URI or key file and password](https://wiki.polkadot.network/docs/learn-accounts) of a transactor account associated with the assigned storage bucket, as well as active `WorkerId` from the Storage Working group.
 
 # Installation
 
@@ -134,8 +134,8 @@ $ yarn storage-node server --apiUrl ws://localhost:9944  -w 0 --accountUri //Ali
 
 ### Prerequisites
 
-- accountURI or keyfile and password
-- workerId from the Storage working group that matches with the account above
+- accountURI or keyfile and password of the transactor account
+- workerId from the Storage working group that matches with the transactor account above
 - Joystream node websocket endpoint URL
 - QueryNode URL
 - (optional) ElasticSearch URL


### PR DESCRIPTION
Addresses https://github.com/Joystream/joystream/issues/4272

Note that the check is only failing if:
- Worker id is invalid
- There is an active bucket assigned to the provided worker, but its transactor key doesn't match the key configured in colossus

There is however a case where there are no active buckets assigned to the worker, in which case the `server` command will only emit a warning, but will not exit. This is because in that case:
- We cannot verify transactor key, since it's not yet set
- We still want to allow the storage worker to start syncing before he accepts a bucket invitation, so that (s)he can already be fully synced when starting to act as bucket operator.