### PR TITLE
[argus] few tweaks

### DIFF
--- a/distributor-node/CHANGELOG.md
+++ b/distributor-node/CHANGELOG.md
@@ -1,8 +1,12 @@
 ##
 
+### 1.4.0
+
+- Add 1s delay between fetching pages for QN state sync. This will allow QN to have some breathing space and process other requests that may have been stuck because of heavy processing.
+
 ### 1.3.1
 
-- Batch fetching of objects details from query-node [#4921](https://github.com/Joystream/joystream/pull/4921)
+- **FIX** QN state sync: The QN state sync that runs on startup and on interval, has been split to multiple paginated queries so that it doesn't crash QN's GraphQL server because of huge payload: [#4921](https://github.com/Joystream/joystream/pull/4921)
 
 ### 1.3.0
 

--- a/distributor-node/CHANGELOG.md
+++ b/distributor-node/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add 1s delay between fetching pages for QN state sync. This will allow QN to have some breathing space and process other requests that may have been stuck because of heavy processing.
 - Add `Access-Control-Expose-Headers` response header to allow web clients checking cache status of downloaded file.
+- Include response headers in `http` logs
 
 ### 1.3.1
 

--- a/distributor-node/CHANGELOG.md
+++ b/distributor-node/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 1.4.0
 
 - Add 1s delay between fetching pages for QN state sync. This will allow QN to have some breathing space and process other requests that may have been stuck because of heavy processing.
+- Add `Access-Control-Expose-Headers` response header to allow web clients checking cache status of downloaded file.
 
 ### 1.3.1
 

--- a/distributor-node/package.json
+++ b/distributor-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/distributor-cli",
   "description": "Joystream distributor node CLI",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "author": "Joystream contributors",
   "bin": {
     "joystream-distributor": "./bin/run"

--- a/distributor-node/src/services/httpApi/HttpApiBase.ts
+++ b/distributor-node/src/services/httpApi/HttpApiBase.ts
@@ -61,7 +61,10 @@ export abstract class HttpApiBase {
       winstonInstance: this.logger,
       level: 'http',
       dynamicMeta: (req, res) => {
-        return { prematurelyClosed: res.locals.prematurelyClosed ?? false }
+        return {
+          prematurelyClosed: res.locals.prematurelyClosed ?? false,
+          res: { headers: res.getHeaders(), statusCode: res.statusCode },
+        }
       },
     }
   }

--- a/distributor-node/src/services/httpApi/controllers/public.ts
+++ b/distributor-node/src/services/httpApi/controllers/public.ts
@@ -224,7 +224,7 @@ export class PublicApiController {
     res.setHeader('timing-allow-origin', '*')
     res.setHeader('accept-ranges', 'bytes')
     res.setHeader('content-disposition', 'inline')
-    res.setHeader('access-control-expose-headers', ['x-cache', 'x-data-source'])
+    res.setHeader('access-control-expose-headers', 'x-cache, x-data-source')
 
     switch (objectStatus.type) {
       case ObjectStatusType.Available:
@@ -272,7 +272,7 @@ export class PublicApiController {
     })
 
     res.setHeader('timing-allow-origin', '*')
-    res.setHeader('access-control-expose-headers', ['x-cache', 'x-data-source'])
+    res.setHeader('access-control-expose-headers', 'x-cache, x-data-source')
 
     switch (objectStatus.type) {
       case ObjectStatusType.Available:

--- a/distributor-node/src/services/httpApi/controllers/public.ts
+++ b/distributor-node/src/services/httpApi/controllers/public.ts
@@ -224,6 +224,7 @@ export class PublicApiController {
     res.setHeader('timing-allow-origin', '*')
     res.setHeader('accept-ranges', 'bytes')
     res.setHeader('content-disposition', 'inline')
+    res.setHeader('access-control-expose-headers', ['x-cache', 'x-data-source'])
 
     switch (objectStatus.type) {
       case ObjectStatusType.Available:
@@ -271,6 +272,7 @@ export class PublicApiController {
     })
 
     res.setHeader('timing-allow-origin', '*')
+    res.setHeader('access-control-expose-headers', ['x-cache', 'x-data-source'])
 
     switch (objectStatus.type) {
       case ObjectStatusType.Available:

--- a/distributor-node/src/services/networking/query-node/api.ts
+++ b/distributor-node/src/services/networking/query-node/api.ts
@@ -230,6 +230,8 @@ export class QueryNodeApi {
           GetDataObjectsWithBagsByIdsQueryVariables
         >(GetDataObjectsWithBagsByIds, { bagIds: bagIdsBatch, limit: bagIdsBatch.length }, 'storageBags'))
       )
+      // wait 1s between requests to avoid overloading the query node
+      await new Promise((resolve) => setTimeout(resolve, 1000))
     }
 
     return fullResult.map((bag) => bag.objects).flat()


### PR DESCRIPTION
- Add 1s delay between fetching pages for QN state sync. This will allow QN to have some breathing space and process other requests that may have been stuck because of heavy processing.
- Add `Access-Control-Expose-Headers` response header to allow web clients checking cache status of downloaded file.
- Include response headers in `http` logs