### PR TITLE
Fix computing code shasum inside docker build

### DIFF
--- a/.github/workflows/joystream-node-docker-dev.yml
+++ b/.github/workflows/joystream-node-docker-dev.yml
@@ -53,7 +53,9 @@ jobs:
           context: .
           file: joystream-node.Dockerfile
           platforms: linux/amd64
-          build-args: CARGO_FEATURES=${{ matrix.cargo_features }}
+          build-args:
+            CARGO_FEATURES=${{ matrix.cargo_features }}
+            CODE_SHASUM=${{ steps.compute_shasum.outputs.shasum }}
           push: true
           tags: ${{ env.REPOSITORY }}:${{ steps.compute_shasum.outputs.shasum }}
         if: ${{ steps.compute_image_exists.outputs.image_exists == 1 }}

--- a/.github/workflows/joystream-node-docker-dev.yml
+++ b/.github/workflows/joystream-node-docker-dev.yml
@@ -53,7 +53,7 @@ jobs:
           context: .
           file: joystream-node.Dockerfile
           platforms: linux/amd64
-          build-args:
+          build-args: |
             CARGO_FEATURES=${{ matrix.cargo_features }}
             CODE_SHASUM=${{ steps.compute_shasum.outputs.shasum }}
           push: true

--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -123,7 +123,7 @@ jobs:
                           repository=${{ env.REPOSITORY }} dockerfile=${{ matrix.file }} \
                           platform=${{ matrix.platform }} \
                           cargo_features='' \
-                          code_shasum=${{ need.repo_check.outputs.shasum }}"
+                          code_shasum=${{ needs.repo_check.outputs.shasum }}"
         if: ${{ steps.compute_image_exists.outputs.image_exists == 1 }}
 
       - name: Delete CloudFormation Stack

--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -121,8 +121,9 @@ jobs:
                           docker_password=${{ secrets.DOCKERHUB_PASSWORD }} \
                           tag_name=${{ needs.repo-check.outputs.shasum }}-${{ matrix.platform_tag }} \
                           repository=${{ env.REPOSITORY }} dockerfile=${{ matrix.file }} \
-                          platform=${{ matrix.platform }}
-                          cargo_features=''"
+                          platform=${{ matrix.platform }} \
+                          cargo_features='' \
+                          code_shasum={{ need.repo_check.outputs.shasum }}"
         if: ${{ steps.compute_image_exists.outputs.image_exists == 1 }}
 
       - name: Delete CloudFormation Stack

--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -123,7 +123,7 @@ jobs:
                           repository=${{ env.REPOSITORY }} dockerfile=${{ matrix.file }} \
                           platform=${{ matrix.platform }} \
                           cargo_features='' \
-                          code_shasum={{ need.repo_check.outputs.shasum }}"
+                          code_shasum=${{ need.repo_check.outputs.shasum }}"
         if: ${{ steps.compute_image_exists.outputs.image_exists == 1 }}
 
       - name: Delete CloudFormation Stack

--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -121,9 +121,9 @@ jobs:
           context: .
           file: joystream-node.Dockerfile
           platforms: linux/amd64
-          build-args:
+          build-args: |
             CARGO_FEATURES=testing-runtime
-            CODE_SHASUM={{ steps.compute_shasum.outputs.shasum }}
+            CODE_SHASUM=${{ steps.compute_shasum.outputs.shasum }}
           push: false
           tags: joystream/node
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -121,7 +121,9 @@ jobs:
           context: .
           file: joystream-node.Dockerfile
           platforms: linux/amd64
-          build-args: CARGO_FEATURES=testing-runtime
+          build-args:
+            CARGO_FEATURES=testing-runtime
+            CODE_SHASUM={{ steps.compute_shasum.outputs.shasum }}
           push: false
           tags: joystream/node
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/build-node-docker.sh
+++ b/build-node-docker.sh
@@ -9,8 +9,8 @@ cd $SCRIPT_PATH
 
 source scripts/features.sh
 
-CODE_HASH=`scripts/runtime-code-shasum.sh`
-IMAGE=joystream/node:${CODE_HASH}
+CODE_SHASUM=`scripts/runtime-code-shasum.sh`
+IMAGE=joystream/node:${CODE_SHASUM}
 
 # Look for image locally
 if ! docker inspect ${IMAGE} > /dev/null;
@@ -26,7 +26,8 @@ then
     docker build . --file joystream-node.Dockerfile \
       --tag ${IMAGE} \
       --build-arg CARGO_FEATURES=${FEATURES} \
-      --build-arg GIT_COMMIT_HASH=$(git rev-parse --short=11 HEAD)
+      --build-arg GIT_COMMIT_HASH=$(git rev-parse --short=11 HEAD) \
+      --build-arg CODE_SHASUM=${CODE_SHASUM}
   fi
 else
   echo "Found ${IMAGE} in local repo"

--- a/devops/ansible/build-joystream-node-docker.yml
+++ b/devops/ansible/build-joystream-node-docker.yml
@@ -34,6 +34,7 @@
           args:
             CARGO_FEATURES: '{{ cargo_features }}'
             GIT_COMMIT_HASH: '{{ result_git_checkout.after[:11] }}'
+            CODE_SHASUM: '{{ code_shasum }}'
         name: '{{ repository }}'
         tag: '{{ tag_name }}'
         push: true

--- a/joystream-node.Dockerfile
+++ b/joystream-node.Dockerfile
@@ -35,7 +35,6 @@ COPY Cargo.lock .
 COPY bin ./bin
 COPY runtime ./runtime
 COPY runtime-modules ./runtime-modules
-COPY scripts/runtime-code-shasum.sh ./runtime-code-shasum.sh
 # Copy over the cached dependencies
 COPY --from=cacher /joystream/target target
 COPY --from=cacher $CARGO_HOME $CARGO_HOME
@@ -46,7 +45,8 @@ ARG CARGO_FEATURES
 RUN echo "CARGO_FEATURES=$CARGO_FEATURES"
 ARG WASM_BUILD_TOOLCHAIN=nightly-2022-05-11
 ARG GIT_COMMIT_HASH="unknown"
-RUN SUBSTRATE_CLI_GIT_COMMIT_HASH="${GIT_COMMIT_HASH}-code-shasum-$(./runtime-code-shasum.sh)" \
+ARG CODE_SHASUM
+RUN SUBSTRATE_CLI_GIT_COMMIT_HASH="${GIT_COMMIT_HASH}-docker-build-${CODE_SHASUM}" \
   cargo build --release --features "${CARGO_FEATURES}"
 
 FROM ubuntu:22.04

--- a/joystream-node.Dockerfile
+++ b/joystream-node.Dockerfile
@@ -54,6 +54,7 @@ LABEL description="Joystream node"
 WORKDIR /joystream
 COPY --from=builder /joystream/target/release/joystream-node /joystream/node
 COPY --from=builder /joystream/target/release/wbuild/joystream-node-runtime/joystream_node_runtime.compact.wasm /joystream/runtime.compact.wasm
+COPY --from=builder /joystream/target/release/wbuild/joystream-node-runtime/joystream_node_runtime.compact.compressed.wasm /joystream/runtime.compact.compressed.wasm
 COPY --from=builder /joystream/target/release/chain-spec-builder /joystream/chain-spec-builder
 COPY --from=builder /joystream/target/release/session-keys /joystream/session-keys
 COPY --from=builder /joystream/target/release/call-sizes /joystream/call-sizes

--- a/scripts/compute-runtime-blob-hash.sh
+++ b/scripts/compute-runtime-blob-hash.sh
@@ -7,7 +7,7 @@
 docker create --name temp-container-joystream-node joystream/node
 
 # Copy the compiled wasm blob from the docker container to our host
-docker cp temp-container-joystream-node:/joystream/runtime.compact.wasm joystream_runtime.wasm
+docker cp temp-container-joystream-node:/joystream/runtime.compact.compressed.wasm joystream_runtime.wasm
 docker rm temp-container-joystream-node
 
 # compute blake2_256 hash of the wasm blob - this should match the hash computed when the runtime file is


### PR DESCRIPTION
Computing shasum of code inside of docker build will not produce the same result as computing on the repo because ~the files are copied and their dates change~ we weren't copying the joystream-node.Dockerfile and setting the RUNTIME_PROFILE env var.

So decided to just pass in the computed value as a build arg.