### PR TITLE
Add a really simple QN benchmarking script

### DIFF
--- a/query-node/benchmark.sh
+++ b/query-node/benchmark.sh
@@ -6,6 +6,7 @@ T=60
 # Pass the endpoint as the first argument, default to local
 endpoint=${1:-'http://localhost:8081/graphql'}
 
+invalidWhen=".errors != null or (.data.proposals | length == 0)"
 query=$(
   cat <<EOF | awk '{ print NR == 1 ? "" : "\\n" } 1' ORS=''
 {"query":"{
@@ -44,7 +45,11 @@ i=-1
 until=$(($(date +%s%N) + $T * $SEC))
 while [ $(date +%s%N) -lt $until ]; do
   i=$((i + 1))
-  curl -s "$endpoint" -H 'Content-Type: application/json' --data-binary "$query" >/dev/null
+  res=$(curl -s "$endpoint" -H 'Content-Type: application/json' --data-binary "$query")
+  if $(echo "$res" | jq -e "$invalidWhen"); then
+    echo "Failed with response $res"
+    exit 1
+  fi
 done
 
 echo "Sent $i queries in $T seconds"

--- a/query-node/benchmark.sh
+++ b/query-node/benchmark.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Run for T seconds
+T=60
+
+# Pass the endpoint as the first argument, default to local
+endpoint=${1:-'http://localhost:8081/graphql'}
+
+query=$(
+  cat <<EOF | awk '{ print NR == 1 ? "" : "\\n" } 1' ORS=''
+{"query":"{
+  proposals (
+    # Check filter/order performance too
+    where: { status_json: { isTypeOf_eq: \"ProposalStatusExecuted\" } }
+    orderBy: createdAt_DESC
+  ) {
+    id
+    createdInEvent { id inBlock }
+    status { __typename }
+    creator {
+      createdAt
+      referredMembers { id }
+      proposalvotedeventvoter {
+        id
+        inBlock
+      }
+    }
+    proposalStatusUpdates {
+      type
+    }
+    votes {
+      inBlock
+      voteKind
+      rationale
+    }
+  }
+}"}
+EOF
+)
+
+SEC=1000000000
+i=-1
+
+until=$(($(date +%s%N) + $T * $SEC))
+while [ $(date +%s%N) -lt $until ]; do
+  i=$((i + 1))
+  curl -s "$endpoint" -H 'Content-Type: application/json' --data-binary "$query" >/dev/null
+done
+
+echo "Sent $i queries in $T seconds"


### PR DESCRIPTION
I ran this with and without the changes from: https://github.com/Joystream/warthog/pull/19

I was only running the `db` and `graphql-server` services. The `query_node_processor` database was initialized with a dump of mainnet with about 5M processed block (11-2023).

The script consistently ran about 200 queries in 1 minutes regardless of the dataloader changes. FYI it ran 230 queries the first time when my CPU was cold but then it gets consistent after that.