### PR TITLE
hotfix: QueryNode handling of membership handle

### DIFF
--- a/distributor-node/src/services/networking/query-node/schema.graphql
+++ b/distributor-node/src/services/networking/query-node/schema.graphql
@@ -17564,6 +17564,11 @@ input MemberProfileUpdatedEventWhereInput {
   newHandle_startsWith: String
   newHandle_endsWith: String
   newHandle_in: [String!]
+  newHandleRaw_eq: String
+  newHandleRaw_contains: String
+  newHandleRaw_startsWith: String
+  newHandleRaw_endsWith: String
+  newHandleRaw_in: [String!]
   member: MembershipWhereInput
   newMetadata: MemberMetadataWhereInput
   AND: [MemberProfileUpdatedEventWhereInput!]
@@ -17582,6 +17587,7 @@ input MemberProfileUpdatedEventCreateInput {
   indexInBlock: Float!
   member: ID!
   newHandle: String
+  newHandleRaw: String
   newMetadata: ID!
 }
 
@@ -17592,6 +17598,7 @@ input MemberProfileUpdatedEventUpdateInput {
   indexInBlock: Float
   member: ID
   newHandle: String
+  newHandleRaw: String
   newMetadata: ID
 }
 
@@ -26273,8 +26280,15 @@ type MemberProfileUpdatedEvent implements Event & BaseGraphQLObject {
   member: Membership!
   memberId: String!
 
-  """New member handle. Null means no new value was provided."""
+  """
+  New member handle (utf-8 string). Null means no new value was provided.
+  """
   newHandle: String
+
+  """
+  New member handle (raw hex string). Null means no new value was provided.
+  """
+  newHandleRaw: String
   newMetadata: MemberMetadata!
   newMetadataId: String!
 }
@@ -30511,6 +30525,8 @@ enum MemberProfileUpdatedEventOrderByInput {
   member_DESC
   newHandle_ASC
   newHandle_DESC
+  newHandleRaw_ASC
+  newHandleRaw_DESC
   newMetadata_ASC
   newMetadata_DESC
 }

--- a/distributor-node/src/services/networking/query-node/schema.graphql
+++ b/distributor-node/src/services/networking/query-node/schema.graphql
@@ -3188,7 +3188,10 @@ type Membership implements BaseGraphQLObject {
   deletedById: ID
   version: Int!
 
-  """The unique handle chosen by member"""
+  """The unique handle chosen by member as raw hex representation"""
+  handleRaw: String!
+
+  """The unique handle chosen by member as utf-8"""
   handle: String!
   metadata: MemberMetadata!
   metadataId: String!
@@ -20790,6 +20793,11 @@ input MembershipWhereInput {
   deletedAt_gte: DateTime
   deletedById_eq: ID
   deletedById_in: [ID!]
+  handleRaw_eq: String
+  handleRaw_contains: String
+  handleRaw_startsWith: String
+  handleRaw_endsWith: String
+  handleRaw_in: [String!]
   handle_eq: String
   handle_contains: String
   handle_startsWith: String
@@ -21086,10 +21094,11 @@ input MembershipWhereInput {
 
 input MembershipWhereUniqueInput {
   id: ID
-  handle: String
+  handleRaw: String
 }
 
 input MembershipCreateInput {
+  handleRaw: String!
   handle: String!
   metadata: ID!
   controllerAccount: String!
@@ -21106,6 +21115,7 @@ input MembershipCreateInput {
 }
 
 input MembershipUpdateInput {
+  handleRaw: String
   handle: String
   metadata: ID
   controllerAccount: String
@@ -30627,6 +30637,8 @@ enum MembershipOrderByInput {
   updatedAt_DESC
   deletedAt_ASC
   deletedAt_DESC
+  handleRaw_ASC
+  handleRaw_DESC
   handle_ASC
   handle_DESC
   metadata_ASC

--- a/query-node/CHANGELOG.md
+++ b/query-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.6.0
+
+- Store membership handles both as utf-8 string and raw bytes - [#4950](https://github.com/Joystream/joystream/pull/4950)
+
 ### 1.5.0
 
 - Add add linked-in to membership external resource [#4927](https://github.com/Joystream/joystream/pull/4927)

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-node-mappings",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Mappings for hydra-processor",
   "main": "lib/src/index.js",
   "license": "MIT",

--- a/query-node/mappings/src/membership.ts
+++ b/query-node/mappings/src/membership.ts
@@ -193,7 +193,7 @@ async function createNewMemberFromParams(
     rootAccount: rootAccount.toString(),
     controllerAccount: controllerAccount.toString(),
     handle: bytesToString(memberHandle),
-    handleRaw: Buffer.from(memberHandle.toU8a(true)).toString('hex'),
+    handleRaw: memberHandle.toHex(),
     metadata: await saveMembershipMetadata(store, undefined, metadata),
     entry: entryMethod,
     referredBy:

--- a/query-node/mappings/src/membership.ts
+++ b/query-node/mappings/src/membership.ts
@@ -193,7 +193,7 @@ async function createNewMemberFromParams(
     rootAccount: rootAccount.toString(),
     controllerAccount: controllerAccount.toString(),
     handle: bytesToString(memberHandle),
-    handleRaw: memberHandle.toHex(),
+    handleRaw: Buffer.from(memberHandle.toU8a(true)).toString('hex'),
     metadata: await saveMembershipMetadata(store, undefined, metadata),
     entry: entryMethod,
     referredBy:
@@ -343,7 +343,9 @@ export async function members_MemberProfileUpdated({ store, event }: EventContex
   }
 
   if (newHandle.isSome) {
-    member.handle = bytesToString(newHandle.unwrap())
+    const memberHandle = newHandle.unwrap()
+    member.handle = bytesToString(memberHandle)
+    member.handleRaw = memberHandle.toHex()
   }
 
   await store.save<MemberMetadata>(member.metadata)
@@ -368,6 +370,7 @@ export async function members_MemberProfileUpdated({ store, event }: EventContex
     ...genericEventFields(event),
     member: member,
     newHandle: member.handle,
+    newHandleRaw: member.handleRaw,
     newMetadata: await saveMembershipMetadata(store, member),
   })
 

--- a/query-node/mappings/src/membership.ts
+++ b/query-node/mappings/src/membership.ts
@@ -187,11 +187,13 @@ async function createNewMemberFromParams(
   const { rootAccount, controllerAccount, handle, metadata: metadataBytes } = params
   const metadata = deserializeMetadata(MembershipMetadata, metadataBytes)
 
+  const memberHandle = 'unwrap' in handle ? handle.unwrap() : handle
   const member = new Membership({
     id: memberId.toString(),
     rootAccount: rootAccount.toString(),
     controllerAccount: controllerAccount.toString(),
-    handle: bytesToString('unwrap' in handle ? handle.unwrap() : handle),
+    handle: bytesToString(memberHandle),
+    handleRaw: memberHandle.toHex(),
     metadata: await saveMembershipMetadata(store, undefined, metadata),
     entry: entryMethod,
     referredBy:

--- a/query-node/package.json
+++ b/query-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-node-root",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "GraphQL server and mappings. Generated with ♥ by Hydra-CLI",
   "scripts": {
     "build": "./build.sh",

--- a/query-node/schemas/membership.graphql
+++ b/query-node/schemas/membership.graphql
@@ -93,8 +93,11 @@ type Membership @entity {
   "MemberId: runtime identifier for a user"
   id: ID!
 
-  "The unique handle chosen by member"
-  handle: String! @unique @fulltext(query: "membersByHandle")
+  "The unique handle chosen by member as raw hex representation"
+  handle_raw: String! @unique
+
+  "The unique handle chosen by member as utf-8"
+  handle: String! @fulltext(query: "membersByHandle")
 
   "Member's metadata"
   metadata: MemberMetadata!

--- a/query-node/schemas/membershipEvents.graphql
+++ b/query-node/schemas/membershipEvents.graphql
@@ -177,8 +177,11 @@ type MemberProfileUpdatedEvent implements Event @entity {
   "Membership being updated."
   member: Membership!
 
-  "New member handle. Null means no new value was provided."
+  "New member handle (utf-8 string). Null means no new value was provided."
   newHandle: String
+
+  "New member handle (raw hex string). Null means no new value was provided."
+  newHandleRaw: String
 
   "New member metadata. (empty values inside metadata mean no new value was provided)"
   newMetadata: MemberMetadata!

--- a/storage-node/src/services/queryNode/schema.graphql
+++ b/storage-node/src/services/queryNode/schema.graphql
@@ -17564,6 +17564,11 @@ input MemberProfileUpdatedEventWhereInput {
   newHandle_startsWith: String
   newHandle_endsWith: String
   newHandle_in: [String!]
+  newHandleRaw_eq: String
+  newHandleRaw_contains: String
+  newHandleRaw_startsWith: String
+  newHandleRaw_endsWith: String
+  newHandleRaw_in: [String!]
   member: MembershipWhereInput
   newMetadata: MemberMetadataWhereInput
   AND: [MemberProfileUpdatedEventWhereInput!]
@@ -17582,6 +17587,7 @@ input MemberProfileUpdatedEventCreateInput {
   indexInBlock: Float!
   member: ID!
   newHandle: String
+  newHandleRaw: String
   newMetadata: ID!
 }
 
@@ -17592,6 +17598,7 @@ input MemberProfileUpdatedEventUpdateInput {
   indexInBlock: Float
   member: ID
   newHandle: String
+  newHandleRaw: String
   newMetadata: ID
 }
 
@@ -26273,8 +26280,15 @@ type MemberProfileUpdatedEvent implements Event & BaseGraphQLObject {
   member: Membership!
   memberId: String!
 
-  """New member handle. Null means no new value was provided."""
+  """
+  New member handle (utf-8 string). Null means no new value was provided.
+  """
   newHandle: String
+
+  """
+  New member handle (raw hex string). Null means no new value was provided.
+  """
+  newHandleRaw: String
   newMetadata: MemberMetadata!
   newMetadataId: String!
 }
@@ -30511,6 +30525,8 @@ enum MemberProfileUpdatedEventOrderByInput {
   member_DESC
   newHandle_ASC
   newHandle_DESC
+  newHandleRaw_ASC
+  newHandleRaw_DESC
   newMetadata_ASC
   newMetadata_DESC
 }

--- a/storage-node/src/services/queryNode/schema.graphql
+++ b/storage-node/src/services/queryNode/schema.graphql
@@ -3188,7 +3188,10 @@ type Membership implements BaseGraphQLObject {
   deletedById: ID
   version: Int!
 
-  """The unique handle chosen by member"""
+  """The unique handle chosen by member as raw hex representation"""
+  handleRaw: String!
+
+  """The unique handle chosen by member as utf-8"""
   handle: String!
   metadata: MemberMetadata!
   metadataId: String!
@@ -20790,6 +20793,11 @@ input MembershipWhereInput {
   deletedAt_gte: DateTime
   deletedById_eq: ID
   deletedById_in: [ID!]
+  handleRaw_eq: String
+  handleRaw_contains: String
+  handleRaw_startsWith: String
+  handleRaw_endsWith: String
+  handleRaw_in: [String!]
   handle_eq: String
   handle_contains: String
   handle_startsWith: String
@@ -21086,10 +21094,11 @@ input MembershipWhereInput {
 
 input MembershipWhereUniqueInput {
   id: ID
-  handle: String
+  handleRaw: String
 }
 
 input MembershipCreateInput {
+  handleRaw: String!
   handle: String!
   metadata: ID!
   controllerAccount: String!
@@ -21106,6 +21115,7 @@ input MembershipCreateInput {
 }
 
 input MembershipUpdateInput {
+  handleRaw: String
   handle: String
   metadata: ID
   controllerAccount: String
@@ -30627,6 +30637,8 @@ enum MembershipOrderByInput {
   updatedAt_DESC
   deletedAt_ASC
   deletedAt_DESC
+  handleRaw_ASC
+  handleRaw_DESC
   handle_ASC
   handle_DESC
   metadata_ASC


### PR DESCRIPTION
Problem:
If member handle has non-valid utf-8 chars and is replaced with the `�` replacement character, two unique (at byte level) handles when converted to string can actually become identical, breaking the uniqueness constraint in the database for the handle column.

Solution:
Update query-node schema to:
- do best effort converting handle to utf-8 string an store it in non-unique column
- store raw bytes as hex string in new column