### PR TITLE
QueryNode, metadata-protobuf and joystream/js package releases

### DIFF
--- a/joystreamjs/CHANGELOG.md
+++ b/joystreamjs/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.5.0
+
+- Update dependency on metadata protobuf to v2.10.0
+
 ### 1.4.0
 
 - Add `generateAppActionCommitment` to utils

--- a/joystreamjs/package.json
+++ b/joystreamjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/js",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "GPL-3.0-only",
   "description": "Joystream JS package provides  utilities required to work with Joystream network.",
   "main": "lib/index.js",
@@ -41,7 +41,7 @@
     "generate:all": "yarn generate:schema-typings"
   },
   "dependencies": {
-    "@joystream/metadata-protobuf": "^2.8.1",
+    "@joystream/metadata-protobuf": "^2.10.0",
     "@joystream/types": "^2.0.0",
     "@polkadot/util-crypto": "9.5.1",
     "axios": "^1.2.1",

--- a/metadata-protobuf/package.json
+++ b/metadata-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/metadata-protobuf",
-  "version": "2.8.1",
+  "version": "2.10.0",
   "description": "Joystream Metadata Protobuf Library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/metadata-protobuf/proto/Token.proto
+++ b/metadata-protobuf/proto/Token.proto
@@ -1,0 +1,35 @@
+syntax = "proto2";
+message CreatorTokenIssuerRemarked {
+    oneof creator_token_issuer_remarked {
+        UpdateTokenMetadata update_token_metadata = 1;
+    }
+}
+
+message UpdateTokenMetadata {
+    optional TokenMetadata new_metadata = 1;
+}
+
+message TokenMetadata {
+  optional string name = 1; // Title
+  optional string symbol = 2; // Symbol
+  optional string description = 3; // token description
+  oneof avatar {
+    uint32 avatar_object = 4; // avatar for token - index into external [assets array](#.Assets)
+    string avatar_uri = 5; // Url to member's avatar
+  }
+  repeated Benefit benefits = 6; // benefits for tokne
+  optional string whitelist_application_note = 7; // note for applicant
+  optional string whitelist_application_apply_link = 8; // link to application process
+  optional uint64 trailer_video_id = 9; // runtime id for video trailer
+}
+
+message Benefit {
+  optional string title = 1;
+  optional string description = 2;
+  optional string emoji = 3;
+  optional uint32 display_order = 4;
+}
+
+message SaleMetadata {
+  optional string terms_and_conditions = 1;
+}

--- a/query-node/CHANGELOG.md
+++ b/query-node/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 1.5.0
+
+- Add add linked-in to membership external resource [#4927](https://github.com/Joystream/joystream/pull/4927)
+- Schema updated, processor needs to be re-synced.
+
 ### 1.4.0
 
 - Adds `StorageBag.objectsSize` field to `StorageBag` entity schema. This enables to query the total size of all objects in a storage bag. [#4818](https://github.com/Joystream/joystream/pull/4818)
@@ -6,7 +11,7 @@
 
 ### 1.3.0
 
-- Fix external resources mapping of membership metadata to ignore unrecognized type.
+- Fix external resources mapping of membership metadata to ignore unrecognized type. [#4838](https://github.com/Joystream/joystream/pull/4838)
 
 ### 1.2.2
 

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -20,7 +20,7 @@
     "@joystream/hydra-common": "5.0.0-alpha.4",
     "@joystream/hydra-db-utils": "5.0.0-alpha.4",
     "@joystream/warthog": "^2.41.9",
-    "@joystream/js": "^1.4.0",
+    "@joystream/js": "^1.5.0",
     "@apollo/client": "^3.2.5"
   },
   "devDependencies": {

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-node-mappings",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Mappings for hydra-processor",
   "main": "lib/src/index.js",
   "license": "MIT",

--- a/query-node/package.json
+++ b/query-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-node-root",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "GraphQL server and mappings. Generated with ♥ by Hydra-CLI",
   "scripts": {
     "build": "./build.sh",

--- a/tests/network-tests/package.json
+++ b/tests/network-tests/package.json
@@ -31,7 +31,7 @@
     "graphql": "^14.7.0",
     "long": "^4.0.0",
     "node-cleanup": "^2.1.2",
-    "@joystream/js": "^1.4.0",
+    "@joystream/js": "^1.5.0",
     "uuid": "^7.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Following https://github.com/Joystream/joystream/pull/4927 preparing releases for affected packages.
Note bump to metadata-protobuf skipping v2.9.0 which was published from crt-release branch that included Token.proto which is being ported into this release on master branch.