### PR TITLE
HotFix for Critical sync error: RangeError: Maximum call stack size exceeded

### DIFF
--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.8.1
+
+- Hotfix: Fix call stack size exceeded when handling large number of initial object to sync.
+
 ### 3.8.0
 
 - Changed Elasticsearch transport to use data streams instead of regular indices. Removed `--elasticSearchIndex` option and replaced with `--elasticSearchIndexPrefix`. Node ID from config will be automatically appended to the index name.

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storage-node",
   "description": "Joystream storage subsystem.",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "author": "Joystream contributors",
   "bin": {
     "storage-node": "./bin/run"

--- a/storage-node/src/services/sync/workingProcess.ts
+++ b/storage-node/src/services/sync/workingProcess.ts
@@ -47,8 +47,16 @@ export class WorkingStack implements TaskSink, TaskSource {
   }
 
   async add(tasks: SyncTask[]): Promise<void> {
-    if (tasks !== null) {
-      this.workingStack.push(...tasks)
+    // Avoid using:
+    //     this.workingStack.push(...tasks)
+    // When tasks array is very large, javasctipy call stack size might
+    // be exceeded and push() will throw an exception.
+    // This is pretty code:
+    //      tasks.map((task) => this.workingStack.push(task))
+    // ..but slow for large array.
+    const len = tasks.length
+    for (let i = 0; i < len; i++) {
+      this.workingStack.push(tasks[i])
     }
   }
 }


### PR DESCRIPTION
We had a case where a new storage node was doing an initial sync. The number of objects to sync was around 380,000.
Sync tasks being added was using pattern `Array.push(...tasks)` this results in a call to `Array.push(....)` with 380,000 arguments which are all added to the javascript call stack which throws an exception, this resulted in the node never being able to complete a sync run.

The fix is to just iterate over the tasks array elements and push them individually into the target array.