### PR TITLE
Revert "Fix BudgetSpendingEvent typo"

### DIFF
--- a/query-node/mappings/src/workingGroups.ts
+++ b/query-node/mappings/src/workingGroups.ts
@@ -1022,14 +1022,14 @@ export async function workingGroups_BudgetSet({ store, event }: EventContext & S
 }
 
 export async function workingGroups_BudgetSpending({ store, event }: EventContext & StoreContext): Promise<void> {
-  const [receiver, amount, optRationale] = new WorkingGroup_BudgetSpendingEvent_V1001(event).params
+  const [reciever, amount, optRationale] = new WorkingGroup_BudgetSpendingEvent_V1001(event).params
   const group = await getWorkingGroupOrFail(store, event)
 
   const budgetSpendingEvent = new BudgetSpendingEvent({
     ...genericEventFields(event),
     group,
     amount,
-    receiver: receiver.toString(),
+    reciever: reciever.toString(),
     rationale: optRationale.isSome ? bytesToString(optRationale.unwrap()) : undefined,
   })
 

--- a/query-node/schemas/workingGroupsEvents.graphql
+++ b/query-node/schemas/workingGroupsEvents.graphql
@@ -671,8 +671,8 @@ type BudgetSpendingEvent implements Event @entity {
   "Related group"
   group: WorkingGroup!
 
-  "Receiver account address"
-  receiver: String!
+  "Reciever account address"
+  reciever: String!
 
   "Amount beeing spent"
   amount: BigInt!

--- a/tests/network-tests/src/fixtures/workingGroups/SpendBudgetFixture.ts
+++ b/tests/network-tests/src/fixtures/workingGroups/SpendBudgetFixture.ts
@@ -52,7 +52,7 @@ export class SpendBudgetFixture extends BaseWorkingGroupFixture {
   protected assertQueryNodeEventIsValid(qEvent: BudgetSpendingEventFieldsFragment, i: number): void {
     assert.equal(qEvent.group.name, this.group)
     assert.equal(qEvent.amount, this.amounts[i].toString())
-    assert.equal(qEvent.receiver, this.recievers[i])
+    assert.equal(qEvent.reciever, this.recievers[i])
     assert.equal(qEvent.rationale, this.getRationale(this.recievers[i]))
   }
 

--- a/tests/network-tests/src/graphql/queries/workingGroupsEvents.graphql
+++ b/tests/network-tests/src/graphql/queries/workingGroupsEvents.graphql
@@ -435,7 +435,7 @@ fragment BudgetSpendingEventFields on BudgetSpendingEvent {
   group {
     name
   }
-  receiver
+  reciever
   amount
   rationale
 }


### PR DESCRIPTION
Follow up to #5123

@kdembler mentioned that `BudgetSpending.reciever` is used by some scripts.

This reverts commit 8d712b4002e9e75820e8305dc5916624f117e1c5.