### PR TITLE
`ChannelDeletedByModerator` and `processBanOrUnbanMemberFromChannelMessage` QN fixes

### DIFF
--- a/query-node/mappings/src/content/commentAndReaction.ts
+++ b/query-node/mappings/src/content/commentAndReaction.ts
@@ -38,7 +38,7 @@ import {
   VideoReactionsCountByReactionType,
   VideoReactionsPreferenceEvent,
 } from 'query-node/dist/model'
-import { genericEventFields, inconsistentState, newMetaprotocolEntityId } from '../common'
+import { genericEventFields, inconsistentState, newMetaprotocolEntityId, unexpectedData } from '../common'
 
 // TODO: Ensure video is actually a video
 // TODO: make sure comment is fully removed (all of its reactions)
@@ -594,7 +594,6 @@ export async function processModerateCommentMessage(
 export async function processPinOrUnpinCommentMessage(
   store: DatabaseManager,
   event: SubstrateEvent,
-  channelOwner: typeof ContentActor,
   channelId: ChannelId,
   message: IPinOrUnpinComment
 ): Promise<void> {
@@ -629,7 +628,6 @@ export async function processPinOrUnpinCommentMessage(
 export async function processBanOrUnbanMemberFromChannelMessage(
   store: DatabaseManager,
   event: SubstrateEvent,
-  channelOwner: typeof ContentActor,
   channelId: ChannelId,
   message: IBanOrUnbanMemberFromChannel
 ): Promise<void> {
@@ -637,6 +635,12 @@ export async function processBanOrUnbanMemberFromChannelMessage(
 
   // load channel
   const channel = await getChannel(store, channelId.toString(), ['bannedMembers'])
+
+  const member = await store.get(Membership, { where: { id: memberId.toString() } })
+  if (!member) {
+    // Error will be caught inside `content_ChannelOwnerRemarked`
+    unexpectedData(`Member by id '${memberId.toString()}' not found!`)
+  }
 
   // ban member from channel; if member is already banned it remains banned
   if (option === BanOrUnbanMemberFromChannel.Option.BAN) {
@@ -668,7 +672,6 @@ export async function processBanOrUnbanMemberFromChannelMessage(
 export async function processVideoReactionsPreferenceMessage(
   store: DatabaseManager,
   event: SubstrateEvent,
-  channelOwner: typeof ContentActor,
   channelId: ChannelId,
   message: IVideoReactionsPreference
 ): Promise<void> {

--- a/tests/network-tests/src/flows/content/commentsAndReactions.ts
+++ b/tests/network-tests/src/flows/content/commentsAndReactions.ts
@@ -23,6 +23,7 @@ import {
   BanOrUnbanMemberParams,
   BanOrUnbanMembersFixture,
 } from '../../fixtures/content'
+import { DeleteChannelAsModeratorFixture } from '../../fixtures/content/curatorModeration/DeleteChannelAsModerator'
 import { FlowProps } from '../../Flow'
 import { createJoystreamCli } from '../utils'
 
@@ -37,7 +38,7 @@ export default async function commentsAndReactions({ api, query }: FlowProps): P
   // settings
   const videoCount = 2
   const videoCategoryCount = 2
-  const channelCount = 1
+  const channelCount = 2
   const sufficientTopupAmount = new BN(10_000_000_000_000) // some very big number to cover fees of all transactions
 
   // flow itself
@@ -270,14 +271,28 @@ export default async function commentsAndReactions({ api, query }: FlowProps): P
         option: BanOrUnbanMemberFromChannel.Option.BAN,
       },
     },
+    {
+      asMember: channelOwner.memberId,
+      channelId: channelIds[1],
+      msg: {
+        memberId: Long.fromString(participants[0].memberId.toString()), // ban participant[0] from channel[1]
+        option: BanOrUnbanMemberFromChannel.Option.BAN,
+      },
+    },
   ]
 
   const banMembersFixture = new BanOrUnbanMembersFixture(api, query, banMembers)
   await new FixtureRunner(banMembersFixture).runWithQueryNodeChecks()
 
   // Delete videos & channels (to ensure all referencing relations are properly removed without causing QN processor crash)
-  const deleteChannelWithVideosFixture = new DeleteChannelWithVideosFixture(api, query, joystreamCli, channelIds)
+  const deleteChannelWithVideosFixture = new DeleteChannelWithVideosFixture(api, query, joystreamCli, [channelIds[0]])
   await new FixtureRunner(deleteChannelWithVideosFixture).run()
+
+  // Delete channel as moderator (to ensure all referencing relations are properly removed without causing QN processor crash)
+  const deleteChannelAsModeratorFixture = new DeleteChannelAsModeratorFixture(api, query, [
+    { channelId: channelIds[1], rationale: 'Test', numOfObjectsToDelete: 2 },
+  ])
+  await new FixtureRunner(deleteChannelAsModeratorFixture).runWithQueryNodeChecks()
 
   debug('Done')
 }


### PR DESCRIPTION
- Remove related entities also when handling `ChannelDeletedByModerator` event
- Check for membership existance in `processBanOrUnbanMemberFromChannelMessage`
- Remove a few unused function parameters
- Add tests