### PR TITLE
bash scripts: proper error handling when invoking sub shell scripts

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,4 @@
 COMPOSE_PROJECT_NAME=joystream
-PROJECT_NAME=query_node
 
 # We use a single postgres service for both the query node indexer and processor.
 # The default `DB_*` environment variables point to query node processor's database.

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -65,8 +65,8 @@ jobs:
 
           docker run -d --entrypoint tail --name temp-container-joystream-node $IMAGE-amd64 -f /dev/null
 
-          RESULT=$(docker exec temp-container-joystream-node b2sum -l 256 runtime.compact.compressed.wasm | awk '{print $1}')
-          VERSION_AND_COMMIT=$(docker exec temp-container-joystream-node /joystream/node --version | awk '{print $2}' | cut -d- -f -2)
+          RESULT=`docker exec temp-container-joystream-node b2sum -l 256 runtime.compact.compressed.wasm | awk '{print $1}'`
+          VERSION_AND_COMMIT=`docker exec temp-container-joystream-node /joystream/node --version | awk '{print $2}' | cut -d- -f -2`
           echo "::set-output name=blob_hash::${RESULT}"
           echo "::set-output name=version_and_commit::${VERSION_AND_COMMIT}"
 
@@ -76,7 +76,7 @@ jobs:
 
           docker rm --force temp-container-joystream-node
 
-          docker cp $(docker create --rm $IMAGE-arm64):/joystream/node ./joystream-node
+          docker cp `docker create --rm $IMAGE-arm64`:/joystream/node ./joystream-node
           tar -czvf joystream-node-$VERSION_AND_COMMIT-arm64-linux-gnu.tar.gz joystream-node
 
       - name: Retrieve saved MacOS binary

--- a/.github/workflows/deploy-node-network.yml
+++ b/.github/workflows/deploy-node-network.yml
@@ -94,9 +94,9 @@ jobs:
         run: |
           VAL1="${{ steps.deploy_stack.outputs.Val1PublicIp }}"
           VAL2="${{ steps.deploy_stack.outputs.Val2PublicIp }}"
-          VAL3="${{ steps.deploy_stack.outputs.Val3PublicIp }}"
+          BOOT1="${{ steps.deploy_stack.outputs.Val3PublicIp }}"
           echo -e "[validators]\n$VAL1\n$VAL2\n\n" >> inventory
-          echo -e "[boot]\n$VAL3\n\n" >> inventory
+          echo -e "[boot]\n$BOOT1\n\n" >> inventory
           echo -e "[build]\n${{ steps.deploy_stack.outputs.BuildPublicIp }}\n\n" >> inventory
           echo -e "[rpc]\n${{ steps.deploy_stack.outputs.RPCPublicIp }}\n" >> inventory
           cat inventory

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -12,7 +12,7 @@ on:
         required: false
         default: 'master'
       runtimeProfile:
-        description: 'STAGING | PLAYGROUND | TESTING - leave balnk for production'
+        description: 'PLAYGROUND | TESTING'
         default: 'PLAYGROUND'
         required: false
       sshPubKey:

--- a/.github/workflows/joystream-apps-docker.yml
+++ b/.github/workflows/joystream-apps-docker.yml
@@ -20,9 +20,9 @@ jobs:
         id: extract_versions
         shell: bash
         run: |
-          echo "colossus_version=$(cat storage-node/package.json | jq -r '.version')" >> $GITHUB_OUTPUT
-          echo "argus_version=$(cat distributor-node/package.json | jq -r '.version')" >> $GITHUB_OUTPUT
-          echo "qn_version=$(cat query-node/package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+          echo "colossus_version=`cat storage-node/package.json | jq -r '.version'`" >> $GITHUB_OUTPUT
+          echo "argus_version=`cat distributor-node/package.json | jq -r '.version'`" >> $GITHUB_OUTPUT
+          echo "qn_version=`cat query-node/package.json | jq -r '.version'`" >> $GITHUB_OUTPUT
 
       - name: Make some space
         shell: bash

--- a/.github/workflows/joystream-node-docker-dev.yml
+++ b/.github/workflows/joystream-node-docker-dev.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        runtime_profile: ['STAGING', 'PLAYGROUND', 'TESTING']
+        runtime_profile: ['FAST-PROD', 'PLAYGROUND', 'TESTING']
         include:
-          - runtime_profile: 'STAGING'
-            cargo_features: 'staging-runtime'
+          - runtime_profile: 'FAST-PROD'
+            cargo_features: 'warp-time'
           - runtime_profile: 'PLAYGROUND'
             cargo_features: 'playground-runtime'
           - runtime_profile: 'TESTING'

--- a/.github/workflows/joystream-node.yml
+++ b/.github/workflows/joystream-node.yml
@@ -108,3 +108,9 @@ jobs:
         run: |
           yarn cargo-checks && yarn cargo-build
         if: env.GIT_DIFF
+      - name: Fast Production Runtime
+        env:
+          RUNTIME_PROFILE: "FAST-PROD"
+        run: |
+          yarn cargo-checks && yarn cargo-build
+        if: env.GIT_DIFF

--- a/.github/workflows/joystream-node.yml
+++ b/.github/workflows/joystream-node.yml
@@ -100,6 +100,7 @@ jobs:
           RUNTIME_PROFILE: "FAST-PROD"
         run: |
           yarn cargo-checks && yarn cargo-build
+        if: env.GIT_DIFF
 
   # Test runtime upgrade with "try-runtime" feature
   runtime_upgrade:

--- a/.pipelines/deploy-node-network-inputs.json
+++ b/.pipelines/deploy-node-network-inputs.json
@@ -5,7 +5,7 @@
   },
   "branchName": {
     "description": "Branch to deploy",
-    "value": "carthage"
+    "value": "master"
   },
   "instanceType": {
     "description": "AWS EC2 instance type for Validators and Rpc (t2.micro, t2.large, t2.xlarge)",
@@ -28,15 +28,15 @@
     "value": ""
   },
   "deploymentType": {
-    "description": "Chain deployment type (live, dev etc.)",
-    "value": "staging"
+    "description": "Chain deployment type (testnet, mainnet)",
+    "value": "testnet"
   },
   "encryptionKey": {
     "description": "Password to encrypt the artifacts",
-    "value": "staging"
+    "value": "testnet"
   },
   "runtimeProfile": {
-    "description": "STAGING | PLAYGROUND | TESTING - leave empty for production",
+    "description": "STAGING | PLAYGROUND | TESTING | FAST-PROD (leave empty for production)",
     "value": "PLAYGROUND"
   },
   "endowAccounts": {

--- a/build-node-docker.sh
+++ b/build-node-docker.sh
@@ -4,11 +4,10 @@ set -e
 # Looks for a cached joystream/node image matching code shasum.
 # Search order: local repo then dockerhub. If no cached image is found we build it.
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
-source scripts/features.sh
-
+FEATURES=`scripts/features.sh`
 CODE_SHASUM=`scripts/runtime-code-shasum.sh`
 IMAGE=joystream/node:${CODE_SHASUM}
 
@@ -34,8 +33,8 @@ else
   # Not guaranteed it has the correct architecture so just log image and local system architecures
 fi
 
-IMG_ARCH=$(docker inspect ${IMAGE} --format='{{.Architecture}}')
-SYS_ARCH=$(uname -m)
+IMG_ARCH=`docker inspect ${IMAGE} --format='{{.Architecture}}'`
+SYS_ARCH=`uname -m`
 if [ "$IMG_ARCH" != "$SYS_ARCH" ]; then
     echo "WARNING: The local image's platform ${IMG_ARCH} does not match the detected host platform ${SYS_ARCH}"
 fi

--- a/docker-compose-no-bind-volumes.yml
+++ b/docker-compose-no-bind-volumes.yml
@@ -7,7 +7,9 @@ services:
     container_name: joystream-node
     volumes:
       - chain-data:/data
-    command: "--dev --alice --validator --pruning=archive --unsafe-ws-external --unsafe-rpc-external
+    environment:
+      - CHAIN=${CHAIN}
+    command: "--chain ${CHAIN:-dev} --alice --validator --pruning=archive --unsafe-ws-external --unsafe-rpc-external
       --rpc-methods Safe --rpc-cors=all --log runtime --base-path /data --no-hardware-benchmarks"
     ports:
       - 9944:9944
@@ -231,10 +233,11 @@ services:
       - .env
     environment:
       - DB_NAME=${INDEXER_DB_NAME}
-      - INDEXER_WORKERS=5
+      - WORKERS_NUMBER=5
       - REDIS_URI=redis://redis:6379/0
       - WS_PROVIDER_ENDPOINT_URI=${JOYSTREAM_NODE_WS}
       - DB_HOST=db
+      - PGSSLMODE=disable
     depends_on:
       - db
       - redis
@@ -259,6 +262,7 @@ services:
       - WARTHOG_STARTER_REDIS_URI=redis://redis:6379/0
       - WARTHOG_APP_PORT=${HYDRA_INDEXER_GATEWAY_PORT}
       - PORT=${HYDRA_INDEXER_GATEWAY_PORT}
+      - PGSSLMODE=disable
     ports:
       - "${HYDRA_INDEXER_GATEWAY_PORT}:${HYDRA_INDEXER_GATEWAY_PORT}"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
     container_name: joystream-node
     volumes:
       - chain-data:/data
-    command: "--dev --alice --validator --pruning=archive --unsafe-ws-external --unsafe-rpc-external
+    environment:
+      - CHAIN=${CHAIN}
+    command: "--chain ${CHAIN:-dev} --alice --validator --pruning=archive --unsafe-ws-external --unsafe-rpc-external
       --rpc-methods Safe --rpc-cors=all --log runtime --base-path /data --no-hardware-benchmarks"
     ports:
       - 9944:9944
@@ -242,10 +244,11 @@ services:
       - .env
     environment:
       - DB_NAME=${INDEXER_DB_NAME}
-      - INDEXER_WORKERS=5
+      - WORKERS_NUMBER=5
       - REDIS_URI=redis://redis:6379/0
       - WS_PROVIDER_ENDPOINT_URI=${JOYSTREAM_NODE_WS}
       - DB_HOST=db
+      - PGSSLMODE=disable
     depends_on:
       - db
       - redis
@@ -270,6 +273,7 @@ services:
       - WARTHOG_STARTER_REDIS_URI=redis://redis:6379/0
       - WARTHOG_APP_PORT=${HYDRA_INDEXER_GATEWAY_PORT}
       - PORT=${HYDRA_INDEXER_GATEWAY_PORT}
+      - PGSSLMODE=disable
     ports:
       - "${HYDRA_INDEXER_GATEWAY_PORT}:${HYDRA_INDEXER_GATEWAY_PORT}"
     depends_on:

--- a/scripts/cargo-build-with-benchmarking.sh
+++ b/scripts/cargo-build-with-benchmarking.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
 export WASM_BUILD_TOOLCHAIN=nightly-2022-11-15

--- a/scripts/cargo-build.sh
+++ b/scripts/cargo-build.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
-source features.sh
+FEATURES=`./features.sh`
 
 export WASM_BUILD_TOOLCHAIN=nightly-2022-11-15
 
-cargo +nightly-2022-11-15 build --release --locked --features "${FEATURES}"
+cargo +nightly-2022-11-15 build --release --locked --features "${FEATURES}" $*

--- a/scripts/cargo-checks-with-benchmarking.sh
+++ b/scripts/cargo-checks-with-benchmarking.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
 echo 'running rust-fmt'

--- a/scripts/cargo-checks.sh
+++ b/scripts/cargo-checks.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
 echo 'running rust-fmt'
 cargo fmt --all -- --check
 
-source ./features.sh
+FEATURES=`./features.sh`
 
 export WASM_BUILD_TOOLCHAIN=nightly-2022-11-15
 
@@ -16,7 +16,7 @@ export WASM_BUILD_TOOLCHAIN=nightly-2022-11-15
 # So we skip building the WASM binary by setting BUILD_DUMMY_WASM_BINARY=1
 # Aggressive linting
 echo 'running cargo clippy'
-cargo "+$WASM_BUILD_TOOLCHAIN" clippy --release --all --features "${FEATURES}" -- -D warnings
+cargo "+$WASM_BUILD_TOOLCHAIN" clippy --release --all --features "${FEATURES}" $* -- -D warnings
 
 echo 'running cargo unit tests'
-cargo "+$WASM_BUILD_TOOLCHAIN" test --release --all --features "${FEATURES}"
+cargo "+$WASM_BUILD_TOOLCHAIN" test --release --all --features "${FEATURES}" $*

--- a/scripts/cargo-test-all.sh
+++ b/scripts/cargo-test-all.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
 echo 'running rust-fmt'
 cargo fmt --all -- --check
 
-source ./features.sh
+FEATURES=`./features.sh`
 
 export WASM_BUILD_TOOLCHAIN=nightly-2022-11-15
 

--- a/scripts/compute-runtime-blob-hash.sh
+++ b/scripts/compute-runtime-blob-hash.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
+set -e
 
 # The script computes the b2sum of the wasm blob in a pre-built joystream/node image
 # Specifically amd64 architecture image, as that is what we use as the "reference" images
 # for deterministic builds.
 # Assumes b2sum is already instally on the host machine.
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`$(dirname "${BASH_SOURCE[0]}")`
 cd $SCRIPT_PATH
-
-source ./features.sh
 
 CODE_SHASUM=`./runtime-code-shasum.sh`
 IMAGE=joystream/node:${CODE_SHASUM}
 
-IMG_ARCH=$(docker inspect ${IMAGE} --format='{{.Architecture}}')
+IMG_ARCH=`docker inspect ${IMAGE} --format='{{.Architecture}}'`
 
 if [ "$IMG_ARCH" != "amd64" ]; then
     echo "You must fetch the amd64 architecture image with following command:"

--- a/scripts/features.sh
+++ b/scripts/features.sh
@@ -1,12 +1,31 @@
-FEATURES=
+#!/usr/bin/env bash
+set -e
+
 if [[ "$RUNTIME_PROFILE" == "TESTING" ]]; then
-  FEATURES="testing-runtime"
+  echo "testing-runtime"
+  exit 0
 fi
 
 if [[ "$RUNTIME_PROFILE" == "STAGING" ]]; then
-  FEATURES="staging-runtime"
+  echo "staging-runtime"
+  exit 0
 fi
 
 if [[ "$RUNTIME_PROFILE" == "PLAYGROUND" ]]; then
-  FEATURES="playground-runtime"
+  echo "playground-runtime"
+  exit 0
 fi
+
+# Production runtime, no extra features needed
+if [[ "$RUNTIME_PROFILE" == "" ]]; then
+  exit 0
+fi
+
+# Fast Production runtime
+if [[ "$RUNTIME_PROFILE" == "FAST-PROD" ]]; then
+  echo "warp-time"
+  exit 0
+fi
+
+>&2 echo "Unrecognized RUNTIME_PROFILE ${RUNTIME_PROFILE}"
+exit -1

--- a/scripts/fetch-chain-metadata.sh
+++ b/scripts/fetch-chain-metadata.sh
@@ -1,4 +1,4 @@
-curl\
+curl \
   -H "Content-Type: application/json"\
   -d '{"id":"1", "jsonrpc":"2.0", "method": "state_getMetadata", "params":[]}'\
   http://localhost:9933

--- a/scripts/fetch-chain-spec-version.sh
+++ b/scripts/fetch-chain-spec-version.sh
@@ -1,5 +1,3 @@
-SPEC_VERSION=$(curl -H "Content-Type: application/json" \
+curl -H "Content-Type: application/json" \
     -s -d '{"id":"1", "jsonrpc":"2.0", "method": "state_getRuntimeVersion"}' \
-    http://localhost:9933 | jq -r '.result.specVersion')
-
-echo $SPEC_VERSION
+    http://localhost:9933 | jq -r '.result.specVersion'

--- a/scripts/generate-weights.sh
+++ b/scripts/generate-weights.sh
@@ -2,7 +2,7 @@
 
 # Executes and replaces all benchmarks with the new weights
 
-SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+SCRIPT_DIR=`dirname "${BASH_SOURCE[0]}"`
 
 STEPS=${1:-50}
 REPEAT=${2:-20}

--- a/scripts/run-dev-chain.sh
+++ b/scripts/run-dev-chain.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
-source features.sh
+FEATURES=`./features.sh`
 
 export WASM_BUILD_TOOLCHAIN=nightly-2022-11-15
 

--- a/scripts/runtime-code-shasum.sh
+++ b/scripts/runtime-code-shasum.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
+set -e
 
 # Compute a hash over files related to building joystream/node docker image
 
 # Assuming cargo workspace root is same as the git repo root
-cd $(git rev-parse --show-toplevel)
+cd `git rev-parse --show-toplevel`
+
+# Make sure a recognized RUNTIME_PROFILE is used
+_=`./scripts/features.sh`
 
 TAR=tar
 SED=sed

--- a/scripts/runtime-code-tarball.sh
+++ b/scripts/runtime-code-tarball.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+set -e
 
 # Assuming cargo workspace root is same as the git repo root
-cd $(git rev-parse --show-toplevel)
+cd `git rev-parse --show-toplevel`
 
 tar -czf joystream.tar.gz \
     Cargo.lock \

--- a/scripts/save-to-docker-images.sh
+++ b/scripts/save-to-docker-images.sh
@@ -12,7 +12,7 @@ trap cleanup EXIT
 
 export RUNTIME_PROFILE=TESTING
 
-TAG=$(./runtime-code-shasum.sh)
+TAG=`./runtime-code-shasum.sh`
 
 #./scripts/cargo-build.sh
 

--- a/scripts/verify-chain-metadata.sh
+++ b/scripts/verify-chain-metadata.sh
@@ -4,8 +4,8 @@ set -e
 SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
 cd $SCRIPT_PATH
 
-JSON_METADATA=$(cat ../chain-metadata.json)
-CHAIN_METADATA=$(./fetch-chain-metadata.sh)
+JSON_METADATA=`cat ../chain-metadata.json`
+CHAIN_METADATA=`./fetch-chain-metadata.sh`
 if [[ $(echo "$JSON_METADATA") == $(echo "$CHAIN_METADATA") ]]; then
   echo "OK";
 else

--- a/setup.sh
+++ b/setup.sh
@@ -17,14 +17,14 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
       sudo apt-get install -y docker.io containerd runc
     fi
     # Install latest version of docker-compose
-    COMPOSE_VERSION=$(curl -sL https://api.github.com/repos/docker/compose/releases/latest | jq -r ".tag_name")
+    COMPOSE_VERSION=`curl -sL https://api.github.com/repos/docker/compose/releases/latest | jq -r ".tag_name"`
     sudo curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     sudo chmod +x /usr/local/bin/docker-compose
     sudo ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # install brew package manager
     if ! which brew >/dev/null 2>&1; then
-      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+      bash -c "`curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh`"
     fi
     # install additional packages
     brew update

--- a/start-qn-orion-faucet.sh
+++ b/start-qn-orion-faucet.sh
@@ -11,5 +11,5 @@ set -e
 export SKIP_QUERY_NODE_CHECKS=true
 ./tests/network-tests/run-test-scenario.sh setupFaucet
 
-export INVITER_KEY=$(cat ./tests/network-tests/output.json | jq -r .faucet.suri)
+export INVITER_KEY=`cat ./tests/network-tests/output.json | jq -r .faucet.suri`
 docker-compose up -d faucet

--- a/tests/network-tests/run-node-docker.sh
+++ b/tests/network-tests/run-node-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
 # Log only to stderr
@@ -13,12 +13,14 @@ DATA_PATH=$PWD/data
 mkdir -p ${DATA_PATH}
 
 # The docker image tag to use for joystream/node
-RUNTIME=${RUNTIME:=$(../../scripts/runtime-code-shasum.sh)}
+if [[ "$RUNTIME" == "" ]]; then
+  RUNTIME=`../../scripts/runtime-code-shasum.sh`
+fi
 
 # Source of funds for all new accounts that are created in the tests.
 TREASURY_INITIAL_BALANCE=${TREASURY_INITIAL_BALANCE:="100000000"}
 TREASURY_ACCOUNT_URI=${TREASURY_ACCOUNT_URI:="//Bob"}
-TREASURY_ACCOUNT=$(docker run --pull never --rm joystream/node:${RUNTIME} key inspect ${TREASURY_ACCOUNT_URI} --output-type json | jq .ss58Address -r)
+TREASURY_ACCOUNT=`docker run --pull never --rm joystream/node:${RUNTIME} key inspect ${TREASURY_ACCOUNT_URI} --output-type json | jq .ss58Address -r`
 
 >&2 echo "treasury account from suri: ${TREASURY_ACCOUNT}"
 
@@ -62,8 +64,8 @@ docker run --pull never --rm -v ${DATA_PATH}:/spec joystream/node:${RUNTIME} bui
 
 # Start a chain with generated chain spec
 export JOYSTREAM_NODE_TAG=${RUNTIME}
-docker-compose -f ../../docker-compose.yml run -d -v ${DATA_PATH}:/spec --name joystream-node \
-  -p 9944:9944 -p 9933:9933 joystream-node \
+docker-compose -p joystream -f ../../docker-compose.yml run -d -v ${DATA_PATH}:/spec --name joystream-node \
+  --service-ports joystream-node \
   --alice --validator --unsafe-ws-external --unsafe-rpc-external \
   --rpc-methods Unsafe --rpc-cors=all -l runtime \
   --chain /spec/chain-spec-raw.json --pruning=archive --no-telemetry \

--- a/tests/network-tests/run-runtime-upgrade-tests.sh
+++ b/tests/network-tests/run-runtime-upgrade-tests.sh
@@ -16,7 +16,7 @@ TARGET_RUNTIME=${TARGET_RUNTIME:=target}
 # Source of funds for all new accounts that are created in the tests.
 TREASURY_INITIAL_BALANCE=${TREASURY_INITIAL_BALANCE:="100000000"}
 TREASURY_ACCOUNT_URI=${TREASURY_ACCOUNT_URI:="//Bob"}
-TREASURY_ACCOUNT=$(docker run --pull never --rm joystream/node:${RUNTIME} key inspect ${TREASURY_ACCOUNT_URI} --output-type json | jq .ss58Address -r)
+TREASURY_ACCOUNT=`docker run --pull never --rm joystream/node:${RUNTIME} key inspect ${TREASURY_ACCOUNT_URI} --output-type json | jq .ss58Address -r`
 
 echo >&2 "treasury account from suri: ${TREASURY_ACCOUNT}"
 

--- a/tests/network-tests/run-test-node-docker.sh
+++ b/tests/network-tests/run-test-node-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
 RUNTIME_PROFILE=TESTING ./run-node-docker.sh

--- a/tests/network-tests/run-test-node.sh
+++ b/tests/network-tests/run-test-node.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
 # Location used to store chain data, generated spec file and initial members

--- a/tests/network-tests/run-test-scenario.sh
+++ b/tests/network-tests/run-test-scenario.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
 # pass the scenario name without .ts extension

--- a/tests/network-tests/run-tests.sh
+++ b/tests/network-tests/run-tests.sh
@@ -4,16 +4,17 @@ set -e
 SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
 cd $SCRIPT_PATH
 
-CONTAINER_ID=$(./run-test-node-docker.sh)
-
 function cleanup() {
-    docker logs ${CONTAINER_ID} --tail 15
-    docker stop ${CONTAINER_ID}
-    docker rm ${CONTAINER_ID}
-    docker-compose -f ../../docker-compose.yml down -v
+    docker logs joystream-node --tail 15 || :
+    docker stop joystream-node || :
+    docker rm joystream-node || :
+    docker-compose -f ../../docker-compose.yml down -v || :
 }
 
-trap cleanup EXIT
+trap cleanup EXIT ERR SIGINT SIGTERM
+
+export JOYSTREAM_NODE_TAG=`RUNTIME_PROFILE=TESTING ../../scripts/runtime-code-shasum.sh`
+CHAIN=dev docker compose -f ../../docker-compose.yml up -d joystream-node
 
 sleep 30
 

--- a/tests/network-tests/test-setup-new-chain.sh
+++ b/tests/network-tests/test-setup-new-chain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-SCRIPT_PATH="$(dirname "${BASH_SOURCE[0]}")"
+SCRIPT_PATH=`dirname "${BASH_SOURCE[0]}"`
 cd $SCRIPT_PATH
 
 # Custom sudo and treasury accounts - export them before start new chain
@@ -9,14 +9,16 @@ cd $SCRIPT_PATH
 export TREASURY_ACCOUNT_URI=//Bob
 export TREASURY_INITIAL_BALANCE=1000000
 
-CONTAINER_ID=$(./run-test-node-docker.sh)
+CONTAINER_ID=`./run-test-node-docker.sh`
 
 function cleanup() {
     docker logs ${CONTAINER_ID} --tail 15
+    docker stop ${CONTAINER_ID}
+    docker rm ${CONTAINER_ID}
     docker-compose -f ../../docker-compose.yml down -v
 }
 
-trap cleanup EXIT
+trap cleanup EXIT ERR SIGINT SIGTERM
 
 sleep 3
 


### PR DESCRIPTION
Depends on https://github.com/Joystream/joystream/pull/4913 and https://github.com/Joystream/joystream/pull/4935

General fix to all shell scripts to correctly exit script when calling a sub script fails.

TLDR:
we have `set -e` in scripts that needs to exit when a subscript fails.

Using this:
```sh
output=$( expression )
```
captures output but doesn't cause calling script to exit with error. (You have to manually check exit code with `$?`) 

```sh
output=`expression`
```

Works better because it captures output and a non zero exit code from the expression/script with make the calling script exit correctly with an error code.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1204404358291458/1205728346610756) by [Unito](https://www.unito.io)
