### PR TITLE
temp folder refactor

### DIFF
--- a/docker-compose-no-bind-volumes.yml
+++ b/docker-compose-no-bind-volumes.yml
@@ -36,11 +36,12 @@ services:
       # - OTEL_RESOURCE_ATTRIBUTES=service.name=colossus-1,deployment.environment=production
     entrypoint: ['yarn']
     command: [
-      'start', '--worker=${COLOSSUS_1_WORKER_ID}', '--port=3333', '--uploads=/data',
+      'start', '--worker=${COLOSSUS_1_WORKER_ID}', '--port=3333', '--uploads=/data/uploads',
       '--sync', '--syncInterval=1',
       '--queryNodeEndpoint=${COLOSSUS_QUERY_NODE_URL}',
       '--apiUrl=${JOYSTREAM_NODE_WS}',
-      '--logFilePath=/logs'
+      '--logFilePath=/logs',
+      '--tempFolder=/data/temp/'
     ]
 
   distributor-1:
@@ -103,11 +104,12 @@ services:
       - ACCOUNT_URI=${COLOSSUS_2_TRANSACTOR_URI}
     entrypoint: ['yarn', 'storage-node']
     command: [
-      'server', '--worker=${COLOSSUS_2_WORKER_ID}', '--port=3333', '--uploads=/data',
+      'server', '--worker=${COLOSSUS_2_WORKER_ID}', '--port=3333', '--uploads=/data/uploads',
       '--sync', '--syncInterval=1',
       '--queryNodeEndpoint=${COLOSSUS_QUERY_NODE_URL}',
       '--apiUrl=${JOYSTREAM_NODE_WS}',
-      '--logFilePath=/logs'
+      '--logFilePath=/logs',
+      '--tempFolder=/data/temp/'
     ]
 
   distributor-2:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,11 +36,12 @@ services:
       - OTEL_RESOURCE_ATTRIBUTES=service.name=colossus-1,deployment.environment=production
     entrypoint: ['/joystream/entrypoints/storage.sh']
     command: [
-      'server', '--worker=${COLOSSUS_1_WORKER_ID}', '--port=3333', '--uploads=/data',
+      'server', '--worker=${COLOSSUS_1_WORKER_ID}', '--port=3333', '--uploads=/data/uploads/',
       '--sync', '--syncInterval=1',
       '--queryNodeEndpoint=${COLOSSUS_QUERY_NODE_URL}',
       '--apiUrl=${JOYSTREAM_NODE_WS}',
-      '--logFilePath=/logs'
+      '--logFilePath=/logs',
+      '--tempFolder=/data/temp/'
     ]
 
   distributor-1:
@@ -106,11 +107,12 @@ services:
       - ACCOUNT_URI=${COLOSSUS_2_TRANSACTOR_URI}
     entrypoint: ['yarn', 'storage-node']
     command: [
-      'server', '--worker=${COLOSSUS_2_WORKER_ID}', '--port=3333', '--uploads=/data',
+      'server', '--worker=${COLOSSUS_2_WORKER_ID}', '--port=3333', '--uploads=/data/uploads',
       '--sync', '--syncInterval=1',
       '--queryNodeEndpoint=${COLOSSUS_QUERY_NODE_URL}',
       '--apiUrl=${JOYSTREAM_NODE_WS}',
-      '--logFilePath=/logs'
+      '--logFilePath=/logs',
+      '--tempFolder=/data/temp/'
     ]
 
   distributor-2:

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -132,6 +132,9 @@
       },
       "operator": {
         "description": "Storage provider(operator) commands."
+      },
+      "util": {
+        "description": "Useful utility commands."
       }
     }
   },

--- a/storage-node/src/commands/server.ts
+++ b/storage-node/src/commands/server.ts
@@ -53,7 +53,7 @@ export default class Server extends ApiCommandBase {
     }),
     tempFolder: flags.string({
       description:
-        'Directory to store tempory files during sync and upload (absolute path).\n,Temporary directory (absolute path). If not specified a subfolder under the uploads directory will be used.',
+        'Directory to store tempory files during sync and upload (absolute path).\nIf not specified a subfolder under the uploads directory will be used.',
     }),
     port: flags.integer({
       char: 'o',
@@ -230,9 +230,10 @@ Supported values: warn, error, debug, info. Default:debug`,
 
     if (!flags.tempFolder) {
       logger.warn(
-        'It is recommended to specify a unique file path for temporary files.' +
-          'For now a temp folder under the uploads folder will be used.' +
-          'In future this will be warning will become and error!'
+        'You did not specify a path to the temporary directory. ' +
+          'A temp folder under the uploads folder willl be used. ' +
+          'In a future release passing an absolute path to a temporary directory with the ' +
+          '"tempFolder" argument will be required.'
       )
     }
 

--- a/storage-node/src/commands/util/cleanup.ts
+++ b/storage-node/src/commands/util/cleanup.ts
@@ -7,13 +7,11 @@ import { performCleanup } from '../../services/sync/cleanupService'
 /**
  * CLI command:
  * Prunes outdated data objects: removes all the local stored data objects that the operator is no longer obliged to store.
- * storage.
  *
  * @remarks
- * Should be run only during the development.
- * Shell command: "dev:cleanup"
+ * Shell command: "util:cleanup"
  */
-export default class DevCleanup extends Command {
+export default class Cleanup extends Command {
   static description = `Runs the data objects cleanup/pruning workflow. It removes all the local stored data objects that the operator is no longer obliged to store`
 
   static flags = {
@@ -48,7 +46,7 @@ export default class DevCleanup extends Command {
   }
 
   async run(): Promise<void> {
-    const { flags } = this.parse(DevCleanup)
+    const { flags } = this.parse(Cleanup)
     const bucketId = flags.bucketId.toString()
     const qnApi = new QueryNodeApi(flags.queryNodeEndpoint)
     logger.info('Cleanup...')

--- a/storage-node/src/commands/util/multihash.ts
+++ b/storage-node/src/commands/util/multihash.ts
@@ -9,10 +9,9 @@ import { print } from '../../services/helpers/stdout'
  * format.
  *
  * @remarks
- * Should be run only during the development.
- * Shell command: "dev:multihash"
+ * Shell command: "util:multihash"
  */
-export default class DevMultihash extends Command {
+export default class Multihash extends Command {
   static description = 'Creates a multihash (blake3) for a file.'
 
   static flags = {
@@ -25,7 +24,7 @@ export default class DevMultihash extends Command {
   }
 
   async run(): Promise<void> {
-    const { flags } = this.parse(DevMultihash)
+    const { flags } = this.parse(Multihash)
 
     logger.info(`Hashing ${flags.file} ....`)
 

--- a/storage-node/src/commands/util/verify-bag-id.ts
+++ b/storage-node/src/commands/util/verify-bag-id.ts
@@ -6,10 +6,9 @@ import { customFlags } from '../../command-base/CustomFlags'
  * Verifies supported bag ID types in the string format.
  *
  * @remarks
- * Should be run only during the development.
  * Shell command: "dev:verify-bag-id"
  */
-export default class DevVerifyBagId extends Command {
+export default class VerifyBagId extends Command {
   static description = 'The command verifies bag id supported by the storage node. Requires chain connection.'
 
   static flags = {
@@ -21,7 +20,7 @@ export default class DevVerifyBagId extends Command {
   }
 
   async run(): Promise<void> {
-    const { flags } = this.parse(DevVerifyBagId)
+    const { flags } = this.parse(VerifyBagId)
 
     logger.info(`Parsed: ${flags.bagId}`)
   }

--- a/storage-node/src/services/caching/localDataObjects.ts
+++ b/storage-node/src/services/caching/localDataObjects.ts
@@ -35,8 +35,17 @@ export async function getDataObjectIDs(): Promise<string[]> {
 export async function loadDataObjectIdCache(uploadDir: string): Promise<void> {
   await lock.acquireAsync()
 
-  const ids = await getLocalFileNames(uploadDir)
-  ids.forEach((id) => idCache.set(id, 0))
+  const names = await getLocalFileNames(uploadDir)
+
+  names
+    .filter((name) => {
+      // Just incase the directory is polluted with other files,
+      // filter out filenames that do not match with an objectid (number)
+      const num = Number(name)
+      return Number.isInteger(num)
+    })
+    .forEach((id) => idCache.set(id, 0))
+
   logger.debug(`Local ID cache loaded.`)
 
   lock.release()

--- a/storage-node/src/services/caching/localDataObjects.ts
+++ b/storage-node/src/services/caching/localDataObjects.ts
@@ -38,12 +38,9 @@ export async function loadDataObjectIdCache(uploadDir: string): Promise<void> {
   const names = await getLocalFileNames(uploadDir)
 
   names
-    .filter((name) => {
-      // Just incase the directory is polluted with other files,
-      // filter out filenames that do not match with an objectid (number)
-      const num = Number(name)
-      return Number.isInteger(num)
-    })
+    // Just incase the directory is polluted with other files,
+    // filter out filenames that do not match with an objectid (number)
+    .filter((name) => Number.isInteger(Number(name)))
     .forEach((id) => idCache.set(id, 0))
 
   logger.debug(`Local ID cache loaded.`)

--- a/storage-node/src/services/sync/tasks.ts
+++ b/storage-node/src/services/sync/tasks.ts
@@ -108,7 +108,7 @@ export class DownloadFileTask implements SyncTask {
     const filepath = path.join(this.uploadsDirectory, this.dataObjectId)
     // We create tempfile first to mitigate partial downloads on app (or remote node) crash.
     // This partial downloads will be cleaned up during the next sync iteration.
-    const tempFilePath = path.join(this.uploadsDirectory, this.tempDirectory, uuidv4())
+    const tempFilePath = path.join(this.tempDirectory, uuidv4())
     try {
       const timeoutMs = this.downloadTimeout * 60 * 1000
       // Casting because of:


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/4977

- Temp folder can now be configured with argument with a fully qualified path, with a check that it is not the same as the uploads folder.
- Added check to ensure logs folder is not the same directory as the uploads folder.
- Improved initialization of the uploads directory, reading data objects from the uploads folder filters out any files/subfolders without a name matching the data-object-id (ie. a number)
- Improved initialization of temp directory. It will not be recursively deleted on startup (risky).
- Renamed the 'dev' commands to 'util' commands although I have some reservation about using the cleanup command outside of the context of the running server.. Perhaps we should drop them.