### PR TITLE
[Argus] Fix distributor node syncing query

### DIFF
--- a/distributor-node/src/services/networking/NetworkingService.ts
+++ b/distributor-node/src/services/networking/NetworkingService.ts
@@ -370,23 +370,19 @@ export class NetworkingService {
   }
 
   async fetchSupportedDataObjects(): Promise<Map<string, DataObjectData>> {
-    const data = this.config.buckets
+    const objects = this.config.buckets
       ? await this.queryNodeApi.getDistributionBucketsWithObjectsByIds(this.config.buckets.map((id) => id.toString()))
       : typeof this.config.workerId === 'number'
       ? await this.queryNodeApi.getDistributionBucketsWithObjectsByWorkerId(this.config.workerId)
       : []
     const objectsData = new Map<string, DataObjectData>()
-    data.forEach((bucket) => {
-      bucket.bags.forEach((bag) => {
-        bag.objects.forEach((object) => {
-          const { ipfsHash, id, size, type } = object
-          objectsData.set(id, {
-            contentHash: ipfsHash,
-            objectId: id,
-            size: parseInt(size),
-            fallbackMimeType: this.parseUserProvidedMimeType(type.subtitle?.mimeType),
-          })
-        })
+    objects.forEach((object) => {
+      const { ipfsHash, id, size, type } = object
+      objectsData.set(id, {
+        contentHash: ipfsHash,
+        objectId: id,
+        size: parseInt(size),
+        fallbackMimeType: this.parseUserProvidedMimeType(type.subtitle?.mimeType),
       })
     })
 

--- a/distributor-node/src/services/networking/query-node/queries/queries.graphql
+++ b/distributor-node/src/services/networking/query-node/queries/queries.graphql
@@ -48,33 +48,48 @@ query getDataObjectDetails($id: ID!) {
   }
 }
 
-fragment DistirubtionBucketWithObjects on DistributionBucket {
+fragment MinimalDataObject on StorageDataObject {
   id
-  bags {
-    objects {
-      id
-      size
-      ipfsHash
-      type {
-        ... on DataObjectTypeVideoSubtitle {
-          subtitle {
-            mimeType
-          }
-        }
+  size
+  ipfsHash
+  type {
+    ... on DataObjectTypeVideoSubtitle {
+      subtitle {
+        mimeType
       }
     }
   }
 }
 
-query getDistributionBucketsWithObjectsByIds($ids: [ID!]) {
-  distributionBuckets(where: { id_in: $ids }) {
-    ...DistirubtionBucketWithObjects
+fragment StorageBagWithObjects on StorageBag {
+  id
+  objects {
+    ...MinimalDataObject
   }
 }
 
-query getDistributionBucketsWithObjectsByWorkerId($workerId: Int!) {
+query getDataObjectsWithBagsByIds($bagIds: [ID!], $limit: Int) {
+  storageBags(where: { id_in: $bagIds }, limit: $limit) {
+    ...StorageBagWithObjects
+  }
+}
+
+fragment DistributionBucketWithBags on DistributionBucket {
+  id
+  bags {
+    id
+  }
+}
+
+query getDistributionBucketsWithBagsByIds($ids: [ID!]) {
+  distributionBuckets(where: { id_in: $ids }) {
+    ...DistributionBucketWithBags
+  }
+}
+
+query getDistributionBucketsWithBagsByWorkerId($workerId: Int!) {
   distributionBuckets(where: { operators_some: { workerId_eq: $workerId, status_eq: ACTIVE } }) {
-    ...DistirubtionBucketWithObjects
+    ...DistributionBucketWithBags
   }
 }
 


### PR DESCRIPTION
## Problem

The distributor node executes [getDistributionBucketsWithObjectsByWorkerId](https://github.com/Joystream/joystream/blob/0d2a068ecd7d4eb07189a48e0be1a1de6c740351/distributor-node/src/services/networking/NetworkingService.ts#L376C33-L376C76) query to get all the data objects that given node is supposed to distribute. The problem is that with the consistent growth of the storage directory, the response size of this query is becoming larger and larger. For some time this query was experiencing `Timeout`, upon investigating it turned out that while executing this query the graphql-server was consistently crashing with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`

<img width="975" alt="image" src="https://github.com/Joystream/joystream/assets/37098720/3ced62df-a13d-436b-b03a-ff93b4e96d04">


## Fix

This PR divides the given query into multiple smaller queries so that the graphql-server is successfully able to process it, until we find the reason for the memory leak happening in the graphql-server and create a proper fix.