### PR TITLE
JoystreamJS: Generate commitment from arbitrary bytes source

### DIFF
--- a/cli/src/commands/content/channelPayoutProofAtByteOffset.ts
+++ b/cli/src/commands/content/channelPayoutProofAtByteOffset.ts
@@ -1,4 +1,5 @@
 import { channelPayoutProofAtByteOffset } from '@joystream/js/content'
+import { readBytesFromFile } from '@joystream/js/utils'
 import { Command, flags } from '@oclif/command'
 import { displayCollapsedRow } from '../../helpers/display'
 
@@ -36,8 +37,8 @@ export default class ChannelPayoutProofAtByteOffset extends Command {
       }
 
       const payoutProof = path
-        ? await channelPayoutProofAtByteOffset('PATH', path, start)
-        : await channelPayoutProofAtByteOffset('URL', url!, start)
+        ? await channelPayoutProofAtByteOffset(readBytesFromFile('PATH', path), start)
+        : await channelPayoutProofAtByteOffset(readBytesFromFile('URL', url!), start)
 
       displayCollapsedRow({
         'Channel Id': payoutProof.channelId,

--- a/cli/src/commands/content/channelPayoutsPayloadHeader.ts
+++ b/cli/src/commands/content/channelPayoutsPayloadHeader.ts
@@ -1,5 +1,6 @@
 import { ChannelPayoutsMetadata } from '@joystream/metadata-protobuf'
 import { serializedPayloadHeader } from '@joystream/js/content'
+import { readBytesFromFile } from '@joystream/js/utils'
 import { Command, flags } from '@oclif/command'
 import chalk from 'chalk'
 import { displayCollapsedRow, displayTable } from '../../helpers/display'
@@ -27,8 +28,8 @@ export default class ChannelPayoutPayloadHeader extends Command {
 
     try {
       const serializedHeader = path
-        ? await serializedPayloadHeader('PATH', path)
-        : await serializedPayloadHeader('URL', url!)
+        ? await serializedPayloadHeader(readBytesFromFile('PATH', path))
+        : await serializedPayloadHeader(readBytesFromFile('URL', url!))
 
       const header = ChannelPayoutsMetadata.Header.decode(serializedHeader)
       this.log(

--- a/cli/src/commands/content/generateChannelPayoutsCommitment.ts
+++ b/cli/src/commands/content/generateChannelPayoutsCommitment.ts
@@ -1,4 +1,5 @@
 import { generateCommitmentFromPayloadFile } from '@joystream/js/content'
+import { readBytesFromFile } from '@joystream/js/utils'
 import { flags } from '@oclif/command'
 import chalk from 'chalk'
 import ContentDirectoryCommandBase from '../../base/ContentDirectoryCommandBase'
@@ -27,8 +28,8 @@ export default class GenerateChannelPayoutsCommitment extends ContentDirectoryCo
 
     try {
       const commitment = path
-        ? await generateCommitmentFromPayloadFile('PATH', path)
-        : await generateCommitmentFromPayloadFile('URL', url!)
+        ? await generateCommitmentFromPayloadFile(readBytesFromFile('PATH', path))
+        : await generateCommitmentFromPayloadFile(readBytesFromFile('URL', url!))
 
       this.log(chalk.green(`Channel Payout payload merkle root is ${chalk.cyanBright(commitment)}!`))
     } catch (error) {

--- a/tests/network-tests/src/fixtures/content/channelPayouts/UpdateChannelPayoutsProposalFixture.ts
+++ b/tests/network-tests/src/fixtures/content/channelPayouts/UpdateChannelPayoutsProposalFixture.ts
@@ -1,6 +1,7 @@
 import { createType } from '@joystream/types'
 import { MemberId } from '@joystream/types/primitives'
 import { generateCommitmentFromPayloadFile } from '@joystream/js/content'
+import { readBytesFromFile } from '@joystream/js/utils'
 import BN from 'bn.js'
 import fs from 'fs'
 import { Api } from '../../../Api'
@@ -43,7 +44,7 @@ export class UpdateChannelPayoutsProposalFixture extends BaseQueryNodeFixture {
       {
         type: 'UpdateChannelPayouts',
         details: createType('PalletContentUpdateChannelPayoutsParametersRecord', {
-          commitment: await generateCommitmentFromPayloadFile('PATH', protobufPayloadFilePath),
+          commitment: await generateCommitmentFromPayloadFile(readBytesFromFile('PATH', protobufPayloadFilePath)),
           payload: {
             objectCreationParams: {
               size_: fs.statSync(protobufPayloadFilePath).size,


### PR DESCRIPTION
This is needed by Joystream/pioneer#4095 because`fs` is not available in the browser. Instead the payload file is provided to the browser as a [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File).