### PR TITLE
Fix setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,9 +30,16 @@ fi
 
 # If OS is supported will install build tools for rust and substrate.
 # Skips installation of substrate and subkey
-curl https://getsubstrate.io -sSf | bash -s -- --fast
+# old script trying to install package 'protobuf' which does not exist
+# curl https://getsubstrate.io -sSf | bash -s -- --fast
+
+# Install Rust toolchain since we no longer use getsubstrate.io script
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 source ~/.cargo/env
+
+rustup update
+rustup update nightly
 
 rustup install nightly-2022-05-11
 rustup target add wasm32-unknown-unknown --toolchain nightly-2022-05-11


### PR DESCRIPTION
This is a linux only issue: `setup.sh` runs a script from https://getsubstrate.io/ which is a outdated and tries to install a package `protobuf` which is no longer found and so exits with error below:

```
Reading package lists... Done
Building dependency tree       
Reading state information... Done

No apt package "protobuf", but there is a snap with that name.
Try "snap install protobuf"

E: Unable to locate package protobuf
```

So we are bypassing it, but we also need to add installation of rustup (the rust toolchain manager) which was handled by the getsubstrate script.