### PR TITLE
fix joystream-node docker build workflow

### DIFF
--- a/.github/workflows/joystream-node-docker.yml
+++ b/.github/workflows/joystream-node-docker.yml
@@ -36,6 +36,13 @@ jobs:
           export RUNTIME_CODE_SHASUM=`scripts/runtime-code-shasum.sh`
           echo "::set-output name=shasum::${RUNTIME_CODE_SHASUM}"
 
+     # docker manifest inspect command requires authentication
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Check if we already have the main image on Dockerhub
         id: compute_main_image_exists
         # Will output 0 if image exists and 1 if does not exists
@@ -73,6 +80,12 @@ jobs:
         with:
           node-version: '14.x'
 
+      # docker manifest inspect requires authentication
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Check if we have pre-built image on Dockerhub
         id: compute_image_exists
         # Will output 0 if image exists and 1 if does not exists

--- a/devops/ansible/roles/common/tasks/install-tools.yml
+++ b/devops/ansible/roles/common/tasks/install-tools.yml
@@ -91,7 +91,7 @@
 - name: Install rustup
   shell: 
     cmd: |
-      bash -ic "curl https://getsubstrate.io -sSf | bash -s -- --fast"
+      bash -ic "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash -s -- -y"
   args:
     executable: /bin/bash
 


### PR DESCRIPTION
Follow up to https://github.com/Joystream/joystream/pull/4770 which fixes workflow when pushing to master: https://github.com/Joystream/joystream/actions/runs/5146012965/jobs/9264471091

With the fix for installing rustup, the workflow is always executing the build because the `docker manifest inspect ..` command to check if a build exists on dockerhub was failing not because image was not found but because of auth failure. eg. https://github.com/Joystream/joystream/actions/runs/5179948547/jobs/9333504405#step:6:9