### PR TITLE
Reduce 'max constitutionality' to 2

### DIFF
--- a/runtime/src/proposals_configuration/defaults.rs
+++ b/runtime/src/proposals_configuration/defaults.rs
@@ -24,7 +24,7 @@ pub(crate) fn set_max_validator_count_proposal() -> ProposalParameters<BlockNumb
         slashing_quorum_percentage: ALL,
         slashing_threshold_percentage: ALL,
         required_stake: Some(dollars!(10_000)),
-        constitutionality: 3,
+        constitutionality: 2,
     }
 }
 
@@ -38,7 +38,7 @@ pub(crate) fn runtime_upgrade_proposal() -> ProposalParameters<BlockNumber, Bala
         slashing_quorum_percentage: ALL,
         slashing_threshold_percentage: ALL,
         required_stake: Some(dollars!(10_000)),
-        constitutionality: 4,
+        constitutionality: 2,
     }
 }
 
@@ -224,7 +224,7 @@ pub(crate) fn set_council_budget_increment_proposal() -> ProposalParameters<Bloc
         slashing_quorum_percentage: ALL,
         slashing_threshold_percentage: ALL,
         required_stake: Some(dollars!(2_000)),
-        constitutionality: 3,
+        constitutionality: 2,
     }
 }
 

--- a/runtime/src/proposals_configuration/staging.rs
+++ b/runtime/src/proposals_configuration/staging.rs
@@ -24,7 +24,7 @@ pub(crate) fn set_max_validator_count_proposal() -> ProposalParameters<BlockNumb
         slashing_quorum_percentage: ALL,
         slashing_threshold_percentage: ALL,
         required_stake: Some(dollars!(10_000)),
-        constitutionality: 3,
+        constitutionality: 2,
     }
 }
 
@@ -38,7 +38,7 @@ pub(crate) fn runtime_upgrade_proposal() -> ProposalParameters<BlockNumber, Bala
         slashing_quorum_percentage: ALL,
         slashing_threshold_percentage: ALL,
         required_stake: Some(dollars!(10_000)),
-        constitutionality: 4,
+        constitutionality: 2,
     }
 }
 
@@ -224,7 +224,7 @@ pub(crate) fn set_council_budget_increment_proposal() -> ProposalParameters<Bloc
         slashing_quorum_percentage: ALL,
         slashing_threshold_percentage: ALL,
         required_stake: Some(dollars!(2_000)),
-        constitutionality: 3,
+        constitutionality: 2,
     }
 }
 


### PR DESCRIPTION
[I'll link to an issue @bedeho is writing for extra context.](https://github.com/Joystream/joystream/issues/4655)

---

A runtime upgrade, when executed, effectively cancels any proposal that is in any of the stages "open" stages (`voting`, `gracing`, `dormant`), this blocks the opportunity of having multiple runtime upgrade proposals in the pipeline at the same time. 

This does of course also affect all other proposals, which although "better" accounted for, should be adjusted to stay in line. If not, one could theoretically never get proposals with constitutionality > 2 executed. 

Still, it's the runtime upgrade that is the key issue here. 

Given that we are in a stage of the project where runtime upgrades should be _somewhat_ frequent, as 
- JSG is still "around"
- the community is (relatively) small, knowledgeable and cohesive
- lots of features in the pipeline
- they are required for changing lots of constants and limits, etc.
   - ...and all existing ones have not been "tested" in production

Finally, as we are still very early for Joystream, there will be bugs. Not clear exactly how much better it will be to patch them in flight, but 4-5 weeks is still better than 8-9...


Note that this would be a temporary change. The next runtime upgrade after `ephesus` would hopefully bring in a way to have proposals (where execution is not affected by the changes ofc.) survive the upgrade. 

--- 

Tests failed, but AFAICT it was only cli/typescript related.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1202078489349362/1204022069281494) by [Unito](https://www.unito.io)
