### PR TITLE
Origo: fix unhandled QN exception in Argus

### DIFF
--- a/distributor-node/src/services/content/ContentService.ts
+++ b/distributor-node/src/services/content/ContentService.ts
@@ -3,7 +3,7 @@ import { ObjectStatus, ObjectStatusType, ReadonlyConfig } from '../../types'
 import { StateCacheService } from '../cache/StateCacheService'
 import { LoggingService } from '../logging'
 import { Logger } from 'winston'
-import { FileContinousReadStream, FileContinousReadStreamOptions } from './FileContinousReadStream'
+import { FileContinuousReadStream, FileContinuousReadStreamOptions } from './FileContinuousReadStream'
 import FileType from 'file-type'
 import { Readable, pipeline } from 'stream'
 import { NetworkingService } from '../networking'
@@ -164,8 +164,11 @@ export class ContentService {
     return fs.createWriteStream(this.path(objectId), { autoClose: true, emitClose: true })
   }
 
-  public createContinousReadStream(objectId: string, options: FileContinousReadStreamOptions): FileContinousReadStream {
-    return new FileContinousReadStream(this.path(objectId), options)
+  public createContinuousReadStream(
+    objectId: string,
+    options: FileContinuousReadStreamOptions
+  ): FileContinuousReadStream {
+    return new FileContinuousReadStream(this.path(objectId), options)
   }
 
   public async readFileChunk(path: string, bytes: number): Promise<Buffer> {

--- a/distributor-node/src/services/content/ContentService.ts
+++ b/distributor-node/src/services/content/ContentService.ts
@@ -45,25 +45,29 @@ export class ContentService {
   }
 
   public async cacheCleanup(): Promise<void> {
-    const supportedObjects = await this.networking.fetchSupportedDataObjects()
-    const cachedObjectsIds = this.stateCache.getCachedObjectsIds()
-    let droppedObjects = 0
+    try {
+      const supportedObjects = await this.networking.fetchSupportedDataObjects()
+      const cachedObjectsIds = this.stateCache.getCachedObjectsIds()
+      let droppedObjects = 0
 
-    this.logger.verbose('Performing cache cleanup...', {
-      supportedObjects: supportedObjects.size,
-      objectsInCache: cachedObjectsIds.length,
-    })
+      this.logger.verbose('Performing cache cleanup...', {
+        supportedObjects: supportedObjects.size,
+        objectsInCache: cachedObjectsIds.length,
+      })
 
-    for (const objectId of cachedObjectsIds) {
-      if (!supportedObjects.has(objectId)) {
-        this.drop(objectId, 'No longer supported')
-        ++droppedObjects
+      for (const objectId of cachedObjectsIds) {
+        if (!supportedObjects.has(objectId)) {
+          this.drop(objectId, 'No longer supported')
+          ++droppedObjects
+        }
       }
-    }
 
-    this.logger.verbose('Cache cleanup finished', {
-      droppedObjects,
-    })
+      this.logger.verbose('Cache cleanup finished', {
+        droppedObjects,
+      })
+    } catch (err) {
+      this.logger.error('Failed to perform cache cleanup ', { err })
+    }
   }
 
   public async startupInit(): Promise<void> {

--- a/distributor-node/src/services/content/FileContinuousReadStream.ts
+++ b/distributor-node/src/services/content/FileContinuousReadStream.ts
@@ -1,7 +1,7 @@
-import { Readable } from 'stream'
 import fs from 'fs'
+import { Readable } from 'stream'
 
-export interface FileContinousReadStreamOptions {
+export interface FileContinuousReadStreamOptions {
   end: number
   start?: number
   chunkSize?: number
@@ -9,7 +9,7 @@ export interface FileContinousReadStreamOptions {
   maxRetries?: number
 }
 
-export class FileContinousReadStream extends Readable {
+export class FileContinuousReadStream extends Readable {
   private fd: number
   private position: number
   private lastByte: number
@@ -18,7 +18,7 @@ export class FileContinousReadStream extends Readable {
   private finished: boolean
   private interval: NodeJS.Timeout | undefined
 
-  public constructor(path: string, options: FileContinousReadStreamOptions) {
+  public constructor(path: string, options: FileContinuousReadStreamOptions) {
     super({
       highWaterMark: options.chunkSize || 1 * 1024 * 1024, // default: 1 MB
     })

--- a/distributor-node/src/services/httpApi/controllers/public.ts
+++ b/distributor-node/src/services/httpApi/controllers/public.ts
@@ -194,7 +194,7 @@ export class PublicApiController {
     range?: { start: number; end: number }
   ) {
     this.logger.verbose(`Serving pending download asset from file`, { objectId, objectSize, range })
-    const stream = this.content.createContinousReadStream(objectId, {
+    const stream = this.content.createContinuousReadStream(objectId, {
       start: range?.start,
       end: range !== undefined ? range.end : objectSize - 1,
     })

--- a/distributor-node/src/services/networking/NetworkingService.ts
+++ b/distributor-node/src/services/networking/NetworkingService.ts
@@ -410,7 +410,7 @@ export class NetworkingService {
         })
       )
     } catch (err) {
-      this.logger.error("Couldn't check active storage node endpooints", { err })
+      this.logger.error("Couldn't check active storage node endpoints", { err })
     }
   }
 


### PR DESCRIPTION
Addresses #4762

## _How to test ?_

Start the distributor-node, after node has been initialised & is up and running, stop the QN(`graphql-server` container). Now there shouldn't be any unhandled promise rejection warning, but an error log with the exception info.

```
(node:3358105) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection
``` 