### PR TITLE
Fix proposals non ASCII text encoding

### DIFF
--- a/query-node/mappings/src/content/channel.ts
+++ b/query-node/mappings/src/content/channel.ts
@@ -28,6 +28,7 @@ import {
   logger,
   saveMetaprotocolTransactionSuccessful,
   saveMetaprotocolTransactionErrored,
+  bytesToString,
 } from '../common'
 import {
   processBanOrUnbanMemberFromChannelMessage,
@@ -153,7 +154,7 @@ export async function content_ChannelAssetsDeletedByModerator({
     actor: await convertContentActor(store, actor),
     channelId: channelId.toNumber(),
     assetIds: Array.from(dataObjectIds).map((item) => Number(item)),
-    rationale: rationale.toHuman() as string,
+    rationale: bytesToString(rationale),
   })
 
   await store.save<ChannelAssetsDeletedByModeratorEvent>(channelAssetsDeletedByModeratorEvent)
@@ -188,7 +189,7 @@ export async function content_ChannelDeletedByModerator({ store, event }: EventC
   const channelDeletedByModeratorEvent = new ChannelDeletedByModeratorEvent({
     ...genericEventFields(event),
 
-    rationale: rationale.toHuman() as string,
+    rationale: bytesToString(rationale),
     actor: await convertContentActor(store, actor),
     channelId: channelId.toNumber(),
   })
@@ -229,7 +230,7 @@ export async function content_ChannelVisibilitySetByModerator({
 
     channelId: channelId.toNumber(),
     isHidden: isCensored.isTrue,
-    rationale: rationale.toHuman() as string,
+    rationale: bytesToString(rationale),
     actor: await convertContentActor(store, actor),
   })
 

--- a/query-node/mappings/src/content/video.ts
+++ b/query-node/mappings/src/content/video.ts
@@ -36,7 +36,7 @@ import {
   VideoSubtitle,
 } from 'query-node/dist/model'
 import { Content } from '../../generated/types'
-import { deserializeMetadata, genericEventFields, inconsistentState, logger } from '../common'
+import { bytesToString, deserializeMetadata, genericEventFields, inconsistentState, logger } from '../common'
 import { DecodedMetadataObject } from '@joystream/metadata-protobuf/types'
 import { getAllManagers } from '../derivedPropertiesManager/applications'
 import { createNft } from './nft'
@@ -283,7 +283,7 @@ export async function content_VideoAssetsDeletedByModerator({
     // load video
     videoId: videoId.toNumber(),
     assetIds: Array.from(dataObjectIds).map((item) => Number(item)),
-    rationale: rationale.toHuman() as string,
+    rationale: bytesToString(rationale),
     actor: await convertContentActor(store, actor),
     areNftAssets: areNftAssets.valueOf(),
   })
@@ -303,7 +303,7 @@ export async function content_VideoDeletedByModerator({ store, event }: EventCon
     ...genericEventFields(event),
 
     videoId: Number(videoId),
-    rationale: rationale.toHuman() as string,
+    rationale: bytesToString(rationale),
     actor: await convertContentActor(store, actor),
   })
 
@@ -347,7 +347,7 @@ export async function content_VideoVisibilitySetByModerator({
 
     videoId: videoId.toNumber(),
     isHidden: isCensored.isTrue,
-    rationale: rationale.toHuman() as string,
+    rationale: bytesToString(rationale),
     actor: await convertContentActor(store, actor),
   })
 

--- a/query-node/mappings/src/proposals.ts
+++ b/query-node/mappings/src/proposals.ts
@@ -57,14 +57,7 @@ import {
   ProposalDiscussionThreadModeOpen,
   ProposalStatus,
 } from 'query-node/dist/model'
-import {
-  bytesToString,
-  genericEventFields,
-  getWorkingGroupModuleName,
-  INT32MAX,
-  perpareString,
-  toNumber,
-} from './common'
+import { bytesToString, genericEventFields, getWorkingGroupModuleName, INT32MAX, toNumber } from './common'
 import { ProposalsEngine, ProposalsCodex } from '../generated/types'
 import { createWorkingGroupOpeningMetadata } from './workingGroups'
 import { blake2AsHex } from '@polkadot/util-crypto'
@@ -103,7 +96,7 @@ async function parseProposalDetails(
   if (proposalDetails.isSignal) {
     const details = new SignalProposalDetails()
     const specificDetails = proposalDetails.asSignal
-    details.text = perpareString(specificDetails.toHuman() as string)
+    details.text = bytesToString(specificDetails)
     return details
   }
   // RuntimeUpgradeProposalDetails:
@@ -211,7 +204,7 @@ async function parseProposalDetails(
   else if (proposalDetails.isAmendConstitution) {
     const details = new AmendConstitutionProposalDetails()
     const specificDetails = proposalDetails.asAmendConstitution
-    details.text = perpareString(specificDetails.toHuman() as string)
+    details.text = bytesToString(specificDetails)
     return details
   }
   // CancelWorkingGroupLeadOpeningProposalDetails:
@@ -319,8 +312,8 @@ export async function proposalsCodex_ProposalCreated({ store, event }: EventCont
     details: proposalDetails,
     councilApprovals: 0,
     creator: new Membership({ id: generalProposalParameters.memberId.toString() }),
-    title: perpareString(generalProposalParameters.title.toHuman() as string),
-    description: perpareString(generalProposalParameters.description.toHuman() as string),
+    title: bytesToString(generalProposalParameters.title),
+    description: bytesToString(generalProposalParameters.description),
     exactExecutionBlock: generalProposalParameters.exactExecutionBlock.isSome
       ? toNumber(generalProposalParameters.exactExecutionBlock.unwrap(), INT32MAX)
       : undefined,


### PR DESCRIPTION
This PR addresses:
- #4128

~~AFAICS from the code this problem should have only affected proposals.~~

In short the problem was that `createType('Bytes', string).toHuman()` returns the original string when string is pure ASCII but weirdly it returns the hex of the string when it contains non ASCII chars.

`bytesToString` encodes the bytes into a UTF8 string and escapes it.