### PR TITLE
CLI: Accept tx params for `constructUnsignedTx`

### DIFF
--- a/cli/src/commands/advanced-transactions/constructUnsignedTx.ts
+++ b/cli/src/commands/advanced-transactions/constructUnsignedTx.ts
@@ -21,6 +21,11 @@ export default class CreateUnsignedTxCommand extends AdvancedTransactionsCommand
       required: true,
       description: 'The method of the extrinsic',
     }),
+    params: flags.string({
+      char: 'p',
+      required: false,
+      description: 'Optional parameters to the extrinsic',
+    }),       
     output: flags.string({
       char: 'o',
       required: true,
@@ -45,11 +50,11 @@ export default class CreateUnsignedTxCommand extends AdvancedTransactionsCommand
   }
 
   async run(): Promise<void> {
-    const { address, module, method, lifetime, tip, nonceIncrement, output } = this.parse(CreateUnsignedTxCommand).flags
+    const { address, module, method, params, lifetime, tip, nonceIncrement, output } = this.parse(CreateUnsignedTxCommand).flags
 
     ensureOutputFileIsWriteable(output)
 
-    const unsignedMethod = await this.promptForTxMethod(module, method)
+    const unsignedMethod = await this.promptForTxMethod(module, method, params)
 
     const txInfo = await this.getTxInfo(address, unsignedMethod, nonceIncrement, lifetime, tip)
 

--- a/cli/src/commands/advanced-transactions/constructUnsignedTx.ts
+++ b/cli/src/commands/advanced-transactions/constructUnsignedTx.ts
@@ -1,5 +1,6 @@
 import { flags } from '@oclif/command'
 import { blake2AsHex } from '@polkadot/util-crypto'
+import { ApiParamsOptions } from '../../Types'
 import AdvancedTransactionsCommandBase from '../../base/AdvancedTransactionsCommandBase'
 import { registry } from '@joystream/types'
 import { OptionsWithMeta } from '@substrate/txwrapper-core'
@@ -54,7 +55,7 @@ export default class CreateUnsignedTxCommand extends AdvancedTransactionsCommand
 
     ensureOutputFileIsWriteable(output)
 
-    const unsignedMethod = await this.promptForTxMethod(module, method, params)
+    const unsignedMethod = await this.promptForTxMethod(module, method, JSON.parse(params) as ApiParamsOptions)
 
     const txInfo = await this.getTxInfo(address, unsignedMethod, nonceIncrement, lifetime, tip)
 


### PR DESCRIPTION
To programmatically pass transaction parameters to `advanced-transactions:constructUnsignedTx`.

Usage:
``` bash
export address=""
export dest=""
export amount="1000000000000"
./cli/bin/run advanced-transactions:constructUnsignedTx -o myTx.json  --module balances --method transfer \
  --address $address \
  --params '{ "dest": "$dest", "amount": $amount }'

  Choose value for dest: (Use arrow keys)
❯ Id
  Index
  Raw
  Address32
  Address20 
```
To suppress the prompt either it should be to possible improve the JSON and/or adapt promptForParam/[promptForTxMethod](https://github.com/Joystream/joystream/blob/master/cli/src/base/ApiCommandBase.ts#L499).