### PR TITLE
cli v0.9.0

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -26,7 +26,7 @@ $ npm install -g @joystream/cli
 $ joystream-cli COMMAND
 running command...
 $ joystream-cli (-v|--version|version)
-@joystream/cli/0.8.0 linux-x64 node-v14.18.0
+@joystream/cli/0.9.0 darwin-x64 node-v14.16.1
 $ joystream-cli --help [COMMAND]
 USAGE
   $ joystream-cli COMMAND
@@ -89,6 +89,13 @@ When using the CLI for the first time there are a few common steps you might wan
 - [`joystream-cli account:info [ADDRESS]`](#joystream-cli-accountinfo-address)
 - [`joystream-cli account:list`](#joystream-cli-accountlist)
 - [`joystream-cli account:transferTokens`](#joystream-cli-accounttransfertokens)
+- [`joystream-cli advanced-transactions:constructSetCodeCall`](#joystream-cli-advanced-transactionsconstructsetcodecall)
+- [`joystream-cli advanced-transactions:constructTxCall`](#joystream-cli-advanced-transactionsconstructtxcall)
+- [`joystream-cli advanced-transactions:constructUnsignedTx`](#joystream-cli-advanced-transactionsconstructunsignedtx)
+- [`joystream-cli advanced-transactions:constructUnsignedTxApproveMs`](#joystream-cli-advanced-transactionsconstructunsignedtxapprovems)
+- [`joystream-cli advanced-transactions:constructUnsignedTxFinalApproveMs`](#joystream-cli-advanced-transactionsconstructunsignedtxfinalapprovems)
+- [`joystream-cli advanced-transactions:constructUnsignedTxInitiateMs`](#joystream-cli-advanced-transactionsconstructunsignedtxinitiatems)
+- [`joystream-cli advanced-transactions:constructWrappedTxCall`](#joystream-cli-advanced-transactionsconstructwrappedtxcall)
 - [`joystream-cli api:getQueryNodeEndpoint`](#joystream-cli-apigetquerynodeendpoint)
 - [`joystream-cli api:getUri`](#joystream-cli-apigeturi)
 - [`joystream-cli api:inspect`](#joystream-cli-apiinspect)
@@ -154,6 +161,7 @@ When using the CLI for the first time there are a few common steps you might wan
 - [`joystream-cli membership:memberRemark MESSAGE`](#joystream-cli-membershipmemberremark-message)
 - [`joystream-cli membership:update`](#joystream-cli-membershipupdate)
 - [`joystream-cli membership:updateAccounts`](#joystream-cli-membershipupdateaccounts)
+- [`joystream-cli sign-offline:signUnsignedTx`](#joystream-cli-sign-offlinesignunsignedtx)
 - [`joystream-cli staking:validate`](#joystream-cli-stakingvalidate)
 - [`joystream-cli working-groups:application WGAPPLICATIONID`](#joystream-cli-working-groupsapplication-wgapplicationid)
 - [`joystream-cli working-groups:apply`](#joystream-cli-working-groupsapply)
@@ -286,6 +294,257 @@ OPTIONS
 ```
 
 _See code: [src/commands/account/transferTokens.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/account/transferTokens.ts)_
+
+## `joystream-cli advanced-transactions:constructSetCodeCall`
+
+Construct a "system.setCode" call.
+
+```
+USAGE
+  $ joystream-cli advanced-transactions:constructSetCodeCall
+
+OPTIONS
+  -o, --output=output              (required) Path to the file where the call should be saved
+  --address=address                (required) The address that is performing the final call.
+  --codeOutput=codeOutput          Path to where the parsed wasm code shold be saved.
+
+  --lifetime=lifetime              [default: 64] Lifetime of the transaction, from creation to included on chain, in
+                                   blocks before it becomes invalid.
+
+  --nonceIncrement=nonceIncrement  [default: 0] If you are preparing multiple transactions from the samme account,
+                                   before broadcasting them, you need to increase the nonce by 1 for each. This value
+                                   will be added to the nonce read from the chain.
+
+  --tip=tip                        [default: 0] Optional "tip" (in base value) for faster block inclusion.
+
+  --wasmPath=wasmPath              (required) The address that is performing the final call.
+```
+
+_See code: [src/commands/advanced-transactions/constructSetCodeCall.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/advanced-transactions/constructSetCodeCall.ts)_
+
+## `joystream-cli advanced-transactions:constructTxCall`
+
+Construct a call that as argument for a transaction, or to wrap in another call.
+
+```
+USAGE
+  $ joystream-cli advanced-transactions:constructTxCall
+
+OPTIONS
+  -o, --output=output              (required) Path to the file where the output JSON should be saved.
+  --address=address                (required) The address that is performing the (final) transaction.
+
+  --lifetime=lifetime              [default: 64] Lifetime of the transaction, from creation to included on chain, in
+                                   blocks before it becomes invalid.
+
+  --method=method                  (required) The method of the extrinsic
+
+  --module=module                  (required) The module (a.k.a. section) of the extrinsic
+
+  --nonceIncrement=nonceIncrement  [default: 0] If you are preparing multiple transactions from the samme account,
+                                   before broadcasting them, you need to increase the nonce by 1 for each. This value
+                                   will be added to the nonce read from the chain.
+
+  --tip=tip                        [default: 0] Optional "tip" (in base value) for faster block inclusion.
+```
+
+_See code: [src/commands/advanced-transactions/constructTxCall.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/advanced-transactions/constructTxCall.ts)_
+
+## `joystream-cli advanced-transactions:constructUnsignedTx`
+
+Create a simple unsigned transaction, for signing offline.
+
+```
+USAGE
+  $ joystream-cli advanced-transactions:constructUnsignedTx
+
+OPTIONS
+  -o, --output=output              (required) Path to the file where the output JSON should be saved.
+  --address=address                (required) The address that is performing the transaction.
+
+  --lifetime=lifetime              Lifetime of the transaction, from constructed to included in a block, in blocks
+                                   before it becomes invalid. Must be a power of two between 4 and 65536
+
+  --method=method                  (required) The method of the extrinsic
+
+  --module=module                  (required) The module of the extrinsic
+
+  --nonceIncrement=nonceIncrement  [default: 0] If you are preparing multiple transactions from the samme account,
+                                   before broadcasting them, you need to increase the nonce by 1 for each. This value
+                                   will be added to the nonce read from the chain.
+
+  --tip=tip                        [default: 0] Optional "tip" (in base value) for faster block inclusion.
+```
+
+_See code: [src/commands/advanced-transactions/constructUnsignedTx.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/advanced-transactions/constructUnsignedTx.ts)_
+
+## `joystream-cli advanced-transactions:constructUnsignedTxApproveMs`
+
+Approve a transaction from a multisig account, as initiated by another signer.
+
+```
+USAGE
+  $ joystream-cli advanced-transactions:constructUnsignedTxApproveMs
+
+OPTIONS
+  -i, --input=input                  Path to JSON file to use as input (if not specified - the input can be provided
+                                     interactively)
+
+  -o, --output=output                (required) Path to the file where the output JSON should be saved.
+
+  --addressMs=addressMs              The address of the multisig that is performing the transaction.
+
+  --addressSigner=addressSigner      (required) The address of the signer that is approving the multisig transaction.
+
+  --inputCall=inputCall              The hex-encoded call that is to be executed by the multisig if successfull.
+
+  --inputCallFile=inputCallFile      Path to a JSON file with the hex-encoded call that is to be executed by the
+                                     multisig if successfull.
+
+  --lifetime=lifetime                Lifetime of the transaction, from constructed to included in a block, in blocks
+                                     before it becomes invalid. Must be a power of two between 4 and 65536
+
+  --nonceIncrement=nonceIncrement    [default: 0] If you are preparing multiple transactions from the samme account,
+                                     before broadcasting them, you need to increase the nonce by 1 for each. This value
+                                     will be added to the nonce read from the chain.
+
+  --others=others                    Comma separated list of the accounts (other than the addressSigner) who can approve
+                                     this call. Ignored if "input" is provided.
+
+  --threshold=threshold              How many (m) of the n signatories (signer+others), are required to sign/approve the
+                                     transaction. Ignored if "input" is provided.
+
+  --timepointHeight=timepointHeight  Reference to the blockheight of the transaction that initiated the multisig
+                                     transaction. Ignored if "input" is provided.
+
+  --timepointIndex=timepointIndex    Reference to the extrinsic index in the "timepointHeight block. Ignored if "input"
+                                     is provided.
+
+  --tip=tip                          [default: 0] Optional "tip" (in base value) for faster block inclusion.
+```
+
+_See code: [src/commands/advanced-transactions/constructUnsignedTxApproveMs.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/advanced-transactions/constructUnsignedTxApproveMs.ts)_
+
+## `joystream-cli advanced-transactions:constructUnsignedTxFinalApproveMs`
+
+Final approval of a transaction from a multisig account, as initiated by another signer.
+
+```
+USAGE
+  $ joystream-cli advanced-transactions:constructUnsignedTxFinalApproveMs
+
+OPTIONS
+  -i, --input=input                  Path to JSON file to use as input (if not specified - the input can be provided
+                                     interactively)
+
+  -o, --output=output                (required) Path to the file where the output JSON should be saved.
+
+  --addressMs=addressMs              The address of the multisig that is performing the transaction.
+
+  --addressSigner=addressSigner      (required) The address of the signer that is approving the multisig transaction.
+
+  --inputCall=inputCall              The hex-encoded call that is to be executed by the multisig if successfull.
+
+  --inputCallFile=inputCallFile      Path to a JSON file with the hex-encoded call that is to be executed by the
+                                     multisig if successfull.
+
+  --lifetime=lifetime                Lifetime of the transaction, from constructed to included in a block, in blocks
+                                     before it becomes invalid. Must be a power of two between 4 and 65536
+
+  --nonceIncrement=nonceIncrement    [default: 0] If you are preparing multiple transactions from the samme account,
+                                     before broadcasting them, you need to increase the nonce by 1 for each. This value
+                                     will be added to the nonce read from the chain.
+
+  --others=others                    Comma separated list of the accounts (other than the addressSigner) who can approve
+                                     this call. Ignored if "input" is provided.
+
+  --threshold=threshold              How many (m) of the n signatories (signer+others), are required to sign/approve the
+                                     transaction. Ignored if "input" is provided.
+
+  --timepointHeight=timepointHeight  Reference to the blockheight of the transaction that initiated the multisig
+                                     transaction. Ignored if "input" is provided.
+
+  --timepointIndex=timepointIndex    Reference to the extrinsic index in the "timepointHeight block. Ignored if "input"
+                                     is provided.
+
+  --tip=tip                          [default: 0] Optional "tip" (in base value) for faster block inclusion.
+```
+
+_See code: [src/commands/advanced-transactions/constructUnsignedTxFinalApproveMs.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/advanced-transactions/constructUnsignedTxFinalApproveMs.ts)_
+
+## `joystream-cli advanced-transactions:constructUnsignedTxInitiateMs`
+
+Initiate a call (transaction) from a multisig account, as the first signer.
+
+```
+USAGE
+  $ joystream-cli advanced-transactions:constructUnsignedTxInitiateMs
+
+OPTIONS
+  -i, --input=input                Path to JSON file to use as input (if not specified - the input can be provided
+                                   interactively)
+
+  -o, --output=output              (required) Path to the file where the output JSON should be saved.
+
+  --addressMs=addressMs            The address of the multisig that is performing the transaction.
+
+  --addressSigner=addressSigner    (required) The address of the signer that is initiating the multisig transaction.
+
+  --inputCall=inputCall            The hex-encoded call that is to be executed by the multisig if successfull.
+
+  --inputCallFile=inputCallFile    Path to a JSON file with the hex-encoded call that is to be executed by the multisig
+                                   if successfull.
+
+  --lifetime=lifetime              Lifetime of the transaction, from constructed to included in a block, in blocks
+                                   before it becomes invalid. Must be a power of two between 4 and 65536
+
+  --nonceIncrement=nonceIncrement  [default: 0] If you are preparing multiple transactions from the samme account,
+                                   before broadcasting them, you need to increase the nonce by 1 for each. This value
+                                   will be added to the nonce read from the chain.
+
+  --others=others                  Comma separated list of the accounts (other than the addressSigner) who can approve
+                                   this call. Ignored if "input" is provided.
+
+  --threshold=threshold            How many (m) of the n signatories (signer+others), are required to sign/approve the
+                                   transaction. Ignored if "input" is provided.
+
+  --tip=tip                        [default: 0] Optional "tip" (in base value) for faster block inclusion.
+```
+
+_See code: [src/commands/advanced-transactions/constructUnsignedTxInitiateMs.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/advanced-transactions/constructUnsignedTxInitiateMs.ts)_
+
+## `joystream-cli advanced-transactions:constructWrappedTxCall`
+
+Construct a wrapped transaction call.
+
+```
+USAGE
+  $ joystream-cli advanced-transactions:constructWrappedTxCall
+
+OPTIONS
+  -o, --output=output              (required) Path to the file where the output JSON should be saved.
+  --address=address                (required) The address that is performing the (final) transaction.
+  --fullOutput=fullOutput          Path to the file where the full output should be saved
+  --inputCall=inputCall            The hex-encoded call that is to be executed by the multisig if successfull.
+
+  --inputCallFile=inputCallFile    Path to a JSON file with the hex-encoded call that is to be executed by the multisig
+                                   if successfull.
+
+  --lifetime=lifetime              [default: 64] Lifetime of the transaction, from creation to included on chain, in
+                                   blocks before it becomes invalid.
+
+  --method=method                  (required) The method of the extrinsic
+
+  --module=module                  (required) The module (a.k.a. section) of the extrinsic
+
+  --nonceIncrement=nonceIncrement  [default: 0] If you are preparing multiple transactions from the samme account,
+                                   before broadcasting them, you need to increase the nonce by 1 for each. This value
+                                   will be added to the nonce read from the chain.
+
+  --tip=tip                        [default: 0] Optional "tip" (in base value) for faster block inclusion.
+```
+
+_See code: [src/commands/advanced-transactions/constructWrappedTxCall.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/advanced-transactions/constructWrappedTxCall.ts)_
 
 ## `joystream-cli api:getQueryNodeEndpoint`
 
@@ -970,18 +1229,25 @@ USAGE
   $ joystream-cli fee-profile:buyMembership
 
 OPTIONS
-  -a, --aboutLength=aboutLength          [default: 0] Length of the member's about text (part of metadata) to use for
-                                         estimating tx fee
+  -E, --externalResourcesCount=externalResourcesCount  [default: 1] Number of external resources (part of metadata) to
+                                                       use for estimating tx fee
 
-  -h, --handleLength=handleLength        [default: 10] Length of the membership handle to use for estimating tx fee
+  -a, --aboutLength=aboutLength                        [default: 0] Length of the member's about text (part of metadata)
+                                                       to use for estimating tx fee
 
-  -j, --joyPrice=joyPrice                [default: 6] Joy price in USD cents for estimating costs in USD
+  -e, --externalResourceLength=externalResourceLength  [default: 25] Length of a single external resource url (part of
+                                                       metadata) to use for estimating tx fee
 
-  -n, --nameLength=nameLength            [default: 10] Length of the member's name (part of metadata) to use for
-                                         estimating tx fee
+  -h, --handleLength=handleLength                      [default: 10] Length of the membership handle to use for
+                                                       estimating tx fee
 
-  -u, --avatarUriLength=avatarUriLength  [default: 25] Length of the member's avatar uri (part of metadata) to use for
-                                         estimating tx fee
+  -j, --joyPrice=joyPrice                              [default: 6] Joy price in USD cents for estimating costs in USD
+
+  -n, --nameLength=nameLength                          [default: 10] Length of the member's name (part of metadata) to
+                                                       use for estimating tx fee
+
+  -u, --avatarUriLength=avatarUriLength                [default: 25] Length of the member's avatar uri (part of
+                                                       metadata) to use for estimating tx fee
 ```
 
 _See code: [src/commands/fee-profile/buyMembership.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/fee-profile/buyMembership.ts)_
@@ -1560,6 +1826,37 @@ OPTIONS
 ```
 
 _See code: [src/commands/membership/updateAccounts.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/membership/updateAccounts.ts)_
+
+## `joystream-cli sign-offline:signUnsignedTx`
+
+Sign an unsigned transaction. Does not require an api connection.
+
+```
+USAGE
+  $ joystream-cli sign-offline:signUnsignedTx
+
+OPTIONS
+  -i, --input=input                      Path to JSON file to use as input (if not specified - the input can be provided
+                                         interactively)
+
+  -o, --output=output                    Path to the file where the JSON with full transaction details should be
+                                         saved.If omitted, only the signed transaction, the signature and the tx hash is
+                                         included
+
+  --backupFilePath=backupFilePath        Path to account backup JSON file
+
+  --keypairType=(sr25519|ed25519|ecdsa)  [default: sr25519] Account type (defaults to sr25519)
+
+  --mnemonic=mnemonic                    Mnemonic phrase
+
+  --password=password                    Account password
+
+  --seed=seed                            Secret seed
+
+  --suri=suri                            Substrate uri
+```
+
+_See code: [src/commands/sign-offline/signUnsignedTx.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/sign-offline/signUnsignedTx.ts)_
 
 ## `joystream-cli staking:validate`
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -35,7 +35,7 @@
     "ajv": "^6.11.0",
     "axios": "^0.21.1",
     "blake3-wasm": "^2.1.5",
-    "chalk": "^5.0.1",
+    "chalk": "^4.1.2",
     "cli-progress": "^3.9.0",
     "cli-ux": "^5.4.5",
     "cross-fetch": "^3.0.6",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/cli",
   "description": "Command Line Interface for Joystream community and governance activities",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": "Leszek Wiesner",
   "bin": {
     "joystream-cli": "./bin/run"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6011,7 +6011,7 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
-chalk@1.1.3, chalk@4.1.2, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2, chalk@^3.0.0, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2, chalk@^5.0.1:
+chalk@1.1.3, chalk@4.1.2, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2, chalk@^3.0.0, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
   integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==


### PR DESCRIPTION
We forgot to bump cli version for carthage release.

There seems to be an issue however running some commands that use the "chalk" module.

```
bin/run account:info
    Error: Must use import to load ES Module: /Users/mokhtar/tmp/package/node_modules/chalk/source/index.js
    require() of ES modules is not supported.
    require() of /Users/mokhtar/tmp/package/node_modules/chalk/source/index.js from 
    /Users/mokhtar/tmp/package/lib/base/DefaultCommandBase.js is an ES module file as it is a .js file whose nearest parent 
    package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
    Instead rename index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from 
    /Users/mokhtar/tmp/package/node_modules/chalk/package.json.

    Code: ERR_REQUIRE_ESM
```

To reproduce, `npm pack`  the cli, extract then run `npm install` in extracted location, finally run with `./bin/run account:info` or `bin/run api:getUri`