### PR TITLE
genesis config: start with PoS instead of PoA

### DIFF
--- a/bin/node/src/chain_spec/mod.rs
+++ b/bin/node/src/chain_spec/mod.rs
@@ -307,7 +307,7 @@ pub fn testnet_genesis(
             minimum_validator_count: initial_authorities.len().min(4) as u32,
             invulnerables: initial_authorities.iter().map(|x| x.0.clone()).collect(),
             slash_reward_fraction: Perbill::from_percent(10),
-            force_era: Forcing::ForceNone,
+            force_era: Forcing::NotForcing,
             stakers,
             min_nominator_bond: GENESIS_MIN_NOMINATOR_BOND,
             min_validator_bond: GENESIS_MIN_VALIDATOR_BOND,


### PR DESCRIPTION
Updating default genesis config to enable staking elections so we have a PoS rather than PoA, ie additional validators can join then network. This is more practical when setting up new testnets. PoA was only really needed at mainnet launch.