### PR TITLE
Add opentelemetry instrumentation for QueryNode graphql-server

### DIFF
--- a/opentelemetry/index.ts
+++ b/opentelemetry/index.ts
@@ -1,7 +1,12 @@
 import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import 'dotenv/config'
-import { DefaultInstrumentation, DistributorNodeInstrumentation, StorageNodeInstrumentation } from './instrumentations'
+import {
+  DefaultInstrumentation,
+  DistributorNodeInstrumentation,
+  GraphqlServerInstrumentation,
+  StorageNodeInstrumentation,
+} from './instrumentations'
 
 // For troubleshooting, set the log level to DiagLogLevel.DEBUG
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO)
@@ -18,7 +23,7 @@ function addInstrumentation() {
       instrumentation = StorageNodeInstrumentation
       diag.info(`Loaded Application Instrumentation: "Storage Node"`)
     } else if (applicationName === 'query-node') {
-      instrumentation = DefaultInstrumentation
+      instrumentation = GraphqlServerInstrumentation
       diag.info(`Loaded Application Instrumentation: "Query Node"`)
     } else {
       instrumentation = DefaultInstrumentation

--- a/opentelemetry/instrumentations/graphql-server.ts
+++ b/opentelemetry/instrumentations/graphql-server.ts
@@ -1,0 +1,28 @@
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-node'
+
+/** Opentelemetry Instrumentation for Query Node's graphql-server */
+
+export const GraphqlServerInstrumentation = new NodeSDK({
+  spanProcessor: new BatchSpanProcessor(new OTLPTraceExporter(), {
+    maxQueueSize: parseInt(process.env.OTEL_MAX_QUEUE_SIZE || '8192'),
+    maxExportBatchSize: parseInt(process.env.OTEL_MAX_EXPORT_BATCH_SIZE || '1024'),
+  }),
+  metricReader: new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter(),
+  }),
+  instrumentations: [
+    // Disable DNS instrumentation, because the instrumentation does not correctly patches `dns.lookup` function
+    // if the function is converted to a promise-based method using `utils.promisify(dns.lookup)`
+    // See: https://github.com/Joystream/joystream/pull/4779#discussion_r1262515887
+    getNodeAutoInstrumentations({
+      '@opentelemetry/instrumentation-dns': { enabled: false },
+      '@opentelemetry/instrumentation-pg': { enhancedDatabaseReporting: true },
+      '@opentelemetry/instrumentation-graphql': { allowValues: true },
+    }),
+  ],
+})

--- a/opentelemetry/instrumentations/index.ts
+++ b/opentelemetry/instrumentations/index.ts
@@ -1,3 +1,4 @@
 export * from './default'
 export * from './distributor-node'
+export * from './graphql-server'
 export * from './storage-node'


### PR DESCRIPTION
This PR:

- Adds separate Query Node instrumentation named `GraphqlServerInstrumentation` in `@joystream/opentelemetry`
- Enable graphql query variables visibility for Graphql spans
- Enable Postgres query params visibility for Postgres spans (parameters will be stored in `labels.db_postgresql_values` key)