### PR TITLE
Joystream-node embed mainnet chainspec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "8.3.1"
+version = "8.4.0"
 dependencies = [
  "assert_cmd",
  "async-std",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '8.3.1'
+version = '8.4.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/bin/node/src/chain_spec/mod.rs
+++ b/bin/node/src/chain_spec/mod.rs
@@ -56,6 +56,10 @@ pub use node_runtime::GenesisConfig;
 
 type AccountPublic = <Signature as Verify>::Signer;
 
+pub fn joystream_mainnet_config() -> Result<ChainSpec, String> {
+    ChainSpec::from_json_bytes(&include_bytes!("../../../../joy-mainnet.json")[..])
+}
+
 /// Node `ChainSpec` extensions.
 ///
 /// Additional parameters for some Substrate core modules,

--- a/bin/node/src/command.rs
+++ b/bin/node/src/command.rs
@@ -63,11 +63,11 @@ impl SubstrateCli for Cli {
     fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
         let spec = match id {
             "" => {
-                return Err(
-                    "Please specify which chain you want to run, e.g. --dev or --chain=local or --chain=prod-test"
-                        .into(),
-                )
+                return Err("Please specify which chain you want to run,
+                    e.g. --chain=joy-mainnet --dev or --chain=local or --chain=prod-test"
+                    .into())
             }
+            "joy-mainnet" => Box::new(chain_spec::joystream_mainnet_config()?),
             "dev" => Box::new(chain_spec::development_config()),
             "prod-test" => Box::new(chain_spec::prod_test_config()),
             "local" => Box::new(chain_spec::local_testnet_config()),

--- a/bin/node/src/command.rs
+++ b/bin/node/src/command.rs
@@ -63,8 +63,8 @@ impl SubstrateCli for Cli {
     fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
         let spec = match id {
             "" => {
-                return Err("Please specify which chain you want to run,
-                    e.g. --chain=joy-mainnet --dev or --chain=local or --chain=prod-test"
+                return Err("Please specify which chain you want to run, eg. --dev or
+                    --chain=joy-mainnet or --chain=local or --chain=prod-test"
                     .into())
             }
             "joy-mainnet" => Box::new(chain_spec::joystream_mainnet_config()?),

--- a/joystream-node.Dockerfile
+++ b/joystream-node.Dockerfile
@@ -20,6 +20,7 @@ COPY Cargo.lock .
 COPY bin ./bin
 COPY runtime ./runtime
 COPY runtime-modules ./runtime-modules
+COPY joy-mainnet.json .
 RUN cargo chef prepare --recipe-path /joystream/recipe.json
 
 FROM rust AS cacher
@@ -38,6 +39,7 @@ COPY Cargo.lock .
 COPY bin ./bin
 COPY runtime ./runtime
 COPY runtime-modules ./runtime-modules
+COPY joy-mainnet.json .
 # Copy over the cached dependencies
 COPY --from=cacher /joystream/target target
 COPY --from=cacher $CARGO_HOME $CARGO_HOME

--- a/scripts/runtime-code-shasum.sh
+++ b/scripts/runtime-code-shasum.sh
@@ -21,6 +21,7 @@ ${TAR} -c --sort=name --owner=root:0 --group=root:0 --mode 644 --mtime='UTC 2020
     runtime-modules \
     joystream-node.Dockerfile \
     bin \
+    joy-mainnet.json \
     | if [[ -n "$RUNTIME_PROFILE" ]]; then ${SED} '$a'"$RUNTIME_PROFILE"; else tee; fi \
     | shasum \
     | cut -d " " -f 1

--- a/scripts/runtime-code-tarball.sh
+++ b/scripts/runtime-code-tarball.sh
@@ -9,4 +9,5 @@ tar -czf joystream.tar.gz \
     runtime \
     runtime-modules \
     joystream-node.Dockerfile \
-    bin
+    bin \
+    joy-mainnet.json


### PR DESCRIPTION
Embed `joy-mainnet.json` chainspec file in joystream-node binary to make it simpler to get started with running a node for mainnet.
So now only need to download binary, and then run a mainnet node like this:

`joystream-node --chain joy-mainnet`

rather than needing to separately download the `joy-mainnet.json` file and running with:

```
joystream-node --chain /path/to/joy-mainnet.json
```