### PR TITLE
fix: properly handle prematurely closed requests

### DIFF
--- a/distributor-node/src/services/httpApi/HttpApiBase.ts
+++ b/distributor-node/src/services/httpApi/HttpApiBase.ts
@@ -23,17 +23,9 @@ export abstract class HttpApiBase {
       // Fix for express-winston in order to also log prematurely closed requests
       res.on('close', () => {
         res.locals.prematurelyClosed = !res.writableFinished
-        res.end()
       })
       try {
-        /**
-         * Call the request handler only if the response has not been sent yet (e.g. because req or res was
-         * closed prematurely). Otherwise, the request handler would try to set header or send the response
-         * again, which would result in an error e.g., "Cannot set headers after they are sent to the client"
-         * */
-        if (!res.headersSent) {
-          await handler(req, res, next)
-        }
+        await handler(req, res, next)
       } catch (err) {
         next(err)
       }


### PR DESCRIPTION
addresses #4760

# Problem
Sometimes a request can be prematurely closed by client or due to bad network conditions. Whenever that happens, an event handler on response object (`res`), manually [closes](https://github.com/Joystream/joystream/blob/master/distributor-node/src/services/httpApi/HttpApiBase.ts#LL25) the response by calling `res.end()`.  However, the problem is that even if the response closes the the control flow is passed the request handlers which then tries to set headers on a closed response, and hence the error.

# How to reproduce

In [routeWrapper](https://github.com/Joystream/joystream/blob/master/distributor-node/src/services/httpApi/HttpApiBase.ts#L22) function, manually close the response by calling `res.socket?.destory()`, 

```diff
  protected routeWrapper(handler: express.RequestHandler) {
    return async (req: express.Request, res: express.Response, next: express.NextFunction): Promise<void> => {
      // Fix for express-winston in order to also log prematurely closed requests
      
+     res.socket.?destroy()
      res.on('close', () => {
        res.locals.prematurelyClosed = !res.writableFinished
        res.end()
      })
      
+     await sleep(1000) // sleep for 1 second to make sure that request does not finish before socket destroy event is emitted
      try {
        await handler(req, res, next)
      } catch (err) {
        next(err)
      }
    }
  }

```