### PR TITLE
chainspec builder rename deployment variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "chain-spec-builder"
-version = "8.3.0"
+version = "8.4.0"
 dependencies = [
  "async-std",
  "clap 3.2.23",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "joystream-node"
-version = "8.4.0"
+version = "8.5.0"
 dependencies = [
  "assert_cmd",
  "async-std",

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'joystream-node'
-version = '8.4.0'
+version = '8.5.0'
 default-run = "joystream-node"
 
 [[bin]]

--- a/bin/utils/chain-spec-builder/Cargo.toml
+++ b/bin/utils/chain-spec-builder/Cargo.toml
@@ -3,7 +3,7 @@ authors = ['Joystream contributors']
 build = 'build.rs'
 edition = '2018'
 name = 'chain-spec-builder'
-version = '8.3.0'
+version = '8.4.0'
 
 [dependencies]
 enum-utils = "0.1.2"

--- a/bin/utils/chain-spec-builder/src/main.rs
+++ b/bin/utils/chain-spec-builder/src/main.rs
@@ -43,9 +43,15 @@ const TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, PartialEq, enum_utils::FromStr)]
 enum ChainDeployment {
+    /// Single node chain with testing genesis config.
+    /// Private IP and local network discovery enabled.
     dev,
+    /// Two nodes (on same machine) chain with testing genesis config.
+    /// Private IP and local network discovery enabled
     local,
+    /// Two or more public nodes chain with testing genesis config.
     testnet,
+    /// Two or more public nodes chain with production genesis config.
     mainnet,
 }
 
@@ -326,10 +332,13 @@ fn generate_chain_spec(
         .map(parse_account)
         .collect::<Result<Vec<_>, String>>()?;
 
-    let telemetry_endpoints = Some(
-        TelemetryEndpoints::new(vec![(TELEMETRY_URL.to_string(), 0)])
-            .expect("Staging telemetry url is valid; qed"),
-    );
+    let telemetry_endpoints = match deployment {
+        ChainDeployment::mainnet => Some(
+            TelemetryEndpoints::new(vec![(TELEMETRY_URL.to_string(), 0)])
+                .expect("Telemetry url is invalid; qed"),
+        ),
+        _ => None,
+    };
 
     let chain_spec = chain_spec::ChainSpec::from_genesis(
         "Joystream Testnet",


### PR DESCRIPTION
Improve naming of deployment configuration in chainspec builder and ensure appropriate number of validators specified for the different configurations.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1204404358291458/1205746748311094) by [Unito](https://www.unito.io)
