### PR TITLE
bump metadata-protobuf version and dependants

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -56,7 +56,7 @@
     "proper-lockfile": "^4.1.1",
     "slug": "^2.1.1",
     "tslib": "^1.11.1",
-    "@joystream/js": "^1.6.0"
+    "@joystream/js": "^1.6.3"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.21.4",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/cli",
   "description": "Command Line Interface for Joystream community and governance activities",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Leszek Wiesner",
   "bin": {
     "joystream-cli": "./bin/run"

--- a/joystreamjs/package.json
+++ b/joystreamjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/js",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "GPL-3.0-only",
   "description": "Joystream JS package provides  utilities required to work with Joystream network.",
   "main": "lib/index.js",
@@ -41,7 +41,7 @@
     "generate:all": "yarn generate:schema-typings"
   },
   "dependencies": {
-    "@joystream/metadata-protobuf": "^2.11.0",
+    "@joystream/metadata-protobuf": "^2.12.0",
     "@joystream/types": "^2.0.0",
     "@polkadot/util-crypto": "9.5.1",
     "axios": "^1.2.1",

--- a/metadata-protobuf/package.json
+++ b/metadata-protobuf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joystream/metadata-protobuf",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Joystream Metadata Protobuf Library",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -19,7 +19,7 @@
     "@apollo/client": "^3.2.5",
     "@joystream/hydra-common": "5.0.0-alpha.4",
     "@joystream/hydra-db-utils": "5.0.0-alpha.4",
-    "@joystream/js": "^1.6.2",
+    "@joystream/js": "^1.6.3",
     "@joystream/warthog": "^2.41.9",
     "@polkadot/types": "8.9.1"
   },

--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-node-mappings",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Mappings for hydra-processor",
   "main": "lib/src/index.js",
   "license": "MIT",

--- a/query-node/package.json
+++ b/query-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-node-root",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "GraphQL server and mappings. Generated with ♥ by Hydra-CLI",
   "scripts": {
     "build": "./build.sh",


### PR DESCRIPTION
Bump package versions:

- metadata: v2.12.0 (minor)
- joystreamjs: v1.6.3 (patch)
- query-node: v1.8.1 (patch)
- cli:v1.2.3 (patch)