### PR TITLE
[Argus] always parse Axios errors before logging

### DIFF
--- a/distributor-node/CHANGELOG.md
+++ b/distributor-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+- Added parsing of Axios errors on logger level so that we never log the whole Axios client instance (which is a circular object and causes the node to crash)
+
 ## 1.5.0
 
 - Changed Elasticsearch transport to use data streams instead of regular indices. Renamed `config.logs.elastic.index` to `config.logs.elastic.indexPrefix`. Node ID from config will be automatically appended to the index name.

--- a/distributor-node/package.json
+++ b/distributor-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@joystream/distributor-cli",
   "description": "Joystream distributor node CLI",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "Joystream contributors",
   "bin": {
     "joystream-distributor": "./bin/run"

--- a/distributor-node/src/services/networking/NetworkingService.ts
+++ b/distributor-node/src/services/networking/NetworkingService.ts
@@ -332,9 +332,7 @@ export class NetworkingService {
       })
 
       objectDownloadQueue.on('error', (err) => {
-        this.logger.error('Download attempt from storage node failed after availability was confirmed:', {
-          err: axios.isAxiosError(err) ? parseAxiosError(err) : err,
-        })
+        this.logger.error('Download attempt from storage node failed after availability was confirmed:', { err })
       })
 
       objectDownloadQueue.on('end', () => {

--- a/distributor-node/src/services/networking/storage-node/api.ts
+++ b/distributor-node/src/services/networking/storage-node/api.ts
@@ -48,7 +48,7 @@ export class StorageNodeApi {
       return true
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        this.logger.debug('Data object not available', { objectId, err: parseAxiosError(err) })
+        this.logger.debug('Data object not available', { objectId, err })
         return false
       }
       this.logger.error('Unexpected error while requesting data object', { objectId, err })

--- a/distributor-node/src/services/networking/storage-node/api.ts
+++ b/distributor-node/src/services/networking/storage-node/api.ts
@@ -3,7 +3,6 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import { LoggingService } from '../../logging'
 import { Logger } from 'winston'
 import { ReadonlyConfig, StorageNodeDownloadResponse } from '../../../types'
-import { parseAxiosError } from '../../parsers/errors'
 
 export class StorageNodeApi {
   private logger: Logger

--- a/distributor-node/src/services/parsers/errors.ts
+++ b/distributor-node/src/services/parsers/errors.ts
@@ -4,12 +4,16 @@ type ParsedAxiosErrorResponse = Pick<AxiosResponse, 'data' | 'status' | 'statusT
 
 type ParsedAxiosError = Pick<AxiosError, 'message' | 'stack'> & {
   response?: ParsedAxiosErrorResponse
+  requestUrl?: string
 }
 
-export function parseAxiosError({ message, stack, response }: AxiosError): ParsedAxiosError {
+export function parseAxiosError({ message, stack, response, config }: AxiosError): ParsedAxiosError {
   const parsedError: ParsedAxiosError = {
     message,
     stack,
+  }
+  if (config) {
+    parsedError.requestUrl = config.url
   }
   if (response) {
     const { data, status, statusText, headers } = response


### PR DESCRIPTION
Added winston format that will always pre-process logs and make sure we don't log raw axios error. This way we don't need to remember to do this in all the different places where the error can be logged