### PR TITLE
Standalone joystream/node docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,15 @@ WASM_BUILD_TOOLCHAIN=nightly-2022-05-11 cargo build --release
 
 Learn more about [joystream-node](bin/node/README.md).
 
-A step by step guide to setup a full node and validator on the Joystream testnet, can be found [here](https://joystream.gitbook.io/testnet-workspace/system/validation#validator).
+A step by step guide to setup a full node and validator on the Joystream main network, can be found [here](https://handbook.joystream.org/system/validation).
+
+### Pre-built joystream-node binaries
+Look under the 'Assets' section:
+
+- Ephesus release [v8.3.0](https://github.com/Joystream/joystream/releases/tag/v12.2001.0)
+
+### Mainnet chainspec file
+- [joy-mainnet.json](https://github.com/Joystream/joystream/releases/download/v12.1000.0/joy-mainnet.json)
 
 ### Integration tests
 

--- a/bin/node/README.md
+++ b/bin/node/README.md
@@ -7,7 +7,7 @@ The joystream-node is the main server application that connects to the network, 
 ### Pre-built binaries
 
 The latest pre-built binaries can be downloaded from the [releases](https://github.com/Joystream/joystream/releases) page.
-Generally these will be built from `master` branch and will pertain to the currently active testnet.
+Generally these will be built from `master` branch and will pertain to the currently active network.
 
 ### Building from source
 
@@ -42,9 +42,10 @@ this script will build and run a fresh new local development chain (purging exis
 ./scripts/run-dev-chain.sh
 ```
 
-### Joystream Public Testnets
+### Joystream Public Networks
 
-Use the `--chain` argument, and specify the path to the genesis `chain.json` file for that public network. The JSON "chain spec" files for Joystream public networks can be found in [../testnets/](../testnets/).
+Use the `--chain` argument, and specify the path to the genesis `chain.json` file for that public network.
+Here is the JSON "chain spec" file for the Joystream mainnet [joy-mainnet.json](../../joy-mainnet.json).
 
 ```bash
 ./target/release/joystream-node --chain joy-mainnet.json
@@ -81,7 +82,7 @@ This will install the executable `joystream-node` to your `~/.cargo/bin` folder,
 WASM_BUILD_TOOLCHAIN=nightly-2022-05-11 cargo +nightly-2022-05-11 install joystream-node --path bin/node/ --locked
 ```
 
-Now you can run and connect to the testnet:
+Now you can run and connect to the network:
 
 ```bash
 joystream-node --chain joy-mainnet.json

--- a/joystream-node.Dockerfile
+++ b/joystream-node.Dockerfile
@@ -61,6 +61,7 @@ COPY --from=builder /joystream/target/release/wbuild/joystream-node-runtime/joys
 COPY --from=builder /joystream/target/release/chain-spec-builder /joystream/chain-spec-builder
 COPY --from=builder /joystream/target/release/session-keys /joystream/session-keys
 COPY --from=builder /joystream/target/release/call-sizes /joystream/call-sizes
+COPY joy-mainnet.json .
 
 # confirm it works
 RUN /joystream/call-sizes
@@ -84,3 +85,4 @@ EXPOSE 30333 9933 9944
 VOLUME ["/data", "/keystore"]
 
 ENTRYPOINT ["/joystream/node"]
+CMD ["--base-path", "/data", "--keystore-path", "/keystore", "--chain", "/joystream/joy-mainnet.json"]

--- a/scripts/runtime-code-shasum.sh
+++ b/scripts/runtime-code-shasum.sh
@@ -14,6 +14,7 @@ fi
 
 # sort/owner/group/mtime arguments only work with gnu version of tar!
 ${TAR} -c --sort=name --owner=root:0 --group=root:0 --mode 644 --mtime='UTC 2020-01-01' \
+    --exclude='*.md' \
     Cargo.lock \
     Cargo.toml \
     runtime \


### PR DESCRIPTION
Package the mainnet chainspec file with the docker image for `joystream/node` to make it simpler to deploy without having to provide it separately.


Some github actions are failing because the github runner is running out of space, a fix is available in this PR https://github.com/Joystream/joystream/pull/4804 so maybe we can merge that first