### PR TITLE
[Colossus] fix: Unhandled event on Superagent due to timeout

### DIFF
--- a/storage-node/src/services/sync/tasks.ts
+++ b/storage-node/src/services/sync/tasks.ts
@@ -120,7 +120,15 @@ export class DownloadFileTask implements SyncTask {
         if (!res.ok) {
           logger.error(`Sync - unexpected status code(${res.statusCode}) for ${res?.request?.url}`)
         }
+
+        // Handle 'error' event on Response too, because it will be emitted if request was
+        // prematurely aborted/closed due to timeout and the response still was not completed
+        // See: https://github.com/nodejs/node/blob/cd171576b2d1376dae3eb371b6da5ccf04dc4a85/lib/_http_client.js#L439-L441
+        res.on('error', (err: Error) => {
+          logger.error(`Sync - fetching data error for ${this.url}: ${err}`, { err })
+        })
       })
+
       request.on('error', (err) => {
         logger.error(`Sync - fetching data error for ${this.url}: ${err}`, { err })
       })


### PR DESCRIPTION
addresses #4995

# Problem

When a timeout is reached, Superagent internally only closes the request stream and not the response, however in [nodejs](https://github.com/nodejs/node/blob/cd171576b2d1376dae3eb371b6da5ccf04dc4a85/lib/_http_client.js#L439-L441), if the request prematurely closes, and response is not finished then response instance also emits the `error` event, so we should also handle that (which was not handled previously).