### PR TITLE
Fix failing tests on ephesus inviting members job

### DIFF
--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scenario: ['full', 'setupNewChain', 'setupNewChainMultiStorage', 'bonding', 'storageSync', 'memberships']
+        scenario: ['full', 'setupNewChain', 'setupNewChainMultiStorage', 'bonding', 'storageSync']
         include:
           - scenario: 'full'
             no_storage: 'false'

--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scenario: ['full', 'setupNewChain', 'setupNewChainMultiStorage', 'bonding', 'storageSync']
+        scenario: ['full', 'setupNewChain', 'setupNewChainMultiStorage', 'bonding', 'storageSync', 'memberships']
         include:
           - scenario: 'full'
             no_storage: 'false'

--- a/tests/network-tests/src/Resources.ts
+++ b/tests/network-tests/src/Resources.ts
@@ -48,6 +48,7 @@ class Lock {
 export enum Resource {
   Council = 'Council',
   Proposals = 'Proposals',
+  MembershipWgBudget = 'MembershipWgBudget',
 }
 
 export class ResourceManager {
@@ -75,6 +76,8 @@ export class ResourceManager {
       // which limits the number of concurrent tests that create proposals
       // TODO: Get the value from api.consts.proposalsEngine.maxActiveProposalLimit
       [Resource.Proposals]: this.add(Resource.Proposals, 20),
+      // mutex for meembership working group budget
+      [Resource.MembershipWgBudget]: this.add(Resource.MembershipWgBudget),
     }
   }
 

--- a/tests/network-tests/src/flows/working-groups/groupBudget.ts
+++ b/tests/network-tests/src/flows/working-groups/groupBudget.ts
@@ -29,7 +29,7 @@ export default async function groupBudget({ api, query, lock }: FlowProps): Prom
       const recievers = (await api.createKeyPairs(5)).map(({ key }) => key.address)
       const amounts = recievers.map((reciever, i) => new BN(10000 * (i + 1)))
 
-      let unlockMembershipBudget = undefined
+      let unlockMembershipBudget
       if (group === 'membershipWorkingGroup') {
         unlockMembershipBudget = await lock(Resource.MembershipWgBudget)
       }

--- a/tests/network-tests/src/flows/working-groups/groupBudget.ts
+++ b/tests/network-tests/src/flows/working-groups/groupBudget.ts
@@ -29,10 +29,15 @@ export default async function groupBudget({ api, query, lock }: FlowProps): Prom
       const recievers = (await api.createKeyPairs(5)).map(({ key }) => key.address)
       const amounts = recievers.map((reciever, i) => new BN(10000 * (i + 1)))
 
-      const unlockWgSpending = await lock(Resource.MembershipWgBudget)
+      let unlockMembershipBudget = undefined
+      if (group === 'membershipWorkingGroup') {
+        unlockMembershipBudget = await lock(Resource.MembershipWgBudget)
+      }
       const spendGroupBudgetFixture = new SpendBudgetFixture(api, query, group, recievers, amounts)
       await new FixtureRunner(spendGroupBudgetFixture).runWithQueryNodeChecks()
-      unlockWgSpending()
+      if (unlockMembershipBudget !== undefined) {
+        unlockMembershipBudget()
+      }
 
       debug('Done')
     })

--- a/tests/network-tests/src/scenarios/full.ts
+++ b/tests/network-tests/src/scenarios/full.ts
@@ -59,6 +59,7 @@ scenario('Full', async ({ job, env }) => {
   job('updating member profile', updatingMemberProfile).after(coreJob)
   job('updating member accounts', updatingMemberAccounts).after(coreJob)
   job('transferring invites', transferringInvites).after(coreJob)
+  job('inviting members', invitingMembers).after(coreJob)
   job('managing staking accounts', managingStakingAccounts).after(coreJob)
 
   // Council (should not interrupt proposalsJob!)
@@ -86,11 +87,10 @@ scenario('Full', async ({ job, env }) => {
   job('upcoming openings', upcomingOpenings).requires(hireLeads)
   job('group status', groupStatus).requires(hireLeads)
   job('worker actions', workerActions).requires(hireLeads)
-  const groupBudgetSet = job('group budget', groupBudget).requires(hireLeads)
+  job('group budget', groupBudget).requires(hireLeads)
 
-  // Memberships (depending on hired lead, group budget set)
+  // Memberships (depending on hired leads)
   job('updating member verification status', updatingVerificationStatus).after(hireLeads)
-  job('inviting members', invitingMembers).requires(groupBudgetSet)
 
   // Forum:
   job('forum categories', categories).requires(hireLeads)


### PR DESCRIPTION
I have added locks for Membership WG budget resource, as the failures appear to be non-deterministic (eg some scenario runs succeed while others don't, also the failure is not reproducible on all machines).
This made me think that NodeJS threads are competing for spending from the membership WG.
#### Current extrinsics that decrease Membership WG
- `working_group::spend_from_budget`
- `membership::invite_member`

I have added a membership wg budget mutex for the fixtures referencing the above extrinsics