### PR TITLE
skip url endpoints of buckets operated by the node

### DIFF
--- a/storage-node/src/commands/dev/cleanup.ts
+++ b/storage-node/src/commands/dev/cleanup.ts
@@ -54,7 +54,7 @@ export default class DevCleanup extends Command {
     logger.info('Cleanup...')
 
     try {
-      await performCleanup([bucketId], flags.cleanupWorkersNumber, qnApi, flags.uploads)
+      await performCleanup([bucketId], flags.cleanupWorkersNumber, qnApi, flags.uploads, '')
     } catch (err) {
       logger.error(err)
       logger.error(stringify(err))

--- a/storage-node/src/commands/dev/cleanup.ts
+++ b/storage-node/src/commands/dev/cleanup.ts
@@ -54,7 +54,7 @@ export default class DevCleanup extends Command {
     logger.info('Cleanup...')
 
     try {
-      await performCleanup(flags.workerId, [bucketId], flags.cleanupWorkersNumber, qnApi, flags.uploads)
+      await performCleanup([bucketId], flags.cleanupWorkersNumber, qnApi, flags.uploads)
     } catch (err) {
       logger.error(err)
       logger.error(stringify(err))

--- a/storage-node/src/commands/dev/sync.ts
+++ b/storage-node/src/commands/dev/sync.ts
@@ -69,7 +69,6 @@ export default class DevSync extends Command {
     try {
       await performSync(
         undefined,
-        flags.workerId,
         [bucketId],
         flags.syncWorkersNumber,
         flags.syncWorkersTimeout,

--- a/storage-node/src/commands/dev/sync.ts
+++ b/storage-node/src/commands/dev/sync.ts
@@ -74,6 +74,7 @@ export default class DevSync extends Command {
         flags.syncWorkersTimeout,
         qnApi,
         flags.uploads,
+        '',
         flags.dataSourceOperatorUrl
       )
     } catch (err) {

--- a/storage-node/src/commands/server.ts
+++ b/storage-node/src/commands/server.ts
@@ -364,16 +364,7 @@ async function runSyncWithInterval(
   while (true) {
     try {
       logger.info(`Resume syncing....`)
-      await performSync(
-        api,
-        workerId,
-        buckets,
-        syncWorkersNumber,
-        syncWorkersTimeout,
-        qnApi,
-        uploadsDirectory,
-        tempDirectory
-      )
+      await performSync(api, buckets, syncWorkersNumber, syncWorkersTimeout, qnApi, uploadsDirectory, tempDirectory)
       logger.info(`Sync run complete. Next run in ${syncIntervalMinutes} minute(s).`)
       await sleep(sleepInterval)
     } catch (err) {
@@ -410,7 +401,7 @@ async function runCleanupWithInterval(
     await sleep(sleepInterval)
     try {
       logger.info(`Resume cleanup....`)
-      await performCleanup(workerId, buckets, syncWorkersNumber, qnApi, uploadsDirectory)
+      await performCleanup(buckets, syncWorkersNumber, qnApi, uploadsDirectory)
     } catch (err) {
       logger.error(`Critical cleanup error: ${err}`)
     }

--- a/storage-node/src/services/sync/cleanupService.ts
+++ b/storage-node/src/services/sync/cleanupService.ts
@@ -123,11 +123,21 @@ async function getDeletionTasksFromMovedDataObjects(
   movedDataObjects: DataObjectDetailsFragment[],
   hostId: string
 ): Promise<DeleteLocalFileTask[]> {
+  const ownOperatorUrls: string[] = []
+  for (const entry of dataObligations.storageBuckets) {
+    if (ownBuckets.includes(entry.id)) {
+      ownOperatorUrls.push(entry.operatorUrl)
+    }
+  }
+
   const bucketOperatorUrlById = new Map()
   for (const entry of dataObligations.storageBuckets) {
-    // Skip buckets operated by this storage provider
     if (!ownBuckets.includes(entry.id)) {
-      bucketOperatorUrlById.set(entry.id, entry.operatorUrl)
+      if (ownOperatorUrls.includes(entry.operatorUrl)) {
+        logger.warn(`(cleanup) Skipping remote bucket ${entry.id} - ${entry.operatorUrl}`)
+      } else {
+        bucketOperatorUrlById.set(entry.id, entry.operatorUrl)
+      }
     }
   }
 

--- a/storage-node/src/services/sync/cleanupService.ts
+++ b/storage-node/src/services/sync/cleanupService.ts
@@ -51,7 +51,8 @@ export async function performCleanup(
   buckets: string[],
   asyncWorkersNumber: number,
   qnApi: QueryNodeApi,
-  uploadDirectory: string
+  uploadDirectory: string,
+  hostId: string
 ): Promise<void> {
   logger.info('Started cleanup service...')
   const qnState = await qnApi.getQueryNodeState()
@@ -97,7 +98,8 @@ export async function performCleanup(
     buckets,
     uploadDirectory,
     model,
-    movedDataObjects
+    movedDataObjects,
+    hostId
   )
 
   await workingStack.add(deletionTasksOfDeletedDataObjects)
@@ -118,7 +120,8 @@ async function getDeletionTasksFromMovedDataObjects(
   ownBuckets: string[],
   uploadDirectory: string,
   dataObligations: DataObligations,
-  movedDataObjects: DataObjectDetailsFragment[]
+  movedDataObjects: DataObjectDetailsFragment[],
+  hostId: string
 ): Promise<DeleteLocalFileTask[]> {
   const bucketOperatorUrlById = new Map()
   for (const entry of dataObligations.storageBuckets) {
@@ -136,7 +139,7 @@ async function getDeletionTasksFromMovedDataObjects(
 
       for (const { id } of movedDataObject.storageBag.storageBuckets) {
         const url = urljoin(bucketOperatorUrlById.get(id), 'api/v1/files', movedDataObject.id)
-        await superagent.head(url).timeout(timeoutMs)
+        await superagent.head(url).timeout(timeoutMs).set('X-COLOSSUS-HOST-ID', hostId)
         dataObjectReplicationCount++
       }
 

--- a/storage-node/src/services/sync/remoteStorageData.ts
+++ b/storage-node/src/services/sync/remoteStorageData.ts
@@ -30,7 +30,7 @@ const badOperatorUrls = new NodeCache({
  *
  * @param operatorUrl - remote storage node URL
  */
-export async function getRemoteDataObjects(operatorUrl: string): Promise<string[]> {
+export async function getRemoteDataObjects(operatorUrl: string, hostId: string): Promise<string[]> {
   const url = urljoin(operatorUrl, 'api/v1/state/data-objects')
 
   const faultyOperator = badOperatorUrls.has(operatorUrl)
@@ -48,7 +48,7 @@ export async function getRemoteDataObjects(operatorUrl: string): Promise<string[
   try {
     logger.debug(`Sync - fetching available data for ${url}`)
     const timeoutMs = 120 * 1000 // 2 min
-    const response = await superagent.get(url).timeout(timeoutMs)
+    const response = await superagent.get(url).timeout(timeoutMs).set('X-COLOSSUS-HOST-ID', hostId)
 
     const data = response.body
     availableIDsCache.set(url, data, ExpirationPeriod)

--- a/storage-node/src/services/sync/synchronizer.ts
+++ b/storage-node/src/services/sync/synchronizer.ts
@@ -114,11 +114,21 @@ async function getPrepareDownloadTasks(
     bagIdByDataObjectId.set(entry.id, entry.bagId)
   }
 
+  const ownOperatorUrls: string[] = []
+  for (const entry of dataObligations.storageBuckets) {
+    if (ownBuckets.includes(entry.id)) {
+      ownOperatorUrls.push(entry.operatorUrl)
+    }
+  }
+
   const bucketOperatorUrlById = new Map()
   for (const entry of dataObligations.storageBuckets) {
-    // Skip buckets operated by this storage provider
     if (!ownBuckets.includes(entry.id)) {
-      bucketOperatorUrlById.set(entry.id, entry.operatorUrl)
+      if (ownOperatorUrls.includes(entry.operatorUrl)) {
+        logger.warn(`(sync) Skipping remote bucket ${entry.id} - ${entry.operatorUrl}`)
+      } else {
+        bucketOperatorUrlById.set(entry.id, entry.operatorUrl)
+      }
     }
   }
 

--- a/storage-node/src/services/sync/synchronizer.ts
+++ b/storage-node/src/services/sync/synchronizer.ts
@@ -43,6 +43,7 @@ export async function performSync(
   qnApi: QueryNodeApi,
   uploadDirectory: string,
   tempDirectory: string,
+  hostId: string,
   operatorUrl?: string
 ): Promise<void> {
   logger.info('Started syncing...')
@@ -68,10 +69,11 @@ export async function performSync(
       uploadDirectory,
       tempDirectory,
       workingStack,
-      asyncWorkersTimeout
+      asyncWorkersTimeout,
+      hostId
     )
   } else {
-    addedTasks = await getDownloadTasks(operatorUrl, added, uploadDirectory, tempDirectory, asyncWorkersTimeout)
+    addedTasks = await getDownloadTasks(operatorUrl, added, uploadDirectory, tempDirectory, asyncWorkersTimeout, hostId)
   }
 
   logger.debug(`Sync - started processing...`)
@@ -104,7 +106,8 @@ async function getPrepareDownloadTasks(
   uploadDirectory: string,
   tempDirectory: string,
   taskSink: TaskSink,
-  asyncWorkersTimeout: number
+  asyncWorkersTimeout: number,
+  hostId: string
 ): Promise<PrepareDownloadFileTask[]> {
   const bagIdByDataObjectId = new Map()
   for (const entry of dataObligations.dataObjects) {
@@ -147,6 +150,7 @@ async function getPrepareDownloadTasks(
 
     return new PrepareDownloadFileTask(
       operatorUrls,
+      hostId,
       bagId,
       id,
       uploadDirectory,
@@ -174,11 +178,12 @@ async function getDownloadTasks(
   addedIds: string[],
   uploadDirectory: string,
   tempDirectory: string,
-  downloadTimeout: number
+  downloadTimeout: number,
+  hostId: string
 ): Promise<DownloadFileTask[]> {
   const addedTasks = addedIds.map(
     (fileName) =>
-      new DownloadFileTask(operatorUrl, fileName, undefined, uploadDirectory, tempDirectory, downloadTimeout)
+      new DownloadFileTask(operatorUrl, fileName, undefined, uploadDirectory, tempDirectory, downloadTimeout, hostId)
   )
 
   return addedTasks

--- a/storage-node/src/services/sync/synchronizer.ts
+++ b/storage-node/src/services/sync/synchronizer.ts
@@ -37,7 +37,6 @@ export const PendingDirName = 'pending'
  */
 export async function performSync(
   api: ApiPromise | undefined,
-  workerId: number,
   buckets: string[],
   asyncWorkersNumber: number,
   asyncWorkersTimeout: number,
@@ -64,7 +63,7 @@ export async function performSync(
     addedTasks = await getPrepareDownloadTasks(
       api,
       model,
-      workerId,
+      buckets,
       added,
       uploadDirectory,
       tempDirectory,
@@ -89,7 +88,7 @@ export async function performSync(
  * Creates the download preparation tasks.
  *
  * @param api - Runtime API promise
- * @param currentWorkerId - Worker ID
+ * @param ownBuckets - list of bucket ids operated this node
  * @param dataObligations - defines the current data obligations for the node
  * @param addedIds - data object IDs to download
  * @param uploadDirectory - local directory for data uploading
@@ -100,7 +99,7 @@ export async function performSync(
 async function getPrepareDownloadTasks(
   api: ApiPromise | undefined,
   dataObligations: DataObligations,
-  currentWorkerId: number,
+  ownBuckets: string[],
   addedIds: string[],
   uploadDirectory: string,
   tempDirectory: string,
@@ -114,8 +113,8 @@ async function getPrepareDownloadTasks(
 
   const bucketOperatorUrlById = new Map()
   for (const entry of dataObligations.storageBuckets) {
-    // Skip all buckets of the current WorkerId (this storage provider)
-    if (entry.workerId !== currentWorkerId) {
+    // Skip buckets operated by this storage provider
+    if (!ownBuckets.includes(entry.id)) {
       bucketOperatorUrlById.set(entry.id, entry.operatorUrl)
     }
   }

--- a/storage-node/src/services/webApi/app.ts
+++ b/storage-node/src/services/webApi/app.ts
@@ -44,6 +44,14 @@ export async function createApp(config: AppConfig): Promise<Express> {
       next()
     },
 
+    // Avoid node connecting to itself
+    (req: express.Request, res: express.Response, next: NextFunction) => {
+      if (res.locals.x_host_id === req.headers['X-COLOSSUS-HOST-ID']) {
+        sendResponseWithError(res, next, new Error('LoopbackRequestDetected'), 'general-request')
+      } else {
+        next()
+      }
+    },
     // Catch aborted requests event early, before we get a chance to handle
     // it in multer middleware. This is an edge case which happens when only
     // a small amount of data is transferred, before multer starts parsing.

--- a/storage-node/src/services/webApi/controllers/common.ts
+++ b/storage-node/src/services/webApi/controllers/common.ts
@@ -207,4 +207,9 @@ export type AppConfig = {
      */
     minReplicationThresholdForPruning: number
   }
+
+  /**
+   * Random unique host id used sent in http request headers to identify the host
+   */
+  x_host_id: string
 }


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/4990

- When selecting "candidate" urls to fetch from, instead of ignoring all endpoints of buckets operated by worker id, we select all urls of buckets except the ones operated by the node. This ensures we don't miss any remote urls of buckets (even if they are operated by the same worker) on a different host.
- Just in-case there is a misconfiguration by the operator with respect to url endpoints, and to avoid the node connecting to itself, we send an http header `X-COLOSSUS-HOST-ID` with a new random value when the node starts up, which is checked by express server when handling requests. If the value belongs to the node, the request is dropped.