### PR TITLE
Fix Hydra services potentially starting in a wrong order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,7 @@ services:
       - "127.0.0.1:${PROCESSOR_STATE_APP_PORT}:${PROCESSOR_STATE_APP_PORT}"
     depends_on:
       - db
+      - processor
     volumes:
       - type: bind
         source: .


### PR DESCRIPTION
Since https://github.com/Joystream/joystream/pull/4413 and until some better fix is implemented in Hydra we need to make sure that `graphql-server` service always starts **after** `processor`.

This is because the `graphql-server` will currently try to retrieve the `processor` ip address from the dns on startup and then limit the access to `/update-processor-state` only to this ip.