### PR TITLE
`generateAppActionCommitment` fixes

### DIFF
--- a/metadata-protobuf/proto/App.proto
+++ b/metadata-protobuf/proto/App.proto
@@ -18,14 +18,14 @@ message AppAction {
   // Signature over app commitment
   optional bytes signature = 4;
 
-  // Nonce to prevent signature reusal
-  optional uint32 nonce = 5;
-
   enum ActionType {
     CREATE_VIDEO = 0;
     CREATE_CHANNEL = 1;
   }
 
-  // Type of the runtime-level action to be performed
-  optional ActionType action_type = 6;
+  enum CreatorType {
+    CHANNEL = 0;
+    MEMBER = 1;
+    CURAOTR_GROUP = 2;
+  }
 }

--- a/metadata-protobuf/proto/App.proto
+++ b/metadata-protobuf/proto/App.proto
@@ -26,6 +26,6 @@ message AppAction {
   enum CreatorType {
     CHANNEL = 0;
     MEMBER = 1;
-    CURAOTR_GROUP = 2;
+    CURATOR_GROUP = 2;
   }
 }

--- a/metadata-protobuf/src/types.ts
+++ b/metadata-protobuf/src/types.ts
@@ -17,7 +17,7 @@ export type AnyMetadataClass<T> = {
 export type DecodedMetadataObject<T> = {
   [K in keyof T]: T[K] extends Long | null | undefined
     ? Exclude<T[K], Long> | string
-    : T[K] extends string | number | boolean | null | undefined
+    : T[K] extends string | number | boolean | Uint8Array | null | undefined
     ? T[K]
     : T[K] extends Array<infer S>
     ? DecodedMetadataObject<S>[]

--- a/query-node/mappings/src/content/channel.ts
+++ b/query-node/mappings/src/content/channel.ts
@@ -78,6 +78,7 @@ export async function content_ChannelCreated(ctx: EventContext & StoreContext): 
     ...channelOwner,
     rewardAccount: rewardAccount.toString(),
     channelStateBloatBond: channelStateBloatBond.amount,
+    totalVideosCreated: 0,
   })
 
   // deserialize & process metadata
@@ -93,20 +94,20 @@ export async function content_ChannelCreated(ctx: EventContext & StoreContext): 
     if (appAction) {
       const channelMetadataBytes = u8aToBytes(appAction.rawAction)
       const channelMetadata = deserializeMetadata(ChannelMetadata, channelMetadataBytes)
-      const appCommitment = generateAppActionCommitment(
+      const creatorType = channel.ownerMember ? AppAction.CreatorType.MEMBER : AppAction.CreatorType.CURAOTR_GROUP
+      const creatorId = (channel.ownerMember ? channel.ownerMember.id : channel.ownerCuratorGroup?.id) ?? ''
+      const expectedCommitment = generateAppActionCommitment(
+        // Note: Curator channels not supported yet
         channelOwner.ownerMember?.totalChannelsCreated ?? -1,
-        channelOwner.ownerMember?.id ? `m:${channelOwner.ownerMember.id}` : `c:${channelOwner.ownerCuratorGroup?.id}`,
+        creatorId,
         AppAction.ActionType.CREATE_CHANNEL,
+        creatorType,
         channelCreationParameters.assets.toU8a(),
-        appAction.rawAction ? channelMetadataBytes : undefined,
-        appAction.metadata ? u8aToBytes(appAction.metadata) : undefined
+        channelMetadataBytes.toU8a(true),
+        appAction.metadata || new Uint8Array()
       )
-      await processAppActionMetadata(
-        ctx,
-        channel,
-        appAction,
-        { ownerNonce: channelOwner.ownerMember?.totalChannelsCreated, appCommitment },
-        (entity: Channel) => processChannelMetadata(ctx, entity, channelMetadata ?? {}, dataObjects)
+      await processAppActionMetadata(ctx, channel, appAction, expectedCommitment, (entity: Channel) =>
+        processChannelMetadata(ctx, entity, channelMetadata ?? {}, dataObjects)
       )
     } else {
       const channelMetadata = deserializeMetadata(ChannelMetadata, channelCreationParameters.meta.unwrap()) ?? {}
@@ -373,8 +374,6 @@ async function updateChannelAgentsPermissions(
 
   // create new records for privledged members
   for (const [memberId, permissions] of Array.from(collaboratorsPermissions)) {
-    const permissionsArray = Array.from(permissions)
-
     const collaborator = new Collaborator({
       channel: new Channel({ id: channel.id.toString() }),
       member: new Membership({ id: memberId.toString() }),

--- a/query-node/mappings/src/content/channel.ts
+++ b/query-node/mappings/src/content/channel.ts
@@ -94,7 +94,7 @@ export async function content_ChannelCreated(ctx: EventContext & StoreContext): 
     if (appAction) {
       const channelMetadataBytes = u8aToBytes(appAction.rawAction)
       const channelMetadata = deserializeMetadata(ChannelMetadata, channelMetadataBytes)
-      const creatorType = channel.ownerMember ? AppAction.CreatorType.MEMBER : AppAction.CreatorType.CURAOTR_GROUP
+      const creatorType = channel.ownerMember ? AppAction.CreatorType.MEMBER : AppAction.CreatorType.CURATOR_GROUP
       const creatorId = (channel.ownerMember ? channel.ownerMember.id : channel.ownerCuratorGroup?.id) ?? ''
       const expectedCommitment = generateAppActionCommitment(
         // Note: Curator channels not supported yet

--- a/query-node/mappings/src/content/utils.ts
+++ b/query-node/mappings/src/content/utils.ts
@@ -176,42 +176,29 @@ async function processVideoSubtitleAssets(
 
 async function validateAndGetApp(
   ctx: EventContext & StoreContext,
-  validationContext: {
-    ownerNonce: number | undefined
-    appCommitment: string | undefined
-  },
+  expectedSignedCommitment: string,
   appAction: DecodedMetadataObject<IAppAction>
 ): Promise<App | undefined> {
   // If one is missing we cannot verify the signature
-  if (
-    !appAction.appId ||
-    !appAction.signature ||
-    typeof appAction.nonce !== 'number' ||
-    !validationContext.appCommitment
-  ) {
+  if (!appAction.appId || !appAction.signature) {
     invalidMetadata('Missing action fields to verify app')
     return undefined
   }
 
   const app = await getAppById(ctx.store, appAction.appId)
 
-  if (!app || !app.authKey) {
+  if (!app) {
     invalidMetadata('No app of given id found')
     return undefined
   }
 
-  if (typeof validationContext.ownerNonce === 'undefined' || validationContext.ownerNonce !== appAction.nonce) {
-    invalidMetadata('Invalid app action nonce')
-
+  if (!app.authKey) {
+    invalidMetadata('The provided app has no auth key assigned')
     return undefined
   }
 
   try {
-    const isSignatureValid = ed25519Verify(
-      validationContext.appCommitment,
-      appAction.signature as Uint8Array,
-      app.authKey
-    )
+    const isSignatureValid = ed25519Verify(expectedSignedCommitment, appAction.signature, app.authKey)
 
     if (!isSignatureValid) {
       invalidMetadata('Invalid app action signature')
@@ -228,13 +215,10 @@ export async function processAppActionMetadata<T extends { entryApp?: App }>(
   ctx: EventContext & StoreContext,
   entity: T,
   meta: DecodedMetadataObject<IAppAction>,
-  validationContext: {
-    ownerNonce: number | undefined
-    appCommitment: string | undefined
-  },
+  expectedSignedCommitment: string,
   entityMetadataProcessor: (entity: T) => Promise<T>
 ): Promise<T> {
-  const app = await validateAndGetApp(ctx, validationContext, meta)
+  const app = await validateAndGetApp(ctx, expectedSignedCommitment, meta)
   if (!app) {
     return entityMetadataProcessor(entity)
   }
@@ -770,22 +754,24 @@ export function mapAgentPermission(permission: PalletContentIterableEnumsChannel
 export function generateAppActionCommitment(
   nonce: number,
   creatorId: string,
-  type: AppAction.ActionType,
+  actionType: AppAction.ActionType,
+  creatorType: AppAction.CreatorType,
   assets: Uint8Array,
-  rawAction?: Bytes,
-  rawAppActionMetadata?: Bytes
+  rawAction?: Uint8Array,
+  rawAppActionMetadata?: Uint8Array
 ): string {
   const rawCommitment = [
     nonce,
     creatorId,
-    type,
+    actionType,
+    creatorType,
     u8aToHex(assets),
-    ...(rawAction ? [u8aToHex(rawAction)] : []),
-    ...(rawAppActionMetadata ? [u8aToHex(rawAppActionMetadata)] : []),
+    u8aToHex(rawAction),
+    u8aToHex(rawAppActionMetadata),
   ]
   return stringToHex(JSON.stringify(rawCommitment))
 }
 
-export function u8aToBytes(array?: DecodedMetadataObject<Uint8Array> | null): Bytes {
-  return createType('Bytes', array ? u8aToHex(array as Uint8Array) : '')
+export function u8aToBytes(array?: Uint8Array | null): Bytes {
+  return createType('Bytes', array ? u8aToHex(array) : '')
 }

--- a/query-node/mappings/src/membership.ts
+++ b/query-node/mappings/src/membership.ts
@@ -159,7 +159,6 @@ async function saveMembershipMetadata(
 
 async function createNewMemberFromParams(
   store: DatabaseManager,
-  event: SubstrateEvent,
   memberId: MemberId,
   entryMethod: typeof MembershipEntryMethod,
   params: BuyMembershipParameters | InviteMembershipParameters | GiftMembershipParameters | CreateMemberParameters,
@@ -182,7 +181,6 @@ async function createNewMemberFromParams(
         : undefined,
     isVerified: isFoundingMember,
     inviteCount,
-    totalVideosCreated: 0,
     totalChannelsCreated: 0,
     boundAccounts: [],
     invitees: [],
@@ -215,7 +213,6 @@ export async function members_MembershipBought({ store, event }: EventContext & 
   const memberEntry = new MembershipEntryPaid()
   const member = await createNewMemberFromParams(
     store,
-    event,
     memberId,
     memberEntry,
     buyMembershipParameters,
@@ -243,7 +240,7 @@ export async function members_MembershipGifted({ store, event }: EventContext & 
   const [memberId, giftMembershipParameters] = new Members.MembershipGiftedEvent(event).params
 
   const memberEntry = new MembershipEntryGifted()
-  const member = await createNewMemberFromParams(store, event, memberId, memberEntry, giftMembershipParameters, 0)
+  const member = await createNewMemberFromParams(store, memberId, memberEntry, giftMembershipParameters, 0)
 
   const membershipGiftedEvent = new MembershipGiftedEvent({
     ...genericEventFields(event),
@@ -267,7 +264,6 @@ export async function members_MemberCreated({ store, event }: EventContext & Sto
   const memberEntry = new MembershipEntryMemberCreated()
   const member = await createNewMemberFromParams(
     store,
-    event,
     memberId,
     memberEntry,
     memberParameters,
@@ -414,14 +410,7 @@ export async function members_InvitesTransferred({ store, event }: EventContext 
 export async function members_MemberInvited({ store, event }: EventContext & StoreContext): Promise<void> {
   const [memberId, inviteMembershipParameters] = new Members.MemberInvitedEvent(event).params
   const entryMethod = new MembershipEntryInvited()
-  const invitedMember = await createNewMemberFromParams(
-    store,
-    event,
-    memberId,
-    entryMethod,
-    inviteMembershipParameters,
-    0
-  )
+  const invitedMember = await createNewMemberFromParams(store, memberId, entryMethod, inviteMembershipParameters, 0)
 
   // Decrease invite count of inviting member
   const invitingMember = await getMemberById(store, inviteMembershipParameters.invitingMemberId)

--- a/query-node/schemas/content.graphql
+++ b/query-node/schemas/content.graphql
@@ -70,6 +70,9 @@ type Channel @entity {
 
   "Channel's privilege level"
   privilegeLevel: Int
+
+  "Number of videos ever created in this channel"
+  totalVideosCreated: Int!
 }
 
 type VideoCategory @entity {

--- a/query-node/schemas/membership.graphql
+++ b/query-node/schemas/membership.graphql
@@ -183,9 +183,6 @@ type Membership @entity {
   "Number of channels ever created by this member"
   totalChannelsCreated: Int!
 
-  "Number of videos ever created by this member"
-  totalVideosCreated: Int!
-
   # Required for EnglishAuctionSettledEvent->members Many-to-Many relationship
   "Member as bidder in EnglishAuctionSettledEvent/s."
   memberEnglishAuctionSettledEvents: [EnglishAuctionSettledEvent!] @derivedFrom(field: "bidders")


### PR DESCRIPTION
- Include new `ownerType` filed in app action commitment to simplify differentiation between different types of owners (member, curator group, channel)
- Remove `nonce` and `actionType` fields from `AppAction` message. They don't actually need to be there, since the correct values are known by the QN, so they can be only included in the commitment/signature
- `ActionType` and `CreatorType` enums are still included in `App.proto` for the purpose of standarizing the encoding of those values across different apps.
- I simplified `generateAppActionCommitment` so that it doesn't rely on values like `rawAction` and `rawAppActionMetadata` being provided as `Bytes`. The `Bytes` type is `@polkadot/types`-specific and is harder to construct than `Uint8Array` (which is universal), as it requires a type registry, importing from `@polkadot/types` or `@joystream/types` library etc. Also now the encoidng of those values is more consistent with `assets` 
- Fixed a few other small issues