### PR TITLE
Fix network-deploy action 

### DIFF
--- a/.github/workflows/deploy-node-network.yml
+++ b/.github/workflows/deploy-node-network.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Install python3 netaddr
         run: sudo apt-get install -y --no-install-recommends python3-netaddr
 
-      - name: Install python netaddr
-        run: sudo apt install -y --no-install-recommends python-netaddr
-
       - name: Install Ansible
         run: |
           pip3 install --upgrade --user ansible


### PR DESCRIPTION
Only install python3-netaddr as ubuntu-latest doesn't have python2 anymore and would cause deployment failure.
ref: https://github.com/Joystream/joystream/actions/runs/4172483517/jobs/7223639256#step:5:13