### PR TITLE
project-token pallet: disable all amm dispatch calls when pallet is frozen

### DIFF
--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -186,7 +186,11 @@ jobs:
     name: Runtime Upgrade from production runtime
     needs: build_images
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
+    # Disabling until we find a workaround
+    # as it is no longer practical to start the node
+    # while importing huge state from production network in genesis block.
+    # if: github.ref != 'refs/heads/master'
+    if: false
     steps:
       # Checkout master branch
       - name: check out master repo

--- a/runtime-modules/content/src/tests/creator_tokens/activate_amm.rs
+++ b/runtime-modules/content/src/tests/creator_tokens/activate_amm.rs
@@ -2,6 +2,9 @@
 use crate::tests::fixtures::*;
 use crate::tests::mock::*;
 use crate::*;
+use frame_support::assert_ok;
+use frame_system::RawOrigin;
+use project_token::Error as ProjectTokenError;
 
 #[test]
 fn unsuccessful_activate_amm_non_existing_channel() {
@@ -153,5 +156,16 @@ fn unsuccessful_activate_member_channel_creator_token_amm_with_ongoing_transfer(
 
         ActivateAmmFixture::default()
             .call_and_assert(Err(Error::<Test>::InvalidChannelTransferStatus.into()));
+    })
+}
+
+#[test]
+fn unsuccessful_activate_creator_token_amm_with_frozen_pallet() {
+    with_default_mock_builder(|| {
+        ContentTest::with_member_channel().setup();
+        IssueCreatorTokenFixture::default().call_and_assert(Ok(()));
+        assert_ok!(Token::set_frozen_status(RawOrigin::Root.into(), true));
+        ActivateAmmFixture::default()
+            .call_and_assert(Err(ProjectTokenError::<Test>::PalletFrozen.into()));
     })
 }

--- a/runtime-modules/content/src/tests/creator_tokens/deactivate_amm.rs
+++ b/runtime-modules/content/src/tests/creator_tokens/deactivate_amm.rs
@@ -2,6 +2,9 @@
 use crate::tests::fixtures::*;
 use crate::tests::mock::*;
 use crate::*;
+use frame_support::assert_ok;
+use frame_system::RawOrigin;
+use project_token::Error as ProjectTokenError;
 
 #[test]
 fn unsuccessful_deactivate_amm_non_existing_channel() {
@@ -133,5 +136,17 @@ fn successful_deactivate_curator_channel_creator_token_amm_by_lead() {
             .with_sender(LEAD_ACCOUNT_ID)
             .with_actor(ContentActor::Lead)
             .call_and_assert(Ok(()));
+    })
+}
+
+#[test]
+fn unsuccessful_deactivate_creator_token_amm_with_frozen_pallet() {
+    with_default_mock_builder(|| {
+        ContentTest::with_member_channel().setup();
+        IssueCreatorTokenFixture::default().call_and_assert(Ok(()));
+        ActivateAmmFixture::default().call_and_assert(Ok(()));
+        assert_ok!(Token::set_frozen_status(RawOrigin::Root.into(), true));
+        DeactivateAmmFixture::default()
+            .call_and_assert(Err(ProjectTokenError::<Test>::PalletFrozen.into()));
     })
 }

--- a/runtime-modules/content/src/weights.rs
+++ b/runtime-modules/content/src/weights.rs
@@ -1310,6 +1310,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Proof: Content CuratorGroupById (max_values: None, max_size: Some(1037), added: 3512, mode: MaxEncodedLen)
 	// Storage: Token TokenInfoById (r:1 w:1)
 	// Proof: Token TokenInfoById (max_values: None, max_size: Some(352), added: 2827, mode: MaxEncodedLen)
+	// Storage: Token PalletFrozen (r:1 w:0)
 	// Storage: Token MinAmmSlopeParameter (r:1 w:0)
 	// Proof: Token MinAmmSlopeParameter (max_values: Some(1), max_size: Some(16), added: 511, mode: MaxEncodedLen)
 	// Storage: System Account (r:1 w:1)
@@ -1321,7 +1322,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 188_296 nanoseconds.
 		Weight::from_parts(192_189_000, 0u64)
 			.saturating_add(Weight::from_parts(0, 21427))
-			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	// Storage: Content ChannelById (r:1 w:0)
@@ -1332,6 +1333,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Proof: Content CuratorGroupById (max_values: None, max_size: Some(1037), added: 3512, mode: MaxEncodedLen)
 	// Storage: Token TokenInfoById (r:1 w:1)
 	// Proof: Token TokenInfoById (max_values: None, max_size: Some(352), added: 2827, mode: MaxEncodedLen)
+	// Storage: Token PalletFrozen (r:1 w:0)
 	// Storage: Token AmmDeactivationThreshold (r:1 w:0)
 	// Proof: Token AmmDeactivationThreshold (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
 	// Storage: System Account (r:1 w:0)
@@ -1343,7 +1345,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 164_519 nanoseconds.
 		Weight::from_parts(166_906_000, 0u64)
 			.saturating_add(Weight::from_parts(0, 21415))
-			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	// Storage: Content ChannelById (r:1 w:0)

--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -1581,6 +1581,8 @@ impl<T: Config>
         member_id: T::MemberId,
         params: AmmParamsOf<T>,
     ) -> DispatchResult {
+        Self::ensure_unfrozen_state()?;
+
         let token_data = Self::ensure_token_exists(token_id)?;
 
         ensure!(
@@ -1624,6 +1626,8 @@ impl<T: Config>
     /// - state set to idle
     /// - event deposited
     fn deactivate_amm(token_id: T::TokenId, member_id: T::MemberId) -> DispatchResult {
+        Self::ensure_unfrozen_state()?;
+
         let token_data = Self::ensure_token_exists(token_id)?;
         Self::ensure_amm_can_be_deactivated(&token_data)?;
 

--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -836,6 +836,8 @@ decl_module! {
         /// - event deposited
         #[weight = WeightInfoToken::<T>::buy_on_amm_with_existing_account()]
         fn buy_on_amm(origin, token_id: T::TokenId, member_id: T::MemberId, amount: <T as Config>::Balance, slippage_tolerance: Option<(Permill, JoyBalanceOf<T>)>) -> DispatchResult {
+            Self::ensure_unfrozen_state()?;
+
             if amount.is_zero() {
                 return Ok(()); // noop
             }
@@ -916,6 +918,8 @@ decl_module! {
         /// - event deposited
         #[weight = WeightInfoToken::<T>::sell_on_amm()]
         fn sell_on_amm(origin, token_id: T::TokenId, member_id: T::MemberId, amount: <T as Config>::Balance, slippage_tolerance: Option<(Permill, JoyBalanceOf<T>)>) -> DispatchResult {
+            Self::ensure_unfrozen_state()?;
+
             if amount.is_zero() {
                return Ok(()); // noop
             }

--- a/runtime-modules/project-token/src/weights.rs
+++ b/runtime-modules/project-token/src/weights.rs
@@ -227,6 +227,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
+	// Storage: Token PalletFrozen (r:1 w:0)
 	// Storage: Membership MembershipById (r:1 w:0)
 	// Proof: Membership MembershipById (max_values: None, max_size: Some(125), added: 2600, mode: MaxEncodedLen)
 	// Storage: Token TokenInfoById (r:1 w:1)
@@ -246,9 +247,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 85_398 nanoseconds.
 		Weight::from_parts(87_934_000, 0u64)
 			.saturating_add(Weight::from_parts(0, 20547))
-			.saturating_add(T::DbWeight::get().reads(7_u64))
+			.saturating_add(T::DbWeight::get().reads(8_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
+	// Storage: Token PalletFrozen (r:1 w:0)
 	// Storage: Membership MembershipById (r:1 w:0)
 	// Proof: Membership MembershipById (max_values: None, max_size: Some(125), added: 2600, mode: MaxEncodedLen)
 	// Storage: Token TokenInfoById (r:1 w:1)
@@ -268,9 +270,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 86_178 nanoseconds.
 		Weight::from_parts(88_253_000, 0u64)
 			.saturating_add(Weight::from_parts(0, 20547))
-			.saturating_add(T::DbWeight::get().reads(7_u64))
+			.saturating_add(T::DbWeight::get().reads(8_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
+	// Storage: Token PalletFrozen (r:1 w:0)
 	// Storage: Membership MembershipById (r:1 w:0)
 	// Proof: Membership MembershipById (max_values: None, max_size: Some(125), added: 2600, mode: MaxEncodedLen)
 	// Storage: Token TokenInfoById (r:1 w:1)
@@ -288,7 +291,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 73_200 nanoseconds.
 		Weight::from_parts(75_404_000, 0u64)
 			.saturating_add(Weight::from_parts(0, 19046))
-			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().reads(8_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 }

--- a/tests/network-tests/package.json
+++ b/tests/network-tests/package.json
@@ -34,7 +34,8 @@
     "multihashes": "^4.0.3",
     "node-cleanup": "^2.1.2",
     "@joystream/js": "^1.6.0",
-    "uuid": "^7.0.3"
+    "uuid": "^7.0.3",
+    "sleep-promise": "^9.1.0"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.21.4",

--- a/tests/network-tests/run-runtime-upgrade-tests.sh
+++ b/tests/network-tests/run-runtime-upgrade-tests.sh
@@ -162,8 +162,6 @@ function main {
     # 2. clone live chainspec with fork it
     fork_off_init
     echo >&2 "storage downloaded & dumped into the raw chainspec"
-    return
-
     # 3. set path to new runtime.wasm
     set_new_runtime_wasm_path
     echo >&2 "new wasm path set"

--- a/tests/network-tests/run-runtime-upgrade-tests.sh
+++ b/tests/network-tests/run-runtime-upgrade-tests.sh
@@ -166,7 +166,6 @@ function main {
     # 3. set path to new runtime.wasm
     set_new_runtime_wasm_path
     echo >&2 "new wasm path set"
-<<<<<<< HEAD
 
     # 4. early chain db init
     export JOYSTREAM_NODE_TAG=${RUNTIME}
@@ -187,29 +186,13 @@ function main {
     # Wait for chain and query node to get in sync
     sleep 200
 
-    # 6. Bootstrap storage infra
-    ./start-storage.sh
-    export REUSE_KEYS=true
-    export SKIP_STORAGE_AND_DISTRIBUTION=true
-
-    # Do some setup and checks before the upgrade
-    ./run-test-scenario.sh preRuntimeUpgrade
-=======
-    # 4. copy chainspec to disk
-    export_chainspec_file_to_disk
-    echo >&2 "chainspec exported"
-    # 5. start node
-    CONTAINER_ID=$(start_old_joystream_node)
-    echo >&2 "mainnet node starting"
-
-    # wait 1 minute
-    sleep 90
-
     # 6. Bootstrap storage infra because we need to run content-directory tests after runtime upgrade
     if [ "${NO_STORAGE}" != true ]; then
         ./start-storage.sh
     fi
->>>>>>> master
+
+    # Do some setup and checks before the upgrade
+    ./run-test-scenario.sh preRuntimeUpgrade
 
     ./run-test-scenario.sh runtimeUpgrade
 

--- a/tests/network-tests/src/flows/content/activeVideoCounters.ts
+++ b/tests/network-tests/src/flows/content/activeVideoCounters.ts
@@ -9,6 +9,7 @@ import {
 } from '../../fixtures/content'
 import BN from 'bn.js'
 import { createJoystreamCli } from '../utils'
+import sleep from 'sleep-promise'
 
 export default async function activeVideoCounters({ api, query, env }: FlowProps): Promise<void> {
   const debug = extendDebug('flow:active-video-counters')
@@ -49,6 +50,9 @@ export default async function activeVideoCounters({ api, query, env }: FlowProps
   )
   await new FixtureRunner(createChannelsAndVideos).run()
   const { channelIds, videosData } = createChannelsAndVideos.getCreatedItems()
+
+  // Allow time for processor to process videos created
+  await sleep(10 * 1000)
 
   // check that active video counters are working
   const activeVideoCountersFixture = new ActiveVideoCountersFixture(

--- a/tests/network-tests/src/flows/content/curatorModerationActions.ts
+++ b/tests/network-tests/src/flows/content/curatorModerationActions.ts
@@ -21,6 +21,7 @@ import {
   DeleteVideoAssetsAsModeratorParams,
 } from '../../fixtures/content/curatorModeration/DeleteVideoAssetsByModerator'
 import { createJoystreamCli } from '../utils'
+import sleep from 'sleep-promise'
 
 export default async function curatorModerationActions({ api, query }: FlowProps): Promise<void> {
   const debug = extendDebug('flow:curator-moderation-actions')
@@ -72,6 +73,9 @@ export default async function curatorModerationActions({ api, query }: FlowProps
   await new FixtureRunner(createChannelsAndVideos).run()
 
   const { channelIds, videosData } = createChannelsAndVideos.getCreatedItems()
+
+  // Allow time for processor to process videos created
+  await sleep(10 * 1000)
 
   // create curator & curator group
 

--- a/utils/api-scripts/package.json
+++ b/utils/api-scripts/package.json
@@ -21,6 +21,7 @@
     "@polkadot/util": "9.5.1",
     "@polkadot/util-crypto": "9.5.1",
     "@types/bn.js": "^5.1.0",
+    "bfj": "^8.0.0",
     "bn.js": "^5.2.1"
   },
   "devDependencies": {

--- a/utils/api-scripts/src/fork-off.ts
+++ b/utils/api-scripts/src/fork-off.ts
@@ -2,6 +2,7 @@ import { ApiPromise, WsProvider } from '@polkadot/api'
 import { xxhashAsHex } from '@polkadot/util-crypto'
 import fs from 'fs'
 import path from 'path'
+import bfj from 'bfj'
 
 /**
  * All module prefixes except those mentioned in the skippedModulesPrefix will be added to this by the script.
@@ -62,8 +63,8 @@ async function main() {
   })
 
   // blank starting chainspec guaranteed to exist
-  const storage: Storage = JSON.parse(fs.readFileSync(storagePath, 'utf8'))
-  const chainSpec = JSON.parse(fs.readFileSync(specPath, 'utf8'))
+  const storage: Storage = await bfj.read(storagePath)
+  const chainSpec = await bfj.read(specPath)
 
   // Grab the items to be moved, then iterate through and insert into storage
   storage.result

--- a/utils/api-scripts/src/fork-off.ts
+++ b/utils/api-scripts/src/fork-off.ts
@@ -1,7 +1,7 @@
 import { ApiPromise, WsProvider } from '@polkadot/api'
 import { xxhashAsHex } from '@polkadot/util-crypto'
-import fs from 'fs'
 import path from 'path'
+
 const bfj = require('bfj')
 
 /**
@@ -36,6 +36,12 @@ const skippedModulesPrefix = [
   'Instance3WorkingGroup', // empty content working group
   'Instance9WorkingGroup', // empty distribution working group
 ]
+const skippedKeys = [
+  // encoded storage key for `minAuctionDuration` key
+  '0xb5a494c92fa4747cc071573e93b32b87f9ad4eaa35a4c52d9289acbc42eba9d9',
+  // encoded storage key for `nftLimitsEnabled` key
+  '0xb5a494c92fa4747cc071573e93b32b87d2c14024f1b303fdc87019c4c1facfde'
+]
 
 async function main() {
   // paths & env variables
@@ -63,22 +69,20 @@ async function main() {
   })
 
   // blank starting chainspec guaranteed to exist
-  const storage: Storage = await bfj.read(storagePath)
+  console.error('Loading state storage')
+  const storage: Storage = await bfj.read(storagePath, { bufferLength: 4096 })
+  console.error('Loading raw chain spec')
   const chainSpec = await bfj.read(specPath)
 
   // Grab the items to be moved, then iterate through and insert into storage
-  storage.result
-    .filter((i) => prefixes.some((prefix) => i[0].startsWith(prefix)))
-    .forEach(([key, value]) => {
-      if (
-        // encoded storage key for `minAuctionDuration` key
-        key !== '0xb5a494c92fa4747cc071573e93b32b87f9ad4eaa35a4c52d9289acbc42eba9d9' &&
-        // encoded storage key for `nftLimitsEnabled` key
-        key !== '0xb5a494c92fa4747cc071573e93b32b87d2c14024f1b303fdc87019c4c1facfde'
-      ) {
-        chainSpec.genesis.raw.top[key] = value
-      }
-    })
+  // We are not using a storage.result.forEach to preserve memory
+  console.error('constructing final genesis chainspec')
+  for (let pair; pair = storage.result.pop();) {
+    const [key, value] = pair
+    if (skippedKeys.includes(key)) continue
+    if (!prefixes.some((prefix) => key.startsWith(prefix))) continue
+    chainSpec.genesis.raw.top[key] = value
+  }
 
   // Delete System.LastRuntimeUpgrade to ensure that the on_runtime_upgrade event is triggered
   delete chainSpec.genesis.raw.top['0x26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8']
@@ -86,12 +90,11 @@ async function main() {
   // To prevent the validator set from changing mid-test, set Staking.ForceEra to ForceNone ('0x02')
   chainSpec.genesis.raw.top['0x5f3e4907f716ac89b6347d15ececedcaf7dad0317324aecae8744b87fc95f2f3'] = '0x02'
 
-  fs.writeFileSync(forkedSpecPath, JSON.stringify(chainSpec, null, 4))
-
-  process.exit()
+  console.error('Writing chainspec to', forkedSpecPath)
+  await bfj.write(forkedSpecPath, chainSpec, { space: 4, bufferLength: 4096 })
 }
 
-main().catch(console.error)
+main().catch(console.error).finally(() => process.exit())
 
 interface Storage {
   'jsonrpc': string

--- a/utils/api-scripts/src/fork-off.ts
+++ b/utils/api-scripts/src/fork-off.ts
@@ -2,7 +2,7 @@ import { ApiPromise, WsProvider } from '@polkadot/api'
 import { xxhashAsHex } from '@polkadot/util-crypto'
 import fs from 'fs'
 import path from 'path'
-import bfj from 'bfj'
+const bfj = require('bfj')
 
 /**
  * All module prefixes except those mentioned in the skippedModulesPrefix will be added to this by the script.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6532,6 +6532,17 @@ bfj@^6.1.1:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+bfj@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/bfj/-/bfj-8.0.0.tgz#d15931bd5ef1ef5c874a59e6ef00653de8416568"
+  integrity sha512-6KJe4gFrZ4lhmvWcUIj37yFAs36mi2FZXuTkw6udZ/QsX/znFypW4SatqcLA5K5T4BAWgJZD73UFEJJQxuJjoA==
+  dependencies:
+    bluebird "^3.7.2"
+    check-types "^11.2.3"
+    hoopy "^0.1.4"
+    jsonpath "^1.1.1"
+    tryer "^1.0.1"
+
 big-integer@^1.6.17:
   version "1.6.51"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
@@ -6633,7 +6644,7 @@ blob-to-it@0.0.2:
   dependencies:
     browser-readablestream-to-it "^0.0.2"
 
-bluebird@^3.3.5, bluebird@^3.5.1, bluebird@^3.5.5:
+bluebird@^3.3.5, bluebird@^3.5.1, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -7287,6 +7298,11 @@ check-type@^0.4.11:
   integrity sha512-dtbWcp8jwTktDzqdOPPAKmgjQD0nrINuKrOu7bZPA3bCaEFJ00OMfFpsO6txy1y+09P9sp6tQq7T5ons/HcNYw==
   dependencies:
     underscore "1.6.0"
+
+check-types@^11.2.3:
+  version "11.2.3"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-11.2.3.tgz#1ffdf68faae4e941fce252840b1787b8edc93b71"
+  integrity sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg==
 
 check-types@^8.0.3:
   version "8.0.3"
@@ -9420,7 +9436,7 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-escodegen@^1.9.1:
+escodegen@^1.8.1, escodegen@^1.9.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
   integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
@@ -9797,6 +9813,11 @@ espree@^7.3.0, espree@^7.3.1:
     acorn "^7.4.0"
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^1.3.0"
+
+esprima@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.2.2.tgz#76a0fd66fcfe154fd292667dc264019750b1657b"
+  integrity sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==
 
 esprima@3.1.0:
   version "3.1.0"
@@ -14099,6 +14120,15 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
+
+jsonpath@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.1.1.tgz#0ca1ed8fb65bb3309248cc9d5466d12d5b0b9901"
+  integrity sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==
+  dependencies:
+    esprima "1.2.2"
+    static-eval "2.0.2"
+    underscore "1.12.1"
 
 jsonpointer@^4.0.1:
   version "4.1.0"
@@ -20033,6 +20063,13 @@ standard-as-callback@^2.1.0:
   resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
   integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
 
+static-eval@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
+  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
+  dependencies:
+    escodegen "^1.8.1"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -21355,6 +21392,11 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
+
+underscore@1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
 underscore@1.6.0:
   version "1.6.0"


### PR DESCRIPTION
Fixes https://github.com/Joystream/joystream/issues/5028

Was there a reason we didn't disable amm buy/sell dispatch calls. Or is this a case that AMM work was merged into nara after freezing feature was added and we simply overlooked it?

- Added frozen pallet guard to following calls:
  - `buy_on_amm`
  - `sell_on_amm`
  - `activate_amm`
  - `deactivate_amm`
- Adjusted weights to account for `+1` storage read, checking frozen status
- Added unit tests for activate and deactive amm tests for frozen pallet cases.