### PR TITLE
Colossus cleanup fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,9 @@ services:
     environment:
       # ACCOUNT_URI overrides command line arg --accountUri
       - ACCOUNT_URI=${COLOSSUS_2_TRANSACTOR_URI}
+      # Env that allows testing cleanup
+      - CLEANUP_NEW_OBJECT_EXPIRATION_PERIOD=10
+      - CLEANUP_MIN_REPLICATION_THRESHOLD=1
     entrypoint: ['yarn', 'storage-node']
     command: [
       'server', '--worker=${COLOSSUS_2_WORKER_ID}', '--port=3333', '--uploads=/data/uploads',
@@ -113,7 +116,10 @@ services:
       '--apiUrl=${JOYSTREAM_NODE_WS}',
       '--logFilePath=/logs',
       '--tempFolder=/data/temp/',
-      '--pendingFolder=/data/pending/'
+      '--pendingFolder=/data/pending/',
+      # Use cleanup on colossus-2 for testing purposes
+      '--cleanup',
+      '--cleanupInterval=1'
     ]
 
   distributor-2:

--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix `util:cleanup` script (call `loadDataObjectIdCache` first)
 - Allow changing default log level using environment variable (`COLOSSUS_DEFAULT_LOG_LEVEL`)
 - Allow adjusting cleanup constants via env (`CLEANUP_MIN_REPLICATION_THRESHOLD`, `CLEANUP_NEW_OBJECT_EXPIRATION_PERIOD`)
+- Error handling: Clearer warning messages if unexpected response encountered during sync (ie. 404)
 
 ### 4.1.2
 

--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 4.2.0
+
+- Fix `util:cleanup` script (call `loadDataObjectIdCache` first)
+- Allow changing default log level using environment variable (`COLOSSUS_DEFAULT_LOG_LEVEL`)
+- Allow adjusting cleanup constants via env (`CLEANUP_MIN_REPLICATION_THRESHOLD`, `CLEANUP_NEW_OBJECT_EXPIRATION_PERIOD`)
+
 ### 4.1.2
 
 - Bump @joystream/types to Petra version

--- a/storage-node/README.md
+++ b/storage-node/README.md
@@ -213,7 +213,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/cancel-invite.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/cancel-invite.ts)_
+_See code: [src/commands/leader/cancel-invite.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/cancel-invite.ts)_
 
 ## `storage-node leader:create-bucket`
 
@@ -244,7 +244,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/create-bucket.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/create-bucket.ts)_
+_See code: [src/commands/leader/create-bucket.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/create-bucket.ts)_
 
 ## `storage-node leader:delete-bucket`
 
@@ -271,7 +271,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/delete-bucket.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/delete-bucket.ts)_
+_See code: [src/commands/leader/delete-bucket.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/delete-bucket.ts)_
 
 ## `storage-node leader:invite-operator`
 
@@ -300,7 +300,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/invite-operator.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/invite-operator.ts)_
+_See code: [src/commands/leader/invite-operator.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/invite-operator.ts)_
 
 ## `storage-node leader:remove-operator`
 
@@ -327,7 +327,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/remove-operator.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/remove-operator.ts)_
+_See code: [src/commands/leader/remove-operator.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/remove-operator.ts)_
 
 ## `storage-node leader:set-bucket-limits`
 
@@ -357,7 +357,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/set-bucket-limits.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/set-bucket-limits.ts)_
+_See code: [src/commands/leader/set-bucket-limits.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/set-bucket-limits.ts)_
 
 ## `storage-node leader:set-global-uploading-status`
 
@@ -385,7 +385,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/set-global-uploading-status.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/set-global-uploading-status.ts)_
+_See code: [src/commands/leader/set-global-uploading-status.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/set-global-uploading-status.ts)_
 
 ## `storage-node leader:update-bag-limit`
 
@@ -412,7 +412,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-bag-limit.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/update-bag-limit.ts)_
+_See code: [src/commands/leader/update-bag-limit.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/update-bag-limit.ts)_
 
 ## `storage-node leader:update-bags`
 
@@ -468,7 +468,7 @@ OPTIONS
       Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-bags.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/update-bags.ts)_
+_See code: [src/commands/leader/update-bags.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/update-bags.ts)_
 
 ## `storage-node leader:update-blacklist`
 
@@ -497,7 +497,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-blacklist.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/update-blacklist.ts)_
+_See code: [src/commands/leader/update-blacklist.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/update-blacklist.ts)_
 
 ## `storage-node leader:update-bucket-status`
 
@@ -526,7 +526,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-bucket-status.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/update-bucket-status.ts)_
+_See code: [src/commands/leader/update-bucket-status.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/update-bucket-status.ts)_
 
 ## `storage-node leader:update-data-fee`
 
@@ -553,7 +553,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-data-fee.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/update-data-fee.ts)_
+_See code: [src/commands/leader/update-data-fee.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/update-data-fee.ts)_
 
 ## `storage-node leader:update-data-object-bloat-bond`
 
@@ -581,7 +581,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-data-object-bloat-bond.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/update-data-object-bloat-bond.ts)_
+_See code: [src/commands/leader/update-data-object-bloat-bond.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/update-data-object-bloat-bond.ts)_
 
 ## `storage-node leader:update-dynamic-bag-policy`
 
@@ -611,7 +611,7 @@ OPTIONS
   --keyStore=keyStore             Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-dynamic-bag-policy.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/update-dynamic-bag-policy.ts)_
+_See code: [src/commands/leader/update-dynamic-bag-policy.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/update-dynamic-bag-policy.ts)_
 
 ## `storage-node leader:update-voucher-limits`
 
@@ -640,7 +640,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-voucher-limits.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/leader/update-voucher-limits.ts)_
+_See code: [src/commands/leader/update-voucher-limits.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/leader/update-voucher-limits.ts)_
 
 ## `storage-node operator:accept-invitation`
 
@@ -673,7 +673,7 @@ OPTIONS
   --keyStore=keyStore                            Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/operator/accept-invitation.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/operator/accept-invitation.ts)_
+_See code: [src/commands/operator/accept-invitation.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/operator/accept-invitation.ts)_
 
 ## `storage-node operator:set-metadata`
 
@@ -704,7 +704,7 @@ OPTIONS
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/operator/set-metadata.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/operator/set-metadata.ts)_
+_See code: [src/commands/operator/set-metadata.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/operator/set-metadata.ts)_
 
 ## `storage-node server`
 
@@ -810,7 +810,7 @@ OPTIONS
                                                                    directory will be used.
 ```
 
-_See code: [src/commands/server.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/server.ts)_
+_See code: [src/commands/server.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/server.ts)_
 
 ## `storage-node util:cleanup`
 
@@ -848,7 +848,7 @@ OPTIONS
   --keyStore=keyStore                              Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/util/cleanup.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/util/cleanup.ts)_
+_See code: [src/commands/util/cleanup.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/util/cleanup.ts)_
 
 ## `storage-node util:fetch-bucket`
 
@@ -881,7 +881,7 @@ OPTIONS
                                                      under the uploads directory will be used.
 ```
 
-_See code: [src/commands/util/fetch-bucket.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/util/fetch-bucket.ts)_
+_See code: [src/commands/util/fetch-bucket.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/util/fetch-bucket.ts)_
 
 ## `storage-node util:multihash`
 
@@ -896,7 +896,7 @@ OPTIONS
   -h, --help       show CLI help
 ```
 
-_See code: [src/commands/util/multihash.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/util/multihash.ts)_
+_See code: [src/commands/util/multihash.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/util/multihash.ts)_
 
 ## `storage-node util:verify-bag-id`
 
@@ -924,5 +924,5 @@ OPTIONS
       - dynamic:member:4
 ```
 
-_See code: [src/commands/util/verify-bag-id.ts](https://github.com/Joystream/joystream/blob/v4.0.0/src/commands/util/verify-bag-id.ts)_
+_See code: [src/commands/util/verify-bag-id.ts](https://github.com/Joystream/joystream/blob/v4.2.0/src/commands/util/verify-bag-id.ts)_
 <!-- commandsstop -->

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storage-node",
   "description": "Joystream storage subsystem.",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "author": "Joystream contributors",
   "bin": {
     "storage-node": "./bin/run"

--- a/storage-node/src/commands/util/cleanup.ts
+++ b/storage-node/src/commands/util/cleanup.ts
@@ -4,6 +4,7 @@ import ApiCommandBase from '../../command-base/ApiCommandBase'
 import logger from '../../services/logger'
 import { QueryNodeApi } from '../../services/queryNode/api'
 import { performCleanup } from '../../services/sync/cleanupService'
+import { loadDataObjectIdCache } from '../../services/caching/localDataObjects'
 
 /**
  * CLI command:
@@ -51,6 +52,7 @@ export default class Cleanup extends ApiCommandBase {
     const bucketId = flags.bucketId.toString()
     const api = await this.getApi()
     const qnApi = new QueryNodeApi(flags.queryNodeEndpoint)
+    await loadDataObjectIdCache(flags.uploads)
 
     logger.info('Cleanup...')
 

--- a/storage-node/src/services/caching/newUploads.ts
+++ b/storage-node/src/services/caching/newUploads.ts
@@ -1,7 +1,8 @@
 import NodeCache from 'node-cache'
 
 // Expiration period in seconds for the new uploads data.
-const ExpirationPeriod = 3600 // seconds (1 hour)
+// Default=3600 (1 hour)
+const ExpirationPeriod = parseInt(process.env.CLEANUP_NEW_OBJECT_EXPIRATION_PERIOD || '0') || 3600
 
 // Max ID number in local cache
 const MaxEntries = 100000

--- a/storage-node/src/services/logger.ts
+++ b/storage-node/src/services/logger.ts
@@ -24,6 +24,10 @@ const levels = {
  */
 function createDefaultLoggerOptions(): winston.LoggerOptions {
   const level = () => {
+    const levelFlag = process.env.COLOSSUS_DEFAULT_LOG_LEVEL
+    if (levelFlag && Object.keys(levels).includes(levelFlag)) {
+      return levelFlag
+    }
     const env = process.env.NODE_ENV || 'development'
     const isDevelopment = env === 'development'
     return isDevelopment ? 'debug' : 'warn'

--- a/storage-node/src/services/sync/cleanupService.ts
+++ b/storage-node/src/services/sync/cleanupService.ts
@@ -20,8 +20,9 @@ export const MAXIMUM_QN_LAGGING_THRESHOLD = 100
 /**
  * The number of (peer) storage operators that should hold the assets, before the
  * cleanup/pruning of the outdated assets from this storage node can be initialed.
+ * Default=2.
  */
-export const MINIMUM_REPLICATION_THRESHOLD = 2
+export const MINIMUM_REPLICATION_THRESHOLD = parseInt(process.env.CLEANUP_MIN_REPLICATION_THRESHOLD || '0') || 2
 
 /**
  * Runs the data objects cleanup/pruning workflow. It removes all the local
@@ -80,6 +81,7 @@ export async function performCleanup(
   const removedIds = _.difference(storedObjectsIds, assignedObjectsIds)
   const removedObjects = await getDataObjectsByIDs(qnApi, removedIds)
 
+  logger.debug(`Cleanup - stored objects: ${storedObjectsIds.length}, assigned objects: ${assignedObjectsIds.length}`)
   logger.debug(`Cleanup - pruning ${removedIds.length} obsolete objects`)
 
   // Data objects permanently deleted from the runtime

--- a/tests/network-tests/ColossusApi.ts
+++ b/tests/network-tests/ColossusApi.ts
@@ -1,15 +1,17 @@
-import { Configuration, FilesApi } from '@joystream/storage-node-client'
+import { Configuration, FilesApi, StateApi } from '@joystream/storage-node-client'
 import { AxiosResponse } from 'axios'
 import { assert } from 'chai'
 
 export class ColossusApi {
   public filesApi: FilesApi
+  public stateApi: StateApi
 
   constructor(url: string) {
     const config = new Configuration({
       basePath: url,
     })
     this.filesApi = new FilesApi(config)
+    this.stateApi = new StateApi(config)
   }
 
   public async fetchAssetAsBuffer(assetId: string): Promise<AxiosResponse<Buffer>> {
@@ -27,5 +29,9 @@ export class ColossusApi {
     assert.equal(response.data.length, expectedData.length)
     assert.deepEqual([...response.data], [...expectedData])
     assert.equal(response.headers['content-type'], expectedMimeType)
+  }
+
+  public async expectAssetNotFound(assetId: string): Promise<AxiosResponse<unknown>> {
+    return this.filesApi.filesApiGetFile(assetId, { validateStatus: (status) => status === 404 })
   }
 }

--- a/tests/network-tests/src/Api.ts
+++ b/tests/network-tests/src/Api.ts
@@ -652,7 +652,7 @@ export class Api {
   public async untilProposalsCanBeCreated(
     numberOfProposals = 1,
     intervalMs = BLOCKTIME,
-    timeoutMs = 180000
+    maxRetries = 180
   ): Promise<void> {
     await Utils.until(
       `${numberOfProposals} proposals can be created`,
@@ -663,7 +663,7 @@ export class Api {
         return maxActiveProposalLimit.sub(activeProposalsN).toNumber() >= numberOfProposals
       },
       intervalMs,
-      timeoutMs
+      maxRetries
     )
   }
 
@@ -671,9 +671,9 @@ export class Api {
     targetStage: 'Announcing' | 'Voting' | 'Revealing' | 'Idle',
     announcementPeriodNr: number | null = null,
     blocksReserve = 4,
-    intervalMs = BLOCKTIME
+    intervalMs = BLOCKTIME,
+    maxRetries = 600
   ): Promise<void> {
-    const stageTimeoutMs = 100 * 6 * 1000
     await Utils.until(
       `council stage ${targetStage} (+${blocksReserve} blocks reserve)`,
       async ({ debug }) => {
@@ -710,7 +710,7 @@ export class Api {
         )
       },
       intervalMs,
-      stageTimeoutMs
+      maxRetries
     )
   }
 

--- a/tests/network-tests/src/flows/storage/storageCleanup.ts
+++ b/tests/network-tests/src/flows/storage/storageCleanup.ts
@@ -1,0 +1,149 @@
+import { FlowProps } from '../../Flow'
+import { extendDebug } from '../../Debugger'
+import { BuyMembershipHappyCaseFixture } from '../../fixtures/membership'
+import { FixtureRunner } from '../../Fixture'
+import { createType } from '@joystream/types'
+import { ChannelCreationInputParameters } from '@joystream/cli/src/Types'
+import { Utils } from '../../utils'
+import { ColossusApi } from '../../../ColossusApi'
+import { doubleBucketConfig } from './initStorage'
+import { readFileSync } from 'fs'
+import { createJoystreamCli } from '../utils'
+import urljoin from 'url-join'
+
+export async function storageCleanup({ api, query }: FlowProps): Promise<void> {
+  const debug = extendDebug('flow:storageCleanup')
+  api.enableDebugTxLogs()
+  debug('Started')
+
+  // Get sotrage leader key
+  const [, storageLeader] = await api.getLeader('storageWorkingGroup')
+  const storageLeaderKey = storageLeader.roleAccountId.toString()
+
+  // Create a member that will create the channels
+  const [, memberKeyPair] = await api.createKeyPairs(2)
+  const memberAddr = memberKeyPair.key.address
+  const buyMembershipFixture = new BuyMembershipHappyCaseFixture(api, query, [memberAddr])
+  await new FixtureRunner(buyMembershipFixture).run()
+  const [memberId] = buyMembershipFixture.getCreatedMembers()
+
+  // Give member 100 JOY, to be able to create a few channels through CLI
+  await api.treasuryTransferBalance(memberAddr, Utils.joy(100))
+
+  // Use JoystreamCLI to create a few channels w/ some avatarPhoto and coverPhoto objects
+  const joystreamCli = await createJoystreamCli()
+  await joystreamCli.importAccount(memberKeyPair.key)
+
+  const numChannels = 3
+
+  const channelsData: { channelId: number; avatarPhotoPath: string; coverPhotoPath: string }[] = []
+  for (let i = 0; i < numChannels; ++i) {
+    const avatarPhotoPath = joystreamCli.getTmpFileManager().randomImgFile(300, 300)
+    const coverPhotoPath = joystreamCli.getTmpFileManager().randomImgFile(1920, 500)
+    const channelInput: ChannelCreationInputParameters = {
+      title: `Cleanup test channel ${i + 1}`,
+      avatarPhotoPath,
+      coverPhotoPath,
+      description: `This is a cleanup test channel ${i + 1}`,
+      isPublic: true,
+      language: 'en',
+    }
+    const channelId = await joystreamCli.createChannel(channelInput, [
+      '--context',
+      'Member',
+      '--useMemberId',
+      memberId.toString(),
+    ])
+    debug(`Created channel ${i + 1}`)
+    channelsData.push({ channelId, avatarPhotoPath, coverPhotoPath })
+  }
+  const channelIds = channelsData.map((c) => c.channelId)
+
+  // Wait until QN processes the channels
+  debug('Waiting for QN to process the channels...')
+  const channels = await query.tryQueryWithTimeout(
+    () => query.channelsByIds(channelIds.map((id) => id.toString())),
+    (r) => Utils.assert(r.length === numChannels, `Expected ${numChannels} channels, found: ${r.length}`)
+  )
+
+  // Give colossus nodes some time to sync
+  debug('Giving colossus nodes 60 seconds to sync...')
+  await Utils.wait(60_000)
+
+  // Verify that both storage nodes store all the assets of created channels
+  const colossus1Endpoint = doubleBucketConfig.buckets[0].metadata.endpoint
+  const colossus2Endpoint = doubleBucketConfig.buckets[1].metadata.endpoint
+  Utils.assert(colossus1Endpoint && colossus2Endpoint, 'Missing one of 2 colossus node endpoints!')
+
+  const colossus1Api = new ColossusApi(urljoin(colossus1Endpoint, 'api/v1'))
+  const colossus2Api = new ColossusApi(urljoin(colossus2Endpoint, 'api/v1'))
+
+  const verifyAssets = async (colossus1StoredChannelIds: number[], colossus2StoredChannelIds: number[]) => {
+    const verifyAssetsPromises = channelsData.map(async ({ channelId, avatarPhotoPath, coverPhotoPath }) => {
+      const channel = channels.find((c) => c.id === channelId.toString())
+      Utils.assert(channel, `Channel ${channelId} missing in QN result`)
+      Utils.assert(channel.coverPhoto && channel.avatarPhoto, `Channel assets missing in QN result`)
+      if (colossus1StoredChannelIds.includes(channelId)) {
+        await Promise.all([
+          colossus1Api.fetchAndVerifyAsset(channel.coverPhoto.id, readFileSync(coverPhotoPath), 'image/bmp'),
+          colossus1Api.fetchAndVerifyAsset(channel.avatarPhoto.id, readFileSync(avatarPhotoPath), 'image/bmp'),
+        ])
+      } else {
+        await Promise.all([
+          colossus1Api.expectAssetNotFound(channel.coverPhoto.id),
+          colossus1Api.expectAssetNotFound(channel.avatarPhoto.id),
+        ])
+      }
+      if (colossus2StoredChannelIds.includes(channelId)) {
+        await Promise.all([
+          colossus2Api.fetchAndVerifyAsset(channel.coverPhoto.id, readFileSync(coverPhotoPath), 'image/bmp'),
+          colossus2Api.fetchAndVerifyAsset(channel.avatarPhoto.id, readFileSync(avatarPhotoPath), 'image/bmp'),
+        ])
+      } else {
+        await Promise.all([
+          colossus2Api.expectAssetNotFound(channel.coverPhoto.id),
+          colossus2Api.expectAssetNotFound(channel.avatarPhoto.id),
+        ])
+      }
+    })
+    await Promise.all(verifyAssetsPromises)
+  }
+
+  // At this point we expect both nodes to store all assets
+  await verifyAssets(channelIds, channelIds)
+  debug('All assets correctly stored!')
+
+  // Delete the 1st channel
+  debug('Deleting 1st channel...')
+  await joystreamCli.deleteChannel(channelIds[0])
+
+  // Update 2nd channel bag to only be stored by colossus1 and
+  // 3rd channel bag to only be stored by colossus2
+  debug('Reassigning 2nd channel to colossus1 only and 3rd channel to colossus2 only...')
+  const bag1Id = createType('PalletStorageBagIdType', { Dynamic: { Channel: channelIds[1] } }) // 2nd channel bag
+  const bag2Id = createType('PalletStorageBagIdType', { Dynamic: { Channel: channelIds[2] } }) // 3rd channel bag
+  const updateTxs = [
+    api.tx.storage.updateStorageBucketsForBag(
+      bag1Id,
+      createType('BTreeSet<u64>', []),
+      createType('BTreeSet<u64>', [1]) // Remove 1st bucket (colossu2)
+    ),
+    api.tx.storage.updateStorageBucketsForBag(
+      bag2Id,
+      createType('BTreeSet<u64>', []),
+      createType('BTreeSet<u64>', [0]) // Remove 0th bucket (colossu1)
+    ),
+  ]
+  await api.sendExtrinsicsAndGetResults(updateTxs, storageLeaderKey)
+
+  // Wait 2 minutes to make sure cleanup is executed
+  debug('Giving nodes 120 seconds to cleanup...')
+  await Utils.wait(120_000)
+
+  // Verify that Colossus2 (w/ auto cleanup) no longer stores 1st and 2nd channel assets,
+  // while Colossus1 still stores all assets
+  await verifyAssets(channelIds, channelIds.slice(2))
+  debug('Cleanup correctly executed!')
+
+  debug('Done')
+}

--- a/tests/network-tests/src/scenarios/full.ts
+++ b/tests/network-tests/src/scenarios/full.ts
@@ -42,6 +42,7 @@ import { updateApp } from '../flows/content/updateApp'
 import curatorModerationActions from '../flows/content/curatorModerationActions'
 import collaboratorAndCuratorPermissions from '../flows/content/collaboratorAndCuratorPermissions'
 import updateValidatorVerificationStatus from '../flows/membership/updateValidatorVerifications'
+import { storageCleanup } from '../flows/storage/storageCleanup'
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 scenario('Full', async ({ job }) => {
@@ -123,8 +124,10 @@ scenario('Full', async ({ job }) => {
 
   const contentDirectoryJob = directChannelPaymentJob // keep updated to last job above
 
+  // Storage cleanup
+  const storageCleanupJob = job('storage cleanup', storageCleanup).after(contentDirectoryJob)
   // Storage & distribution CLIs
   job('init storage and distribution buckets via CLI', [initDistributionBucket, initStorageBucket]).after(
-    contentDirectoryJob
+    storageCleanupJob
   )
 })

--- a/tests/network-tests/src/utils.ts
+++ b/tests/network-tests/src/utils.ts
@@ -143,7 +143,14 @@ export class Utils {
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => reject(new Error(`Awaiting ${name} - timeout reached`)), timeoutMs)
       const check = async () => {
-        if (await conditionFunc({ debug })) {
+        let result = false
+        try {
+          result = await conditionFunc({ debug })
+        } catch (e: any) {
+          debug(`conditionFunc error: ${e.toString()}`)
+          return
+        }
+        if (result) {
           clearInterval(interval)
           clearTimeout(timeout)
           debug('Condition satisfied!')

--- a/tests/network-tests/src/utils.ts
+++ b/tests/network-tests/src/utils.ts
@@ -137,32 +137,27 @@ export class Utils {
     name: string,
     conditionFunc: (props: { debug: Debugger.Debugger }) => Promise<boolean>,
     intervalMs = BLOCKTIME,
-    timeoutMs = 10 * 60 * 1000
+    maxRetries = 600
   ): Promise<void> {
     const debug = extendDebug(`awaiting:${name}`)
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error(`Awaiting ${name} - timeout reached`)), timeoutMs)
-      const check = async () => {
-        let result = false
-        try {
-          result = await conditionFunc({ debug })
-        } catch (e: any) {
-          debug(`conditionFunc error: ${e.toString()}`)
-          return
-        }
+    for (let i = 0; i < maxRetries; ++i) {
+      try {
+        const result = await conditionFunc({ debug })
         if (result) {
-          clearInterval(interval)
-          clearTimeout(timeout)
           debug('Condition satisfied!')
-          resolve()
           return
         }
-        debug('Condition not satisfied, waiting...')
+      } catch (e: any) {
+        debug(`conditionFunc error: ${e.toString()}`)
+        // Continue the loop...
       }
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      const interval = setInterval(check, intervalMs)
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      check()
-    })
+
+      if (i !== maxRetries - 1) {
+        debug(`Attempt ${i + 1}/${maxRetries}: Condition not satisfied, waiting...`)
+        await Utils.wait(intervalMs)
+      }
+    }
+
+    throw new Error(`Awaiting ${name} - max retries reached!`)
   }
 }


### PR DESCRIPTION
- Fix `util:cleanup` script (call `loadDataObjectIdCache` first)
- Allow changing default log level using environment variable (`COLOSSUS_DEFAULT_LOG_LEVEL`)
- Allow adjusting cleanup constants via env (`CLEANUP_MIN_REPLICATION_THRESHOLD`, `CLEANUP_NEW_OBJECT_EXPIRATION_PERIOD`)
- Error handling: Clearer warning messages if unexpected response encountered during sync (ie. 404)
- Add tests to verify cleanup behavior with `--cleanup` flag enabled

Related issue: https://github.com/Joystream/joystream/issues/5182