### PR TITLE
Fix query node scalability issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,7 +211,7 @@ services:
     command: ['yarn', 'workspace', 'query-node-root', 'processor:start']
 
   indexer:
-    image: joystream/hydra-indexer:v4.0.0-alpha.0
+    image: joystream/hydra-indexer:v4.0.0-alpha.7
     container_name: indexer
     restart: unless-stopped
     env_file:
@@ -232,7 +232,7 @@ services:
       sh -c "yarn db:bootstrap && yarn start:prod"
 
   hydra-indexer-gateway:
-    image: joystream/hydra-indexer-gateway:4.0.0-alpha.0
+    image: joystream/hydra-indexer-gateway:4.0.0-alpha.7
     container_name: hydra-indexer-gateway
     restart: unless-stopped
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,9 @@ services:
       - INDEXER_ENDPOINT_URL=${PROCESSOR_INDEXER_GATEWAY}
       - TYPEORM_HOST=db
       - TYPEORM_DATABASE=${DB_NAME}
+      - BATCH_SIZE=100
+      - QUEUE_FACTOR=1
+      - QUEUE_MAX_CAP_FACTOR=4
     depends_on:
       - db
     volumes:


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/4360
Partially relies on https://github.com/Joystream/hydra/pull/510, which introduces additional optimalization and prevents unnecessary event entity size bloat.

## Processor parameters
By setting  `BATCH_SIZE=100` and `QUEUE_FACTOR=1` we limit the number of events fetched from the indexer to `100` in a single query. This is because in worst case scenario an event can be ~5 MB in size (max block size), which gives 500 MB of data. Serializing data to a string larger than 512 MB can already cause issues on 32-bit platforms.

With `QUEUE_MAX_CAP_FACTOR=4` we allow 4x more events to be stored in memory, so ~2 GB in worst case scenario.

## Impact of this PR on indexing/processing speed
### Empty blocks
* Indexing speed: `~19 blocks / second` => `~19 blocks / second` _**(no change)**_
* Processing speed: `~1000 blocks / second => ~1000 blocks / second` _**(no change)**_

### batchSize=100 members migration (4400 members over 176 blocks)
* Indexing speed: `26s` => `14s` _**(-12s / -46%)**_
* Processing speed: `27s` => `30s` _**(+3s / +11%)**_

### batchSize=1000 members migration (4400 members over 18 blocks)
* Indexing speed: `135s` => `6s` _**(-129s / -95%)**_
* Processing speed: `ERROR` => `68s`



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202132419573087/1203161686425352) by [Unito](https://www.unito.io)
