### PR TITLE
[Colossus] Add option to not rotate logs on time basis

### DIFF
--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.4.0
+- Added option 'none' to 'logFileChangeFrequency' argument. The default is still 'daily'. 'none' prevents log rotaion on time basis and only rotates when max  size for logs files is reached.
+
 ### 3.3.0
 
 - Added customization options for Elasticsearch logging. Users can now specify index name and auth options.

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storage-node",
   "description": "Joystream storage subsystem.",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "author": "Joystream contributors",
   "bin": {
     "storage-node": "./bin/run"


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/4781

Added new option `none` to `logFileChangeFrequency` argument used to configure frequency of log rotation.
Using this option, log rotation only occurs when the log file grows larger than `logMaxFileSize` which defaults to `50000000` bytes (~5MB)

```
-z, --logFileChangeFrequency=(yearly|monthly|daily|hourly|none)
```

old logs are now compressed, and a symlink to current active logfile is created automatically.