### PR TITLE
Argus fix: Cache cleanup not working properly for objects in group `0`

### DIFF
--- a/distributor-node/CHANGELOG.md
+++ b/distributor-node/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.2.0
 
 - Add support for Elasticsearch authentication (`logs.elastic.auth` config section)
+- **FIX:** Objects belonging to group `0` of LRU-SP cache were never fully dropped from the state because of a bug in `StateCacheService.dropById`
 
 ### 1.1.0 (Ephesus release)
 

--- a/distributor-node/src/services/cache/StateCacheService.ts
+++ b/distributor-node/src/services/cache/StateCacheService.ts
@@ -182,7 +182,7 @@ export class StateCacheService {
     this.dropPendingDownload(objectId)
     const cacheGroupNumber = this.memoryState.groupNumberByObjectId.get(objectId)
     this.logger.debug('Cache group by object id established', { objectId, cacheGroupNumber })
-    if (cacheGroupNumber) {
+    if (cacheGroupNumber !== undefined) {
       this.memoryState.groupNumberByObjectId.delete(objectId)
       this.storedState.lruCacheGroups[cacheGroupNumber].delete(objectId)
     }


### PR DESCRIPTION
One of the results of this bug were lots of warnings during cache cleanup, like:
```
2023-03-10 15:11:33:1133 ContentService warn: Trying to drop content that no loger exists
```