### PR TITLE
colossus: do not serve content from pending folder

### DIFF
--- a/storage-node/src/services/webApi/controllers/filesApi.ts
+++ b/storage-node/src/services/webApi/controllers/filesApi.ts
@@ -39,10 +39,8 @@ export async function getFile(
 
     const dataObjectId = new BN(req.params.id)
     const uploadsDir = res.locals.uploadsDir
-    const pendingObjectsDir = res.locals.pendingDataObjectsDir
-    const pending = res.locals.acceptPendingObjectsService.getPendingDataObject(dataObjectId.toString())
 
-    const fullPath = path.resolve(pending ? pendingObjectsDir : uploadsDir, dataObjectId.toString())
+    const fullPath = path.resolve(uploadsDir, dataObjectId.toString())
 
     const fileInfo = await getFileInfo(fullPath)
     const fileStats = await fsPromises.stat(fullPath)
@@ -54,7 +52,6 @@ export async function getFile(
       res.setHeader('Content-Disposition', 'inline')
       res.setHeader('Content-Type', fileInfo.mimeType)
       res.setHeader('Content-Length', fileStats.size)
-      res.setHeader('X-Status', pending ? 'pending' : 'accepted')
     })
 
     stream.on('error', (err) => {


### PR DESCRIPTION
It is not clearly obvious how the node will behave, if while service a file from temp pending, the file is moved/renamed into the uploads folder. Will the move fail or will the http request handler to getFile fail. So it seems safer and more predictable behavior to only serve objects in the main uploads folder.

This PR reverts change added in https://github.com/Joystream/joystream/pull/4971 which allows serving objects in pending folder.