### PR TITLE
Add new QN timeout variables to `.env`

### DIFF
--- a/.env
+++ b/.env
@@ -45,6 +45,15 @@ HYDRA_INDEXER_GATEWAY_PORT=4000
 # Default GraphQL server host. It is required during "query-node config:dev"
 GRAPHQL_SERVER_HOST=localhost
 
+# GraphQL server resolver execution maximum time
+WARTHOG_RESOLVER_TIMEOUT_MS=2000
+
+# GraphQL server maximum number of relations a resolver can query in parallel
+WARTHOG_RELATION_CONCURRENCY=30
+
+# GraphQL server maximum DB request time
+GRAPHQL_SERVER_DB_QUERY_TIMEOUT=1000
+
 # Websocket RPC endpoint containers will use.
 JOYSTREAM_NODE_WS=ws://joystream-node:9944/
 


### PR DESCRIPTION
Add variables defined in https://github.com/Joystream/hydra/pull/538 to the `.env` file.

Context: https://github.com/Joystream/joystream/issues/5088