### PR TITLE
Query node: add `reset-processor.sh` script

### DIFF
--- a/query-node/reset-processor.sh
+++ b/query-node/reset-processor.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+cd $SCRIPT_PATH
+
+docker-compose -f ../docker-compose.yml rm -vsf processor
+docker-compose -f ../docker-compose.yml rm -vsf graphql-server
+docker exec db psql -U postgres -c "DROP DATABASE query_node_processor;"
+./start.sh


### PR DESCRIPTION
Introduces `./query-node/reset-processor.sh` script, allowing to clean the processor database and reprocessing the chain using the new mappings without the need for reindexing from scratch, which takes much more time.

**Testing:**

You can start the local playground using the `master` branch:
```
git checkout master
export RUNTIME_PROFILE=TESTING
yarn build:packages
yarn start
```

Then once the playground is initialized, switch to ephesus branch and reset the processor:
```
git checkout ephesus
yarn build:packages
./query-node/reset-processor.sh
```

The chain should be then reprocessed with ephesus mappings, while the indexer database state will be preserved.

**How it works:**

1. Brings down the current `processor` and `graphql-server` docker services
2. Removes processor postgresql database (`query_node_processor`)
3. Starts the query node using `./query-node/start.sh` script, this will:
    1. Update the `db` service (without affecting the storage), in case there were any environment variable or image version changes
    2. Re-create `query_node_processor` database and execute the new migrations
    3. Update `indexer` and `hydra-indexer-gateway` services in case there were any environment variable or image version changes (in the `ephesus` example it will fetch version `v5.0.0-alpha.1` of the images and restart those services)
    4. Bring up the new `processor` and `graphql-server` services