### PR TITLE
Colossus prevalidate upload params

### DIFF
--- a/cli/src/base/UploadCommandBase.ts
+++ b/cli/src/base/UploadCommandBase.ts
@@ -274,9 +274,6 @@ export default abstract class UploadCommandBase extends ContentDirectoryCommandB
       // cli.action.start('Waiting for the file to be processed...')
     })
     const formData = new FormData()
-    formData.append('dataObjectId', objectId.toString())
-    formData.append('storageBucketId', storageNodeInfo.bucketId)
-    formData.append('bagId', bagId)
     formData.append('file', fileStream, {
       filename: path.basename(filePath),
       filepath: filePath,

--- a/cli/src/base/UploadCommandBase.ts
+++ b/cli/src/base/UploadCommandBase.ts
@@ -285,6 +285,11 @@ export default abstract class UploadCommandBase extends ContentDirectoryCommandB
     this.log(`Uploading object ${objectId.toString()} (${filePath})`)
     try {
       await axios.post(`${storageNodeInfo.apiEndpoint}/files`, formData, {
+        params: {
+          dataObjectId: objectId.toString(),
+          storageBucketId: storageNodeInfo.bucketId,
+          bagId,
+        },
         maxBodyLength: Infinity,
         maxContentLength: Infinity,
         headers: {

--- a/distributor-node/src/commands/dev/batchUpload.ts
+++ b/distributor-node/src/commands/dev/batchUpload.ts
@@ -92,7 +92,7 @@ export default class DevBatchUpload extends AccountsCommandBase {
               url: urljoin(endpoint, 'api/v1/files'),
               data: formData,
               params: {
-                dataObjectId: dataObject.toString(),
+                dataObjectId: dataObjectId.toString(),
                 storageBucketId: bucketId.toString(),
                 bagId,
               },

--- a/distributor-node/src/commands/dev/batchUpload.ts
+++ b/distributor-node/src/commands/dev/batchUpload.ts
@@ -84,9 +84,6 @@ export default class DevBatchUpload extends AccountsCommandBase {
         batch.map(async ([, dataObject], k) => {
           const dataObjectId = nextObjectId + k
           const formData = new FormData()
-          formData.append('dataObjectId', dataObjectId.toString())
-          formData.append('storageBucketId', bucketId.toString())
-          formData.append('bagId', bagId)
           formData.append('file', dataObject, { filename: 'test.jpg', knownLength: dataObject.byteLength })
           this.log(`Uploading object ${dataObjectId}`)
           try {
@@ -94,6 +91,11 @@ export default class DevBatchUpload extends AccountsCommandBase {
               method: 'POST',
               url: urljoin(endpoint, 'api/v1/files'),
               data: formData,
+              params: {
+                dataObjectId: dataObject.toString(),
+                storageBucketId: bucketId.toString(),
+                bagId,
+              },
               headers: {
                 'content-type': 'multipart/form-data',
                 ...formData.getHeaders(),

--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 3.0.0
+
+- **Carthage release:** Breaking change for files upload endpoint, the parameters except the file itself i.e., `dataObjectId`, `storageBucketId` and `bagId` are removed from the request body and are now part of the query string. This allows the pre-validation of the request params to validate the request before the complete file is uploaded successfully,

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storage-node",
   "description": "Joystream storage subsystem.",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "author": "Joystream contributors",
   "bin": {
     "storage-node": "./bin/run"

--- a/storage-node/src/api-spec/openapi.yaml
+++ b/storage-node/src/api-spec/openapi.yaml
@@ -6,22 +6,20 @@ info:
     email: info@joystream.org
   license:
     name: GPL-3.0-only
-    url: https://opensource.org/licenses/GPL-3.0
+    url: 'https://opensource.org/licenses/GPL-3.0'
   version: 0.1.0
 externalDocs:
   description: Storage node API
-  url: https://github.com/Joystream/joystream/issues/2224
+  url: 'https://github.com/Joystream/joystream/issues/2224'
 servers:
-  - url: http://localhost:3333/api/v1/
-
+  - url: 'http://localhost:3333/api/v1/'
 tags:
   - name: files
     description: Storage node Files API
   - name: state
     description: Storage node State API
-
 paths:
-  /files/{id}:
+  '/files/{id}':
     get:
       operationId: filesApi.getFile
       description: Returns a media file.
@@ -35,7 +33,7 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Ok
           content:
             video/*:
@@ -54,25 +52,25 @@ paths:
               schema:
                 type: string
                 format: binary
-        400:
+        '400':
           description: Bad request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        401:
+        '401':
           description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        404:
+        '404':
           description: File not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-        500:
+        '500':
           description: Unknown server error
     head:
       operationId: filesApi.getFileHeaders
@@ -87,13 +85,13 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Ok
-        400:
+        '400':
           description: Bad request
-        404:
+        '404':
           description: File not found
-        500:
+        '500':
           description: Unknown server error
   /files:
     post:
@@ -101,34 +99,41 @@ paths:
       operationId: filesApi.uploadFile
       tags:
         - files
+      parameters:
+        - name: dataObjectId
+          required: true
+          in: query
+          description: Data object runtime ID
+          schema:
+            type: string
+            pattern: ^\d+$ #integer
+        - name: storageBucketId
+          required: true
+          in: query
+          description: Storage bucket ID
+          schema:
+            type: string
+            pattern: ^\d+$ #integer
+        - name: bagId
+          required: true
+          in: query
+          description: Bag ID
+          schema:
+            type: string
+          allowReserved: true
       requestBody:
         content:
           multipart/form-data:
             schema:
               type: object
-              required:
-                - dataObjectId
-                - storageBucketId
-                - bagId
               properties:
                 file:
                   description: Data file
                   type: string
                   format: binary
-                dataObjectId:
-                  description: Data object runtime ID
-                  type: string
-                  pattern: '^\d+$' #integer
-                storageBucketId:
-                  description: Storage bucket ID
-                  type: string
-                  pattern: '^\d+$' #integer
-                bagId:
-                  description: Bag ID
-                  type: string
         required: true
       responses:
-        201:
+        '201':
           description: Created
           content:
             application/json:
@@ -137,13 +142,12 @@ paths:
                 properties:
                   id:
                     type: string
-        400:
+        '400':
           description: Bad request
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-
   /state/data-objects:
     get:
       operationId: stateApi.getAllLocalDataObjects
@@ -151,14 +155,13 @@ paths:
       tags:
         - state
       responses:
-        200:
+        '200':
           description: Ok
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataObjectResponse'
-
-  /state/bags/{bagId}/data-objects:
+  '/state/bags/{bagId}/data-objects':
     get:
       operationId: stateApi.getLocalDataObjectsByBagId
       description: Returns local data objects for the bag.
@@ -172,13 +175,12 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Ok
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataObjectResponse'
-
   /version:
     get:
       operationId: stateApi.getVersion
@@ -186,7 +188,7 @@ paths:
       tags:
         - state
       responses:
-        200:
+        '200':
           description: Ok
           content:
             application/json:
@@ -199,13 +201,12 @@ paths:
       tags:
         - state
       responses:
-        200:
+        '200':
           description: Ok
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataStatsResponse'
-
 components:
   schemas:
     TokenRequest:

--- a/storage-node/src/services/helpers/auth.ts
+++ b/storage-node/src/services/helpers/auth.ts
@@ -40,11 +40,11 @@ export interface RequestData {
   /**
    * Runtime data object ID.
    */
-  dataObjectId: number
+  dataObjectId: string
   /**
    * Runtime storage bucket ID.
    */
-  storageBucketId: number
+  storageBucketId: string
   /**
    * Bag ID in the string format.
    */

--- a/storage-node/src/services/runtime/extrinsics.ts
+++ b/storage-node/src/services/runtime/extrinsics.ts
@@ -6,6 +6,7 @@ import { PalletStorageBagIdType as BagId, PalletStorageDynamicBagType as Dynamic
 import logger from '../../services/logger'
 import { timeout } from 'promise-timeout'
 import { createType } from '@joystream/types'
+import BN from 'bn.js'
 
 /**
  * Creates storage bucket.
@@ -164,8 +165,8 @@ export async function acceptPendingDataObjects(
   bagId: BagId,
   account: KeyringPair,
   workerId: number,
-  storageBucketId: number,
-  dataObjects: number[]
+  storageBucketId: BN,
+  dataObjects: BN[]
 ): Promise<boolean> {
   return await extrinsicWrapper(() => {
     const dataObjectSet = api.createType('BTreeSet<u64>', dataObjects)

--- a/storage-node/src/services/webApi/app.ts
+++ b/storage-node/src/services/webApi/app.ts
@@ -42,13 +42,9 @@ export async function createApp(config: AppConfig): Promise<Express> {
     },
 
     // Pre validate file upload params
-    async (req: express.Request, res: express.Response<unknown, AppConfig>, next: NextFunction) => {
-      try {
-        if (req.path === '/api/v1/files') {
-          await validateUploadFileParams(req, res)
-        }
-      } catch (error) {
-        sendResponseWithError(res, next, error, 'upload')
+    (req: express.Request, res: express.Response<unknown, AppConfig>, next: NextFunction) => {
+      if (req.path === '/api/v1/files') {
+        validateUploadFileParams(req, res).catch((error) => sendResponseWithError(res, next, error, 'upload'))
       }
 
       next()
@@ -208,12 +204,12 @@ async function validateUploadFileParams(req: express.Request, res: express.Respo
 
   const storageBucketId = Number(req.query.storageBucketId)
   const dataObjectId = Number(req.query.dataObjectId)
-  const bagId = req.query.bagId!.toString()
+  const bagId = req.query.bagId?.toString() || ''
 
   const parsedBagId = parseBagId(bagId)
 
   const [dataObject] = await Promise.all([
-    api.query.storage.dataObjectsById(parsedBagId, Number(dataObjectId)),
+    api.query.storage.dataObjectsById(parsedBagId, dataObjectId),
     verifyBagAssignment(api, parsedBagId, storageBucketId),
     verifyBucketId(queryNodeEndpoint, workerId, storageBucketId),
   ])

--- a/storage-node/src/services/webApi/app.ts
+++ b/storage-node/src/services/webApi/app.ts
@@ -155,9 +155,9 @@ function validateUpload(api: ApiPromise, account: KeyringPair): ValidateUploadFu
     const token = parseUploadToken(tokenString)
 
     const sourceTokenRequest: RequestData = {
-      dataObjectId: parseInt(req.body.dataObjectId),
-      storageBucketId: parseInt(req.body.storageBucketId),
-      bagId: req.body.bagId,
+      dataObjectId: req.query.dataObjectId?.toString() || '',
+      storageBucketId: req.query.storageBucketId?.toString() || '',
+      bagId: req.query.bagId?.toString() || '',
     }
 
     verifyUploadTokenData(account.address, token, sourceTokenRequest)

--- a/storage-node/src/services/webApi/controllers/filesApi.ts
+++ b/storage-node/src/services/webApi/controllers/filesApi.ts
@@ -271,6 +271,10 @@ async function verifyDataObjectInfo(
 ): Promise<boolean> {
   const dataObject = await api.query.storage.dataObjectsById(bagId, dataObjectId)
 
+  if (dataObject.isEmpty) {
+    throw new WebApiError(`Data object ${dataObjectId} doesn't exist in storage bag ${bagId}`, 400)
+  }
+
   // Cannot get 'size' as a regular property.
   const dataObjectSize = dataObject.size_
 

--- a/storage-node/src/services/webApi/controllers/filesApi.ts
+++ b/storage-node/src/services/webApi/controllers/filesApi.ts
@@ -332,7 +332,7 @@ export async function getVersion(req: express.Request, res: express.Response<unk
  * @param bucketId - storage bucket ID
  * @returns void promise.
  */
-export async function verifyBucketId(queryNodeUrl: string, workerId: number, bucketId: number): Promise<void> {
+export async function verifyBucketId(queryNodeUrl: string, workerId: number, bucketId: BN): Promise<void> {
   const bucketIds = await getStorageBucketIdsByWorkerId(queryNodeUrl, workerId)
 
   if (!bucketIds.includes(bucketId.toString())) {
@@ -349,10 +349,10 @@ export async function verifyBucketId(queryNodeUrl: string, workerId: number, buc
  * @param bucketId - storage bucket ID
  * @returns void promise.
  */
-export async function verifyBagAssignment(api: ApiPromise, bagId: BagId, bucketId: number): Promise<void> {
+export async function verifyBagAssignment(api: ApiPromise, bagId: BagId, bucketId: BN): Promise<void> {
   const bag = await api.query.storage.bags(bagId)
 
-  if (![...bag.storedBy].map((s) => s.toNumber()).includes(bucketId)) {
+  if (![...bag.storedBy].map((s) => s.toString()).includes(bucketId.toString())) {
     throw new WebApiError(`Storage bag ${bagId} is not assigned to storage bucket ${bucketId}.`, 400)
   }
 }


### PR DESCRIPTION
Addresses #4295

Based on #4381 & #4383


### Solution 
This PR moves the parameters that needs to be pre validated (before upload is completed) from the request body to query params i.e., `dataObjectId`, `storageBucketId` and `bagId`. This way the query params can be validated right away in the middleware when the request hits the server. And returning an error if the parameters are not valid, both providing the better upload UX for end users, and saving network resources of the storage node
