### PR TITLE
small readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This is the main code repository for all Joystream software. In this mono-repo y
 
 ## Overview
 
-The Joystream network builds on a pre-release version of [substrate v2.0](https://substrate.dev/) and adds additional
-functionality to support the [various roles](https://www.joystream.org/roles) that can be entered into on the platform.
+The Joystream network builds on the [substrate](https://substrate.io/) blockchain framework, and adds additional
+functionality to support the [various roles](https://joystream.gitbook.io/testnet-workspace/system/working-groups) that can be entered into on the platform.
 
-## Development Tools
+## Development
 
 The following tools are required for building, testing and contributing to this repo:
 
@@ -22,7 +22,7 @@ If you use VSCode as your code editor we recommend using the workspace [settings
 After cloning the repo run the following initialization scripts:
 
 ```sh
-# Install rust toolchain
+# Install development tools
 ./setup.sh
 
 # build local npm packages
@@ -39,7 +39,7 @@ yarn start
 
 **Substrate blockchain**
 
-- [joystream-node](./node)
+- [joystream-node](./bin/node)
 - [runtime](./runtime)
 - [runtime modules](./runtime-modules)
 
@@ -67,12 +67,12 @@ yarn start
 ```sh
 git checkout master
 WASM_BUILD_TOOLCHAIN=nightly-2022-05-11 cargo build --release
-./target/release/joystream-node -- --pruning archive --chain testnets/joy-testnet-4.json
+./target/release/joystream-node -- --pruning archive --chain testnets/joy-testnet-7-carthage.json
 ```
 
 Learn more about [joystream-node](bin/node/README.md).
 
-A step by step guide to setup a full node and validator on the Joystream testnet, can be found [here](https://github.com/Joystream/helpdesk/tree/master/roles/validators).
+A step by step guide to setup a full node and validator on the Joystream testnet, can be found [here](https://joystream.gitbook.io/testnet-workspace/system/validation#validator).
 
 ### Integration tests
 

--- a/bin/node/README.md
+++ b/bin/node/README.md
@@ -4,8 +4,6 @@
 
 The joystream-node is the main server application that connects to the network, synchronizes the blockchain with other nodes and produces blocks if configured as a validator node.
 
-A step by step guide to setup a full node and validator on the Joystream testnet, can be found [here](https://github.com/Joystream/helpdesk/tree/master/roles/validators).
-
 ### Pre-built binaries
 
 The latest pre-built binaries can be downloaded from the [releases](https://github.com/Joystream/joystream/releases) page.
@@ -49,7 +47,7 @@ this script will build and run a fresh new local development chain (purging exis
 Use the `--chain` argument, and specify the path to the genesis `chain.json` file for that public network. The JSON "chain spec" files for Joystream public networks can be found in [../testnets/](../testnets/).
 
 ```bash
-./target/release/joystream-node --chain testnets/joy-testnet-5.json
+./target/release/joystream-node --chain testnets/joy-testnet-7-carthage.json
 ```
 
 ### Tests and code quality
@@ -85,5 +83,5 @@ WASM_BUILD_TOOLCHAIN=nightly-2022-05-11 cargo +nightly-2022-05-11 install joystr
 Now you can run and connect to the testnet:
 
 ```bash
-joystream-node --chain testnets/joy-testnet-5.json
+joystream-node --chain testnets/joy-testnet-7-carthage.json
 ```

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Version 11.0.0 - Carthage - new chain
+### Version 11.3.0 - Carthage - new chain
   - Update to substrate v0.9.23
   - Introduce project-token pallet into runtime
   - Dropped blog pallet

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -7,10 +7,11 @@ The runtime is the code that defines the consensus rules of the Joystream protoc
 It is compiled to WASM and lives on chain.
 Joystream node execute the code's logic to validate transactions and blocks on the blockchain.
 
-When building joystream-node as described in [../node/README.md](../node/README.md), in addition to the joystream-node binary being built the WASM blob artifact is produced in:
+When building joystream-node as described in [../bin/node/README.md](../bin/node/README.md), in addition to the joystream-node binary being built the WASM blob artifact is produced in:
 
 `./target/release/wbuild/joystream-node-runtime/joystream_node_runtime.compact.wasm`
 
+.. relative to the project root directory
 
 ### Deployment
 


### PR DESCRIPTION
Update some outdated links in README files and reference to old testnet chainspec.
Added reference to new carthage chainspec which will be added to repo after release.