### PR TITLE
Opentelemetry fixes

### DIFF
--- a/entrypoints/distributor.sh
+++ b/entrypoints/distributor.sh
@@ -2,6 +2,7 @@
 
 # docker entrypoint fot distributor node, to allow running with telemetry
 if [[ "$TELEMETRY_ENABLED" = "yes" ]] && [[ $1 = "start" ]]; then
+    export OTEL_APPLICATION=distributor-node
     node --require @joystream/opentelemetry /joystream/distributor-node/bin/run $*
 else
     /joystream/distributor-node/bin/run $*

--- a/entrypoints/graphql-server.sh
+++ b/entrypoints/graphql-server.sh
@@ -2,6 +2,7 @@
 
 # docker entrypoint fot graphql-server, to allow running with telemetry
 if [[ "$TELEMETRY_ENABLED" = "yes" ]]; then
+    export OTEL_APPLICATION=query-node
     yarn workspace query-node-root query-node:start:prod:with-instrumentation $*
 else
     yarn workspace query-node-root query-node:start:prod:pm2 $*

--- a/entrypoints/storage.sh
+++ b/entrypoints/storage.sh
@@ -2,6 +2,7 @@
 
 # docker entrypoint fot storage node, to allow running with telemetry
 if [[ "$TELEMETRY_ENABLED" = "yes" ]] && [[ $1 = "server" ]]; then
+    export OTEL_APPLICATION=storage-node
     node --require @joystream/opentelemetry /joystream/storage-node/bin/run $*
 else
     /joystream/storage-node/bin/run $*

--- a/opentelemetry/.env
+++ b/opentelemetry/.env
@@ -5,3 +5,7 @@ OTEL_APPLICATION=
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:8200
 OTEL_RESOURCE_ATTRIBUTES="service.name=test-service,deployment.environment=development"
 OTEL_METRICS_EXPORTER="otlp"
+
+# Optional env vars to configure the opentelemetry exporters
+OTEL_MAX_QUEUE_SIZE=8192        # 4 times of default queue size
+OTEL_MAX_EXPORT_BATCH_SIZE=1024 # 2 times of default batch size

--- a/opentelemetry/index.ts
+++ b/opentelemetry/index.ts
@@ -1,16 +1,12 @@
 import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api'
 import { NodeSDK } from '@opentelemetry/sdk-node'
-import { config } from 'dotenv'
-import path from 'path'
+import 'dotenv/config'
 import { DefaultInstrumentation, DistributorNodeInstrumentation, StorageNodeInstrumentation } from './instrumentations'
 
 // For troubleshooting, set the log level to DiagLogLevel.DEBUG
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO)
 
 async function addInstrumentation() {
-  // Load env variables
-  config({ path: path.join(__dirname, '../.env') })
-
   const applicationName = process.env.OTEL_APPLICATION
 
   let instrumentation: NodeSDK

--- a/opentelemetry/instrumentations/default.ts
+++ b/opentelemetry/instrumentations/default.ts
@@ -9,8 +9,8 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-node'
 
 export const DefaultInstrumentation = new NodeSDK({
   spanProcessor: new BatchSpanProcessor(new OTLPTraceExporter(), {
-    maxQueueSize: 8192 /* 4 times of default queue size */,
-    maxExportBatchSize: 1024 /* 2 times of default batch size */,
+    maxQueueSize: parseInt(process.env.OTEL_MAX_QUEUE_SIZE || '8192'),
+    maxExportBatchSize: parseInt(process.env.OTEL_MAX_EXPORT_BATCH_SIZE || '1024'),
   }),
   metricReader: new PeriodicExportingMetricReader({
     exporter: new OTLPMetricExporter(),

--- a/opentelemetry/instrumentations/distributor-node.ts
+++ b/opentelemetry/instrumentations/distributor-node.ts
@@ -12,8 +12,8 @@ import { ClientRequest, ServerResponse } from 'http'
 
 export const DistributorNodeInstrumentation = new NodeSDK({
   spanProcessor: new BatchSpanProcessor(new OTLPTraceExporter(), {
-    maxQueueSize: 8192 /* 4 times of default queue size */,
-    maxExportBatchSize: 1024 /* 2 times of default batch size */,
+    maxQueueSize: parseInt(process.env.OTEL_MAX_QUEUE_SIZE || '8192'),
+    maxExportBatchSize: parseInt(process.env.OTEL_MAX_EXPORT_BATCH_SIZE || '1024'),
   }),
   metricReader: new PeriodicExportingMetricReader({
     exporter: new OTLPMetricExporter(),

--- a/opentelemetry/instrumentations/distributor-node.ts
+++ b/opentelemetry/instrumentations/distributor-node.ts
@@ -5,13 +5,19 @@ import { FsInstrumentation } from '@opentelemetry/instrumentation-fs'
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
 import { NodeSDK } from '@opentelemetry/sdk-node'
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-node'
+import { BatchSpanProcessor, Span } from '@opentelemetry/sdk-trace-node'
 import { ClientRequest, ServerResponse } from 'http'
 
 /** Opentelemetry Instrumentation for Joystream Distributor Node */
 
+class CustomSpanProcessor extends BatchSpanProcessor {
+  onStart(span: Span) {
+    span.setAttribute('nodeId', process.env.JOYSTREAM_DISTRIBUTOR__ID)
+  }
+}
+
 export const DistributorNodeInstrumentation = new NodeSDK({
-  spanProcessor: new BatchSpanProcessor(new OTLPTraceExporter(), {
+  spanProcessor: new CustomSpanProcessor(new OTLPTraceExporter(), {
     maxQueueSize: parseInt(process.env.OTEL_MAX_QUEUE_SIZE || '8192'),
     maxExportBatchSize: parseInt(process.env.OTEL_MAX_EXPORT_BATCH_SIZE || '1024'),
   }),

--- a/opentelemetry/instrumentations/storage-node.ts
+++ b/opentelemetry/instrumentations/storage-node.ts
@@ -12,8 +12,8 @@ import { ClientRequest, ServerResponse } from 'http'
 
 export const StorageNodeInstrumentation = new NodeSDK({
   spanProcessor: new BatchSpanProcessor(new OTLPTraceExporter(), {
-    maxQueueSize: 8192 /* 4 times of default queue size */,
-    maxExportBatchSize: 1024 /* 2 times of default batch size */,
+    maxQueueSize: parseInt(process.env.OTEL_MAX_QUEUE_SIZE || '8192'),
+    maxExportBatchSize: parseInt(process.env.OTEL_MAX_EXPORT_BATCH_SIZE || '1024'),
   }),
   metricReader: new PeriodicExportingMetricReader({
     exporter: new OTLPMetricExporter(),


### PR DESCRIPTION
This PR

- Fixes loading env vars from `.env` file in `@joystream/opentelemetry` module. Due to this bug the `OTEL_APPLICATION` was not exported and hence [DefaultInstrumentation](https://github.com/zeeshanakram3/joystream/blob/a91634aae25735e9d5baf73d56d1496306493ce0/opentelemetry/index.ts#L23) was used for Argus, and hence argus related attributes were not exported to ES.
- make OTEL `maxQueueSize` & `maxExportBatchSize` span processor options configurable
- Add 'nodeId' attribute to all Argus spans