### PR TITLE
[Colossus] fix: upload aborted error

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -68,7 +68,7 @@
     "@oclif/test": "^1.2.5",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.17.18",
+    "@types/node": "^18.6.0",
     "chai": "^4.2.0",
     "eslint": "^7.6.0",
     "eslint-config-oclif": "^3.1.0",

--- a/devops/kubernetes/argus/package.json
+++ b/devops/kubernetes/argus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eks-cluster",
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@types/node": "^18.6.0"
   },
   "dependencies": {
     "@pulumi/aws": "^4.0.0",

--- a/devops/kubernetes/node-network/package.json
+++ b/devops/kubernetes/node-network/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joystream-node-network",
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@types/node": "^18.6.0"
   },
   "dependencies": {
     "@pulumi/aws": "^4.0.0",

--- a/devops/kubernetes/orion/package.json
+++ b/devops/kubernetes/orion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eks-cluster",
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@types/node": "^18.6.0"
   },
   "dependencies": {
     "@pulumi/awsx": "^0.30.0",

--- a/devops/kubernetes/pulumi-common/package.json
+++ b/devops/kubernetes/pulumi-common/package.json
@@ -2,7 +2,7 @@
   "name": "pulumi-common",
   "version": "1.0.0",
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@types/node": "^18.6.0"
   },
   "dependencies": {
     "@pulumi/kubernetes": "^3.0.0",

--- a/devops/kubernetes/query-node/package.json
+++ b/devops/kubernetes/query-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "query-node",
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@types/node": "^18.6.0"
   },
   "dependencies": {
     "@pulumi/aws": "^4.0.0",

--- a/devops/kubernetes/storage-node/package.json
+++ b/devops/kubernetes/storage-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eks-cluster",
   "devDependencies": {
-    "@types/node": "^10.0.0"
+    "@types/node": "^18.6.0"
   },
   "dependencies": {
     "@pulumi/aws": "^4.0.0",

--- a/distributor-node/CHANGELOG.md
+++ b/distributor-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.0.0
+
+- Replaced `Query-Node` API with `Storage-Squid` Graphql API. This is a breaking change and requires the `endpoints.queryNode` configuration option to be replaced with `endpoints.storageSquid`.
+
 ## 1.5.1
 
 - Added parsing of Axios errors on logger level so that we never log the whole Axios client instance (which is a circular object and causes the node to crash)

--- a/distributor-node/package.json
+++ b/distributor-node/package.json
@@ -69,7 +69,7 @@
     "@types/inquirer": "^8.1.1",
     "@types/mime": "^3.0.1",
     "@types/mocha": "^5",
-    "@types/node": "^14",
+    "@types/node": "^18.6.0",
     "@types/node-cache": "^4.2.5",
     "@types/node-cleanup": "^2.1.1",
     "@types/send": "^0.17.0",

--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,4 +1,13 @@
+### 4.0.1
+
+- Set the `server.requestTimeout` option in `http.Server` instance to 0 to disable the timeout. This was default behaviour pre Node.js `18.x`
+
+### 4.0.0
+
+- Replaced `Query-Node` API with `Storage-Squid` Graphql API. This is a breaking change and requires the `--queryNodeEndpoint` configuration option to be replaced with `--storageSquidEndpoint`.
+
 ### 3.10.2
+
 - Fix processing large arrays causing high cpu during sync and cleanup runs [#5033](https://github.com/Joystream/joystream/pull/5033)
 
 - Fix task runner to avoid ending prematurely on individual task failure [#5033](https://github.com/Joystream/joystream/pull/5033)

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storage-node",
   "description": "Joystream storage subsystem.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Joystream contributors",
   "bin": {
     "storage-node": "./bin/run"

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -79,7 +79,7 @@
     "@types/chai": "^4",
     "@types/cors": "^2.8.12",
     "@types/mocha": "^5",
-    "@types/node": "^10",
+    "@types/node": "^18.6.0",
     "@types/pg": "^8.6.1",
     "@types/swagger-ui-express": "^4.1.2",
     "@types/ws": "^5.1.2",

--- a/storage-node/src/commands/server.ts
+++ b/storage-node/src/commands/server.ts
@@ -350,7 +350,11 @@ Supported values: warn, error, debug, info. Default:debug`,
         },
         x_host_id: X_HOST_ID,
       })
-      app.listen(port, () => logger.info(`Listening on http://localhost:${port}`))
+      const server = app.listen(port, () => logger.info(`Listening on http://localhost:${port}`))
+
+      // INFO: https://nodejs.org/dist/latest-v18.x/docs/api/http.html#serverrequesttimeout
+      // Set the server request timeout to 0 to disable it. This was default behaviour pre Node.js 18.x
+      server.requestTimeout = 0
     } catch (err) {
       logger.error(`Server error: ${err}`)
       this.exit(ExitCodes.ServerError)

--- a/utils/migration-scripts/package.json
+++ b/utils/migration-scripts/package.json
@@ -42,7 +42,7 @@
     "@graphql-codegen/typescript-document-nodes": "^1.17.11",
     "@graphql-codegen/typescript-operations": "^1.17.16",
     "@oclif/dev-cli": "^1",
-    "@types/node": "^14",
+    "@types/node": "^18.6.0",
     "globby": "^10",
     "ts-node": "^10.9.1",
     "typescript": "^3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4934,7 +4934,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.5.tgz#26d295f3570323b2837d322180dfbf1ba156fefb"
   integrity sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==
 
-"@types/node@^10", "@types/node@^10.0.3", "@types/node@^10.1.0", "@types/node@^10.17.18":
+"@types/node@^10.0.3", "@types/node@^10.1.0":
   version "10.17.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
@@ -4944,15 +4944,17 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.52.tgz#2fd2dc6bfa185601b15457398d4ba1ef27f81251"
   integrity sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==
 
-"@types/node@^14":
-  version "14.18.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
-  integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
-
 "@types/node@^14.11.2":
   version "14.18.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.22.tgz#fd2a15dca290fc9ad565b672fde746191cd0c6e6"
   integrity sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw==
+
+"@types/node@^18.6.0":
+  version "18.19.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.22.tgz#f622f92514b897e6b09903e97c16a0db8e94689f"
+  integrity sha512-p3pDIfuMg/aXBmhkyanPshdfJuX5c5+bQjYLIikPLXAUycEogij/c50n/C+8XOA5L93cU4ZRXtn+dNQGi0IZqQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^8.0.0":
   version "8.10.66"
@@ -21525,6 +21527,11 @@ underscore@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
   integrity sha1-izixDKze9jM3uLJOT/htRa6lKag=
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici@^5.1.0:
   version "5.2.0"


### PR DESCRIPTION
addresses #5081

- Updates `@types/node` dependency version to `18.6.0`
- Fix colossus upload aborted error


# Context

There is a [server.requestTimeout](https://nodejs.org/dist/latest-v18.x/docs/api/http.html#serverrequesttimeout) configuration option in the `http.Server` instance (remember `express` is just a wrapper around nodejs native HTTP Server), from the nodejs official documentation what this option means:

> Sets the timeout value in milliseconds for receiving the entire request from the client.
>
> If the timeout expires, the server responds with status 408 without forwarding the request to the request listener and then closes the connection.

The default value for the option is 300s for node versions `>=18.x`, while for the previous version the default value was 0 (no timeout)

So, the uploads failing problem started to occur when we updated the Nodejs from `v14` to `v18.6.0` in #4778


This timeout value of 300s also validates Ignazio's investigation that Colossus aborts errors after ~5 minutes.