### PR TITLE
QueryNode: handle invalid protobuf message decoding

### DIFF
--- a/query-node/mappings/package.json
+++ b/query-node/mappings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-node-mappings",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Mappings for hydra-processor",
   "main": "lib/src/index.js",
   "license": "MIT",

--- a/query-node/mappings/src/content/commentAndReaction.ts
+++ b/query-node/mappings/src/content/commentAndReaction.ts
@@ -545,7 +545,7 @@ export async function processModerateCommentMessage(
   event: SubstrateEvent,
   channelOwnerOrCurator: typeof ContentActor,
   channel: Channel,
-  message: IModerateComment
+  message: DecodedMetadataObject<IModerateComment>
 ): Promise<Comment | MetaprotocolTxError> {
   const { commentId, rationale } = message
 
@@ -606,7 +606,7 @@ export async function processPinOrUnpinCommentMessage(
   store: DatabaseManager,
   event: SubstrateEvent,
   channel: Channel,
-  message: IPinOrUnpinComment
+  message: DecodedMetadataObject<IPinOrUnpinComment>
 ): Promise<Comment | MetaprotocolTxError> {
   const { commentId, option } = message
 
@@ -647,7 +647,7 @@ export async function processBanOrUnbanMemberFromChannelMessage(
   store: DatabaseManager,
   event: SubstrateEvent,
   channel: Channel,
-  message: IBanOrUnbanMemberFromChannel
+  message: DecodedMetadataObject<IBanOrUnbanMemberFromChannel>
 ): Promise<Membership | MetaprotocolTxError> {
   const { memberId, option } = message
 
@@ -689,7 +689,7 @@ export async function processVideoReactionsPreferenceMessage(
   store: DatabaseManager,
   event: SubstrateEvent,
   channel: Channel,
-  message: IVideoReactionsPreference
+  message: DecodedMetadataObject<IVideoReactionsPreference>
 ): Promise<Channel | MetaprotocolTxError> {
   const { videoId, option } = message
 

--- a/query-node/package.json
+++ b/query-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "query-node-root",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "GraphQL server and mappings. Generated with ♥ by Hydra-CLI",
   "scripts": {
     "build": "./build.sh",


### PR DESCRIPTION
Solves processor failing with error

```
INFO: Processing block: 0009303780-14959, events count: 1
ERROR: Stopping the proccessor due to errors: {} name: Error, message: invalid wire type 4 at offset 1, stack: Error: invalid wire type 4 at offset 1
    at Reader.skipType (/joystream/metadata-protobuf/node_modules/protobufjs/src/reader.js:377:19)
    at Function.decode (/joystream/metadata-protobuf/compiled/index.js:8365:24)
    at content_ChannelOwnerRemarked (/joystream/query-node/mappings/lib/src/content/channel.js:158:63)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async MappingsLookupService.call (/joystream/node_modules/@joystream/hydra-processor/lib/executor/MappingsLookupService.js:80:9)
    at async /joystream/node_modules/@joystream/hydra-processor/lib/executor/TransactionalExecutor.js:41:17
INFO: Shutting down...
```

Fixed by used the `deserializeMetadata` helper method.