### PR TITLE
[Argus] allow specifying elastic logs index

### DIFF
--- a/distributor-node/docs/schema/definition-properties-logs-properties-elasticsearch-logging-options-properties-index.md
+++ b/distributor-node/docs/schema/definition-properties-logs-properties-elasticsearch-logging-options-properties-index.md
@@ -1,0 +1,3 @@
+## index Type
+
+`string`

--- a/distributor-node/docs/schema/definition-properties-logs-properties-elasticsearch-logging-options.md
+++ b/distributor-node/docs/schema/definition-properties-logs-properties-elasticsearch-logging-options.md
@@ -8,6 +8,7 @@
 | :-------------------- | :------- | :------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [level](#level)       | `string` | Required | cannot be null | [Distributor node configuration](definition-properties-logs-properties-file-logging-options-properties-level.md "https://joystream.org/schemas/argus/config#/properties/logs/properties/elastic/properties/level")                |
 | [endpoint](#endpoint) | `string` | Required | cannot be null | [Distributor node configuration](definition-properties-logs-properties-elasticsearch-logging-options-properties-endpoint.md "https://joystream.org/schemas/argus/config#/properties/logs/properties/elastic/properties/endpoint") |
+| [index](#index)       | `string` | Optional | cannot be null | [Distributor node configuration](definition-properties-logs-properties-elasticsearch-logging-options-properties-index.md "https://joystream.org/schemas/argus/config#/properties/logs/properties/elastic/properties/index")       |
 | [auth](#auth)         | `object` | Optional | cannot be null | [Distributor node configuration](definition-properties-logs-properties-elasticsearch-logging-options-properties-auth.md "https://joystream.org/schemas/argus/config#/properties/logs/properties/elastic/properties/auth")         |
 
 ## level
@@ -57,6 +58,24 @@ Elastichsearch endpoint to push the logs to (for example: <http://localhost:9200
 *   defined in: [Distributor node configuration](definition-properties-logs-properties-elasticsearch-logging-options-properties-endpoint.md "https://joystream.org/schemas/argus/config#/properties/logs/properties/elastic/properties/endpoint")
 
 ### endpoint Type
+
+`string`
+
+## index
+
+Elasticsearch index to push the logs to. If not provided, will fallback to "distributor-node"
+
+`index`
+
+*   is optional
+
+*   Type: `string`
+
+*   cannot be null
+
+*   defined in: [Distributor node configuration](definition-properties-logs-properties-elasticsearch-logging-options-properties-index.md "https://joystream.org/schemas/argus/config#/properties/logs/properties/elastic/properties/index")
+
+### index Type
 
 `string`
 

--- a/distributor-node/src/schemas/configSchema.ts
+++ b/distributor-node/src/schemas/configSchema.ts
@@ -102,6 +102,11 @@ export const configSchema: JSONSchema4 = objectSchema({
               description: 'Elastichsearch endpoint to push the logs to (for example: http://localhost:9200)',
               type: 'string',
             },
+            index: {
+              description:
+                'Elasticsearch index to push the logs to. If not provided, will fallback to "distributor-node"',
+              type: 'string',
+            },
             auth: objectSchema({
               description: 'Elasticsearch basic authentication credentials',
               properties: {

--- a/distributor-node/src/services/logging/LoggingService.ts
+++ b/distributor-node/src/services/logging/LoggingService.ts
@@ -78,7 +78,7 @@ export class LoggingService {
     let esTransport: ElasticsearchTransport | undefined
     if (config.logs?.elastic) {
       esTransport = new ElasticsearchTransport({
-        index: 'distributor-node',
+        index: config.logs.elastic.index || 'distributor-node',
         level: config.logs.elastic.level,
         format: winston.format.combine(pauseFormat({ id: 'es' }), escFormat()),
         retryLimit: 10,


### PR DESCRIPTION
It may be useful in the future to create a separate index for each worker to better partition logs