### PR TITLE
[Nara] make tests dependent of block production time to not run on "fast production" runtime

### DIFF
--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -193,8 +193,8 @@ mod tests {
         assert!(0 < transfer_fee && transfer_fee < CENTS);
     }
 
-    // This test does not make sense for `testing-runtime`, because of 1s blocks
-    #[cfg(not(feature = "testing-runtime"))]
+    // This test does not make sense for `fast-block-production`, because of 1s blocks
+    #[cfg(not(feature = "fast-block-production"))]
     #[test]
     // This test verifies that the cost of filling blocks with max. normal dispatch extrinsics
     // total weight for 1 day is within the pre-determined bounds
@@ -222,8 +222,8 @@ mod tests {
         assert!(day_of_full_blocks_cost <= BLOCK_WEIGHT_FILL_MAX_DAILY_COST);
     }
 
-    // This test does not make sense for `testing-runtime`, because of 1s blocks
-    #[cfg(not(feature = "testing-runtime"))]
+    // This test does not make sense for `fast-block-productione`, because of 1s blocks
+    #[cfg(not(feature = "fast-block-production"))]
     #[test]
     // This test verifies that the cost of filling blocks with max. normal dispatch extrinsics
     // total length for 1 day is within the pre-determined bounds


### PR DESCRIPTION


┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1204404358291458/1205793205691623) by [Unito](https://www.unito.io)
