### PR TITLE
Filter channel payouts proposal

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -283,10 +283,11 @@ fn filter_stage_2(call: &<Runtime as frame_system::Config>::Call) -> bool {
         Call::ProposalsCodex(proposals_codex::Call::<Runtime>::create_proposal {
             general_proposal_parameters: _,
             proposal_details,
-        }) => !matches!(
-            proposal_details,
-            proposals_codex::ProposalDetails::UpdateGlobalNftLimit(..)
-        ),
+        }) => match proposal_details {
+            proposals_codex::ProposalDetails::UpdateGlobalNftLimit(..) => false,
+            proposals_codex::ProposalDetails::UpdateChannelPayouts(..) => false,
+            _ => true,
+        },
         _ => true,
     }
 }


### PR DESCRIPTION
It seems to me that we should be filtering out channel payouts proposal until ephesus release as there is no support in QN for this proposal type and would cause the processor to fail as we have seen on test playground:

```
INFO: Last block: 34144 	: 57842 blocks behind
processor                | INFO: Starting the event queue
processor                | INFO: Processing block: 0000034148-8ee2e, events count: 2 
processor                | ERROR: Stopping the proccessor due to errors: {} name: Error, message: Unspported proposal details type: UpdateChannelPayouts, stack: Error: Unspported proposal details type: UpdateChannelPayouts
processor                |     at parseProposalDetails (/joystream/query-node/mappings/lib/src/proposals.js:206:15)
processor                |     at proposalsCodex_ProposalCreated (/joystream/query-node/mappings/lib/src/proposals.js:225:35)
processor                |     at MappingsLookupService.call (/joystream/node_modules/@joystream/hydra-processor/lib/executor/MappingsLookupService.js:80:15)
processor                |     at /joystream/node_modules/@joystream/hydra-processor/lib/executor/TransactionalExecutor.js:41:43
processor                |     at processTicksAndRejections (internal/process/task_queues.js:95:5)
processor                | ERROR: {} name: Error, message: Error: Unspported proposal details type: UpdateChannelPayouts, stack: Error: Error: Unspported proposal details type: UpdateChannelPayouts
processor                |     at MappingsProcessor.processingLoop (/joystream/node_modules/@joystream/hydra-processor/lib/process/MappingsProcessor.js:75:23)
processor                |     at processTicksAndRejections (internal/process/task_queues.js:95:5)
processor                |     at async Promise.all (index 1)
processor                |     at async MappingsProcessor.start (/joystream/node_modules/@joystream/hydra-processor/lib/process/MappingsProcessor.js:25:9)
processor                |     at async ProcessorRunner.process (/joystream/node_modules/@joystream/hydra-processor/lib/start/ProcessorRunner.js:47:9)
processor                |     at async Run.run (/joystream/node_modules/@joystream/hydra-processor/lib/commands/run.js:27:13)
processor                |     at async Run._run (/joystream/node_modules/@oclif/command/lib/command.js:43:20)
processor                |     at async Config.runCommand (/joystream/node_modules/@oclif/config/lib/config.js:173:24)
processor                |     at async Main.run (/joystream/node_modules/@oclif/command/lib/main.js:27:9)
processor                |     at async Main._run (/joystream/node_modules/@oclif/command/lib/command.js:43:20)
processor                | INFO: Shutting down...
processor                | INFO: Closing the database connection...
processor                | error Command failed with exit code 1.

```