### PR TITLE
runtime: add warp-time feature for "fast" runtime

### DIFF
--- a/bin/node/src/chain_spec/content_config.rs
+++ b/bin/node/src/chain_spec/content_config.rs
@@ -1,7 +1,6 @@
 use node_runtime::{
-    constants::{currency, MINUTES},
-    days, dollars, hours, ChannelStateBloatBondValue, ContentConfig, ExpectedBlockTime,
-    VideoStateBloatBondValue,
+    constants::currency, days, dollars, hours, minutes, ChannelStateBloatBondValue, ContentConfig,
+    ExpectedBlockTime, VideoStateBloatBondValue,
 };
 use sp_runtime::Perbill;
 
@@ -43,7 +42,7 @@ pub fn testing_config() -> ContentConfig {
         max_cashout_allowed: dollars!(100_000),
         min_cashout_allowed: dollars!(10),
         channel_cashouts_enabled: true,
-        min_auction_duration: MINUTES,
+        min_auction_duration: minutes!(1),
         max_auction_duration: days!(30),
         min_auction_extension_period: 0,
         max_auction_extension_period: days!(30),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -226,12 +226,26 @@ runtime-benchmarks = [
     "project-token/runtime-benchmarks",
 ]
 
-# Staging and testing configurations
-# configuration suitable for staging networks and playground
+# Configuration suitable for staging networks and playground
 staging-runtime = []
 playground-runtime = []
-# configuration suitable for integration testing
-testing-runtime = []
+# Configuration suitable for automated integration testing only
+testing-runtime = [
+    "fast-block-production"
+]
+
+# Default block production interval is 6s. Enabling this feature will configure chain for 1s interval instead.
+fast-block-production = []
+
+# Configures 1s block interval for the chain, but changes behaviour of `minutes!`, `hours!`, `days!` util macros
+# to compute periods (in blocks) based on 6s block interval.
+# This configuration is meant for QA (manual testing) of production runtime configuration.
+# that has long time periods for things like council elections, proposals voting periods etc.
+# Enabling warp-time with playground-runtime, staging-runtime or testing-runtime will most likely result in time periods to be too
+# short (in real time sense) and beyond practicality.
+warp-time = [
+    "fast-block-production"
+]
 
 try-runtime = [
     "frame-try-runtime",

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -208,7 +208,8 @@ mod tests {
 
         let full_block_cost: Balance =
             WeightToFee::weight_to_fee(&max_normal_dispatch_block_weight);
-        let day_of_full_blocks_cost = full_block_cost.saturating_mul(Balance::from(super::DAYS));
+        let day_of_full_blocks_cost =
+            full_block_cost.saturating_mul(Balance::from(super::MINUTES * 60 * 24));
 
         println!(
             "weight per block: {}, block cost: {}¢, cost/day: ${}",
@@ -238,7 +239,8 @@ mod tests {
             <Runtime as pallet_transaction_payment::Config>::LengthToFee::weight_to_fee(
                 &Weight::from_parts(max_normal_dispatch_block_length, 0),
             );
-        let day_of_full_blocks_cost = full_block_cost.saturating_mul(Balance::from(super::DAYS));
+        let day_of_full_blocks_cost =
+            full_block_cost.saturating_mul(Balance::from(super::MINUTES * 60 * 24));
 
         println!(
             "bytes per block: {}, block cost: {}¢, cost/day: ${}",

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -22,25 +22,25 @@ use sp_std::vec::Vec;
 /// <https://research.web3.foundation/en/latest/polkadot/BABE/Babe/#6-practical-results>
 
 // Normal 6s block interval
-#[cfg(not(feature = "testing-runtime"))]
+#[cfg(not(feature = "fast-block-production"))]
 pub const MILLISECS_PER_BLOCK: Moment = 6000;
-#[cfg(not(feature = "testing-runtime"))]
+#[cfg(not(feature = "fast-block-production"))]
 pub const SLOT_DURATION: Moment = 6000;
 
 // 1s block interval for integration testing
-#[cfg(feature = "testing-runtime")]
+#[cfg(feature = "fast-block-production")]
 pub const MILLISECS_PER_BLOCK: Moment = 1000;
-#[cfg(feature = "testing-runtime")]
+#[cfg(feature = "fast-block-production")]
 pub const SLOT_DURATION: Moment = 1000;
 
-pub const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
-pub const BONDING_DURATION: u32 = 4 * 28; // 4 * 28 eras = 28 days (since 1 era = 6h)
-pub const SLASH_DEFER_DURATION: u32 = BONDING_DURATION - 1;
+const SECS_PER_BLOCK: Moment = MILLISECS_PER_BLOCK / 1000;
+const MINUTES: BlockNumber = 60 / (SECS_PER_BLOCK as BlockNumber);
 
-#[cfg(feature = "testing-runtime")] // 30 seconds sessions for faster tests
+// Short epoch for faster tests related to bonding/unbonding
+#[cfg(feature = "testing-runtime")]
 pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = MINUTES / 2;
 #[cfg(not(feature = "testing-runtime"))]
-pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = HOURS;
+pub const EPOCH_DURATION_IN_BLOCKS: BlockNumber = MINUTES * 60;
 
 pub const EPOCH_DURATION_IN_SLOTS: u64 = {
     const SLOT_FILL_RATE: f64 = MILLISECS_PER_BLOCK as f64 / SLOT_DURATION as f64;
@@ -48,11 +48,10 @@ pub const EPOCH_DURATION_IN_SLOTS: u64 = {
     (EPOCH_DURATION_IN_BLOCKS as f64 * SLOT_FILL_RATE) as u64
 };
 
-// These time units are defined in number of blocks.
-pub const MINUTES: BlockNumber = 60 / (SECS_PER_BLOCK as BlockNumber);
-pub const HOURS: BlockNumber = MINUTES * 60;
-pub const DAYS: BlockNumber = HOURS * 24;
-pub const WEEKS: BlockNumber = DAYS * 7;
+// Session (aka Epoch) in BABE
+pub const SESSIONS_PER_ERA: u32 = 6;
+pub const BONDING_DURATION: u32 = 4 * 28; // 4 * 28 Eras (for 1h epoch this equals 6 * 4 * 28 -> 28 Days)
+pub const SLASH_DEFER_DURATION: u32 = BONDING_DURATION - 1;
 
 // 1 in 4 blocks (on average, not counting collisions) will be primary babe blocks.
 pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -552,7 +552,7 @@ impl EraPayout<Balance> for NoInflationIfNoEras {
 }
 
 parameter_types! {
-    pub const SessionsPerEra: sp_staking::SessionIndex = 6;
+    pub const SessionsPerEra: sp_staking::SessionIndex = SESSIONS_PER_ERA;
     pub const BondingDuration: sp_staking::EraIndex = BONDING_DURATION;
     pub const SlashDeferDuration: sp_staking::EraIndex = SLASH_DEFER_DURATION;
     pub const RewardCurve: &'static PiecewiseLinear<'static> = &REWARD_CURVE;
@@ -810,19 +810,19 @@ parameter_types! {
     pub const ContentModuleId: PalletId = PalletId(*b"mContent"); // module content
     pub const MaxKeysPerCuratorGroupPermissionsByLevelMap: u8 = 25;
     pub const DefaultGlobalDailyNftLimit: LimitPerPeriod<BlockNumber> = LimitPerPeriod {
-        block_number_period: DAYS,
+        block_number_period: days!(1),
         limit: 100,
     };
     pub const DefaultGlobalWeeklyNftLimit: LimitPerPeriod<BlockNumber> = LimitPerPeriod {
-        block_number_period: WEEKS,
+        block_number_period: days!(7),
         limit: 400,
     };
     pub const DefaultChannelDailyNftLimit: LimitPerPeriod<BlockNumber> = LimitPerPeriod {
-        block_number_period: DAYS,
+        block_number_period: days!(1),
         limit: 10,
     };
     pub const DefaultChannelWeeklyNftLimit: LimitPerPeriod<BlockNumber> = LimitPerPeriod {
-        block_number_period: WEEKS,
+        block_number_period: days!(7),
         limit: 40,
     };
     pub const MinimumCashoutAllowedLimit: Balance = dollars!(10);

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -133,6 +133,7 @@ macro_rules! mega_bytes {
     }};
 }
 
+#[cfg(not(feature = "warp-time"))]
 #[macro_export]
 macro_rules! minutes {
     ($a:expr) => {{
@@ -140,6 +141,7 @@ macro_rules! minutes {
     }};
 }
 
+#[cfg(not(feature = "warp-time"))]
 #[macro_export]
 macro_rules! hours {
     ($a:expr) => {{
@@ -151,6 +153,22 @@ macro_rules! hours {
 macro_rules! days {
     ($a:expr) => {{
         hours!(24) * $a
+    }};
+}
+
+#[cfg(feature = "warp-time")]
+#[macro_export]
+macro_rules! minutes {
+    ($a:expr) => {{
+        ((60 * 1000) / ExpectedBlockTime::get()) as u32 * $a / 6
+    }};
+}
+
+#[cfg(feature = "warp-time")]
+#[macro_export]
+macro_rules! hours {
+    ($a:expr) => {{
+        ((60 * 60 * 1000) / ExpectedBlockTime::get()) as u32 * $a / 6
     }};
 }
 


### PR DESCRIPTION
Added a "warp-time" cargo feature for use with production runtime configuration to address https://github.com/Joystream/joystream/issues/4894

To test build and run local chain (with production configration)

```sh
WASM_BUILD_TOOLCHAIN=nightly-2022-11-15 cargo build --release --features warp-time
```

```
./target/release/joystream-node --chain prod-test --tmp --alice --rpc-cors=all --pruning=archive
```

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1204404358291458/1205678974517544) by [Unito](https://www.unito.io)
