### PR TITLE
aws ec2 instances: update sec policy 

### DIFF
--- a/devops/aws/cloudformation/single-instance.yml
+++ b/devops/aws/cloudformation/single-instance.yml
@@ -44,6 +44,14 @@ Resources:
           FromPort: 30333
           ToPort: 30333
           CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 8081
+          ToPort: 8081
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 4000
+          ToPort: 4000
+          CidrIp: 0.0.0.0/0
       Tags:
         - Key: Name
           Value: !Sub '${AWS::StackName}_substrate_node'


### PR DESCRIPTION
Make TCP ports 8081 and 4000 reachable (query-node and indexer gateway) to work behind external load balancer (AWS and non AWS).