### PR TITLE
storage-node: moveFile

### DIFF
--- a/storage-node/src/services/helpers/moveFile.ts
+++ b/storage-node/src/services/helpers/moveFile.ts
@@ -1,0 +1,8 @@
+import fs from 'fs'
+const fsPromises = fs.promises
+
+// Alternative to fsPromises.rename to allow moving files between volumes
+export async function moveFile(src: fs.PathLike, dest: fs.PathLike): Promise<void> {
+  await fsPromises.copyFile(src, dest)
+  await fsPromises.unlink(src)
+}

--- a/storage-node/src/services/helpers/moveFile.ts
+++ b/storage-node/src/services/helpers/moveFile.ts
@@ -1,8 +1,21 @@
 import fs from 'fs'
 const fsPromises = fs.promises
 
-// Alternative to fsPromises.rename to allow moving files between volumes
+/**
+ * Asynchronously copies `src` to `dest`. If `dest` already exists, operation is aborted
+ * to avoid corrupting destination file or removal by nodejs when an error occurs after
+ * it has been opened for writing.
+ * Use this function instead of `rename` to move files between volumes, otherwise
+ * operation fails with: EXDEV: cross-device link not permitted.
+ * @param src A path to the source file.
+ * @param dest A path to the destination file.
+ */
 export async function moveFile(src: fs.PathLike, dest: fs.PathLike): Promise<void> {
-  await fsPromises.copyFile(src, dest)
+  // `COPYFILE_EXCL` flag causes the copy operation to fail if `dest` already exists.
+  const { COPYFILE_EXCL } = fs.constants
+  // Try to copy source file to destination
+  await fsPromises.copyFile(src, dest, COPYFILE_EXCL)
+
+  // Only if copy operation succeeds we delete the source file
   await fsPromises.unlink(src)
 }

--- a/storage-node/src/services/sync/acceptPendingObjects.ts
+++ b/storage-node/src/services/sync/acceptPendingObjects.ts
@@ -9,6 +9,7 @@ import logger from '../logger'
 import { QueryNodeApi } from '../queryNode/api'
 import { acceptPendingDataObjectsBatch } from '../runtime/extrinsics'
 import { hashFile } from '../helpers/hashing'
+import { moveFile } from '../helpers/moveFile'
 
 const fsPromises = fs.promises
 
@@ -159,7 +160,7 @@ export class AcceptPendingObjectsService {
         await fsPromises.unlink(currentPath)
       } catch {
         // If the file does not exist in the uploads directory, proceed with the rename
-        await fsPromises.rename(currentPath, newPath)
+        await moveFile(currentPath, newPath)
         registerNewDataObjectId(dataObjectId)
         addDataObjectIdToCache(dataObjectId)
       }

--- a/storage-node/src/services/sync/tasks.ts
+++ b/storage-node/src/services/sync/tasks.ts
@@ -14,6 +14,7 @@ import {
 } from '../caching/localDataObjects'
 import { isNewDataObject } from '../caching/newUploads'
 import { hashFile } from '../helpers/hashing'
+import { moveFile } from '../helpers/moveFile'
 const fsPromises = fs.promises
 
 /**
@@ -147,7 +148,7 @@ export class DownloadFileTask implements SyncTask {
       })
       await streamPipeline(request, fileStream)
       await this.verifyDownloadedFile(tempFilePath)
-      await fsPromises.rename(tempFilePath, filepath)
+      await moveFile(tempFilePath, filepath)
       addDataObjectIdToCache(this.dataObjectId)
     } catch (err) {
       logger.warn(`Sync - fetching data error for ${url}: ${err}`, { err })

--- a/storage-node/src/services/webApi/controllers/filesApi.ts
+++ b/storage-node/src/services/webApi/controllers/filesApi.ts
@@ -25,7 +25,7 @@ import {
 } from '../types'
 import { AppConfig, WebApiError, getHttpStatusCodeByError, sendResponseWithError } from './common'
 import _ from 'lodash'
-import { moveFile } from 'src/services/helpers/moveFile'
+import { moveFile } from '../../helpers/moveFile'
 const fsPromises = fs.promises
 
 /**

--- a/storage-node/src/services/webApi/controllers/filesApi.ts
+++ b/storage-node/src/services/webApi/controllers/filesApi.ts
@@ -25,6 +25,7 @@ import {
 } from '../types'
 import { AppConfig, WebApiError, getHttpStatusCodeByError, sendResponseWithError } from './common'
 import _ from 'lodash'
+import { moveFile } from 'src/services/helpers/moveFile'
 const fsPromises = fs.promises
 
 /**
@@ -143,7 +144,7 @@ export async function uploadFile(
     const { pendingDataObjectsDir } = res.locals
     const newPathPending = path.join(pendingDataObjectsDir, dataObjectId)
 
-    await fsPromises.rename(fileObj.path, newPathPending)
+    await moveFile(fileObj.path, newPathPending)
 
     res.status(201).json({
       id: hash,


### PR DESCRIPTION
Introduce `moveFile(src, dest)` in place of  `fs.promises.rename(src, dest)`, to avoid `EXDEV: cross-device link not permitted` error when moving a file from `temp` and `pending` folders into the `uploads` folder when they exist on different volumes.