### PR TITLE
Network tests: Fix memory leak, increase storageSync wait time

### DIFF
--- a/tests/network-tests/src/flows/storage/storageSync.ts
+++ b/tests/network-tests/src/flows/storage/storageSync.ts
@@ -107,8 +107,8 @@ export async function storageSync({ api, query }: FlowProps): Promise<void> {
   Utils.assert(channel && channel.coverPhoto && channel.avatarPhoto, `Channel ${channelId} has missing assets`)
   Utils.assert(colossus1Endpoint && colossus2Endpoint, `Colossus endpoints not set`)
 
-  debug('Giving nodes 120 seconds to sync...')
-  await Utils.wait(120_000)
+  debug('Giving nodes 300 seconds to sync...')
+  await Utils.wait(300_000)
 
   // Verify that both storage nodes have the right assets
   const colossus1Api = new ColossusApi(urljoin(colossus1Endpoint, 'api/v1'))

--- a/tests/network-tests/src/sender.ts
+++ b/tests/network-tests/src/sender.ts
@@ -50,7 +50,7 @@ export class Sender {
     const addr = this.keyring.encodeAddress(account)
     const senderKeyPair: KeyringPair = this.keyring.getPair(addr)
 
-    let unsunscribe: () => void
+    let unsubscribe: () => void
     let finalized: { (result: ISubmittableResult): void }
     const whenFinalized: Promise<ISubmittableResult> = new Promise((resolve, reject) => {
       finalized = resolve
@@ -125,8 +125,8 @@ export class Sender {
       // Always resolve irrespective of success or failure. Error handling should
       // be dealt with by caller.
       if (success || failed) {
-        if (unsunscribe) {
-          unsunscribe()
+        if (unsubscribe) {
+          unsubscribe()
         }
         finalized(result)
       }
@@ -147,7 +147,7 @@ export class Sender {
       sentTx = signedTx.toHuman()
       const { method, section } = signedTx.method
       try {
-        unsunscribe = await signedTx.send(handleEvents)
+        unsubscribe = await signedTx.send(handleEvents)
         if (this.logs === LogLevel.Verbose) {
           this.debug('Submitted tx:', `${section}.${method} (nonce: ${nonce}, tip: ${formatBalance(tip)})`)
         }

--- a/tests/network-tests/src/sender.ts
+++ b/tests/network-tests/src/sender.ts
@@ -50,6 +50,7 @@ export class Sender {
     const addr = this.keyring.encodeAddress(account)
     const senderKeyPair: KeyringPair = this.keyring.getPair(addr)
 
+    let unsunscribe: () => void
     let finalized: { (result: ISubmittableResult): void }
     const whenFinalized: Promise<ISubmittableResult> = new Promise((resolve, reject) => {
       finalized = resolve
@@ -123,7 +124,12 @@ export class Sender {
 
       // Always resolve irrespective of success or failure. Error handling should
       // be dealt with by caller.
-      if (success || failed) finalized(result)
+      if (success || failed) {
+        if (unsunscribe) {
+          unsunscribe()
+        }
+        finalized(result)
+      }
     }
 
     // We used to do this: Sender.asyncLock.acquire(`${senderKeyPair.address}` ...
@@ -141,7 +147,7 @@ export class Sender {
       sentTx = signedTx.toHuman()
       const { method, section } = signedTx.method
       try {
-        await signedTx.send(handleEvents)
+        unsunscribe = await signedTx.send(handleEvents)
         if (this.logs === LogLevel.Verbose) {
           this.debug('Submitted tx:', `${section}.${method} (nonce: ${nonce}, tip: ${formatBalance(tip)})`)
         }


### PR DESCRIPTION
Example failure caused by insufficient wait time: https://github.com/Joystream/joystream/actions/runs/4245801993/jobs/7381940413

Example failure caused by memory leak: https://github.com/Joystream/joystream/actions/runs/4242498829/jobs/7375275681