### PR TITLE
Increase storageSync QN timeout even more (5m)

### DIFF
--- a/tests/network-tests/src/flows/storage/storageSync.ts
+++ b/tests/network-tests/src/flows/storage/storageSync.ts
@@ -62,15 +62,13 @@ export async function storageSync({ api, query }: FlowProps): Promise<void> {
     await api.sendExtrinsicsAndGetResults(createChannelTxBatch, memberAddr)
   }
 
-  debug('Giving the query node 2 minutes to sync...')
-  await Utils.wait(120_000)
-
+  debug('Waiting until the query node processes 10_000 channels...')
   // Make sure there are indeed 10_000 channels processed by the QN
   await query.tryQueryWithTimeout(
     () => query.getChannelsCount(),
     (r) => assert.equal(r, 10_000),
-    12,
-    10
+    9,
+    100 // 9 * 100 = 900s = 15 minutes timeout
   )
 
   // Create channel w/ some data objects

--- a/tests/network-tests/src/flows/storage/storageSync.ts
+++ b/tests/network-tests/src/flows/storage/storageSync.ts
@@ -67,8 +67,8 @@ export async function storageSync({ api, query }: FlowProps): Promise<void> {
   await query.tryQueryWithTimeout(
     () => query.getChannelsCount(),
     (r) => assert.equal(r, 10_000),
-    9,
-    100 // 9 * 100 = 900s = 15 minutes timeout
+    10_000,
+    30 // 10s * 30 = 300s = 5 minutes timeout
   )
 
   // Create channel w/ some data objects


### PR DESCRIPTION
Storage sync failing again: https://github.com/Joystream/joystream/actions/runs/4196136901/jobs/7278686492

- Increased total timeout to 5 minutes
- Fixes arguments to `tryQueryWithTimeout`: number of seconds was passed instead of number of miliseconds 
- Removed the arbitrary `Giving the query node X minutes to sync...` period in favor of using more retries in `tryQueryWithTimeout`