### PR TITLE
[Argus] add workerId to status response

### DIFF
--- a/distributor-node/docs/api/public/index.md
+++ b/distributor-node/docs/api/public/index.md
@@ -79,6 +79,7 @@ Returns json object describing current node status.
 {
   "id": "string",
   "version": "string",
+  "workerId": 0,
   "objectsInCache": 0,
   "storageLimit": 0,
   "storageUsed": 0,
@@ -333,6 +334,7 @@ This operation does not require authentication
 {
   "id": "string",
   "version": "string",
+  "workerId": 0,
   "objectsInCache": 0,
   "storageLimit": 0,
   "storageUsed": 0,
@@ -353,6 +355,7 @@ This operation does not require authentication
 |---|---|---|---|---|
 |id|string|true|none|none|
 |version|string|true|none|none|
+|workerId|integer|false|none|none|
 |objectsInCache|integer|true|none|none|
 |storageLimit|integer|true|none|none|
 |storageUsed|integer|true|none|none|

--- a/distributor-node/src/api-spec/public.yml
+++ b/distributor-node/src/api-spec/public.yml
@@ -172,6 +172,8 @@ components:
           type: string
         version:
           type: string
+        workerId:
+          type: integer
         objectsInCache:
           type: integer
           minimum: 0

--- a/distributor-node/src/services/httpApi/controllers/public.ts
+++ b/distributor-node/src/services/httpApi/controllers/public.ts
@@ -296,6 +296,7 @@ export class PublicApiController {
     const data: StatusResponse = {
       id: this.config.id,
       version: this.config.version,
+      workerId: this.config.workerId,
       objectsInCache: this.stateCache.getCachedObjectsCount(),
       storageLimit: this.config.limits.storage,
       storageUsed: this.content.usedSpace,


### PR DESCRIPTION
Sometimes operators will have `workerId` misconfigured which leads to issues, it'd be useful to just expose that config publicly for troubleshooting