### PR TITLE
[CLI] Add  `working-groups:verifyValidator`

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -197,7 +197,7 @@ When using the CLI for the first time there are a few common steps you might wan
 - [`joystream-cli working-groups:updateRewardAccount [ADDRESS]`](#joystream-cli-working-groupsupdaterewardaccount-address)
 - [`joystream-cli working-groups:updateRoleAccount [ADDRESS]`](#joystream-cli-working-groupsupdateroleaccount-address)
 - [`joystream-cli working-groups:updateWorkerReward WORKERID NEWREWARD`](#joystream-cli-working-groupsupdateworkerreward-workerid-newreward)
-- [`joystream-cli working-groups:verifyValidator MEMBERID`](#joystream-cli-working-groupsverifyvalidator-memberid)
+- [`joystream-cli working-groups:verifyValidator --group=membership MEMBERID`](#joystream-cli-working-groupsverifyvalidator---groupmembership-memberid)
 
 ## `joystream-cli account:create`
 
@@ -2723,18 +2723,22 @@ OPTIONS
 
 _See code: [src/commands/working-groups/updateWorkerReward.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/working-groups/updateWorkerReward.ts)_
 
-## `joystream-cli working-groups:verifyValidator MEMBERID`
+## `joystream-cli working-groups:verifyValidator --group=membership MEMBERID`
 
 Verify or un-verify the membership profile bound to a validator account. Available to membership workers only.
 
 ```
 USAGE
-  $ joystream-cli working-groups:verifyValidator MEMBERID
+  $ joystream-cli working-groups:verifyValidator --group=membership MEMBERID
 
 ARGUMENTS
   MEMBERID   ID of the membership bound to the validator account.
 
 OPTIONS
+  -g, --group=membership
+      The working group context in which the command should be executed
+      membership is the only valid value for this command.
+
   --unverify
       Whether the profile should be un-verified.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -197,6 +197,7 @@ When using the CLI for the first time there are a few common steps you might wan
 - [`joystream-cli working-groups:updateRewardAccount [ADDRESS]`](#joystream-cli-working-groupsupdaterewardaccount-address)
 - [`joystream-cli working-groups:updateRoleAccount [ADDRESS]`](#joystream-cli-working-groupsupdateroleaccount-address)
 - [`joystream-cli working-groups:updateWorkerReward WORKERID NEWREWARD`](#joystream-cli-working-groupsupdateworkerreward-workerid-newreward)
+- [`joystream-cli working-groups:verifyValidator MEMBERID`](#joystream-cli-working-groupsverifyvalidator-memberid)
 
 ## `joystream-cli account:create`
 
@@ -2721,5 +2722,29 @@ OPTIONS
 ```
 
 _See code: [src/commands/working-groups/updateWorkerReward.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/working-groups/updateWorkerReward.ts)_
+
+## `joystream-cli working-groups:verifyValidator MEMBERID`
+
+Verify or un-verify the membership profile bound to a validator account. Available to membership workers only.
+
+```
+USAGE
+  $ joystream-cli working-groups:verifyValidator MEMBERID
+
+ARGUMENTS
+  MEMBERID   ID of the membership bound to the validator account.
+
+OPTIONS
+  --unverify
+      Whether the profile should be un-verified.
+
+  --useMemberId=useMemberId
+      Try using the specified member id as context whenever possible
+
+  --useWorkerId=useWorkerId
+      Try using the specified worker id as context whenever possible
+```
+
+_See code: [src/commands/working-groups/verifyValidator.ts](https://github.com/Joystream/joystream/blob/master/cli/src/commands/working-groups/verifyValidator.ts)_
 
 <!-- commandsstop -->

--- a/cli/src/commands/working-groups/verifyValidator.ts
+++ b/cli/src/commands/working-groups/verifyValidator.ts
@@ -7,20 +7,21 @@ import Long from 'long'
 import chalk from 'chalk'
 
 export default class VerifyValidatorCommand extends WorkingGroupsCommandBase {
-  static description = 'Membership lead/worker verifies validator membership profile'
+  static description =
+    'Verify or un-verify the membership profile bound to a validator account. Available to membership workers only.'
 
   static args = [
     {
       name: 'memberId',
       required: true,
-      description: 'Membership ID of the validator to verify',
+      description: 'ID of the membership bound to the validator account.',
     },
   ]
 
   static flags = {
     unverify: flags.boolean({
       default: false,
-      description: 'Verification state of the validator',
+      description: 'Whether the profile should be un-verified.',
     }),
 
     ...WorkingGroupsCommandBase.flags,

--- a/cli/src/commands/working-groups/verifyValidator.ts
+++ b/cli/src/commands/working-groups/verifyValidator.ts
@@ -53,8 +53,14 @@ export default class VerifyValidatorCommand extends WorkingGroupsCommandBase {
     const message = metadataToString(RemarkMetadataAction, meta)
 
     const keyPair = await this.getDecodedPair(worker.roleAccount)
-    await this.sendAndFollowNamedTx(keyPair, 'membershipWorkingGroup', 'workerRemark', [worker.workerId, message])
+    const result = await this.sendAndFollowNamedTx(keyPair, 'membershipWorkingGroup', 'workerRemark', [
+      worker.workerId,
+      message,
+    ])
 
-    this.log(chalk.green(`The validator profile ${args.memberId} is now${verifyValidator ? '' : ' not'} verified`))
+    const block = result.status.isInBlock ? result.status.asInBlock : undefined
+    const successMessage = `The validator profile ${args.memberId} was set to${verifyValidator ? '' : ' not'} verified.`
+    const inBlockMessage = block ? `(In block ${block})` : ''
+    this.log(chalk.green(`${successMessage} ${inBlockMessage}`))
   }
 }

--- a/cli/src/commands/working-groups/verifyValidator.ts
+++ b/cli/src/commands/working-groups/verifyValidator.ts
@@ -27,12 +27,12 @@ export default class VerifyValidatorCommand extends WorkingGroupsCommandBase {
     ...WorkingGroupsCommandBase.flags,
   }
 
-  async init(): Promise<void> {
-    await super.init()
-    this._group = WorkingGroups.Membership
-  }
-
   async run(): Promise<void> {
+    const worker = await this.getRequiredWorkerContext()
+    if (!worker || this.group === WorkingGroups.Membership) {
+      return this.error('Only membership workers can perform this command')
+    }
+
     const { args, flags } = this.parse(VerifyValidatorCommand)
     const memberId = Long.fromNumber(args.memberId)
     const verifyValidator = !flags.unverify
@@ -43,13 +43,6 @@ export default class VerifyValidatorCommand extends WorkingGroupsCommandBase {
         isVerified: verifyValidator,
       }),
     })
-
-    const worker = await this.getRequiredWorkerContext()
-
-    if (!worker) {
-      return this.error('Only membership workers can perform this command')
-    }
-
     const message = metadataToString(RemarkMetadataAction, meta)
 
     const keyPair = await this.getDecodedPair(worker.roleAccount)

--- a/cli/src/commands/working-groups/verifyValidator.ts
+++ b/cli/src/commands/working-groups/verifyValidator.ts
@@ -1,0 +1,61 @@
+import { flags } from '@oclif/command'
+import WorkingGroupsCommandBase from '../../base/WorkingGroupsCommandBase'
+import { WorkingGroups } from '../../Types'
+import { VerifyValidator, RemarkMetadataAction } from '@joystream/metadata-protobuf'
+import { metadataToString } from '../../helpers/serialization'
+import Long from 'long'
+import chalk from 'chalk'
+export default class VerifyValidatorAccountCommand extends WorkingGroupsCommandBase {
+  static description = 'Membership lead/worker verifies validator membership profile'
+  static flags = {
+    memberId: flags.integer({
+      required: true,
+      description: 'Membership ID of the validator to verify',
+    }),
+    isVerified: flags.boolean({
+      required: true,
+      description: 'Verification state of the validator',
+    }),
+
+    ...WorkingGroupsCommandBase.flags,
+  }
+
+  async run(): Promise<void> {
+    const { memberId, isVerified } = this.parse(VerifyValidatorAccountCommand).flags
+
+    const id = Long.fromNumber(memberId)
+    const meta = new RemarkMetadataAction({
+      verifyValidator: new VerifyValidator({
+        memberId: id,
+        isVerified,
+      }),
+    })
+
+    const message = metadataToString(RemarkMetadataAction, meta)
+
+    const nowGroup = this.group
+
+    await this.setPreservedState({ defaultWorkingGroup: WorkingGroups.Membership })
+
+    const worker = await this.getRequiredWorkerContext()
+
+    const [Id, controllerAccount] = await this.getValidatedMemberRemarkParams()
+
+    if (!worker) {
+      this.error('Only membership WG lead/worker can perform this command')
+    } else {
+      const keypair = await this.getDecodedPair(controllerAccount)
+      const result = await this.sendAndFollowNamedTx(keypair, 'membershipWorkingGroup', 'workerRemark', [Id, message])
+
+      const [workerid] = this.getEvent(result, 'membershipWorkingGroup', 'WorkerRemarked').data
+
+      this.log(
+        chalk.green(
+          `member ${memberId} verified successfully by membership WG worker ${workerid}!`
+        )
+      )
+    }
+
+    await this.setPreservedState({ defaultWorkingGroup: nowGroup })
+  }
+}


### PR DESCRIPTION
Replace #4933

- #4930

@zeeshanakram3 
- This can only be called by membership working group workers so regarding https://github.com/Joystream/joystream/pull/4933#discussion_r1463151390 I also enforced `WorkingGroups.Membership` but in a different way than #4933. If you think it's a bad idea I can remove it. (Also for the same reason I didn't document the `--group` `-g` flags.
- I updated the Readme but I'm not sure whether it's supposed to be automatized.
- I tested the command on [Atlas Dev](https://atlas-dev.joystream.org/network/config.json) it executed without error but the validator status wasn't set correctly `true` (but maybe the this network processor isn't up to date :shrug:). I'll have to check locally.