### PR TITLE
Amm buy/sell operations not allowed during revenue split

### DIFF
--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -911,6 +911,8 @@ decl_module! {
             )?;
 
             let token_data = Self::ensure_token_exists(token_id)?;
+            token_data.ensure_can_modify_supply::<T>()?;
+
             let curve = token_data.amm_curve.ok_or(Error::<T>::NotInAmmState)?;
 
             let user_account_data_exists = AccountInfoByTokenAndMember::<T>::contains_key(token_id, member_id);
@@ -997,6 +999,8 @@ decl_module! {
             )?;
 
             let token_data = Self::ensure_token_exists(token_id)?;
+            token_data.ensure_can_modify_supply::<T>()?;
+
             let curve = token_data.amm_curve.ok_or(Error::<T>::NotInAmmState)?;
             let user_acc_data = Self::ensure_account_data_exists(token_id, &member_id)?;
 

--- a/runtime-modules/project-token/src/lib.rs
+++ b/runtime-modules/project-token/src/lib.rs
@@ -890,6 +890,7 @@ decl_module! {
         /// - user usable JOY balance must be enough for buying (+ existential deposit)
         /// - slippage tolerance constraints respected if provided
         /// - token total supply and amount value must be s.t. `eval` function doesn't overflow
+        /// - token supply can be modified (there is no active revenue split)
         ///
         /// Postconditions
         /// - `amount` CRT minted into account (which is created if necessary with existential deposit transferred to it)
@@ -977,6 +978,7 @@ decl_module! {
         /// - slippage tolerance constraints respected if provided
         /// - token total supply and amount value must be s.t. `eval` function doesn't overflow
         /// - amm treasury account must have sufficient JOYs for the operation
+        /// - token supply can be modified (there is no active revenue split)
         ///
         /// Postconditions
         /// - `amount` burned from user account


### PR DESCRIPTION
Alternative to https://github.com/Joystream/joystream/pull/5125
AMM and Revenue split can both be active at the same time, but during revenue split the token supply cannot be modified by amm buy/sell (just as burning tokens is not permitted during revenue split)

cc: @WRadoslaw 