### PR TITLE
Colossus: Rework sync and cleanup

### DIFF
--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -3,7 +3,7 @@
 - **Optimizations:** The way data objects / data object ids are queried and processed during sync and cleanup has been optimized:
     - Sync and cleanup services now process tasks in batches of configurable size (`--syncBatchSize`, `--cleanupBatchSize`) to avoid overflowing the memory.
     - Synchronous operations like `sort` or `filter` on larger arrays of data objects have been optimized (for example, by replacing `.filter(Array.includes(...))` with `.filter(Set.has(...))`).
-    - Enforced a limit of max. results per single GraphQL query to `10,000` and max input arguments per query to `1,000`
+    - Enforced a limit of max. results per single GraphQL query to `10,000` and max input arguments per query to `1,000`.
     - Added `--cleanupWorkersNumber` flag to limit the number of concurrent async requests during cleanup.
 - A safety mechanism was added to avoid removing "deleted" objects for which a related `DataObjectDeleted` event cannot be found in storage squid.
 - Improved logging during sync and cleanup.

--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,10 +1,12 @@
 ### 4.4.0
 
 - **Optimizations:** The way data objects / data object ids are queried and processed during sync and cleanup has been optimized:
-    - Sync and cleanup services now process tasks in batches of `10_000` to avoid overflowing the memory.
+    - Sync and cleanup services now process tasks in batches of configurable size (`--syncBatchSize`, `--cleanupBatchSize`) to avoid overflowing the memory.
     - Synchronous operations like `sort` or `filter` on larger arrays of data objects have been optimized (for example, by replacing `.filter(Array.includes(...))` with `.filter(Set.has(...))`).
+    - Enforced a limit of max. results per single GraphQL query to `10,000` and max input arguments per query to `1,000`
+    - Added `--cleanupWorkersNumber` flag to limit the number of concurrent async requests during cleanup.
 - A safety mechanism was added to avoid removing "deleted" objects for which a related `DataObjectDeleted` event cannot be found in storage squid.
-- Improved logging during cleanup.
+- Improved logging during sync and cleanup.
 
 ### 4.3.0
 

--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -4,8 +4,9 @@
 - **Optimizations:** The way data objects / data object ids are queried and processed during sync and cleanup has been optimized:
     - `DataObjectDetailsLoader` and `DataObjectIdsLoader` were implemented. They allow loading data objects / data object ids in batches using a connection query and avoid fetching redundant data from the GraphQL server.
     - Sync and cleanup services now process tasks in batches of `10_000` to avoid overflowing the memory.
-    - Synchronous operations like `sort` or `filter` on larger arrays of data objects have been optimized (for example, by replacing `.filter(Array.includes(...))` with `.filter(Set.has(...))`)
-- Improved logging during cleanup
+    - Synchronous operations like `sort` or `filter` on larger arrays of data objects have been optimized (for example, by replacing `.filter(Array.includes(...))` with `.filter(Set.has(...))`).
+- A safety mechanism was added to avoid removing "deleted" objects for which a related `DataObjectDeleted` event cannot be found in storage squid.
+- Improved logging during cleanup.
 
 
 ### 4.2.0

--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,6 +1,5 @@
-### 4.3.0
+### 4.4.0
 
-- **New feature:** `archive` mode / command, which allows downloading, compressing and uploading all data objects to an external S3 bucket that can be used as a backup.
 - **Optimizations:** The way data objects / data object ids are queried and processed during sync and cleanup has been optimized:
     - `DataObjectDetailsLoader` and `DataObjectIdsLoader` were implemented. They allow loading data objects / data object ids in batches using a connection query and avoid fetching redundant data from the GraphQL server.
     - Sync and cleanup services now process tasks in batches of `10_000` to avoid overflowing the memory.
@@ -8,6 +7,9 @@
 - A safety mechanism was added to avoid removing "deleted" objects for which a related `DataObjectDeleted` event cannot be found in storage squid.
 - Improved logging during cleanup.
 
+### 4.3.0
+
+- Adds `archive` mode / command, which allows downloading, compressing and uploading all data objects to an external S3 bucket that can be used as a backup.
 
 ### 4.2.0
 

--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,6 +1,12 @@
 ### 4.3.0
 
-- Adds `archive` mode / command, which allows downloading, compressing and uploading all data objects to an external S3 bucket that can be used as a backup.
+- **New feature:** `archive` mode / command, which allows downloading, compressing and uploading all data objects to an external S3 bucket that can be used as a backup.
+- **Optimizations:** The way data objects / data object ids are queried and processed during sync and cleanup has been optimized:
+    - `DataObjectDetailsLoader` and `DataObjectIdsLoader` were implemented. They allow loading data objects / data object ids in batches using a connection query and avoid fetching redundant data from the GraphQL server.
+    - Sync and cleanup services now process tasks in batches of `10_000` to avoid overflowing the memory.
+    - Synchronous operations like `sort` or `filter` on larger arrays of data objects have been optimized (for example, by replacing `.filter(Array.includes(...))` with `.filter(Set.has(...))`)
+- Improved logging during cleanup
+
 
 ### 4.2.0
 

--- a/storage-node/CHANGELOG.md
+++ b/storage-node/CHANGELOG.md
@@ -1,7 +1,6 @@
 ### 4.4.0
 
 - **Optimizations:** The way data objects / data object ids are queried and processed during sync and cleanup has been optimized:
-    - `DataObjectDetailsLoader` and `DataObjectIdsLoader` were implemented. They allow loading data objects / data object ids in batches using a connection query and avoid fetching redundant data from the GraphQL server.
     - Sync and cleanup services now process tasks in batches of `10_000` to avoid overflowing the memory.
     - Synchronous operations like `sort` or `filter` on larger arrays of data objects have been optimized (for example, by replacing `.filter(Array.includes(...))` with `.filter(Set.has(...))`).
 - A safety mechanism was added to avoid removing "deleted" objects for which a related `DataObjectDeleted` event cannot be found in storage squid.

--- a/storage-node/README.md
+++ b/storage-node/README.md
@@ -170,6 +170,7 @@ There is also an option to run Colossus as [Docker container](../colossus.Docker
 * [`storage-node util:cleanup`](#storage-node-utilcleanup)
 * [`storage-node util:fetch-bucket`](#storage-node-utilfetch-bucket)
 * [`storage-node util:multihash`](#storage-node-utilmultihash)
+* [`storage-node util:search-archives`](#storage-node-utilsearch-archives)
 * [`storage-node util:verify-bag-id`](#storage-node-utilverify-bag-id)
 
 ## `storage-node archive`
@@ -181,11 +182,6 @@ USAGE
   $ storage-node archive
 
 OPTIONS
-  -b, --buckets=buckets
-      [default: 1] Comma separated list of bucket IDs to sync. Buckets that are not assigned to
-      worker are ignored.
-      If not specified all buckets will be synced.
-
   -e, --elasticSearchEndpoint=elasticSearchEndpoint
       Elasticsearch endpoint (e.g.: http://some.com:8081).
       Log level could be set using the ELASTIC_LOG_LEVEL environment variable.
@@ -210,12 +206,12 @@ OPTIONS
       [default: 7] Maximum rolling log files number.
 
   -p, --password=password
-      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files. If
-      not specified a single password can be set in ACCOUNT_PWD environment variable.
+      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files. If not specified a single
+      password can be set in ACCOUNT_PWD environment variable.
 
   -q, --storageSquidEndpoint=storageSquidEndpoint
-      (required) [default: http://localhost:4352/graphql] Storage Squid graphql server endpoint
-      (e.g.: http://some.com:4352/graphql)
+      (required) [default: http://localhost:4352/graphql] Storage Squid graphql server endpoint (e.g.:
+      http://some.com:4352/graphql)
 
   -r, --syncWorkersNumber=syncWorkersNumber
       [default: 8] Sync workers number (max async operations in progress).
@@ -233,19 +229,17 @@ OPTIONS
       [default: 50000000] Maximum rolling log files size in bytes.
 
   -y, --accountUri=accountUri
-      Account URI (optional). If not specified a single key can be set in ACCOUNT_URI environment
-      variable.
+      Account URI (optional). If not specified a single key can be set in ACCOUNT_URI environment variable.
 
   -z, --logFileChangeFrequency=(yearly|monthly|daily|hourly|none)
       [default: daily] Log files update frequency.
 
   --archiveFileSizeLimitMB=archiveFileSizeLimitMB
-      [default: 1000] Try to avoid creating archive files larger than this size limit (in MB)
-      unless necessary
+      [default: 1000] Try to avoid creating archive files larger than this size limit (in MB) unless unaviodable.
 
   --archiveTrackfileBackupFreqMinutes=archiveTrackfileBackupFreqMinutes
-      [default: 60] Determines how frequently the archive tracking file (containing information
-      about .7z files content) should be uploaded to S3 in case a change is detected.
+      [default: 60] Specifies how frequently the archive tracking file (containing information about archive files
+      content) should be uploaded to S3 (in case it's changed).
 
   --awsS3BucketName=awsS3BucketName
       (required) Name of the AWS S3 bucket where the files will be stored.
@@ -253,52 +247,65 @@ OPTIONS
   --awsS3BucketRegion=awsS3BucketRegion
       (required) AWS region of the AWS S3 bucket where the files will be stored.
 
+  --awsStorageClass=(DEEP_ARCHIVE|EXPRESS_ONEZONE|GLACIER|GLACIER_IR|INTELLIGENT_TIERING|ONEZONE_IA|OUTPOSTS|REDUCED_RED
+  UNDANCY|SNOW|STANDARD|STANDARD_IA)
+      (required) [default: DEEP_ARCHIVE] AWS S3 storage class to use when uploading the archives to S3.
+
+  --compressionAlgorithm=(7zip|zstd|none)
+      (required) [default: zstd] Compression algorithm to use for archive files
+
+  --compressionLevel=(low|medium|high)
+      (required) [default: medium] Compression level to use for archive files (lower is faster, but provides lower storage
+      savings)
+
+  --compressionThreads=compressionThreads
+      (required) [default: 1] Number of threads to use for compression. Note that {uploadWorkersNumber} upload tasks may
+      be running at once and each of them can spawn a separate compression task which uses {compressionThreads} threads!
+
   --elasticSearchIndexPrefix=elasticSearchIndexPrefix
-      [default: logs-colossus] Elasticsearch index prefix. Node ID will be appended to the prefix.
-      Default: logs-colossus. Can be passed through ELASTIC_INDEX_PREFIX environment variable.
+      [default: logs-colossus] Elasticsearch index prefix. Node ID will be appended to the prefix. Default: logs-colossus.
+      Can be passed through ELASTIC_INDEX_PREFIX environment variable.
 
   --elasticSearchPassword=elasticSearchPassword
-      Elasticsearch password for basic authentication. Can be passed through ELASTIC_PASSWORD
-      environment variable.
+      Elasticsearch password for basic authentication. Can be passed through ELASTIC_PASSWORD environment variable.
 
   --elasticSearchUser=elasticSearchUser
-      Elasticsearch user for basic authentication. Can be passed through ELASTIC_USER environment
-      variable.
+      Elasticsearch user for basic authentication. Can be passed through ELASTIC_USER environment variable.
 
   --keyStore=keyStore
       Path to a folder with multiple key files to load into keystore.
 
   --localAgeTriggerThresholdMinutes=localAgeTriggerThresholdMinutes
-      [default: 1440] Compress and upload local data objects to S3 if the oldest of them was
-      downloaded more than X minutes ago
+      [default: 1440] Compress and upload all local data objects to S3 if the oldest of them was downloaded more than X
+      minutes ago
 
   --localCountTriggerThreshold=localCountTriggerThreshold
-      Compress and upload local data objects to S3 if the number of them reaches this threshold.
+      Compress and upload all local data objects to S3 if the number of them reaches this threshold.
 
   --localSizeTriggerThresholdMB=localSizeTriggerThresholdMB
-      [default: 10000] Compress and upload local data objects to S3 if the combined size of them
-      reaches this threshold (in MB)
+      [default: 10000] Compress and upload all local data objects to S3 if the combined size of them reaches this
+      threshold (in MB)
+
+  --statsLoggingInterval=statsLoggingInterval
+      (required) [default: 60] How often the upload/download/compression statistics summary will be logged (in minutes).
 
   --tmpDownloadDir=tmpDownloadDir
-      (required) Directory to store tempory files during sync (absolute path).
+      (required) Directory to store temporary data (downloads in progress) during sync (absolute path).
 
   --uploadQueueDir=uploadQueueDir
-      (required) Directory to store fully downloaded data objects before compressing them and
-      uploading to S3 (absolute path).
+      (required) Directory to store fully downloaded data objects before compressing them and uploading to S3 (absolute
+      path).
 
   --uploadQueueDirSizeLimitMB=uploadQueueDirSizeLimitMB
-      (required) [default: 20000] Limits the total size of files stored in upload queue directory
-      (in MB). Download of the new objects will be limitted in order to prevent exceeding this
-      limit. To leave a safe margin of error, it should be set to ~50% of available disk space.
-
-  --uploadRetryInterval=uploadRetryInterval
-      [default: 3] Interval before retrying failed upload (in minutes)
+      (required) [default: 20000] Limits the total size of files stored in upload queue directory (in MB). Download of the
+      new objects may be slowed down in order to try to prevent exceeding this limit. WARNING: To leave a safe margin of
+      error (for compression etc.), it should be set to ~50% of available disk space.
 
   --uploadWorkersNumber=uploadWorkersNumber
       [default: 4] Upload workers number (max async operations in progress).
 ```
 
-_See code: [src/commands/archive.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/archive.ts)_
+_See code: [src/commands/archive.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/archive.ts)_
 
 ## `storage-node help [COMMAND]`
 
@@ -331,20 +338,18 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/cancel-invite.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/cancel-invite.ts)_
+_See code: [src/commands/leader/cancel-invite.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/cancel-invite.ts)_
 
 ## `storage-node leader:create-bucket`
 
@@ -362,22 +367,20 @@ OPTIONS
   -m, --dev                    Use development mode
   -n, --number=number          Storage bucket max total objects number
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
   -s, --size=size              Storage bucket max total objects size
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/create-bucket.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/create-bucket.ts)_
+_See code: [src/commands/leader/create-bucket.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/create-bucket.ts)_
 
 ## `storage-node leader:delete-bucket`
 
@@ -393,20 +396,18 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/delete-bucket.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/delete-bucket.ts)_
+_See code: [src/commands/leader/delete-bucket.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/delete-bucket.ts)_
 
 ## `storage-node leader:invite-operator`
 
@@ -422,22 +423,20 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
   -w, --operatorId=operatorId  (required) Storage bucket operator ID (storage group worker ID)
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/invite-operator.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/invite-operator.ts)_
+_See code: [src/commands/leader/invite-operator.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/invite-operator.ts)_
 
 ## `storage-node leader:remove-operator`
 
@@ -453,20 +452,18 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/remove-operator.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/remove-operator.ts)_
+_See code: [src/commands/leader/remove-operator.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/remove-operator.ts)_
 
 ## `storage-node leader:set-bucket-limits`
 
@@ -483,22 +480,20 @@ OPTIONS
   -m, --dev                    Use development mode
   -o, --objects=objects        (required) New 'voucher object number limit' value
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
   -s, --size=size              (required) New 'voucher object size limit' value
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/set-bucket-limits.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/set-bucket-limits.ts)_
+_See code: [src/commands/leader/set-bucket-limits.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/set-bucket-limits.ts)_
 
 ## `storage-node leader:set-global-uploading-status`
 
@@ -513,22 +508,20 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
   -s, --set=(on|off)           (required) Sets global uploading block (on/off).
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/set-global-uploading-status.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/set-global-uploading-status.ts)_
+_See code: [src/commands/leader/set-global-uploading-status.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/set-global-uploading-status.ts)_
 
 ## `storage-node leader:update-bag-limit`
 
@@ -544,20 +537,18 @@ OPTIONS
   -l, --limit=limit            (required) New StorageBucketsPerBagLimit value
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-bag-limit.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/update-bag-limit.ts)_
+_See code: [src/commands/leader/update-bag-limit.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/update-bag-limit.ts)_
 
 ## `storage-node leader:update-bags`
 
@@ -594,8 +585,8 @@ OPTIONS
       Use development mode
 
   -p, --password=password
-      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files. If
-      not specified a single password can be set in ACCOUNT_PWD environment variable.
+      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files. If not specified a single
+      password can be set in ACCOUNT_PWD environment variable.
 
   -r, --remove=remove
       [default: ] Comma separated list of bucket IDs to remove from all bag/s
@@ -607,14 +598,13 @@ OPTIONS
       [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
   -y, --accountUri=accountUri
-      Account URI (optional). If not specified a single key can be set in ACCOUNT_URI environment
-      variable.
+      Account URI (optional). If not specified a single key can be set in ACCOUNT_URI environment variable.
 
   --keyStore=keyStore
       Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-bags.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/update-bags.ts)_
+_See code: [src/commands/leader/update-bags.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/update-bags.ts)_
 
 ## `storage-node leader:update-blacklist`
 
@@ -630,22 +620,20 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
   -r, --remove=remove          [default: ] Content ID to remove
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-blacklist.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/update-blacklist.ts)_
+_See code: [src/commands/leader/update-blacklist.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/update-blacklist.ts)_
 
 ## `storage-node leader:update-bucket-status`
 
@@ -661,23 +649,20 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
-  -s, --set=(on|off)           (required) Sets 'accepting new bags' parameter for the bucket
-                               (on/off).
+  -s, --set=(on|off)           (required) Sets 'accepting new bags' parameter for the bucket (on/off).
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-bucket-status.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/update-bucket-status.ts)_
+_See code: [src/commands/leader/update-bucket-status.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/update-bucket-status.ts)_
 
 ## `storage-node leader:update-data-fee`
 
@@ -693,20 +678,18 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-data-fee.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/update-data-fee.ts)_
+_See code: [src/commands/leader/update-data-fee.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/update-data-fee.ts)_
 
 ## `storage-node leader:update-data-object-bloat-bond`
 
@@ -721,22 +704,20 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
   -v, --value=value            (required) New data object bloat bond value
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-data-object-bloat-bond.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/update-data-object-bloat-bond.ts)_
+_See code: [src/commands/leader/update-data-object-bloat-bond.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/update-data-object-bloat-bond.ts)_
 
 ## `storage-node leader:update-dynamic-bag-policy`
 
@@ -752,23 +733,21 @@ OPTIONS
   -m, --dev                       Use development mode
   -n, --number=number             (required) New storage buckets number
 
-  -p, --password=password         Password to unlock keyfiles. Multiple passwords can be passed,
-                                  to try against all files. If not specified a single password
-                                  can be set in ACCOUNT_PWD environment variable.
+  -p, --password=password         Password to unlock keyfiles. Multiple passwords can be passed, to try against all
+                                  files. If not specified a single password can be set in ACCOUNT_PWD environment
+                                  variable.
 
   -t, --bagType=(Channel|Member)  (required) Dynamic bag type (Channel, Member).
 
-  -u, --apiUrl=apiUrl             [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                                  non-dev environment.
+  -u, --apiUrl=apiUrl             [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri     Account URI (optional). If not specified a single key can be
-                                  set in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri     Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                                  environment variable.
 
-  --keyStore=keyStore             Path to a folder with multiple key files to load into
-                                  keystore.
+  --keyStore=keyStore             Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-dynamic-bag-policy.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/update-dynamic-bag-policy.ts)_
+_See code: [src/commands/leader/update-dynamic-bag-policy.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/update-dynamic-bag-policy.ts)_
 
 ## `storage-node leader:update-voucher-limits`
 
@@ -784,22 +763,20 @@ OPTIONS
   -m, --dev                    Use development mode
   -o, --objects=objects        (required) New 'max voucher object number limit' value
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
   -s, --size=size              (required) New 'max voucher object size limit' value
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/leader/update-voucher-limits.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/leader/update-voucher-limits.ts)_
+_See code: [src/commands/leader/update-voucher-limits.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/leader/update-voucher-limits.ts)_
 
 ## `storage-node operator:accept-invitation`
 
@@ -815,27 +792,24 @@ OPTIONS
   -k, --keyFile=keyFile                          Path to key file to add to the keyring.
   -m, --dev                                      Use development mode
 
-  -p, --password=password                        Password to unlock keyfiles. Multiple passwords
-                                                 can be passed, to try against all files. If not
-                                                 specified a single password can be set in
+  -p, --password=password                        Password to unlock keyfiles. Multiple passwords can be passed, to try
+                                                 against all files. If not specified a single password can be set in
                                                  ACCOUNT_PWD environment variable.
 
   -t, --transactorAccountId=transactorAccountId  (required) Transactor account ID (public key)
 
-  -u, --apiUrl=apiUrl                            [default: ws://localhost:9944] Runtime API URL.
-                                                 Mandatory in non-dev environment.
+  -u, --apiUrl=apiUrl                            [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev
+                                                 environment.
 
   -w, --workerId=workerId                        (required) Storage operator worker ID
 
-  -y, --accountUri=accountUri                    Account URI (optional). If not specified a
-                                                 single key can be set in ACCOUNT_URI
-                                                 environment variable.
+  -y, --accountUri=accountUri                    Account URI (optional). If not specified a single key can be set in
+                                                 ACCOUNT_URI environment variable.
 
-  --keyStore=keyStore                            Path to a folder with multiple key files to
-                                                 load into keystore.
+  --keyStore=keyStore                            Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/operator/accept-invitation.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/operator/accept-invitation.ts)_
+_See code: [src/commands/operator/accept-invitation.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/operator/accept-invitation.ts)_
 
 ## `storage-node operator:set-metadata`
 
@@ -853,22 +827,20 @@ OPTIONS
   -k, --keyFile=keyFile        Path to key file to add to the keyring.
   -m, --dev                    Use development mode
 
-  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to
-                               try against all files. If not specified a single password can be
-                               set in ACCOUNT_PWD environment variable.
+  -p, --password=password      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files.
+                               If not specified a single password can be set in ACCOUNT_PWD environment variable.
 
-  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in
-                               non-dev environment.
+  -u, --apiUrl=apiUrl          [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
 
   -w, --workerId=workerId      (required) Storage operator worker ID
 
-  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set
-                               in ACCOUNT_URI environment variable.
+  -y, --accountUri=accountUri  Account URI (optional). If not specified a single key can be set in ACCOUNT_URI
+                               environment variable.
 
   --keyStore=keyStore          Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/operator/set-metadata.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/operator/set-metadata.ts)_
+_See code: [src/commands/operator/set-metadata.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/operator/set-metadata.ts)_
 
 ## `storage-node server`
 
@@ -879,109 +851,102 @@ USAGE
   $ storage-node server
 
 OPTIONS
-  -b, --buckets=buckets
-      [default: ] Comma separated list of bucket IDs to service. Buckets that are not assigned to
-      worker are ignored. If not specified all buckets will be serviced.
+  -b, --buckets=buckets                                            [default: ] Comma separated list of bucket IDs to
+                                                                   service. Buckets that are not assigned to worker are
+                                                                   ignored. If not specified all buckets will be
+                                                                   serviced.
 
-  -c, --cleanup
-      Enable cleanup/pruning of no-longer assigned assets.
+  -c, --cleanup                                                    Enable cleanup/pruning of no-longer assigned assets.
 
-  -d, --uploads=uploads
-      (required) Data uploading directory (absolute path).
+  -d, --uploads=uploads                                            (required) Data uploading directory (absolute path).
 
-  -e, --elasticSearchEndpoint=elasticSearchEndpoint
-      Elasticsearch endpoint (e.g.: http://some.com:8081).
-      Log level could be set using the ELASTIC_LOG_LEVEL environment variable.
-      Supported values: warn, error, debug, info. Default:debug
+  -e, --elasticSearchEndpoint=elasticSearchEndpoint                Elasticsearch endpoint (e.g.: http://some.com:8081).
+                                                                   Log level could be set using the ELASTIC_LOG_LEVEL
+                                                                   environment variable.
+                                                                   Supported values: warn, error, debug, info.
+                                                                   Default:debug
 
-  -h, --help
-      show CLI help
+  -h, --help                                                       show CLI help
 
-  -i, --cleanupInterval=cleanupInterval
-      [default: 360] Interval between periodic cleanup actions (in minutes)
+  -i, --cleanupInterval=cleanupInterval                            [default: 360] Interval between periodic cleanup
+                                                                   actions (in minutes)
 
-  -i, --syncInterval=syncInterval
-      [default: 20] Interval between synchronizations (in minutes)
+  -i, --syncInterval=syncInterval                                  [default: 20] Interval between synchronizations (in
+                                                                   minutes)
 
-  -k, --keyFile=keyFile
-      Path to key file to add to the keyring.
+  -k, --keyFile=keyFile                                            Path to key file to add to the keyring.
 
-  -l, --logFilePath=logFilePath
-      Absolute path to the rolling log files.
+  -l, --logFilePath=logFilePath                                    Absolute path to the rolling log files.
 
-  -m, --dev
-      Use development mode
+  -m, --dev                                                        Use development mode
 
-  -n, --logMaxFileNumber=logMaxFileNumber
-      [default: 7] Maximum rolling log files number.
+  -n, --logMaxFileNumber=logMaxFileNumber                          [default: 7] Maximum rolling log files number.
 
-  -o, --port=port
-      (required) Server port.
+  -o, --port=port                                                  (required) Server port.
 
-  -p, --password=password
-      Password to unlock keyfiles. Multiple passwords can be passed, to try against all files. If
-      not specified a single password can be set in ACCOUNT_PWD environment variable.
+  -p, --password=password                                          Password to unlock keyfiles. Multiple passwords can
+                                                                   be passed, to try against all files. If not specified
+                                                                   a single password can be set in ACCOUNT_PWD
+                                                                   environment variable.
 
-  -q, --storageSquidEndpoint=storageSquidEndpoint
-      (required) [default: http://localhost:4352/graphql] Storage Squid graphql server endpoint
-      (e.g.: http://some.com:4352/graphql)
+  -q, --storageSquidEndpoint=storageSquidEndpoint                  (required) [default: http://localhost:4352/graphql]
+                                                                   Storage Squid graphql server endpoint (e.g.:
+                                                                   http://some.com:4352/graphql)
 
-  -r, --syncWorkersNumber=syncWorkersNumber
-      [default: 20] Sync workers number (max async operations in progress).
+  -r, --syncWorkersNumber=syncWorkersNumber                        [default: 20] Sync workers number (max async
+                                                                   operations in progress).
 
-  -s, --sync
-      Enable data synchronization.
+  -s, --sync                                                       Enable data synchronization.
 
-  -t, --syncWorkersTimeout=syncWorkersTimeout
-      [default: 30] Asset downloading timeout for the syncronization (in minutes).
+  -t, --syncWorkersTimeout=syncWorkersTimeout                      [default: 30] Asset downloading timeout for the
+                                                                   syncronization (in minutes).
 
-  -u, --apiUrl=apiUrl
-      [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev environment.
+  -u, --apiUrl=apiUrl                                              [default: ws://localhost:9944] Runtime API URL.
+                                                                   Mandatory in non-dev environment.
 
-  -w, --worker=worker
-      (required) Storage provider worker ID
+  -w, --worker=worker                                              (required) Storage provider worker ID
 
-  -x, --logMaxFileSize=logMaxFileSize
-      [default: 50000000] Maximum rolling log files size in bytes.
+  -x, --logMaxFileSize=logMaxFileSize                              [default: 50000000] Maximum rolling log files size in
+                                                                   bytes.
 
-  -y, --accountUri=accountUri
-      Account URI (optional). If not specified a single key can be set in ACCOUNT_URI environment
-      variable.
+  -y, --accountUri=accountUri                                      Account URI (optional). If not specified a single key
+                                                                   can be set in ACCOUNT_URI environment variable.
 
-  -z, --logFileChangeFrequency=(yearly|monthly|daily|hourly|none)
-      [default: daily] Log files update frequency.
+  -z, --logFileChangeFrequency=(yearly|monthly|daily|hourly|none)  [default: daily] Log files update frequency.
 
-  --elasticSearchIndexPrefix=elasticSearchIndexPrefix
-      Elasticsearch index prefix. Node ID will be appended to the prefix. Default: logs-colossus.
-      Can be passed through ELASTIC_INDEX_PREFIX environment variable.
+  --elasticSearchIndexPrefix=elasticSearchIndexPrefix              Elasticsearch index prefix. Node ID will be appended
+                                                                   to the prefix. Default: logs-colossus. Can be passed
+                                                                   through ELASTIC_INDEX_PREFIX environment variable.
 
-  --elasticSearchPassword=elasticSearchPassword
-      Elasticsearch password for basic authentication. Can be passed through ELASTIC_PASSWORD
-      environment variable.
+  --elasticSearchPassword=elasticSearchPassword                    Elasticsearch password for basic authentication. Can
+                                                                   be passed through ELASTIC_PASSWORD environment
+                                                                   variable.
 
-  --elasticSearchUser=elasticSearchUser
-      Elasticsearch user for basic authentication. Can be passed through ELASTIC_USER environment
-      variable.
+  --elasticSearchUser=elasticSearchUser                            Elasticsearch user for basic authentication. Can be
+                                                                   passed through ELASTIC_USER environment variable.
 
-  --keyStore=keyStore
-      Path to a folder with multiple key files to load into keystore.
+  --keyStore=keyStore                                              Path to a folder with multiple key files to load into
+                                                                   keystore.
 
-  --maxBatchTxSize=maxBatchTxSize
-      [default: 20] Maximum number of `accept_pending_data_objects` in a batch transactions.
+  --maxBatchTxSize=maxBatchTxSize                                  [default: 20] Maximum number of
+                                                                   `accept_pending_data_objects` in a batch
+                                                                   transactions.
 
-  --pendingFolder=pendingFolder
-      Directory to store pending files which are being uploaded (absolute path).
-      If not specified a subfolder under the uploads directory will be used.
+  --pendingFolder=pendingFolder                                    Directory to store pending files which are being
+                                                                   uploaded (absolute path).
+                                                                   If not specified a subfolder under the uploads
+                                                                   directory will be used.
 
-  --syncRetryInterval=syncRetryInterval
-      [default: 3] Interval before retrying failed synchronization run (in minutes)
+  --syncRetryInterval=syncRetryInterval                            [default: 3] Interval before retrying failed
+                                                                   synchronization run (in minutes)
 
-  --tempFolder=tempFolder
-      Directory to store tempory files during sync (absolute path).
-      If not specified a subfolder under the uploads directory will be used.
+  --tempFolder=tempFolder                                          Directory to store tempory files during sync
+                                                                   (absolute path).
+                                                                   If not specified a subfolder under the uploads
+                                                                   directory will be used.
 ```
 
-_See code: [src/commands/server.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/server.ts)_
+_See code: [src/commands/server.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/server.ts)_
 
 ## `storage-node util:cleanup`
 
@@ -993,42 +958,33 @@ USAGE
 
 OPTIONS
   -b, --bucketId=bucketId                          (required) The buckerId to sync prune/cleanup
-
-  -d, --uploads=uploads                            (required) Data uploading directory (absolute
-                                                   path).
-
+  -d, --uploads=uploads                            (required) Data uploading directory (absolute path).
   -h, --help                                       show CLI help
-
   -k, --keyFile=keyFile                            Path to key file to add to the keyring.
-
   -m, --dev                                        Use development mode
 
-  -p, --cleanupWorkersNumber=cleanupWorkersNumber  [default: 20] Cleanup/Pruning workers number
-                                                   (max async operations in progress).
+  -p, --cleanupWorkersNumber=cleanupWorkersNumber  [default: 20] Cleanup/Pruning workers number (max async operations in
+                                                   progress).
 
-  -p, --password=password                          Password to unlock keyfiles. Multiple
-                                                   passwords can be passed, to try against all
-                                                   files. If not specified a single password can
-                                                   be set in ACCOUNT_PWD environment variable.
+  -p, --password=password                          Password to unlock keyfiles. Multiple passwords can be passed, to try
+                                                   against all files. If not specified a single password can be set in
+                                                   ACCOUNT_PWD environment variable.
 
-  -q, --queryNodeEndpoint=queryNodeEndpoint        [default: http://localhost:4352/graphql]
-                                                   Storage Squid graphql server endpoint (e.g.:
-                                                   http://some.com:4352/graphql)
+  -q, --queryNodeEndpoint=queryNodeEndpoint        [default: http://localhost:4352/graphql] Storage Squid graphql server
+                                                   endpoint (e.g.: http://some.com:4352/graphql)
 
-  -u, --apiUrl=apiUrl                              [default: ws://localhost:9944] Runtime API
-                                                   URL. Mandatory in non-dev environment.
+  -u, --apiUrl=apiUrl                              [default: ws://localhost:9944] Runtime API URL. Mandatory in non-dev
+                                                   environment.
 
   -w, --workerId=workerId                          (required) Storage node operator worker ID.
 
-  -y, --accountUri=accountUri                      Account URI (optional). If not specified a
-                                                   single key can be set in ACCOUNT_URI
-                                                   environment variable.
+  -y, --accountUri=accountUri                      Account URI (optional). If not specified a single key can be set in
+                                                   ACCOUNT_URI environment variable.
 
-  --keyStore=keyStore                              Path to a folder with multiple key files to
-                                                   load into keystore.
+  --keyStore=keyStore                              Path to a folder with multiple key files to load into keystore.
 ```
 
-_See code: [src/commands/util/cleanup.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/util/cleanup.ts)_
+_See code: [src/commands/util/cleanup.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/util/cleanup.ts)_
 
 ## `storage-node util:fetch-bucket`
 
@@ -1040,33 +996,28 @@ USAGE
 
 OPTIONS
   -b, --bucketId=bucketId                            (required) The buckerId to fetch
-
-  -d, --uploads=uploads                              (required) Data uploading directory
-                                                     (absolute path).
-
+  -d, --uploads=uploads                              (required) Data uploading directory (absolute path).
   -h, --help                                         show CLI help
 
-  -n, --syncWorkersNumber=syncWorkersNumber          [default: 20] Sync workers number (max
-                                                     async operations in progress).
+  -n, --syncWorkersNumber=syncWorkersNumber          [default: 20] Sync workers number (max async operations in
+                                                     progress).
 
-  -o, --dataSourceOperatorUrl=dataSourceOperatorUrl  Storage node url base (e.g.:
-                                                     http://some.com:3333) to get data from.
+  -o, --dataSourceOperatorUrl=dataSourceOperatorUrl  Storage node url base (e.g.: http://some.com:3333) to get data
+                                                     from.
 
-  -q, --queryNodeEndpoint=queryNodeEndpoint          [default: http://localhost:4352/graphql]
-                                                     Storage Squid graphql server endpoint
-                                                     (e.g.: http://some.com:4352/graphql)
+  -q, --queryNodeEndpoint=queryNodeEndpoint          [default: http://localhost:4352/graphql] Storage Squid graphql
+                                                     server endpoint (e.g.: http://some.com:4352/graphql)
 
-  -t, --syncWorkersTimeout=syncWorkersTimeout        [default: 30] Asset downloading timeout for
-                                                     the syncronization (in minutes).
+  -t, --syncWorkersTimeout=syncWorkersTimeout        [default: 30] Asset downloading timeout for the syncronization (in
+                                                     minutes).
 
-  --tempFolder=tempFolder                            Directory to store tempory files during
-                                                     sync and upload (absolute path).
-                                                     ,Temporary directory (absolute path). If
-                                                     not specified a subfolder under the uploads
-                                                     directory will be used.
+  --tempFolder=tempFolder                            Directory to store tempory files during sync and upload (absolute
+                                                     path).
+                                                     ,Temporary directory (absolute path). If not specified a subfolder
+                                                     under the uploads directory will be used.
 ```
 
-_See code: [src/commands/util/fetch-bucket.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/util/fetch-bucket.ts)_
+_See code: [src/commands/util/fetch-bucket.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/util/fetch-bucket.ts)_
 
 ## `storage-node util:multihash`
 
@@ -1081,7 +1032,24 @@ OPTIONS
   -h, --help       show CLI help
 ```
 
-_See code: [src/commands/util/multihash.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/util/multihash.ts)_
+_See code: [src/commands/util/multihash.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/util/multihash.ts)_
+
+## `storage-node util:search-archives`
+
+Searches for the archive file names given an archive trackfile and a list of data objects of interest.
+
+```
+USAGE
+  $ storage-node util:search-archives
+
+OPTIONS
+  -f, --archiveTrackfile=archiveTrackfile  (required) Path to the archive trackfile (jsonl)
+  -j, --json                               Output as JSON
+  -n, --nameOnly                           Output only the archive names
+  -o, --dataObjects=dataObjects            (required) List of the data object ids to look for (comma-separated)
+```
+
+_See code: [src/commands/util/search-archives.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/util/search-archives.ts)_
 
 ## `storage-node util:verify-bag-id`
 
@@ -1109,5 +1077,5 @@ OPTIONS
       - dynamic:member:4
 ```
 
-_See code: [src/commands/util/verify-bag-id.ts](https://github.com/Joystream/joystream/blob/v4.3.0/src/commands/util/verify-bag-id.ts)_
+_See code: [src/commands/util/verify-bag-id.ts](https://github.com/Joystream/joystream/blob/v4.4.0/src/commands/util/verify-bag-id.ts)_
 <!-- commandsstop -->

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storage-node",
   "description": "Joystream storage subsystem.",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "author": "Joystream contributors",
   "bin": {
     "storage-node": "./bin/run"

--- a/storage-node/package.json
+++ b/storage-node/package.json
@@ -54,6 +54,7 @@
     "multihashes": "^4.0.2",
     "node-cache": "^5.1.2",
     "openapi-editor": "^0.3.0",
+    "p-limit": "^3",
     "promise-timeout": "^1.3.0",
     "proper-lockfile": "^4.1.2",
     "react": "^18.2.0",

--- a/storage-node/src/commands/util/cleanup.ts
+++ b/storage-node/src/commands/util/cleanup.ts
@@ -27,6 +27,10 @@ export default class Cleanup extends ApiCommandBase {
       required: true,
       description: 'The buckerId to sync prune/cleanup',
     }),
+    cleanupBatchSize: flags.integer({
+      description: 'Maximum number of objects to process in a single batch during cleanup.',
+      default: 10_000,
+    }),
     cleanupWorkersNumber: flags.integer({
       char: 'p',
       required: false,
@@ -57,7 +61,15 @@ export default class Cleanup extends ApiCommandBase {
     logger.info('Cleanup...')
 
     try {
-      await performCleanup([bucketId], flags.cleanupWorkersNumber, api, qnApi, flags.uploads, '')
+      await performCleanup(
+        [bucketId],
+        flags.cleanupWorkersNumber,
+        api,
+        qnApi,
+        flags.uploads,
+        flags.cleanupBatchSize,
+        ''
+      )
     } catch (err) {
       logger.error(err)
       logger.error(stringify(err))

--- a/storage-node/src/commands/util/fetch-bucket.ts
+++ b/storage-node/src/commands/util/fetch-bucket.ts
@@ -36,6 +36,10 @@ export default class FetchBucket extends Command {
       description: 'Asset downloading timeout for the syncronization (in minutes).',
       default: 30,
     }),
+    syncBatchSize: flags.integer({
+      description: 'Maximum number of objects to process in a single batch.',
+      default: 10_000,
+    }),
     queryNodeEndpoint: flags.string({
       char: 'q',
       required: false,
@@ -74,6 +78,7 @@ export default class FetchBucket extends Command {
         qnApi,
         flags.uploads,
         flags.tempFolder ? flags.tempFolder : path.join(flags.uploads, 'temp'),
+        flags.syncBatchSize,
         '',
         flags.dataSourceOperatorUrl
       )

--- a/storage-node/src/services/archive/ArchiveService.ts
+++ b/storage-node/src/services/archive/ArchiveService.ts
@@ -13,7 +13,7 @@ import {
   OBJECTS_TRACKING_FILENAME,
 } from './tracking'
 import { QueryNodeApi } from '../queryNode/api'
-import { DataObjectDetailsLoader, getStorageObligationsFromRuntime } from '../sync/storageObligations'
+import { getDataObjectsByIDs, getStorageObligationsFromRuntime } from '../sync/storageObligations'
 import { getDownloadTasks } from '../sync/synchronizer'
 import sleep from 'sleep-promise'
 import { Logger } from 'winston'
@@ -369,21 +369,21 @@ export class ArchiveService {
   public async performSync(): Promise<void> {
     const model = await getStorageObligationsFromRuntime(this.queryNodeApi)
 
-    const assignedObjectsIds = await model.createAssignedObjectsIdsLoader(true).getAll()
-    const unsyncedIds = assignedObjectsIds
+    const unsyncedIds = (await model.getAssignedDataObjectIds(true))
       .filter((id) => !this.objectTrackingService.isTracked(id))
       .map((id) => parseInt(id))
+      // Sort unsynced ids in ASCENDING order (oldest first)
       .sort((a, b) => a - b)
 
     this.logger.info(`Sync - new objects: ${unsyncedIds.length}`)
 
     // Sync objects in batches of 10_000
     for (const unsyncedIdsBatch of _.chunk(unsyncedIds, 10_000)) {
-      const objectsBatchLoader = new DataObjectDetailsLoader(this.queryNodeApi, {
-        by: 'ids',
-        ids: unsyncedIdsBatch.map((id) => id.toString()),
-      })
-      const objectsBatch = (await objectsBatchLoader.getAll()).sort((a, b) => parseInt(b.id) - parseInt(a.id))
+      const objectIdsBatch = unsyncedIdsBatch.map((id) => id.toString())
+      // Sort objectsBatch by ids in DESCENDING order (because we're using .pop() to get the next object)
+      const objectsBatch = (await getDataObjectsByIDs(this.queryNodeApi, objectIdsBatch)).sort(
+        (a, b) => parseInt(b.id) - parseInt(a.id)
+      )
       // Add new download tasks while the upload dir size limit allows
       while (objectsBatch.length) {
         const uploadDirectorySize = await this.getUploadDirSize()

--- a/storage-node/src/services/archive/ArchiveService.ts
+++ b/storage-node/src/services/archive/ArchiveService.ts
@@ -383,7 +383,7 @@ export class ArchiveService {
         by: 'ids',
         ids: unsyncedIdsBatch.map((id) => id.toString()),
       })
-      const objectsBatch = await objectsBatchLoader.getAll()
+      const objectsBatch = (await objectsBatchLoader.getAll()).sort((a, b) => parseInt(b.id) - parseInt(a.id))
       // Add new download tasks while the upload dir size limit allows
       while (objectsBatch.length) {
         const uploadDirectorySize = await this.getUploadDirSize()

--- a/storage-node/src/services/queryNode/queries/queries.graphql
+++ b/storage-node/src/services/queryNode/queries/queries.graphql
@@ -83,13 +83,7 @@ fragment DataObjectWithBagDetails on StorageDataObject {
   }
 }
 
-query dataObjectsByBagsConnection(
-  $bagIds: [String!]
-  $limit: Int
-  $after: String
-  $includeDetails: Boolean!
-  $isAccepted: Boolean
-) {
+query dataObjectIdsByBagIdsConnection($bagIds: [String!], $limit: Int, $after: String, $isAccepted: Boolean) {
   storageDataObjectsConnection(
     where: { storageBag: { id_in: $bagIds }, isAccepted_eq: $isAccepted }
     first: $limit
@@ -99,7 +93,6 @@ query dataObjectsByBagsConnection(
     edges {
       node {
         id
-        ...DataObjectDetails @include(if: $includeDetails)
       }
     }
     pageInfo {
@@ -110,30 +103,16 @@ query dataObjectsByBagsConnection(
   }
 }
 
-query dataObjectsByIdsConnection(
-  $ids: [String!]
-  $limit: Int
-  $after: String
-  $includeDetails: Boolean!
-  $isAccepted: Boolean
-) {
-  storageDataObjectsConnection(
-    where: { id_in: $ids, isAccepted_eq: $isAccepted }
-    first: $limit
-    after: $after
-    orderBy: id_ASC
-  ) {
-    edges {
-      node {
-        id
-        ...DataObjectDetails @include(if: $includeDetails)
-      }
-    }
-    pageInfo {
-      startCursor
-      endCursor
-      hasNextPage
-    }
+# For verifying if data objects still exist
+query dataObjectIdsByIds($ids: [String!]) {
+  storageDataObjects(where: { id_in: $ids }) {
+    id
+  }
+}
+
+query dataObjectDetailsByIds($ids: [String!]) {
+  storageDataObjects(where: { id_in: $ids }) {
+    ...DataObjectDetails
   }
 }
 

--- a/storage-node/src/services/queryNode/queries/queries.graphql
+++ b/storage-node/src/services/queryNode/queries/queries.graphql
@@ -59,7 +59,13 @@ query getAllStorageBagDetails {
   }
 }
 
-fragment DataObjectByBagIdsDetails on StorageDataObject {
+query dataObjectIdsByBagId($bagId: String) {
+  storageDataObjects(where: { storageBag: { id_eq: $bagId } }) {
+    id
+  }
+}
+
+fragment DataObjectDetails on StorageDataObject {
   id
   size
   ipfsHash
@@ -68,13 +74,7 @@ fragment DataObjectByBagIdsDetails on StorageDataObject {
   }
 }
 
-query getDataObjectsByBagIds($bagIds: StorageBagWhereInput) {
-  storageDataObjects(where: { storageBag: $bagIds, isAccepted_eq: true }) {
-    ...DataObjectByBagIdsDetails
-  }
-}
-
-fragment DataObjectDetails on StorageDataObject {
+fragment DataObjectWithBagDetails on StorageDataObject {
   id
   isAccepted
   ipfsHash
@@ -83,9 +83,63 @@ fragment DataObjectDetails on StorageDataObject {
   }
 }
 
-query getDataObjects($dataObjectIds: [String!]) {
-  storageDataObjects(where: { id_in: $dataObjectIds }) {
-    ...DataObjectDetails
+query dataObjectsByBagsConnection(
+  $bagIds: [String!]
+  $limit: Int
+  $after: String
+  $includeDetails: Boolean!
+  $isAccepted: Boolean
+) {
+  storageDataObjectsConnection(
+    where: { storageBag: { id_in: $bagIds }, isAccepted_eq: $isAccepted }
+    first: $limit
+    after: $after
+    orderBy: id_ASC
+  ) {
+    edges {
+      node {
+        id
+        ...DataObjectDetails @include(if: $includeDetails)
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+    }
+  }
+}
+
+query dataObjectsByIdsConnection(
+  $ids: [String!]
+  $limit: Int
+  $after: String
+  $includeDetails: Boolean!
+  $isAccepted: Boolean
+) {
+  storageDataObjectsConnection(
+    where: { id_in: $ids, isAccepted_eq: $isAccepted }
+    first: $limit
+    after: $after
+    orderBy: id_ASC
+  ) {
+    edges {
+      node {
+        id
+        ...DataObjectDetails @include(if: $includeDetails)
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+    }
+  }
+}
+
+query dataObjectsWithBagDetailsByIds($ids: [String!]) {
+  storageDataObjects(where: { id_in: $ids }) {
+    ...DataObjectWithBagDetails
   }
 }
 

--- a/storage-node/src/services/sync/acceptPendingObjects.ts
+++ b/storage-node/src/services/sync/acceptPendingObjects.ts
@@ -91,7 +91,7 @@ export class AcceptPendingObjectsService {
   }
 
   private async processPendingObjects(pendingIds: string[]): Promise<PendingObjectDetails> {
-    const pendingDataObjects = await this.qnApi.getDataObjectDetails(pendingIds)
+    const pendingDataObjects = await this.qnApi.getDataObjectsWithBagDetails(pendingIds)
 
     // objects not found in the query node
     const maybeDeletedObjectIds = pendingIds.filter(

--- a/storage-node/src/services/sync/cleanupService.ts
+++ b/storage-node/src/services/sync/cleanupService.ts
@@ -3,12 +3,13 @@ import _ from 'lodash'
 import superagent from 'superagent'
 import urljoin from 'url-join'
 import { getDataObjectIDs } from '../../services/caching/localDataObjects'
-import logger from '../../services/logger'
+import rootLogger from '../../services/logger'
 import { QueryNodeApi } from '../queryNode/api'
-import { DataObjectDetailsFragment } from '../queryNode/generated/queries'
-import { DataObligations, getDataObjectsByIDs, getStorageObligationsFromRuntime } from './storageObligations'
+import { DataObjectIdsLoader, DataObligations, getStorageObligationsFromRuntime } from './storageObligations'
 import { DeleteLocalFileTask } from './tasks'
 import { TaskProcessorSpawner, WorkingStack } from '../processing/workingProcess'
+import { DataObjectWithBagDetailsFragment } from '../queryNode/generated/queries'
+import { Logger } from 'winston'
 
 /**
  * The maximum allowed threshold by which the QN processor can lag behind
@@ -43,7 +44,7 @@ export const MINIMUM_REPLICATION_THRESHOLD = parseInt(process.env.CLEANUP_MIN_RE
  * @param api - (optional) runtime API promise
  * @param workerId - current storage provider ID
  * @param buckets - Selected storage buckets
- * @param asyncWorkersNumber - maximum parallel downloads number
+ * @param asyncWorkersNumber - maximum parallel cleanups number
  * @param asyncWorkersTimeout - downloading asset timeout
  * @param qnApi - Query Node API
  * @param uploadDirectory - local directory to get file names from
@@ -57,6 +58,7 @@ export async function performCleanup(
   uploadDirectory: string,
   hostId: string
 ): Promise<void> {
+  const logger = rootLogger.child({ label: 'Cleanup' })
   logger.info('Started cleanup service...')
   const squidStatus = await qnApi.getState()
   if (!squidStatus || !squidStatus.height) {
@@ -77,89 +79,93 @@ export async function performCleanup(
   const model = await getStorageObligationsFromRuntime(qnApi, buckets)
   const storedObjectsIds = getDataObjectIDs()
 
-  const assignedObjectsIds = model.dataObjects.map((obj) => obj.id)
-  const removedIds = _.difference(storedObjectsIds, assignedObjectsIds)
-  const removedObjects = await getDataObjectsByIDs(qnApi, removedIds)
+  const assignedObjectsLoader = model.createAssignedObjectsIdsLoader()
+  const assignedObjectIds = new Set(await assignedObjectsLoader.getAll())
+  const obsoleteObjectIds = new Set(storedObjectsIds.filter((id) => !assignedObjectIds.has(id)))
 
-  logger.debug(`Cleanup - stored objects: ${storedObjectsIds.length}, assigned objects: ${assignedObjectsIds.length}`)
-  logger.debug(`Cleanup - pruning ${removedIds.length} obsolete objects`)
+  // If objects are obsolete but still exist: They are "moved" objects
+  const movedObjectsLoader = new DataObjectIdsLoader(qnApi, { by: 'ids', ids: Array.from(obsoleteObjectIds) })
+  const movedObjectIds = new Set(await movedObjectsLoader.getAll())
 
-  // Data objects permanently deleted from the runtime
-  const deletedDataObjects = removedIds.filter(
-    (removedId) => !removedObjects.some((removedObject) => removedObject.id === removedId)
+  // If objects are obsolete and don't exist: They are "deleted objects"
+  const deletedDataObjectIds = new Set([...obsoleteObjectIds].filter((id) => !movedObjectIds.has(id)))
+
+  logger.info(`stored objects: ${storedObjectsIds.length}, assigned objects: ${assignedObjectIds.size}`)
+  logger.info(
+    `pruning ${obsoleteObjectIds.size} obsolete objects ` +
+      `(${movedObjectIds.size} moved, ${deletedDataObjectIds.size} deleted)`
   )
-
-  // Data objects no-longer assigned to current storage-node
-  // operated buckets, and have been moved to other buckets
-  const movedDataObjects = removedObjects
 
   const workingStack = new WorkingStack()
   const processSpawner = new TaskProcessorSpawner(workingStack, asyncWorkersNumber)
 
-  const deletionTasksOfDeletedDataObjects = await Promise.all(
-    deletedDataObjects.map((dataObject) => new DeleteLocalFileTask(uploadDirectory, dataObject))
-  )
-  const deletionTasksOfMovedDataObjects = await getDeletionTasksFromMovedDataObjects(
-    buckets,
-    uploadDirectory,
-    model,
-    movedDataObjects,
-    hostId
-  )
+  // Execute deleted objects removal tasks in batches of 10_000
+  let deletedProcessed = 0
+  logger.info(`removing ${deletedDataObjectIds.size} deleted objects...`)
+  for (const deletedObjectsIdsBatch of _.chunk([...deletedDataObjectIds], 10_000)) {
+    const deletionTasks = deletedObjectsIdsBatch.map((id) => new DeleteLocalFileTask(uploadDirectory, id))
+    await workingStack.add(deletionTasks)
+    await processSpawner.process()
+    deletedProcessed += deletedObjectsIdsBatch.length
+    logger.debug(`${deletedProcessed} / ${deletedDataObjectIds.size} deleted objects processed...`)
+  }
 
-  await workingStack.add(deletionTasksOfDeletedDataObjects)
-  await workingStack.add(deletionTasksOfMovedDataObjects)
-  await processSpawner.process()
+  // Execute moved objects removal tasks in batches of 10_000
+  let movedProcessed = 0
+  logger.info(`removing ${movedObjectIds.size} moved objects...`)
+  for (const movedObjectsIdsBatch of _.chunk([...movedObjectIds], 10_000)) {
+    const movedDataObjectsBatch = await qnApi.getDataObjectsWithBagDetails(movedObjectsIdsBatch)
+    const deletionTasksOfMovedDataObjects = await getDeletionTasksFromMovedDataObjects(
+      logger,
+      uploadDirectory,
+      model,
+      movedDataObjectsBatch,
+      hostId
+    )
+    await workingStack.add(deletionTasksOfMovedDataObjects)
+    await processSpawner.process()
+    movedProcessed += movedDataObjectsBatch.length
+    logger.debug(`${movedProcessed} / ${movedObjectIds.size} moved objects processed...`)
+  }
+
   logger.info('Cleanup ended.')
 }
 
 /**
  * Creates the local file deletion tasks.
  *
- * @param ownBuckets - list of bucket ids operated by this node
+ * @param logger - cleanup service logger
  * @param uploadDirectory - local directory for data uploading
  * @param dataObligations - defines the current data obligations for the node
  * @param movedDataObjects- obsolete (no longer assigned) data objects that has been moved to other buckets
+ * @param hostId - host id of the current node
  */
 async function getDeletionTasksFromMovedDataObjects(
-  ownBuckets: string[],
+  logger: Logger,
   uploadDirectory: string,
   dataObligations: DataObligations,
-  movedDataObjects: DataObjectDetailsFragment[],
+  movedDataObjects: DataObjectWithBagDetailsFragment[],
   hostId: string
 ): Promise<DeleteLocalFileTask[]> {
-  const ownOperatorUrls: string[] = []
-  for (const entry of dataObligations.storageBuckets) {
-    if (ownBuckets.includes(entry.id)) {
-      ownOperatorUrls.push(entry.operatorUrl)
-    }
-  }
-
-  const bucketOperatorUrlById = new Map()
-  for (const entry of dataObligations.storageBuckets) {
-    if (!ownBuckets.includes(entry.id)) {
-      if (ownOperatorUrls.includes(entry.operatorUrl)) {
-        logger.warn(`(cleanup) Skipping remote bucket ${entry.id} - ${entry.operatorUrl}`)
-      } else {
-        bucketOperatorUrlById.set(entry.id, entry.operatorUrl)
-      }
-    }
-  }
-
   const timeoutMs = 60 * 1000 // 1 minute since it's only a HEAD request
   const deletionTasks: DeleteLocalFileTask[] = []
+
+  const { bucketOperatorUrlById } = dataObligations
   await Promise.allSettled(
     movedDataObjects.map(async (movedDataObject) => {
       let dataObjectReplicationCount = 0
 
       for (const { storageBucket } of movedDataObject.storageBag.storageBuckets) {
-        const url = urljoin(bucketOperatorUrlById.get(storageBucket.id), 'api/v1/files', movedDataObject.id)
-        await superagent.head(url).timeout(timeoutMs).set('X-COLOSSUS-HOST-ID', hostId)
-        dataObjectReplicationCount++
+        const nodeUrl = bucketOperatorUrlById.get(storageBucket.id)
+        if (nodeUrl) {
+          const fileUrl = urljoin(nodeUrl, 'api/v1/files', movedDataObject.id)
+          await superagent.head(fileUrl).timeout(timeoutMs).set('X-COLOSSUS-HOST-ID', hostId)
+          dataObjectReplicationCount++
+        }
       }
 
       if (dataObjectReplicationCount < MINIMUM_REPLICATION_THRESHOLD) {
-        logger.warn(`Cleanup - data object replication threshold unmet - file deletion canceled: ${movedDataObject.id}`)
+        logger.warn(`data object replication threshold unmet - file deletion canceled: ${movedDataObject.id}`)
         return
       }
 

--- a/storage-node/src/services/sync/storageObligations.ts
+++ b/storage-node/src/services/sync/storageObligations.ts
@@ -194,7 +194,7 @@ async function getAllBuckets(api: QueryNodeApi): Promise<StorageBucketDetailsFra
   return await getAllObjectsWithPaging(async (offset, limit) => {
     const idsPart = ids.slice(offset, offset + limit)
     if (!_.isEmpty(idsPart)) {
-      logger.debug(`Sync - getting all storage buckets: offset = ${offset}, limit = ${limit}`)
+      logger.debug(`Getting all storage buckets: offset = ${offset}, limit = ${limit}`)
       return await api.getStorageBucketDetails(idsPart)
     } else {
       return false

--- a/storage-node/src/services/sync/synchronizer.ts
+++ b/storage-node/src/services/sync/synchronizer.ts
@@ -35,6 +35,7 @@ export const PendingDirName = 'pending'
  * @param qnApi - Query Node API
  * @param uploadDirectory - local directory to get file names from
  * @param tempDirectory - local directory for temporary data uploading
+ * @param batchSize - maximum number of data objects to process in a single batch
  * @param selectedOperatorUrl - (optional) defines the data source URL. If not set
  * the source URL is resolved for each data object separately using the Query
  * Node information about the storage providers.
@@ -46,6 +47,7 @@ export async function performSync(
   qnApi: QueryNodeApi,
   uploadDirectory: string,
   tempDirectory: string,
+  batchSize: number,
   hostId: string,
   selectedOperatorUrl?: string
 ): Promise<void> {
@@ -64,10 +66,10 @@ export async function performSync(
   const workingStack = new WorkingStack()
   const processSpawner = new TaskProcessorSpawner(workingStack, asyncWorkersNumber)
 
-  // Process unsynced objects in batches od 10_000
+  // Process unsynced objects in batches
   logger.debug(`Sync - started processing...`)
   let processed = 0
-  for (const unsyncedIdsBatch of _.chunk(unsyncedObjectIds, 10_000)) {
+  for (const unsyncedIdsBatch of _.chunk(unsyncedObjectIds, batchSize)) {
     const objectsBatch = await getDataObjectsByIDs(qnApi, unsyncedIdsBatch)
     const syncTasks = await getDownloadTasks(
       model,

--- a/storage-node/src/services/webApi/controllers/stateApi.ts
+++ b/storage-node/src/services/webApi/controllers/stateApi.ts
@@ -8,7 +8,6 @@ import { promisify } from 'util'
 import { getDataObjectIDs } from '../../../services/caching/localDataObjects'
 import logger from '../../logger'
 import { QueryNodeApi } from '../../queryNode/api'
-import { getDataObjectIDsByBagId } from '../../sync/storageObligations'
 import {
   DataObjectResponse,
   DataStatsResponse,
@@ -168,7 +167,7 @@ async function getCachedDataObjectsObligations(qnApi: QueryNodeApi, bagId: strin
   const entryName = `data_object_obligations_${bagId}`
 
   if (!dataCache.has(entryName)) {
-    const data = await getDataObjectIDsByBagId(qnApi, bagId)
+    const data = await qnApi.getDataObjectIdsByBagId(bagId)
 
     dataCache.set(entryName, data)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18274,7 +18274,7 @@ p-is-promise@^2.0.0:
   resolved "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz"
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
-p-limit@3.1.0, p-limit@^3.0.2:
+p-limit@3.1.0, p-limit@^3, p-limit@^3.0.2:
   version "3.1.0"
   resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==


### PR DESCRIPTION
Resolves #5182 

- **Optimizations:** The way data objects / data object ids are queried and processed during sync and cleanup has been optimized:
    - Sync and cleanup services now process tasks in batches of configurable size (`--syncBatchSize`, `--cleanupBatchSize`) to avoid overflowing the memory.
    - Synchronous operations like `sort` or `filter` on larger arrays of data objects have been optimized (for example, by replacing `.filter(Array.includes(...))` with `.filter(Set.has(...))`).
    - Enforced a limit of max. results per single GraphQL query to `10,000` and max input arguments per query to `1,000`.
    - Added `--cleanupWorkersNumber` flag to limit the number of concurrent async requests during cleanup.
- A safety mechanism was added to avoid removing "deleted" objects for which a related `DataObjectDeleted` event cannot be found in storage squid.
- Improved logging during sync and cleanup.