### PR TITLE
remove validatorAccount

### DIFF
--- a/distributor-node/src/services/networking/query-node/schema.graphql
+++ b/distributor-node/src/services/networking/query-node/schema.graphql
@@ -2029,7 +2029,6 @@ type MemberMetadata implements BaseGraphQLObject {
   member: Membership
   externalResources: [MembershipExternalResource!]
   isVerifiedValidator: Boolean
-  validatorAccount: String
   membercreatedeventmetadata: [MemberCreatedEvent!]
   memberinvitedeventmetadata: [MemberInvitedEvent!]
   memberprofileupdatedeventnewMetadata: [MemberProfileUpdatedEvent!]
@@ -17745,11 +17744,6 @@ input MemberMetadataWhereInput {
   about_in: [String!]
   isVerifiedValidator_eq: Boolean
   isVerifiedValidator_in: [Boolean!]
-  validatorAccount_eq: String
-  validatorAccount_contains: String
-  validatorAccount_startsWith: String
-  validatorAccount_endsWith: String
-  validatorAccount_in: [String!]
   member: MembershipWhereInput
   externalResources_none: MembershipExternalResourceWhereInput
   externalResources_some: MembershipExternalResourceWhereInput
@@ -30510,8 +30504,6 @@ enum MemberMetadataOrderByInput {
   about_DESC
   isVerifiedValidator_ASC
   isVerifiedValidator_DESC
-  validatorAccount_ASC
-  validatorAccount_DESC
 }
 
 enum MemberProfileUpdatedEventOrderByInput {

--- a/metadata-protobuf/proto/Membership.proto
+++ b/metadata-protobuf/proto/Membership.proto
@@ -26,10 +26,5 @@ message MembershipMetadata {
     optional ResourceType type = 1;
     optional string value = 2;
   }
-  
   repeated ExternalResource externalResources = 5;
-  
-  optional string validatorAccount = 6;
 }
-
-

--- a/query-node/mappings/src/membership.ts
+++ b/query-node/mappings/src/membership.ts
@@ -163,7 +163,6 @@ async function saveMembershipMetadata(
     avatar,
     externalResources: undefined,
     isVerifiedValidator: false,
-    validatorAccount: metadata?.validatorAccount || undefined,
   })
 
   await store.save<MemberMetadata>(metadataEntity)
@@ -347,13 +346,7 @@ export async function members_MemberProfileUpdated({ store, event }: EventContex
     }
   }
 
-  if (
-    typeof metadata?.validatorAccount === 'string' &&
-    metadata.validatorAccount !== member.metadata.validatorAccount
-  ) {
-    member.metadata.validatorAccount = (metadata.validatorAccount || null) as string | undefined
-    member.metadata.isVerifiedValidator = false
-  }
+  member.metadata.isVerifiedValidator = false
 
   if (newHandle.isSome) {
     setMemberHandle(member, newHandle.unwrap())

--- a/query-node/schemas/membership.graphql
+++ b/query-node/schemas/membership.graphql
@@ -50,7 +50,6 @@ type MemberMetadata @entity {
   externalResources: [MembershipExternalResource] @derivedFrom(field: "memberMetadata")
 
   isVerifiedValidator: Boolean
-  validatorAccount: String
 }
 
 type MembershipEntryPaid @variant {

--- a/storage-node/src/services/queryNode/schema.graphql
+++ b/storage-node/src/services/queryNode/schema.graphql
@@ -2029,7 +2029,6 @@ type MemberMetadata implements BaseGraphQLObject {
   member: Membership
   externalResources: [MembershipExternalResource!]
   isVerifiedValidator: Boolean
-  validatorAccount: String
   membercreatedeventmetadata: [MemberCreatedEvent!]
   memberinvitedeventmetadata: [MemberInvitedEvent!]
   memberprofileupdatedeventnewMetadata: [MemberProfileUpdatedEvent!]
@@ -17745,11 +17744,6 @@ input MemberMetadataWhereInput {
   about_in: [String!]
   isVerifiedValidator_eq: Boolean
   isVerifiedValidator_in: [Boolean!]
-  validatorAccount_eq: String
-  validatorAccount_contains: String
-  validatorAccount_startsWith: String
-  validatorAccount_endsWith: String
-  validatorAccount_in: [String!]
   member: MembershipWhereInput
   externalResources_none: MembershipExternalResourceWhereInput
   externalResources_some: MembershipExternalResourceWhereInput
@@ -17783,7 +17777,6 @@ input MemberMetadataCreateInput {
   avatar: JSONObject!
   about: String
   isVerifiedValidator: Boolean
-  validatorAccount: String
 }
 
 input MemberMetadataUpdateInput {
@@ -17791,7 +17784,6 @@ input MemberMetadataUpdateInput {
   avatar: JSONObject
   about: String
   isVerifiedValidator: Boolean
-  validatorAccount: String
 }
 
 input MembershipGiftedEventWhereInput {
@@ -30510,8 +30502,6 @@ enum MemberMetadataOrderByInput {
   about_DESC
   isVerifiedValidator_ASC
   isVerifiedValidator_DESC
-  validatorAccount_ASC
-  validatorAccount_DESC
 }
 
 enum MemberProfileUpdatedEventOrderByInput {

--- a/tests/network-tests/src/fixtures/membership/GiftMembershipHappyCaseFixture.ts
+++ b/tests/network-tests/src/fixtures/membership/GiftMembershipHappyCaseFixture.ts
@@ -58,7 +58,7 @@ export class GiftMembershipHappyCaseFixture extends StandardizedFixture {
         handle,
         rootAccount,
         controllerAccount,
-        metadata: { name, about, avatar, externalResources, validatorAccount },
+        metadata: { name, about, avatar, externalResources, isVerifiedValidator },
         isVerified,
         isFoundingMember,
         entry,
@@ -81,7 +81,7 @@ export class GiftMembershipHappyCaseFixture extends StandardizedFixture {
       Utils.assert(entry.__typename === 'MembershipEntryGifted', 'Query node: Invalid membership entry method')
       Utils.assert(entry.membershipGiftedEvent)
       assert.equal(entry.membershipGiftedEvent.id, qEvent.id)
-      assert.equal(validatorAccount, metadata.validatorAccount)
+      assert.equal(isVerifiedValidator, false)
     })
   }
 

--- a/tests/network-tests/src/fixtures/membership/InviteMembersHappyCaseFixture.ts
+++ b/tests/network-tests/src/fixtures/membership/InviteMembersHappyCaseFixture.ts
@@ -61,7 +61,7 @@ export class InviteMembersHappyCaseFixture extends StandardizedFixture {
         handle,
         rootAccount,
         controllerAccount,
-        metadata: { name, about, avatar, externalResources, validatorAccount },
+        metadata: { name, about, avatar, externalResources, isVerifiedValidator },
         isVerified,
         entry,
         invitedBy,
@@ -75,7 +75,7 @@ export class InviteMembersHappyCaseFixture extends StandardizedFixture {
       assert.equal(about, metadata.about)
       assert.equal(inviteCount, 0)
       assert.equal(avatar?.avatarUri, metadata.avatarUri || undefined)
-      assert.equal(validatorAccount, metadata.validatorAccount)
+      assert.equal(isVerifiedValidator, false)
       assert.includeDeepMembers(
         externalResources ?? [],
         metadata.externalResources?.map(asMembershipExternalResource) ?? []

--- a/tests/network-tests/src/fixtures/membership/UpdateProfileHappyCaseFixture.ts
+++ b/tests/network-tests/src/fixtures/membership/UpdateProfileHappyCaseFixture.ts
@@ -16,7 +16,6 @@ export type MemberProfileData = {
   about?: string | null
   avatarUri?: string | null
   externalResources?: MembershipMetadata.IExternalResource[] | null
-  validatorAccount?: string | null
 }
 
 export class UpdateProfileHappyCaseFixture extends BaseQueryNodeFixture {
@@ -57,7 +56,6 @@ export class UpdateProfileHappyCaseFixture extends BaseQueryNodeFixture {
     )
     assert.isFalse(Utils.hasDuplicates(metadata.externalResources?.map(({ type }) => type)))
     assert.equal(metadata.isVerifiedValidator, false)
-    assert.equal(metadata.validatorAccount, expected.validatorAccount)
   }
 
   public getExpectedValues(): MemberProfileData {
@@ -69,9 +67,6 @@ export class UpdateProfileHappyCaseFixture extends BaseQueryNodeFixture {
       externalResources: isSet(this.newValues.externalResources)
         ? this.newValues.externalResources || null
         : this.oldValues.externalResources,
-      validatorAccount: isSet(this.newValues.validatorAccount)
-        ? this.newValues.validatorAccount || null
-        : this.oldValues.validatorAccount,
     }
   }
 
@@ -107,7 +102,6 @@ export class UpdateProfileHappyCaseFixture extends BaseQueryNodeFixture {
       about: this.newValues.about,
       avatarUri: this.newValues.avatarUri,
       externalResources: this.newValues.externalResources,
-      validatorAccount: this.newValues.validatorAccount,
     })
     this.tx = this.api.tx.members.updateProfile(
       this.memberContext.memberId,

--- a/tests/network-tests/src/fixtures/membership/utils.ts
+++ b/tests/network-tests/src/fixtures/membership/utils.ts
@@ -19,7 +19,6 @@ type MemberCreationParams = {
   externalResources?: MembershipMetadata.IExternalResource[] | null
   metadata: Bytes
   is_founding_member: boolean
-  validatorAccount?: string
 }
 
 // Common code for Membership fixtures
@@ -34,13 +33,11 @@ export function generateParamsFromAccountId(accountId: string, isFoundingMember 
       value: `https://${affix}.com`,
     },
   ]
-  const validatorAccount = `validator address`
   const metadataBytes = Utils.metadataToBytes(MembershipMetadata, {
     name,
     about,
     avatarUri,
     externalResources,
-    validatorAccount,
   })
 
   return {
@@ -51,7 +48,6 @@ export function generateParamsFromAccountId(accountId: string, isFoundingMember 
     about,
     avatarUri,
     externalResources,
-    validatorAccount,
     metadata: metadataBytes,
     is_founding_member: isFoundingMember,
   }

--- a/tests/network-tests/src/flows/membership/updatingProfile.ts
+++ b/tests/network-tests/src/flows/membership/updatingProfile.ts
@@ -21,7 +21,6 @@ export default async function updatingProfile({ api, query }: FlowProps): Promis
     {
       handle: 'New handle 1',
       name: 'New name',
-      validatorAccount: 'validator address',
     },
     {
       handle: 'New handle 2',
@@ -38,7 +37,6 @@ export default async function updatingProfile({ api, query }: FlowProps): Promis
           value: 'A@example.com',
         },
       ],
-      validatorAccount: '',
     },
     // Full update
     {

--- a/tests/network-tests/src/graphql/queries/membership.graphql
+++ b/tests/network-tests/src/graphql/queries/membership.graphql
@@ -11,7 +11,6 @@ fragment MemberMetadataFields on MemberMetadata {
     value
   }
   isVerifiedValidator
-  validatorAccount
 }
 
 fragment MembershipFields on Membership {


### PR DESCRIPTION
- #4905

Remove validatorAccount from membership metadata,  reset `verifiedValidtor` field to `false` whenever any membership metadata field is changed.