### PR TITLE
Add a `SKIP_ORION` option to the start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -35,11 +35,14 @@ fi
 ## Query Node Infrastructure
 ./query-node/start.sh
 
-## Orion
-./start-orion.sh
+if [ "${SKIP_ORION}" != true ]
+then
+  ## Orion
+  ./start-orion.sh
 
-## Storage Squid
-docker-compose -f ./docker-compose.storage-squid.yml up -d
+  ## Storage Squid
+  docker-compose -f ./docker-compose.storage-squid.yml up -d
+fi
 
 ## Init the chain with some state
 if [[ $SKIP_CHAIN_SETUP != 'true' ]]; then


### PR DESCRIPTION
This is just a DX thing but I keep on adding this to the start script.

Here's why: only Atlas usues Orion, and a lot of the work on Atlas is done using a playgrounds ATM. OTOH when working on Orion directly IMO it's easier to run Orion from the local repository not from the monorepos.