### PR TITLE
Mainnet: readme and changelog updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ yarn start
 ```sh
 git checkout master
 WASM_BUILD_TOOLCHAIN=nightly-2022-05-11 cargo build --release
-./target/release/joystream-node -- --pruning archive --chain testnets/joy-testnet-7-carthage.json
+./target/release/joystream-node -- --pruning archive --chain joy-mainnet.json
 ```
 
 Learn more about [joystream-node](bin/node/README.md).

--- a/bin/node/README.md
+++ b/bin/node/README.md
@@ -47,7 +47,7 @@ this script will build and run a fresh new local development chain (purging exis
 Use the `--chain` argument, and specify the path to the genesis `chain.json` file for that public network. The JSON "chain spec" files for Joystream public networks can be found in [../testnets/](../testnets/).
 
 ```bash
-./target/release/joystream-node --chain testnets/joy-testnet-7-carthage.json
+./target/release/joystream-node --chain joy-mainnet.json
 ```
 
 ### Tests and code quality
@@ -83,5 +83,5 @@ WASM_BUILD_TOOLCHAIN=nightly-2022-05-11 cargo +nightly-2022-05-11 install joystr
 Now you can run and connect to the testnet:
 
 ```bash
-joystream-node --chain testnets/joy-testnet-7-carthage.json
+joystream-node --chain joy-mainnet.json
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,6 +181,7 @@ services:
       - "127.0.0.1:${PROCESSOR_STATE_APP_PORT}:${PROCESSOR_STATE_APP_PORT}"
     depends_on:
       - db
+      - processor
     volumes:
       - type: bind
         source: .

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 12.1000.0 - Mainnet
+  - Disabled channel payouts proposal
+
 ### Version 11.3.0 - Carthage - new chain
   - Update to substrate v0.9.23
   - Introduce project-token pallet into runtime

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Version 12.1000.0 - Mainnet
   - Disabled channel payouts proposal
+  - Renamed 'Gateway' working group to 'App' working group
 
 ### Version 11.3.0 - Carthage - new chain
   - Update to substrate v0.9.23


### PR DESCRIPTION
Update reference to chainspec for mainnet in READMEs and bumped the runtime CHANGELOG