### PR TITLE
Fix active video counter and moderator action tests frequent failure

### DIFF
--- a/tests/network-tests/package.json
+++ b/tests/network-tests/package.json
@@ -33,7 +33,8 @@
     "long": "^4.0.0",
     "node-cleanup": "^2.1.2",
     "@joystream/js": "^1.6.0",
-    "uuid": "^7.0.3"
+    "uuid": "^7.0.3",
+    "sleep-promise": "^9.1.0"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^1.21.4",

--- a/tests/network-tests/src/flows/content/activeVideoCounters.ts
+++ b/tests/network-tests/src/flows/content/activeVideoCounters.ts
@@ -9,6 +9,7 @@ import {
 } from '../../fixtures/content'
 import BN from 'bn.js'
 import { createJoystreamCli } from '../utils'
+import sleep from 'sleep-promise'
 
 export default async function activeVideoCounters({ api, query, env }: FlowProps): Promise<void> {
   const debug = extendDebug('flow:active-video-counters')
@@ -49,6 +50,9 @@ export default async function activeVideoCounters({ api, query, env }: FlowProps
   )
   await new FixtureRunner(createChannelsAndVideos).run()
   const { channelIds, videosData } = createChannelsAndVideos.getCreatedItems()
+
+  // Allow time for processor to process videos created
+  await sleep(10 * 1000)
 
   // check that active video counters are working
   const activeVideoCountersFixture = new ActiveVideoCountersFixture(

--- a/tests/network-tests/src/flows/content/curatorModerationActions.ts
+++ b/tests/network-tests/src/flows/content/curatorModerationActions.ts
@@ -25,6 +25,7 @@ import {
   DeleteChannelAsModeratorFixture,
   DeleteChannelAsModeratorParams,
 } from '../../fixtures/content/curatorModeration/DeleteChannelAsModerator'
+import sleep from 'sleep-promise'
 
 export default async function curatorModerationActions({ api, query, env }: FlowProps): Promise<void> {
   const debug = extendDebug('flow:curator-moderation-actions')
@@ -107,6 +108,9 @@ export default async function curatorModerationActions({ api, query, env }: Flow
 
   const addCuratorToGroupFixture = new AddCuratorToCuratorGroupFixture(api, query, addCuratorToGroupParams)
   await new FixtureRunner(addCuratorToGroupFixture).run()
+
+  // Allow time for processor to process videos created
+  await sleep(10 * 1000)
 
   // test curator moderation actions
 


### PR DESCRIPTION
Video counter and Moderator action tests frequently fail because the processor hasn't processed video creation events fast enough, and the steps in the tests following creating the videos happen too soon.

So simply adding a short 10s delay as a quick fix.

Common occurrences:
https://github.com/Joystream/joystream/actions/runs/7489520997/job/20386242438?pr=5033#step:12:17690

https://github.com/Joystream/joystream/actions/runs/7421119400/job/20193831192#step:12:17186