### PR TITLE
make 'payloadDataObject' nullable & remove redundant  `isCommitmemtValid` field

### DIFF
--- a/cli/src/commands/content/channelPayoutProof.ts
+++ b/cli/src/commands/content/channelPayoutProof.ts
@@ -29,7 +29,7 @@ export default class ChannelPayoutProof extends UploadCommandBase {
 
     const payoutProof = await channelPayoutProof(
       'URL',
-      `${storageNodeInfo.apiEndpoint}/files/${payloadDataObject.id}`,
+      `${storageNodeInfo.apiEndpoint}/files/${payloadDataObject?.id}`,
       Number(channelId)
     )
 

--- a/cli/src/commands/content/claimChannelReward.ts
+++ b/cli/src/commands/content/claimChannelReward.ts
@@ -35,7 +35,7 @@ export default class ClaimChannelReward extends UploadCommandBase {
     const [{ payloadDataObject }] = await this.getQNApi().getChannelPayoutsUpdatedEventByCommitment(commitment)
     const payoutProof = await channelPayoutProof(
       'URL',
-      `${storageNodeInfo.apiEndpoint}/files/${payloadDataObject.id}`,
+      `${storageNodeInfo.apiEndpoint}/files/${payloadDataObject?.id}`,
       Number(channelId)
     )
     const maxCashoutAllowed = await this.getOriginalApi().query.content.maxCashoutAllowed()

--- a/cli/src/graphql/generated/queries.ts
+++ b/cli/src/graphql/generated/queries.ts
@@ -32,7 +32,7 @@ export type ChannelPayoutsUpdatedEventFragment = {
   minCashoutAllowed?: Types.Maybe<any>
   maxCashoutAllowed?: Types.Maybe<any>
   channelCashoutsEnabled?: Types.Maybe<boolean>
-  payloadDataObject: { id: string }
+  payloadDataObject?: Types.Maybe<{ id: string }>
 }
 
 export type GetChannelPayoutsUpdatedEventByCommitmentQueryVariables = Types.Exact<{

--- a/cli/src/graphql/generated/schema.ts
+++ b/cli/src/graphql/generated/schema.ts
@@ -6979,8 +6979,8 @@ export type ChannelPayoutsUpdatedEvent = BaseGraphQlObject & {
   indexInBlock: Scalars['Int']
   /** Merkle root of the channel payouts */
   commitment?: Maybe<Scalars['String']>
-  payloadDataObject: StorageDataObject
-  payloadDataObjectId: Scalars['String']
+  payloadDataObject?: Maybe<StorageDataObject>
+  payloadDataObjectId?: Maybe<Scalars['String']>
   /** Size of the serialized channel payouts payload */
   payloadSize?: Maybe<Scalars['BigInt']>
   /** Hash of the serialized channel payouts payload */
@@ -6991,8 +6991,6 @@ export type ChannelPayoutsUpdatedEvent = BaseGraphQlObject & {
   maxCashoutAllowed?: Maybe<Scalars['BigInt']>
   /** Can channel cashout the rewards */
   channelCashoutsEnabled?: Maybe<Scalars['Boolean']>
-  /** Is the commitment valid. Most recent commitment would be considered valid */
-  isCommitmentValid: Scalars['Boolean']
 }
 
 export type ChannelPayoutsUpdatedEventConnection = {
@@ -7007,13 +7005,12 @@ export type ChannelPayoutsUpdatedEventCreateInput = {
   network: Network
   indexInBlock: Scalars['Float']
   commitment?: Maybe<Scalars['String']>
-  payloadDataObject: Scalars['ID']
+  payloadDataObject?: Maybe<Scalars['ID']>
   payloadSize?: Maybe<Scalars['String']>
   payloadHash?: Maybe<Scalars['String']>
   minCashoutAllowed?: Maybe<Scalars['String']>
   maxCashoutAllowed?: Maybe<Scalars['String']>
   channelCashoutsEnabled?: Maybe<Scalars['Boolean']>
-  isCommitmentValid: Scalars['Boolean']
 }
 
 export type ChannelPayoutsUpdatedEventEdge = {
@@ -7050,8 +7047,6 @@ export enum ChannelPayoutsUpdatedEventOrderByInput {
   MaxCashoutAllowedDesc = 'maxCashoutAllowed_DESC',
   ChannelCashoutsEnabledAsc = 'channelCashoutsEnabled_ASC',
   ChannelCashoutsEnabledDesc = 'channelCashoutsEnabled_DESC',
-  IsCommitmentValidAsc = 'isCommitmentValid_ASC',
-  IsCommitmentValidDesc = 'isCommitmentValid_DESC',
 }
 
 export type ChannelPayoutsUpdatedEventUpdateInput = {
@@ -7066,7 +7061,6 @@ export type ChannelPayoutsUpdatedEventUpdateInput = {
   minCashoutAllowed?: Maybe<Scalars['String']>
   maxCashoutAllowed?: Maybe<Scalars['String']>
   channelCashoutsEnabled?: Maybe<Scalars['Boolean']>
-  isCommitmentValid?: Maybe<Scalars['Boolean']>
 }
 
 export type ChannelPayoutsUpdatedEventWhereInput = {
@@ -7143,8 +7137,6 @@ export type ChannelPayoutsUpdatedEventWhereInput = {
   maxCashoutAllowed_in?: Maybe<Array<Scalars['BigInt']>>
   channelCashoutsEnabled_eq?: Maybe<Scalars['Boolean']>
   channelCashoutsEnabled_in?: Maybe<Array<Scalars['Boolean']>>
-  isCommitmentValid_eq?: Maybe<Scalars['Boolean']>
-  isCommitmentValid_in?: Maybe<Array<Scalars['Boolean']>>
   payloadDataObject?: Maybe<StorageDataObjectWhereInput>
   AND?: Maybe<Array<ChannelPayoutsUpdatedEventWhereInput>>
   OR?: Maybe<Array<ChannelPayoutsUpdatedEventWhereInput>>

--- a/query-node/mappings/src/content/channel.ts
+++ b/query-node/mappings/src/content/channel.ts
@@ -461,7 +461,6 @@ export async function content_ChannelPayoutsUpdated({ store, event }: EventConte
     maxCashoutAllowed,
     channelCashoutsEnabled,
     payloadDataObject,
-    isCommitmentValid: true,
   })
 
   // save new channel payout parameters record (with new commitment)

--- a/query-node/schemas/contentEvents.graphql
+++ b/query-node/schemas/contentEvents.graphql
@@ -650,7 +650,7 @@ type ChannelPayoutsUpdatedEvent @entity {
   commitment: String
 
   "Storage data object corresponding to the channel payouts payload"
-  payloadDataObject: StorageDataObject!
+  payloadDataObject: StorageDataObject
 
   "Size of the serialized channel payouts payload"
   payloadSize: BigInt
@@ -666,9 +666,6 @@ type ChannelPayoutsUpdatedEvent @entity {
 
   "Can channel cashout the rewards"
   channelCashoutsEnabled: Boolean
-
-  "Is the commitment valid. Most recent commitment would be considered valid"
-  isCommitmentValid: Boolean!
 }
 
 type PaymentContextVideo @variant {

--- a/tests/network-tests/src/flows/proposals/channelPayouts.ts
+++ b/tests/network-tests/src/flows/proposals/channelPayouts.ts
@@ -90,10 +90,12 @@ export default async function channelPayouts({ api, query, lock, env }: FlowProp
   // Council bag ID
   const COUNCIL_BAG_ID = 'static:council'
 
+  Utils.assert(channelPayoutsUpdatedEvent.payloadDataObject, 'Payload data object missing!')
+
   // Upload channel payouts payload to the council bag
   await joystreamCli.reuploadAssets({
     bagId: COUNCIL_BAG_ID,
-    assets: [{ objectId: channelPayoutsUpdatedEvent.payloadDataObject?.id || '', path: protobufPayloadFilePath }],
+    assets: [{ objectId: channelPayoutsUpdatedEvent.payloadDataObject.id, path: protobufPayloadFilePath }],
   })
 
   // Fetch channel payout proof from payload data object in council bag

--- a/tests/network-tests/src/flows/proposals/channelPayouts.ts
+++ b/tests/network-tests/src/flows/proposals/channelPayouts.ts
@@ -93,7 +93,7 @@ export default async function channelPayouts({ api, query, lock, env }: FlowProp
   // Upload channel payouts payload to the council bag
   await joystreamCli.reuploadAssets({
     bagId: COUNCIL_BAG_ID,
-    assets: [{ objectId: channelPayoutsUpdatedEvent.payloadDataObject.id, path: protobufPayloadFilePath }],
+    assets: [{ objectId: channelPayoutsUpdatedEvent.payloadDataObject?.id || '', path: protobufPayloadFilePath }],
   })
 
   // Fetch channel payout proof from payload data object in council bag
@@ -101,7 +101,7 @@ export default async function channelPayouts({ api, query, lock, env }: FlowProp
     query,
     COUNCIL_BAG_ID,
     rewardChannelId,
-    channelPayoutsUpdatedEvent.payloadDataObject.id
+    channelPayoutsUpdatedEvent.payloadDataObject?.id || ''
   )
 
   // Channel reward for given channel

--- a/tests/network-tests/src/graphql/generated/queries.ts
+++ b/tests/network-tests/src/graphql/generated/queries.ts
@@ -574,7 +574,7 @@ export type ChannelPayoutsUpdatedEventFragment = {
   minCashoutAllowed?: Types.Maybe<any>
   maxCashoutAllowed?: Types.Maybe<any>
   channelCashoutsEnabled?: Types.Maybe<boolean>
-  payloadDataObject: { id: string }
+  payloadDataObject?: Types.Maybe<{ id: string }>
 }
 
 export type GetMostRecentChannelPayoutsUpdatedEventQueryVariables = Types.Exact<{ [key: string]: never }>

--- a/tests/network-tests/src/graphql/generated/schema.ts
+++ b/tests/network-tests/src/graphql/generated/schema.ts
@@ -6979,8 +6979,8 @@ export type ChannelPayoutsUpdatedEvent = BaseGraphQlObject & {
   indexInBlock: Scalars['Int']
   /** Merkle root of the channel payouts */
   commitment?: Maybe<Scalars['String']>
-  payloadDataObject: StorageDataObject
-  payloadDataObjectId: Scalars['String']
+  payloadDataObject?: Maybe<StorageDataObject>
+  payloadDataObjectId?: Maybe<Scalars['String']>
   /** Size of the serialized channel payouts payload */
   payloadSize?: Maybe<Scalars['BigInt']>
   /** Hash of the serialized channel payouts payload */
@@ -6991,8 +6991,6 @@ export type ChannelPayoutsUpdatedEvent = BaseGraphQlObject & {
   maxCashoutAllowed?: Maybe<Scalars['BigInt']>
   /** Can channel cashout the rewards */
   channelCashoutsEnabled?: Maybe<Scalars['Boolean']>
-  /** Is the commitment valid. Most recent commitment would be considered valid */
-  isCommitmentValid: Scalars['Boolean']
 }
 
 export type ChannelPayoutsUpdatedEventConnection = {
@@ -7007,13 +7005,12 @@ export type ChannelPayoutsUpdatedEventCreateInput = {
   network: Network
   indexInBlock: Scalars['Float']
   commitment?: Maybe<Scalars['String']>
-  payloadDataObject: Scalars['ID']
+  payloadDataObject?: Maybe<Scalars['ID']>
   payloadSize?: Maybe<Scalars['String']>
   payloadHash?: Maybe<Scalars['String']>
   minCashoutAllowed?: Maybe<Scalars['String']>
   maxCashoutAllowed?: Maybe<Scalars['String']>
   channelCashoutsEnabled?: Maybe<Scalars['Boolean']>
-  isCommitmentValid: Scalars['Boolean']
 }
 
 export type ChannelPayoutsUpdatedEventEdge = {
@@ -7050,8 +7047,6 @@ export enum ChannelPayoutsUpdatedEventOrderByInput {
   MaxCashoutAllowedDesc = 'maxCashoutAllowed_DESC',
   ChannelCashoutsEnabledAsc = 'channelCashoutsEnabled_ASC',
   ChannelCashoutsEnabledDesc = 'channelCashoutsEnabled_DESC',
-  IsCommitmentValidAsc = 'isCommitmentValid_ASC',
-  IsCommitmentValidDesc = 'isCommitmentValid_DESC',
 }
 
 export type ChannelPayoutsUpdatedEventUpdateInput = {
@@ -7066,7 +7061,6 @@ export type ChannelPayoutsUpdatedEventUpdateInput = {
   minCashoutAllowed?: Maybe<Scalars['String']>
   maxCashoutAllowed?: Maybe<Scalars['String']>
   channelCashoutsEnabled?: Maybe<Scalars['Boolean']>
-  isCommitmentValid?: Maybe<Scalars['Boolean']>
 }
 
 export type ChannelPayoutsUpdatedEventWhereInput = {
@@ -7143,8 +7137,6 @@ export type ChannelPayoutsUpdatedEventWhereInput = {
   maxCashoutAllowed_in?: Maybe<Array<Scalars['BigInt']>>
   channelCashoutsEnabled_eq?: Maybe<Scalars['Boolean']>
   channelCashoutsEnabled_in?: Maybe<Array<Scalars['Boolean']>>
-  isCommitmentValid_eq?: Maybe<Scalars['Boolean']>
-  isCommitmentValid_in?: Maybe<Array<Scalars['Boolean']>>
   payloadDataObject?: Maybe<StorageDataObjectWhereInput>
   AND?: Maybe<Array<ChannelPayoutsUpdatedEventWhereInput>>
   OR?: Maybe<Array<ChannelPayoutsUpdatedEventWhereInput>>


### PR DESCRIPTION
SSIA.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202078489349362/1203837085018298) by [Unito](https://www.unito.io)
