### PR TITLE
Bounty weight function: Fix parameters passed in the wrong order

### DIFF
--- a/runtime-modules/bounty/src/lib.rs
+++ b/runtime-modules/bounty/src/lib.rs
@@ -1270,8 +1270,9 @@ decl_module! {
         ///    - `O(1)` doesn't depend on the state or parameters
         /// # </weight>
         #[weight = WeightInfoBounty::<T>::announce_work_entry(
-            T::ClosedContractSizeLimit::get().saturated_into(),
-            work_description.len().saturated_into())]
+            work_description.len().saturated_into(),
+            T::ClosedContractSizeLimit::get().saturated_into()
+        )]
         pub fn announce_work_entry(
             origin,
             member_id: MemberId<T>,


### PR DESCRIPTION
Fixes an issue identified in https://github.com/Joystream/joystream/pull/4374#discussion_r997088342