### PR TITLE
Fix joystream-node docker build

### DIFF
--- a/joystream-node.Dockerfile
+++ b/joystream-node.Dockerfile
@@ -1,13 +1,14 @@
 FROM rust:1.61.0-buster AS rust
 WORKDIR /joystream
+RUN apt-get update && \
+  apt-get install -y curl git gcc xz-utils sudo pkg-config unzip clang llvm libc6-dev cmake
 RUN rustup self update
 RUN rustup install nightly-2022-05-11 --force
 RUN rustup default nightly-2022-05-11
 RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2022-05-11
 RUN rustup component add --toolchain nightly-2022-05-11 clippy
-RUN cargo install cargo-chef
-RUN apt-get update && \
-  apt-get install -y curl git gcc xz-utils sudo pkg-config unzip clang llvm libc6-dev cmake
+RUN rustup install nightly
+RUN cargo +nightly install cargo-chef
 
 FROM rust AS planner
 LABEL description="Cargo chef prepare"


### PR DESCRIPTION
use rust nightly to install cargo-chef to fix docker build issue seen here: https://github.com/Joystream/joystream/actions/runs/3890545247/jobs/6662531689#step:12:360