### PR TITLE
[Argus] fix: Parse Axios error before logging & exporting to the Elasticsearch

### DIFF
--- a/distributor-node/CHANGELOG.md
+++ b/distributor-node/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Include response headers in `http` logs
 - Disable open-api express response validation if NODE_ENV is set to 'production' or 'prod'. This should improve response times when serving assets.
 - Include `nodeEnv` in `/api/v1/status` response, to help detect mis-configured nodes.
+- **FIX** Axios Error Logging: Logging the error, when asset download from storage-node time outs, has been fixed to include the _only_ error message, response, status code and bunch of other fields. Previously, logging error object (which includes axios client instance), failed with `Converting circular structure to JSON` error and causing the distributor-node to crash.
 
 ### 1.3.1
 

--- a/distributor-node/src/services/networking/NetworkingService.ts
+++ b/distributor-node/src/services/networking/NetworkingService.ts
@@ -333,7 +333,7 @@ export class NetworkingService {
 
       objectDownloadQueue.on('error', (err) => {
         this.logger.error('Download attempt from storage node failed after availability was confirmed:', {
-          err: parseAxiosError(err),
+          err: axios.isAxiosError(err) ? parseAxiosError(err) : err,
         })
       })
 

--- a/distributor-node/src/services/networking/NetworkingService.ts
+++ b/distributor-node/src/services/networking/NetworkingService.ts
@@ -332,7 +332,9 @@ export class NetworkingService {
       })
 
       objectDownloadQueue.on('error', (err) => {
-        this.logger.error('Download attempt from storage node failed after availability was confirmed:', { err })
+        this.logger.error('Download attempt from storage node failed after availability was confirmed:', {
+          err: parseAxiosError(err),
+        })
       })
 
       objectDownloadQueue.on('end', () => {


### PR DESCRIPTION
# Problem

Thanks to @kdembler for investigation
> it seems that full axios client is logged with error and we are trying to serialize it including buffers for sending to elastic
which fails because of circular reference
