### PR TITLE
Playgrounds: choose correct ami for region

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # When changing region double check ami image is available in deploy step
           aws-region: eu-central-1
 
       - name: Check if CloudFormation stack exists
@@ -86,7 +87,8 @@ jobs:
           name: ${{ env.STACK_NAME }}
           template: devops/aws/cloudformation/single-instance.yml
           no-fail-on-empty-changeset: '1'
-          parameter-overrides: 'KeyName=joystream-github-action-key-new,EC2InstanceType=t2.xlarge'
+          # Make sure ami image is available in the region specified in configure aws creds step
+          parameter-overrides: 'KeyName=joystream-github-action-key-new,EC2InstanceType=t2.xlarge,EC2AMI=ami-06b4d9ba1f23a8da4'
 
       - name: Run playbook
         uses: dawidd6/action-ansible-playbook@v2


### PR DESCRIPTION
Picked the correct image with:

```sh
aws ssm get-parameters --names  /aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id --region eu-central-1
{
    "Parameters": [
        {
            "Name": "/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id",
            "Type": "String",
            "Value": "ami-06b4d9ba1f23a8da4",
            "Version": 22,
            "LastModifiedDate": "2023-02-16T07:11:31.424000+04:00",
            "ARN": "arn:aws:ssm:eu-central-1::parameter/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id",
            "DataType": "aws:ec2:image"
        }
    ],
    "InvalidParameters": []
}
```

to override default for us-east-1 region in https://github.com/Joystream/joystream/blob/master/devops/aws/cloudformation/single-instance.yml#L10