### PR TITLE
Hydra processor host DNS resolution fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,6 @@ services:
       - "127.0.0.1:${PROCESSOR_STATE_APP_PORT}:${PROCESSOR_STATE_APP_PORT}"
     depends_on:
       - db
-      - processor
     volumes:
       - type: bind
         source: .

--- a/query-node/codegen/package.json
+++ b/query-node/codegen/package.json
@@ -10,7 +10,7 @@
     "bn.js": "^5.2.0"
   },
   "dependencies": {
-    "@joystream/hydra-cli": "^4.0.0-alpha.8",
-    "@joystream/hydra-typegen": "^4.0.0-alpha.8"
+    "@joystream/hydra-cli": "4.0.0-alpha.9",
+    "@joystream/hydra-typegen": "4.0.0-alpha.9"
   }
 }

--- a/query-node/codegen/yarn.lock
+++ b/query-node/codegen/yarn.lock
@@ -306,10 +306,10 @@
   resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
   integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
-"@joystream/hydra-cli@^4.0.0-alpha.8":
-  version "4.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@joystream/hydra-cli/-/hydra-cli-4.0.0-alpha.8.tgz#4e8455b471901762e8f9d10ba94888760a6cd539"
-  integrity sha512-vQAP9EI483vII1eVkrRlPW686ip9jptisSddbgm1WI1tpV0zU583gOgjLK80juhqyYDqofLKWPEnk6slufcJuQ==
+"@joystream/hydra-cli@4.0.0-alpha.9":
+  version "4.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@joystream/hydra-cli/-/hydra-cli-4.0.0-alpha.9.tgz#101da208f451c90ffc42634393714e3fdfe243af"
+  integrity sha512-CLY0vqXU4QQY7n+B8UyNhbbrfACTzXQJc6J5CUyYKxL04mgKps5olHrX9b4XdDeHqcYWhzUKE5+JbEoDy+7f2A==
   dependencies:
     "@inquirer/input" "^0.0.13-alpha.0"
     "@inquirer/password" "^0.0.12-alpha.0"
@@ -342,10 +342,10 @@
     pluralize "^8.0.0"
     tslib "1.11.2"
 
-"@joystream/hydra-typegen@^4.0.0-alpha.8":
-  version "4.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@joystream/hydra-typegen/-/hydra-typegen-4.0.0-alpha.8.tgz#f9181b82e0e3ba953a59c925b4e75f9ffe34fbb0"
-  integrity sha512-Sgz+WxE/v9IxSBLrB6Md2kTPEiPUtSqgXIj7RTpAmsiMVx6tIBDjiSiXG04ss2V0rxVekpxxXuQpuxsmX1jOGA==
+"@joystream/hydra-typegen@4.0.0-alpha.9":
+  version "4.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@joystream/hydra-typegen/-/hydra-typegen-4.0.0-alpha.9.tgz#815045129957cc070905982fbafdc1570f42e65e"
+  integrity sha512-GhQNRLGOuT5ZpTuTkjt74oN/uV3gDQdokSPAjJeOtKc6iyh5Y3mPWbCU1Qa23zCqMaeMEbTzpeLWnCd8Bf8McA==
   dependencies:
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1"

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@polkadot/types": "8.9.1",
-    "@joystream/hydra-common": "^4.0.0-alpha.8",
-    "@joystream/hydra-db-utils": "^4.0.0-alpha.8",
+    "@joystream/hydra-common": "4.0.0-alpha.9",
+    "@joystream/hydra-db-utils": "4.0.0-alpha.9",
     "@joystream/metadata-protobuf": "^2.5.0",
     "@joystream/types": "^0.20.5",
     "@joystream/warthog": "^2.41.9",

--- a/query-node/package.json
+++ b/query-node/package.json
@@ -37,7 +37,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@joystream/hydra-processor": "4.0.0-alpha.8",
+    "@joystream/hydra-processor": "4.0.0-alpha.9",
     "@types/bn.js": "^5.1.0",
     "bn.js": "^5.2.1",
     "tslib": "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,32 +2165,32 @@
   resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
   integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
-"@joystream/hydra-common@^4.0.0-alpha.8":
-  version "4.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@joystream/hydra-common/-/hydra-common-4.0.0-alpha.8.tgz#b40a921af05ba3b1d2b1c563712164ed0d660fbd"
-  integrity sha512-SZj12jEThwmrbsBK0QX9hDihveJhlOdCHDYzPB9mXAQeBdz61ugEdxav6DtvTapvKyZTSoYR3whwSTSbICprfA==
+"@joystream/hydra-common@4.0.0-alpha.9", "@joystream/hydra-common@^4.0.0-alpha.9":
+  version "4.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@joystream/hydra-common/-/hydra-common-4.0.0-alpha.9.tgz#0ffa897ea7206944fa0ab9613dc537da874afeb1"
+  integrity sha512-XFUFkHM11hhyovZGwDLZyybXTJHh4M92NZn+GhUPjnygJNF3gtjklkxFHv70bz7FpAA8R+lWk7z3JptexOwNbg==
   dependencies:
     bn.js "^5.2.1"
 
-"@joystream/hydra-db-utils@^4.0.0-alpha.8":
-  version "4.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@joystream/hydra-db-utils/-/hydra-db-utils-4.0.0-alpha.8.tgz#a6475ea2e61029208c64ab5098d204562af98c21"
-  integrity sha512-qC6mtu+E+POVX6Mb/ZhNYYuQjPwS/JomKpTQWZ2+gVlP3OpxfE8MY2TXvGlZ933/fYAbzvc6qg3gtyA18yVEgQ==
+"@joystream/hydra-db-utils@4.0.0-alpha.9", "@joystream/hydra-db-utils@^4.0.0-alpha.9":
+  version "4.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@joystream/hydra-db-utils/-/hydra-db-utils-4.0.0-alpha.9.tgz#7bf89a819a1372e227023c368805b952ae01b3bf"
+  integrity sha512-NpVuHC9/emLvB8qDl/cWWn/rikcalch8+/wRHw1R5INbWM3i3LBLLN2DVWtRGCfZW8aKPNzrjEFwmLKocgJ0Iw==
   dependencies:
-    "@joystream/hydra-common" "^4.0.0-alpha.8"
+    "@joystream/hydra-common" "^4.0.0-alpha.9"
     "@types/ioredis" "^4.17.4"
     bn.js "^5.2.1"
     ioredis "^4.17.3"
     lodash "^4.17.20"
     typeorm "https://github.com/Joystream/typeorm/releases/download/0.3.5/typeorm-v0.3.5.tgz"
 
-"@joystream/hydra-processor@4.0.0-alpha.8":
-  version "4.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@joystream/hydra-processor/-/hydra-processor-4.0.0-alpha.8.tgz#cad5b8758090c71672cef05a123ea030191bfa14"
-  integrity sha512-INZGEo36ATBdjgv+kdf2omSXUPCNiYx2ycXBX983zlTeOVMCzBDv2ZFaQPosKfbGdchhB1ZTNqHr/x/DuguKcw==
+"@joystream/hydra-processor@4.0.0-alpha.9":
+  version "4.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@joystream/hydra-processor/-/hydra-processor-4.0.0-alpha.9.tgz#6611ac1e557db54953a972309aeb1ebfc5703363"
+  integrity sha512-1xEx5LM+xfStDMRRgOFLLPw0tnzhHNuqjwE9mr7alIdlDI1cvyOa5MAleamZIogLY1jWFgVctLzFMFrXjS7TNQ==
   dependencies:
-    "@joystream/hydra-common" "^4.0.0-alpha.8"
-    "@joystream/hydra-db-utils" "^4.0.0-alpha.8"
+    "@joystream/hydra-common" "^4.0.0-alpha.9"
+    "@joystream/hydra-db-utils" "^4.0.0-alpha.9"
     "@oclif/command" "^1.8.0"
     "@oclif/config" "^1"
     "@oclif/errors" "^1.3.3"
@@ -2205,6 +2205,7 @@
     figlet "^1.5.2"
     graphql "^15.4.0"
     graphql-request "^3.3.0"
+    lodash.debounce "^4.0.8"
     p-immediate "^3.2.0"
     p-throttle "~4.1.1"
     p-wait-for "~3.2.0"


### PR DESCRIPTION
Updates Hydra dependencies to include the latest fix: https://github.com/Joystream/hydra/pull/512
Removes `graphql-server` service dependency on `processor` in `docker-compose.yml` (no longer needed)