### PR TITLE
GitHub workflows: Migrate actions/(upload|download)-artifact to v4

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,7 +39,7 @@ jobs:
           tar czvf joystream-node-macos.tar.gz -C ./target/release joystream-node
 
       - name: Temporarily save node binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: joystream-node-macos-${{ steps.compute_shasum.outputs.shasum }}
           path: joystream-node-macos.tar.gz
@@ -80,7 +80,7 @@ jobs:
           tar -czvf joystream-node-$VERSION_AND_COMMIT-arm64-linux-gnu.tar.gz joystream-node
 
       - name: Retrieve saved MacOS binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: joystream-node-macos-${{ steps.compute_shasum.outputs.shasum }}
 

--- a/.github/workflows/deploy-node-network.yml
+++ b/.github/workflows/deploy-node-network.yml
@@ -168,7 +168,7 @@ jobs:
           7z a -p${{ steps.network_config.outputs.encryptionKey }} chain-data.7z deploy_artifacts/*
 
       - name: Save the output as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: data-chainspec-auth
           path: devops/ansible/chain-data.7z

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -34,7 +34,7 @@ on:
         description: 'SURI of treasury account'
         required: false
         default: '//Alice'
-      initialBalances: 
+      initialBalances:
         description: 'JSON string or http URL to override initial balances and vesting config'
         default: ''
         required: false
@@ -112,7 +112,7 @@ jobs:
             --verbose
 
       - name: Save the endpoints file as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: endpoints
           path: devops/ansible/endpoints.json

--- a/.github/workflows/run-network-tests.yml
+++ b/.github/workflows/run-network-tests.yml
@@ -141,7 +141,7 @@ jobs:
         if: steps.check_files.outputs.files_exists == 'false'
 
       - name: Save joystream/node image to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.compute_shasum.outputs.shasum }}-joystream-node-docker-image.tar.gz
           path: joystream-node-docker-image.tar.gz
@@ -166,7 +166,7 @@ jobs:
         with:
           node-version: '18.x'
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build_images.outputs.use_artifact }}
       - name: Install artifacts

--- a/devops/extrinsic-ordering/tx-ordering.yml
+++ b/devops/extrinsic-ordering/tx-ordering.yml
@@ -74,7 +74,7 @@ jobs:
         run: pkill polkadot
 
       - name: Save output as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CHAIN }}
           path: |


### PR DESCRIPTION
Migrate `actions/(upload|download)-artifact` to `v4` in GitHub workflows to fix failing checks (see: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)