### PR TITLE
Colossus 3.10.2

### DIFF
--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.10.2
+- Fix processing large arrays causing high cpu during sync and cleanup runs [#5033](https://github.com/Joystream/joystream/pull/5033)
+
+- Fix task runner to avoid ending prematurely on individual task failure [#5033](https://github.com/Joystream/joystream/pull/5033)
+
 ### 3.10.1
 
 - Bug fix: call stack size exceeded error - [#5021](https://github.com/Joystream/joystream/pull/5021)

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storage-node",
   "description": "Joystream storage subsystem.",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "author": "Joystream contributors",
   "bin": {
     "storage-node": "./bin/run"

--- a/storage-node/src/commands/util/fetch-bucket.ts
+++ b/storage-node/src/commands/util/fetch-bucket.ts
@@ -4,10 +4,10 @@ import { QueryNodeApi } from '../..//services/queryNode/api'
 import logger from '../../services/logger'
 import stringify from 'fast-safe-stringify'
 import path from 'path'
-
+import { loadDataObjectIdCache } from '../../services/caching/localDataObjects'
 /**
  * CLI command:
- * Fetch all data objects from a bucket into local store.
+ * Fetch data objects assigned to assigned bucket from remote node(s) into local store.
  *
  * @remarks
  * Should not be executed while server is running.
@@ -18,11 +18,6 @@ export default class FetchBucket extends Command {
 
   static flags = {
     help: flags.help({ char: 'h' }),
-    workerId: flags.integer({
-      char: 'w',
-      required: true,
-      description: 'Storage node operator worker ID.',
-    }),
     bucketId: flags.integer({
       char: 'b',
       required: true,
@@ -66,6 +61,8 @@ export default class FetchBucket extends Command {
     const { flags } = this.parse(FetchBucket)
     const bucketId = flags.bucketId.toString()
     const qnApi = new QueryNodeApi(flags.queryNodeEndpoint)
+    await loadDataObjectIdCache(flags.uploads)
+
     logger.info('Fetching bucket...')
 
     try {

--- a/storage-node/src/services/caching/localDataObjects.ts
+++ b/storage-node/src/services/caching/localDataObjects.ts
@@ -114,6 +114,15 @@ export function getDataObjectIdFromCache(
 }
 
 /**
+ * Checks if data object is present.
+ * @param dataObjectId
+ * @returns boolean
+ */
+export function isDataObjectIdInCache(dataObjectId: string): boolean {
+  return idCache.has(dataObjectId)
+}
+
+/**
  * Returns file names from the local directory, ignoring subfolders.
  *
  * @param directory - local directory to get file names from

--- a/storage-node/src/services/sync/cleanupService.ts
+++ b/storage-node/src/services/sync/cleanupService.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import superagent from 'superagent'
 import urljoin from 'url-join'
 import { getDataObjectIDs } from '../../services/caching/localDataObjects'
@@ -73,8 +72,8 @@ export async function performCleanup(
     getStorageObligationsFromRuntime(qnApi, buckets),
     getDataObjectIDs(),
   ])
-  const assignedObjectsIds = model.dataObjects.map((obj) => obj.id)
-  const removedIds = _.difference(storedObjectsIds, assignedObjectsIds)
+  const assignedObjectsIds = new Set(model.dataObjects.map((obj) => obj.id))
+  const removedIds = storedObjectsIds.filter((id) => !assignedObjectsIds.has(id))
   const removedObjects = await getDataObjectsByIDs(qnApi, removedIds)
 
   logger.debug(`Cleanup - pruning ${removedIds.length} obsolete objects`)

--- a/storage-node/src/services/sync/synchronizer.ts
+++ b/storage-node/src/services/sync/synchronizer.ts
@@ -1,5 +1,4 @@
-import _ from 'lodash'
-import { getDataObjectIDs } from '../../services/caching/localDataObjects'
+import { isDataObjectIdInCache } from '../../services/caching/localDataObjects'
 import logger from '../../services/logger'
 import { QueryNodeApi } from '../queryNode/api'
 import { DataObligations, getStorageObligationsFromRuntime } from './storageObligations'
@@ -45,15 +44,13 @@ export async function performSync(
   selectedOperatorUrl?: string
 ): Promise<void> {
   logger.info('Started syncing...')
-  const [model, files] = await Promise.all([getStorageObligationsFromRuntime(qnApi, buckets), getDataObjectIDs()])
+  const model = await getStorageObligationsFromRuntime(qnApi, buckets)
 
   const required = model.dataObjects
 
-  const added = _.differenceWith(required, files, (required, file) => required.id === file)
-  const removed = _.differenceWith(files, required, (file, required) => file === required.id)
+  const added = required.filter((obj) => !isDataObjectIdInCache(obj.id))
 
   logger.debug(`Sync - new objects: ${added.length}`)
-  logger.debug(`Sync - obsolete objects: ${removed.length}`)
 
   const workingStack = new WorkingStack()
 

--- a/storage-node/src/services/sync/workingProcess.ts
+++ b/storage-node/src/services/sync/workingProcess.ts
@@ -89,7 +89,12 @@ export class TaskProcessor {
 
       if (task !== null) {
         logger.debug(task.description())
-        await task.execute()
+        try {
+          await task.execute()
+        } catch (err) {
+          // Catch the task failure to avoid the current process worker failing
+          logger.warn(`task failed: ${err.message}`)
+        }
       } else {
         if (this.exitOnCompletion) {
           return
@@ -126,6 +131,6 @@ export class TaskProcessorSpawner {
       processes.push(processor.process())
     }
 
-    await Promise.all(processes)
+    await Promise.allSettled(processes)
   }
 }


### PR DESCRIPTION
After doing some [measurements](https://github.com/Joystream/joystream/blob/cf117617388ae41dc9f82407d2561d433142e695/storage-node/src/commands/util/test-1.ts) on the performance of `lodash.differenceWith` it became evident that this was main cause of high CPU usage at start of sync run when handling very large arrays.

In this PR we use the `Map.has()` and `Set.has()` method in combination with `Array.filter` to get faster performance and avoid the node process hanging for multiple seconds at a time.

In addition to task processor is updated to catch task failures to avoid entire sync run ending prematurely.

I have chosen not to include additional improvements from https://github.com/Joystream/joystream/pull/5026 for now although they will be very beneficial.

edit:
I was curios why `v3.8.x` version had no issues, and it seems there is a huge performance hit we got when we switched from using `_.difference()` to `_.differenceWith()` in `v3.9.x` and up

```
_.difference   23ms
_.differenceWith   14480ms
filter with array.includes   8678ms
filter map.has   2ms
```
Example for running test on my branch https://github.com/mnaamani/joystream/tree/colossus-tweaks
`yarn storage-node util:test-1 --obligationCount 300000 --storedCount 100000`